### PR TITLE
feat(posts): schedule posts from both composers

### DIFF
--- a/packages/shared/src/components/fields/form/FormWrapper.tsx
+++ b/packages/shared/src/components/fields/form/FormWrapper.tsx
@@ -21,6 +21,7 @@ export interface FormWrapperProps {
   copy?: Copy;
   leftButtonProps?: ButtonProps<'button'>;
   rightButtonProps?: ButtonProps<'button'>;
+  headerActions?: ReactNode;
   title?: string | React.ReactNode;
   isHeaderTitle?: boolean;
   headerRef?: MutableRefObject<HTMLDivElement>;
@@ -33,6 +34,7 @@ export function FormWrapper({
   copy = {},
   leftButtonProps = {},
   rightButtonProps = {},
+  headerActions,
   title,
   isHeaderTitle,
   headerRef,
@@ -63,14 +65,17 @@ export function FormWrapper({
           {isHeaderTitle ? null : left}
         </Button>
         {isHeaderTitle && title && titleElement}
-        <Button
-          {...rightButtonProps}
-          variant={ButtonVariant.Primary}
-          form={form}
-          className={classNames('ml-auto', rightButtonProps.className)}
-        >
-          {right}
-        </Button>
+        <div className="ml-auto flex items-center gap-2">
+          {headerActions}
+          <Button
+            {...rightButtonProps}
+            variant={ButtonVariant.Primary}
+            form={form}
+            className={rightButtonProps.className}
+          >
+            {right}
+          </Button>
+        </div>
       </PageHeader>
       {!isHeaderTitle && title && titleElement}
       {children}

--- a/packages/shared/src/components/modals/post/SmartComposerModal.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.tsx
@@ -357,8 +357,6 @@ export function SmartComposerModal({
     submitLabel = isStandupScheduled ? 'Schedule standup' : 'Create standup';
   } else if (canSchedule && schedule.isScheduled) {
     submitLabel = 'Schedule post';
-  } else if (kind === 'poll') {
-    submitLabel = 'Post poll';
   } else {
     submitLabel = 'Post';
   }
@@ -405,16 +403,18 @@ export function SmartComposerModal({
       size={ButtonSize.Small}
       disabled={isSubmitDisabled || isCoverUploading || (isEditing && !isDirty)}
       loading={isInFlight || isCoverUploading}
-      className="ml-2 px-5"
+      className="px-5"
     >
       {submitLabel}
     </Button>
   );
+  // Self-contained flex with its own gap so the button pair keeps identical
+  // spacing regardless of the parent (rich-text toolbar vs. bottom action bar).
   const primaryActionsNode = (
-    <>
+    <div className="flex items-center gap-2">
       {scheduleButtonNode}
       {postButtonNode}
-    </>
+    </div>
   );
   const notificationToggleNode = shouldShowCta ? (
     <Switch

--- a/packages/shared/src/components/modals/post/SmartComposerModal.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.tsx
@@ -34,7 +34,9 @@ import { LogEvent } from '../../../lib/log';
 import { useViewSize, ViewSize } from '../../../hooks';
 import { usePrompt } from '../../../hooks/usePrompt';
 import type { ExternalLinkPreview, Post } from '../../../graphql/posts';
+import type { Squad } from '../../../graphql/sources';
 import { getPostByIdKey } from '../../../lib/query';
+import { moderationRequired } from '../../squads/utils';
 import { AudienceChip } from '../../post/composer/AudienceChip';
 import { KindModePicker } from '../../post/composer/KindModePicker';
 import {
@@ -52,6 +54,8 @@ import {
 } from '../../post/composer/useComposerAudience';
 import { useComposerSubmit } from '../../post/composer/useComposerSubmit';
 import { useStandupCreation } from '../../../hooks/liveRooms/useStandupCreation';
+import { useSchedulePost } from '../../post/schedule/useSchedulePost';
+import { SchedulePostButton } from '../../post/schedule/SchedulePostButton';
 import {
   DEFAULT_LINK,
   DEFAULT_POLL,
@@ -299,6 +303,16 @@ export function SmartComposerModal({
   const primary = selected[0];
   const isMulti = selected.length > 1;
 
+  const schedule = useSchedulePost();
+  // Scheduling: single-source, non-moderated create only (any post type
+  // except standups, which schedule themselves).
+  const canSchedule =
+    kind !== 'standup' &&
+    !isEditing &&
+    !isMulti &&
+    !!primary &&
+    !moderationRequired(primary as Squad);
+
   const {
     handleSubmit,
     isSubmitDisabled,
@@ -319,6 +333,7 @@ export function SmartComposerModal({
     isMulti,
     initialPreview,
     editPostId: editPost?.id,
+    resolveScheduledAt: canSchedule ? schedule.resolveScheduledAt : undefined,
     onComplete: () => {
       if (editPost?.id) {
         queryClient.invalidateQueries({
@@ -340,6 +355,8 @@ export function SmartComposerModal({
     submitLabel = 'Save changes';
   } else if (isStandup) {
     submitLabel = isStandupScheduled ? 'Schedule standup' : 'Create standup';
+  } else if (canSchedule && schedule.isScheduled) {
+    submitLabel = 'Schedule post';
   } else if (kind === 'poll') {
     submitLabel = 'Post poll';
   } else {
@@ -367,6 +384,19 @@ export function SmartComposerModal({
   );
 
   const isCoverUploading = !!cover?.isUploading;
+  const scheduleButtonNode = canSchedule ? (
+    <SchedulePostButton
+      isScheduled={schedule.isScheduled}
+      scheduledStart={schedule.scheduledStart}
+      timezone={schedule.timezone}
+      error={schedule.error}
+      disabled={isInFlight}
+      onScheduledStartChange={schedule.setScheduledStart}
+      onSeedDefault={schedule.seedDefault}
+      onConfirm={schedule.confirmSchedule}
+      onClear={schedule.clearSchedule}
+    />
+  ) : null;
   const postButtonNode = (
     <Button
       form="smart_composer"
@@ -379,6 +409,12 @@ export function SmartComposerModal({
     >
       {submitLabel}
     </Button>
+  );
+  const primaryActionsNode = (
+    <>
+      {scheduleButtonNode}
+      {postButtonNode}
+    </>
   );
   const notificationToggleNode = shouldShowCta ? (
     <Switch
@@ -493,7 +529,7 @@ export function SmartComposerModal({
             cover={cover}
             onCoverChange={onCoverChange}
             toolbarLeading={kindPickerNode}
-            toolbarRightActions={postButtonNode}
+            toolbarRightActions={primaryActionsNode}
             onMarkdownModeChange={onMarkdownModeChange}
           />
           {!isMarkdownMode && notificationToggleNode && (
@@ -535,7 +571,9 @@ export function SmartComposerModal({
         <div className="flex shrink-0 flex-col gap-3 px-5 pb-5 pt-4">
           <div className="flex items-center justify-between gap-3">
             {kindPickerNode}
-            <span className="ml-auto">{postButtonNode}</span>
+            <span className="ml-auto flex items-center">
+              {primaryActionsNode}
+            </span>
           </div>
           {notificationToggleNode}
         </div>

--- a/packages/shared/src/components/post/composer/useComposerSubmit.ts
+++ b/packages/shared/src/components/post/composer/useComposerSubmit.ts
@@ -24,6 +24,7 @@ import {
 } from './types';
 import type { TextFormCover } from './TextForm';
 import { isPreviewForComposerUrl } from './utils';
+import type { ResolvedScheduledAt } from '../schedule/useSchedulePost';
 
 export interface StandupFieldErrors {
   topic?: string;
@@ -72,6 +73,7 @@ interface UseComposerSubmitProps {
   initialPreview?: ExternalLinkPreview;
   onComplete: () => void;
   editPostId?: string;
+  resolveScheduledAt?: () => ResolvedScheduledAt;
 }
 
 interface UseComposerSubmit {
@@ -97,6 +99,7 @@ export const useComposerSubmit = ({
   initialPreview,
   onComplete,
   editPostId,
+  resolveScheduledAt,
 }: UseComposerSubmitProps): UseComposerSubmit => {
   const { displayToast } = useToastNotification();
   const router = useRouter();
@@ -119,6 +122,12 @@ export const useComposerSubmit = ({
     displayMutationErrors: true,
     onPostSuccess: (post) => {
       if (editPostId) {
+        return;
+      }
+      // Scheduled posts aren't visible yet, so don't navigate to the post
+      // page — just confirm and let onComplete close the composer.
+      if (post.flags?.scheduledAt) {
+        displayToast('✅ Your post has been scheduled!');
         return;
       }
       router.push(
@@ -174,7 +183,10 @@ export const useComposerSubmit = ({
     return !isPollValid(poll);
   };
 
-  const submitText = async () => {
+  // Scheduling is single-source and non-moderated only. The `scheduledAt` here
+  // is already gated by the caller (undefined unless the post is schedulable),
+  // and it routes through the dedicated single-source mutation for each type.
+  const submitText = async (scheduledAt?: string) => {
     const payload = {
       title: text.title.trim(),
       content: text.body,
@@ -192,6 +204,12 @@ export const useComposerSubmit = ({
       );
       return;
     }
+
+    if (scheduledAt) {
+      await onSubmitFreeformPost({ ...payload, scheduledAt }, primary as Squad);
+      return;
+    }
+
     if (isMulti) {
       await createMulti({
         sourceIds: selectedIds,
@@ -207,10 +225,10 @@ export const useComposerSubmit = ({
     );
   };
 
-  const submitPoll = async () => {
+  const submitPoll = async (scheduledAt?: string) => {
     const options = trimmedOptions(poll);
     const duration = poll.durationDays;
-    if (isMulti) {
+    if (!scheduledAt && isMulti) {
       await createMulti({
         sourceIds: selectedIds,
         title: poll.question.trim(),
@@ -224,19 +242,27 @@ export const useComposerSubmit = ({
         title: poll.question.trim(),
         options,
         ...(duration != null ? { duration } : {}),
+        ...(scheduledAt ? { scheduledAt } : {}),
       },
       primary as Squad,
     );
   };
 
-  const submitLink = async (event: FormEvent<HTMLFormElement>) => {
+  const submitLink = async (
+    event: FormEvent<HTMLFormElement>,
+    scheduledAt?: string,
+  ) => {
     if (!isPreviewForComposerUrl(preview, link.url)) {
       displayToast('Invalid link');
       return;
     }
     const commentary = link.commentary.trim();
     if (!isMulti) {
-      await onSubmitPost(event, primary as Squad, commentary);
+      await onSubmitPost(event, primary as Squad, commentary, scheduledAt);
+      // submitExternalLink returns no post, so onPostSuccess can't confirm it.
+      if (scheduledAt && !preview?.id) {
+        displayToast('✅ Your post has been scheduled!');
+      }
       return;
     }
     const url = preview?.finalUrl ?? preview?.url;
@@ -273,19 +299,30 @@ export const useComposerSubmit = ({
       if (getIsSubmitDisabled()) {
         return;
       }
-      if (kind === 'text') {
-        await submitText();
-        return;
-      }
-      if (kind === 'poll') {
-        await submitPoll();
-        return;
-      }
       if (kind === 'standup') {
         await submitStandup();
         return;
       }
-      await submitLink(event);
+
+      let scheduledAt: string | undefined;
+      if (!editPostId) {
+        const schedule = resolveScheduledAt?.() ?? {};
+        if (schedule.error) {
+          displayToast(schedule.error);
+          return;
+        }
+        scheduledAt = schedule.iso;
+      }
+
+      if (kind === 'text') {
+        await submitText(scheduledAt);
+        return;
+      }
+      if (kind === 'poll') {
+        await submitPoll(scheduledAt);
+        return;
+      }
+      await submitLink(event, scheduledAt);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
@@ -301,6 +338,7 @@ export const useComposerSubmit = ({
       selectedIds,
       isInFlight,
       editPostId,
+      resolveScheduledAt,
     ],
   );
 

--- a/packages/shared/src/components/post/schedule/SchedulePostButton.tsx
+++ b/packages/shared/src/components/post/schedule/SchedulePostButton.tsx
@@ -1,0 +1,209 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import { Popover, PopoverTrigger } from '@radix-ui/react-popover';
+import { PopoverContent } from '../../popover/Popover';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { CalendarIcon, MiniCloseIcon } from '../../icons';
+import { Tooltip } from '../../tooltip/Tooltip';
+import { TextField } from '../../fields/TextField';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import Link from '../../utilities/Link';
+import { Drawer, DrawerPosition } from '../../drawers/Drawer';
+import { useViewSize, ViewSize } from '../../../hooks/useViewSize';
+import { getTimezoneNameWithOffset } from '../../../lib/timezones';
+import { timezoneSettingsUrl } from '../../../lib/constants';
+import {
+  formatScheduleDelta,
+  parsePostScheduledStart,
+} from '../../../lib/scheduledPost';
+import styles from '../../fields/dateTimeInput.module.css';
+
+interface SchedulePostButtonProps {
+  isScheduled: boolean;
+  scheduledStart: string;
+  timezone: string;
+  error?: string | null;
+  disabled?: boolean;
+  onScheduledStartChange: (value: string) => void;
+  onSeedDefault: () => void;
+  onConfirm: () => boolean;
+  onClear: () => void;
+}
+
+export function SchedulePostButton({
+  isScheduled,
+  scheduledStart,
+  timezone,
+  error,
+  disabled,
+  onScheduledStartChange,
+  onSeedDefault,
+  onConfirm,
+  onClear,
+}: SchedulePostButtonProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const isTablet = useViewSize(ViewSize.Tablet);
+  const scheduledDate = parsePostScheduledStart(scheduledStart, timezone);
+  const delta = formatScheduleDelta(scheduledDate);
+  const timezoneLabel = getTimezoneNameWithOffset(timezone);
+  const tooltipContent =
+    isScheduled && delta ? `Scheduled ${delta}` : 'Schedule post';
+
+  const onOpenChange = (next: boolean) => {
+    setOpen(next);
+    if (next) {
+      onSeedDefault();
+    }
+  };
+
+  const pickerBody = (
+    <>
+      <div className="flex flex-col gap-1.5">
+        <TextField
+          inputId="post-scheduled-start"
+          name="post-scheduled-start"
+          // Required by TextField, but rendered as a tertiary field so the
+          // (redundant) floating label isn't shown next to the popover title.
+          label="Scheduled time"
+          fieldType="tertiary"
+          aria-label="Scheduled time"
+          type="datetime-local"
+          value={scheduledStart}
+          onChange={(event) =>
+            onScheduledStartChange(event.currentTarget.value)
+          }
+          valid={!error}
+          className={{ input: styles.dateTimeInput }}
+        />
+        {error ? (
+          <Typography
+            type={TypographyType.Caption1}
+            color={TypographyColor.StatusError}
+          >
+            {error}
+          </Typography>
+        ) : (
+          <div className="flex flex-col gap-0.5">
+            {delta && (
+              <Typography
+                type={TypographyType.Caption1}
+                color={TypographyColor.Tertiary}
+              >
+                {delta}
+              </Typography>
+            )}
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+            >
+              {`${timezoneLabel} · `}
+              <Link href={timezoneSettingsUrl} passHref>
+                <a className="text-text-link">Change timezone</a>
+              </Link>
+            </Typography>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-2">
+        {isScheduled ? (
+          <Button
+            type="button"
+            variant={ButtonVariant.Subtle}
+            size={ButtonSize.Small}
+            onClick={() => {
+              onClear();
+              setOpen(false);
+            }}
+          >
+            Publish now
+          </Button>
+        ) : (
+          <span />
+        )}
+        <Button
+          type="button"
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Small}
+          onClick={() => {
+            if (onConfirm()) {
+              setOpen(false);
+            }
+          }}
+        >
+          {isScheduled ? 'Update schedule' : 'Schedule'}
+        </Button>
+      </div>
+    </>
+  );
+
+  if (!isTablet) {
+    return (
+      <>
+        <Tooltip content={tooltipContent}>
+          <Button
+            type="button"
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            icon={<CalendarIcon secondary={isScheduled} />}
+            pressed={isScheduled}
+            disabled={disabled}
+            aria-label="Schedule post"
+            onClick={() => onOpenChange(true)}
+          />
+        </Tooltip>
+        <Drawer
+          isOpen={open}
+          onClose={() => setOpen(false)}
+          position={DrawerPosition.Bottom}
+          className={{ wrapper: 'flex flex-col gap-3 p-4' }}
+        >
+          <div className="flex shrink-0 items-center justify-between">
+            <Typography type={TypographyType.Title3} bold>
+              Schedule post
+            </Typography>
+            <Button
+              type="button"
+              icon={<MiniCloseIcon />}
+              onClick={() => setOpen(false)}
+              aria-label="Close"
+            />
+          </div>
+          {pickerBody}
+        </Drawer>
+      </>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <Tooltip content={tooltipContent}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            icon={<CalendarIcon secondary={isScheduled} />}
+            pressed={isScheduled}
+            disabled={disabled}
+            aria-label="Schedule post"
+          />
+        </PopoverTrigger>
+      </Tooltip>
+      <PopoverContent
+        side="top"
+        align="end"
+        avoidCollisions
+        className="flex w-80 flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-popover p-4 shadow-2 data-[side=bottom]:mt-1 data-[side=top]:mb-1"
+      >
+        <Typography type={TypographyType.Body} bold>
+          Schedule post
+        </Typography>
+        {pickerBody}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/shared/src/components/post/schedule/SchedulePostControl.tsx
+++ b/packages/shared/src/components/post/schedule/SchedulePostControl.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { SchedulePostButton } from './SchedulePostButton';
+import type { UseSchedulePost } from './useSchedulePost';
+
+interface SchedulePostControlProps {
+  schedule: UseSchedulePost;
+  disabled?: boolean;
+}
+
+export function SchedulePostControl({
+  schedule,
+  disabled,
+}: SchedulePostControlProps): ReactElement {
+  return (
+    <SchedulePostButton
+      isScheduled={schedule.isScheduled}
+      scheduledStart={schedule.scheduledStart}
+      timezone={schedule.timezone}
+      error={schedule.error}
+      disabled={disabled}
+      onScheduledStartChange={schedule.setScheduledStart}
+      onSeedDefault={schedule.seedDefault}
+      onConfirm={schedule.confirmSchedule}
+      onClear={schedule.clearSchedule}
+    />
+  );
+}

--- a/packages/shared/src/components/post/schedule/useSchedulePost.ts
+++ b/packages/shared/src/components/post/schedule/useSchedulePost.ts
@@ -1,0 +1,90 @@
+import { useCallback, useState } from 'react';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { DEFAULT_TIMEZONE } from '../../../lib/timezones';
+import {
+  getDefaultPostScheduledStart,
+  validatePostScheduledStart,
+} from '../../../lib/scheduledPost';
+
+export interface ResolvedScheduledAt {
+  iso?: string;
+  error?: string;
+}
+
+export interface UseSchedulePost {
+  isScheduled: boolean;
+  scheduledStart: string;
+  timezone: string;
+  error: string | null;
+  setScheduledStart: (value: string) => void;
+  seedDefault: () => void;
+  confirmSchedule: () => boolean;
+  clearSchedule: () => void;
+  resolveScheduledAt: () => ResolvedScheduledAt;
+}
+
+export const useSchedulePost = (): UseSchedulePost => {
+  const { user } = useAuthContext();
+  const timezone = user?.timezone || DEFAULT_TIMEZONE;
+  const [isScheduled, setIsScheduled] = useState(false);
+  const [scheduledStart, setScheduledStartState] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const setScheduledStart = useCallback((value: string) => {
+    setScheduledStartState(value);
+    setError(null);
+  }, []);
+
+  // Seed a sensible default when the picker opens without overwriting an
+  // existing selection.
+  const seedDefault = useCallback(() => {
+    setScheduledStartState(
+      (current) => current || getDefaultPostScheduledStart(timezone),
+    );
+  }, [timezone]);
+
+  const confirmSchedule = useCallback((): boolean => {
+    const result = validatePostScheduledStart(scheduledStart, timezone);
+
+    if ('error' in result) {
+      setError(result.error);
+      return false;
+    }
+
+    setError(null);
+    setIsScheduled(true);
+    return true;
+  }, [scheduledStart, timezone]);
+
+  const clearSchedule = useCallback(() => {
+    setIsScheduled(false);
+    setError(null);
+  }, []);
+
+  const resolveScheduledAt = useCallback((): ResolvedScheduledAt => {
+    if (!isScheduled) {
+      return {};
+    }
+
+    const result = validatePostScheduledStart(scheduledStart, timezone);
+
+    if ('error' in result) {
+      setError(result.error);
+      return { error: result.error };
+    }
+
+    return { iso: result.iso };
+  }, [isScheduled, scheduledStart, timezone]);
+
+  return {
+    isScheduled,
+    scheduledStart,
+    timezone,
+    error,
+    setScheduledStart,
+    seedDefault,
+    confirmSchedule,
+    clearSchedule,
+    resolveScheduledAt,
+  };
+};

--- a/packages/shared/src/components/post/write/WriteFooter.tsx
+++ b/packages/shared/src/components/post/write/WriteFooter.tsx
@@ -6,6 +6,8 @@ import { useNotificationToggle } from '../../../hooks/notifications';
 import useSidebarRendered from '../../../hooks/useSidebarRendered';
 import { Button, ButtonColor, ButtonVariant } from '../../buttons/Button';
 import PollDurationDropdown from '../poll/PollDurationDropdown';
+import { useWritePostContext } from '../../../contexts';
+import { SchedulePostControl } from '../schedule/SchedulePostControl';
 
 interface WriteFooterProps {
   isLoading?: boolean;
@@ -19,6 +21,7 @@ export function WriteFooter({
   isPoll,
 }: WriteFooterProps): ReactElement {
   const { sidebarRendered } = useSidebarRendered();
+  const { schedule } = useWritePostContext();
   const { shouldShowCta, isEnabled, onToggle, onSubmitted } =
     useNotificationToggle();
 
@@ -46,20 +49,27 @@ export function WriteFooter({
           Receive updates whenever your Squad members engage with your post
         </Switch>
       )}
-      <Button
-        type="submit"
-        variant={ButtonVariant.Primary}
-        color={ButtonColor.Cabbage}
+      <div
         className={classNames(
-          'ml-auto hidden w-full tablet:mt-0 tablet:w-32 laptop:flex',
+          'ml-auto hidden w-full items-center gap-2 tablet:w-auto laptop:flex',
           shouldShowCta && 'mt-6',
         )}
-        disabled={isLoading}
-        loading={isLoading}
-        onClick={onSubmitted}
       >
-        Post
-      </Button>
+        {schedule && (
+          <SchedulePostControl schedule={schedule} disabled={isLoading} />
+        )}
+        <Button
+          type="submit"
+          variant={ButtonVariant.Primary}
+          color={ButtonColor.Cabbage}
+          className="w-full tablet:mt-0 tablet:w-32"
+          disabled={isLoading}
+          loading={isLoading}
+          onClick={onSubmitted}
+        >
+          {schedule?.isScheduled ? 'Schedule' : 'Post'}
+        </Button>
+      </div>
     </span>
   );
 }

--- a/packages/shared/src/contexts/WritePostContext.tsx
+++ b/packages/shared/src/contexts/WritePostContext.tsx
@@ -17,6 +17,8 @@ import ConditionalWrapper from '../components/ConditionalWrapper';
 import { FormWrapper } from '../components/fields/form';
 import type { SourcePostModeration } from '../graphql/squads';
 import { useViewSize, ViewSize } from '../hooks/useViewSize';
+import type { UseSchedulePost } from '../components/post/schedule/useSchedulePost';
+import { SchedulePostControl } from '../components/post/schedule/SchedulePostControl';
 
 export interface WriteForm {
   title: string;
@@ -55,6 +57,8 @@ export interface WritePostProps {
   updateDraft?: (props: Partial<WriteForm>) => Promise<void>;
   isUpdatingDraft?: boolean;
   formId?: string;
+  // When provided, the schedule control is offered next to the submit button.
+  schedule?: UseSchedulePost;
 }
 
 export const WritePostContext = React.createContext<WritePostProps>({
@@ -95,6 +99,14 @@ export const WritePostContextProvider = ({
             copy={{ right: rightCopy ?? 'Post' }}
             rightButtonProps={{ disabled: props.isPosting }}
             leftButtonProps={{ onClick: () => router.back() }}
+            headerActions={
+              props.schedule ? (
+                <SchedulePostControl
+                  schedule={props.schedule}
+                  disabled={props.isPosting}
+                />
+              ) : undefined
+            }
             form={formId}
           >
             {component}

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -180,6 +180,7 @@ type PostFlags = {
   sources?: number;
   savedTime?: number;
   generatedAt?: Date;
+  scheduledAt?: string | null;
   digestPostIds?: string[];
   ad?: DigestPostAd | null;
 };
@@ -699,6 +700,7 @@ export const SUBMIT_EXTERNAL_LINK_MUTATION = gql`
     $title: String
     $image: String
     $commentary: String
+    $scheduledAt: DateTime
   ) {
     submitExternalLink(
       url: $url
@@ -706,6 +708,7 @@ export const SUBMIT_EXTERNAL_LINK_MUTATION = gql`
       image: $image
       sourceId: $sourceId
       commentary: $commentary
+      scheduledAt: $scheduledAt
     ) {
       _
     }
@@ -764,6 +767,7 @@ export interface SubmitExternalLink
   extends Pick<ExternalLinkPreview, 'title' | 'image' | 'url'> {
   sourceId: string;
   commentary: string;
+  scheduledAt?: string | null;
 }
 
 export const submitExternalLink = (
@@ -778,8 +782,15 @@ export const EDIT_POST_MUTATION = gql`
     $title: String
     $content: String
     $image: Upload
+    $scheduledAt: DateTime
   ) {
-    editPost(id: $id, title: $title, content: $content, image: $image) {
+    editPost(
+      id: $id
+      title: $title
+      content: $content
+      image: $image
+      scheduledAt: $scheduledAt
+    ) {
       ...SharedPostInfo
       trending
       content
@@ -789,6 +800,9 @@ export const EDIT_POST_MUTATION = gql`
       }
       description
       summary
+      flags {
+        scheduledAt
+      }
       toc {
         text
         id
@@ -803,11 +817,12 @@ export type EditPostProps = {
   title: string;
   content: string;
   image?: File;
+  scheduledAt?: string | null;
 };
 
 export type CreatePostProps = Pick<
   EditPostProps,
-  'title' | 'content' | 'image'
+  'title' | 'content' | 'image' | 'scheduledAt'
 >;
 
 export interface CreatePostPollProps
@@ -827,6 +842,7 @@ type CreatePollOption = Pick<PollOption, 'text' | 'order'>;
 export interface CreatePollPostForm extends Pick<EditPostProps, 'title'> {
   options: string[];
   duration?: number;
+  scheduledAt?: string | null;
 }
 
 export interface CreatePostModerationProps {
@@ -939,12 +955,14 @@ export const CREATE_POST_MUTATION = gql`
     $title: String!
     $content: String
     $image: Upload
+    $scheduledAt: DateTime
   ) {
     createFreeformPost(
       sourceId: $sourceId
       title: $title
       content: $content
       image: $image
+      scheduledAt: $scheduledAt
     ) {
       ...SharedPostInfo
       content
@@ -954,6 +972,9 @@ export const CREATE_POST_MUTATION = gql`
       }
       description
       summary
+      flags {
+        scheduledAt
+      }
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}
@@ -1001,7 +1022,7 @@ export const CREATE_POST_IN_MULTIPLE_SOURCES = gql`
 `;
 
 export interface CreatePostInMultipleSourcesArgs
-  extends Partial<CreatePostProps>,
+  extends Partial<Omit<CreatePostProps, 'scheduledAt'>>,
     Partial<Pick<CreatePollPostProps, 'options' | 'duration'>> {
   commentary?: string;
   externalLink?: string;
@@ -1068,14 +1089,19 @@ export const CREATE_POLL_POST_MUTATION = gql`
     $title: String!
     $options: [PollOptionInput!]!
     $duration: Int
+    $scheduledAt: DateTime
   ) {
     createPollPost(
       sourceId: $sourceId
       title: $title
       options: $options
       duration: $duration
+      scheduledAt: $scheduledAt
     ) {
       ...SharedPostInfo
+      flags {
+        scheduledAt
+      }
     }
   }
   ${SHARED_POST_INFO_FRAGMENT}

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -59,6 +59,7 @@ interface PostToSquadProps {
   id: string;
   sourceId?: string;
   commentary: string;
+  scheduledAt?: string | null;
 }
 
 export const UPDATE_MEMBER_ROLE_MUTATION = gql`
@@ -236,9 +237,22 @@ export const EDIT_SQUAD_MUTATION = gql`
 `;
 
 export const ADD_POST_TO_SQUAD_MUTATION = gql`
-  mutation AddPostToSquad($id: ID!, $sourceId: ID!, $commentary: String) {
-    sharePost(id: $id, sourceId: $sourceId, commentary: $commentary) {
+  mutation AddPostToSquad(
+    $id: ID!
+    $sourceId: ID!
+    $commentary: String
+    $scheduledAt: DateTime
+  ) {
+    sharePost(
+      id: $id
+      sourceId: $sourceId
+      commentary: $commentary
+      scheduledAt: $scheduledAt
+    ) {
       id
+      flags {
+        scheduledAt
+      }
     }
   }
 `;

--- a/packages/shared/src/hooks/squads/usePostToSquad.tsx
+++ b/packages/shared/src/hooks/squads/usePostToSquad.tsx
@@ -63,6 +63,7 @@ interface UsePostToSquad {
     e: BaseSyntheticEvent,
     squad: Squad,
     commentary: string,
+    scheduledAt?: string,
   ) => Promise<unknown>;
   onSubmitFreeformPost: (post: CreatePostProps, squad: Squad) => Promise<void>;
   onSubmitPollPost: (post: CreatePollPostForm, squad: Squad) => Promise<void>;
@@ -260,8 +261,10 @@ export const usePostToSquad = ({
         const squadId = getSquadIdOrThrow(squad);
         moderationCreationRef.current = null;
 
+        // Scheduling isn't supported for moderated posts.
+        const { scheduledAt, ...moderationPost } = editedPost;
         await onCreatePostModeration({
-          ...editedPost,
+          ...moderationPost,
           type: PostType.Freeform,
           postId: editedPost.id,
           sourceId: squadId,
@@ -279,16 +282,23 @@ export const usePostToSquad = ({
     ],
   );
 
-  const onSharedPostSuccessfully = async (update = false) => {
-    const customToast = getSharedPostSuccessToast?.({ isUpdate: update });
-    if (customToast) {
-      displayToast(customToast.message, customToast.options);
-    } else {
-      displayToast(
-        update
-          ? 'The post has been updated'
-          : 'This post has been shared to your squad',
-      );
+  const onSharedPostSuccessfully = async (
+    update = false,
+    isScheduled = false,
+  ) => {
+    // Scheduled posts aren't live yet — the "scheduled" toast is shown by the
+    // caller, so suppress the misleading "shared to your squad" copy here.
+    if (!isScheduled) {
+      const customToast = getSharedPostSuccessToast?.({ isUpdate: update });
+      if (customToast) {
+        displayToast(customToast.message, customToast.options);
+      } else {
+        displayToast(
+          update
+            ? 'The post has been updated'
+            : 'This post has been shared to your squad',
+        );
+      }
     }
     await client.invalidateQueries({
       queryKey: ['sourceFeed', user?.id],
@@ -302,14 +312,14 @@ export const usePostToSquad = ({
     isSuccess: isPostSuccess,
   } = useMutation({
     mutationFn: addPostToSquad(requestMethod),
-    onSuccess: (data) => {
+    onSuccess: (data, variables) => {
       logPostCreated({
         postId: data.id,
         postType: data.type,
         sourceCount: 1,
         targetType: 'post',
       });
-      onSharedPostSuccessfully();
+      onSharedPostSuccessfully(false, !!variables.scheduledAt);
       handlePostSuccess(data);
     },
     onError: (err) => handleMutationError(err),
@@ -335,12 +345,13 @@ export const usePostToSquad = ({
   } = useMutation({
     mutationFn: (params: SubmitExternalLink) =>
       submitExternalLink(params, requestMethod),
-    onSuccess: (_, { url }) => {
+    onSuccess: (_, variables) => {
       logPostCreated({
         postType: PostType.Share,
         sourceCount: 1,
       });
-      onSharedPostSuccessfully();
+      onSharedPostSuccessfully(false, !!variables.scheduledAt);
+      const { url } = variables;
       if (!url) {
         throw new Error('Missing external link url in usePostToSquad');
       }
@@ -375,7 +386,7 @@ export const usePostToSquad = ({
     isEditPostSuccess;
 
   const onSubmitPost = useCallback<UsePostToSquad['onSubmitPost']>(
-    async (e, squad, commentary) => {
+    async (e, squad, commentary, scheduledAt) => {
       e?.preventDefault();
       if (isPosting) {
         return Promise.resolve();
@@ -398,6 +409,7 @@ export const usePostToSquad = ({
           id: preview.id,
           sourceId: squadId,
           commentary,
+          ...(scheduledAt ? { scheduledAt } : {}),
         });
       }
 
@@ -427,6 +439,7 @@ export const usePostToSquad = ({
         image,
         sourceId: squadId,
         commentary,
+        ...(scheduledAt ? { scheduledAt } : {}),
       });
     },
     [
@@ -475,8 +488,10 @@ export const usePostToSquad = ({
 
       if (moderationRequired(squad)) {
         moderationCreationRef.current = PostType.Freeform;
+        // Scheduling isn't supported for moderated posts.
+        const { scheduledAt, ...moderationPost } = post;
         await onCreatePostModeration({
-          ...post,
+          ...moderationPost,
           sourceId: squadId,
           type: PostType.Freeform,
         });
@@ -501,8 +516,10 @@ export const usePostToSquad = ({
 
       if (moderationRequired(squad)) {
         moderationCreationRef.current = PostType.Poll;
+        // Scheduling isn't supported for moderated posts.
+        const { scheduledAt, ...moderationPost } = post;
         await onCreatePostModeration({
-          ...post,
+          ...moderationPost,
           pollOptions: orderedOpts,
           sourceId: squadId,
           type: PostType.Poll,

--- a/packages/shared/src/lib/scheduledPost.spec.ts
+++ b/packages/shared/src/lib/scheduledPost.spec.ts
@@ -1,0 +1,46 @@
+import { dateFormatInTimezone } from './timezones';
+import {
+  MAX_POST_SCHEDULE_DAYS,
+  validatePostScheduledStart,
+} from './scheduledPost';
+
+const tz = 'Etc/UTC';
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+const toLocal = (date: Date): string =>
+  dateFormatInTimezone(date, "yyyy-MM-dd'T'HH:mm", tz);
+
+describe('validatePostScheduledStart', () => {
+  it('returns an ISO string for a valid future time within the limit', () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000);
+    const result = validatePostScheduledStart(toLocal(future), tz);
+
+    expect('iso' in result).toBe(true);
+    if ('iso' in result) {
+      expect(new Date(result.iso).getTime()).toBeGreaterThan(Date.now());
+    }
+  });
+
+  it('rejects empty input', () => {
+    expect(validatePostScheduledStart('', tz)).toEqual({
+      error: 'Scheduled time is invalid',
+    });
+  });
+
+  it('rejects a time in the past', () => {
+    const past = new Date(Date.now() - ONE_DAY_MS);
+
+    expect(validatePostScheduledStart(toLocal(past), tz)).toEqual({
+      error: 'Scheduled time must be in the future',
+    });
+  });
+
+  it(`rejects a time more than ${MAX_POST_SCHEDULE_DAYS} days ahead`, () => {
+    const tooFar = new Date(
+      Date.now() + (MAX_POST_SCHEDULE_DAYS + 1) * ONE_DAY_MS,
+    );
+
+    expect(validatePostScheduledStart(toLocal(tooFar), tz)).toEqual({
+      error: `Scheduled time must be within ${MAX_POST_SCHEDULE_DAYS} days`,
+    });
+  });
+});

--- a/packages/shared/src/lib/scheduledPost.ts
+++ b/packages/shared/src/lib/scheduledPost.ts
@@ -1,0 +1,78 @@
+import zonedTimeToUtc from 'date-fns-tz/zonedTimeToUtc';
+import { dateFormatInTimezone, DEFAULT_TIMEZONE } from './timezones';
+
+// Keep in sync with daily-api MAX_POST_SCHEDULE_DAYS in src/common/postScheduling.ts
+export const MAX_POST_SCHEDULE_DAYS = 14;
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+export const MAX_POST_SCHEDULE_MS = MAX_POST_SCHEDULE_DAYS * ONE_DAY_MS;
+const DEFAULT_SCHEDULE_DELAY_MS = 60 * 60 * 1000;
+
+export type PostScheduleValidation = { iso: string } | { error: string };
+
+export const getDefaultPostScheduledStart = (timezone?: string): string =>
+  dateFormatInTimezone(
+    new Date(Date.now() + DEFAULT_SCHEDULE_DELAY_MS),
+    "yyyy-MM-dd'T'HH:mm",
+    timezone,
+  );
+
+export const parsePostScheduledStart = (
+  value: string | undefined | null,
+  timezone?: string,
+): Date | null => {
+  if (!value) {
+    return null;
+  }
+
+  const date = zonedTimeToUtc(value, timezone || DEFAULT_TIMEZONE);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+export const formatScheduleDelta = (date: Date | null): string | null => {
+  if (!date) {
+    return null;
+  }
+
+  const diffMs = date.getTime() - Date.now();
+  if (diffMs <= 0) {
+    return 'now';
+  }
+
+  const minutes = Math.max(1, Math.round(diffMs / 60_000));
+  if (minutes < 60) {
+    return `${minutes} minute${minutes === 1 ? '' : 's'} from now`;
+  }
+
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) {
+    return `${hours} hour${hours === 1 ? '' : 's'} from now`;
+  }
+
+  const days = Math.round(hours / 24);
+  return `${days} day${days === 1 ? '' : 's'} from now`;
+};
+
+// Validation copy mirrors the daily-api errors so the client blocks the same
+// inputs the server would reject.
+export const validatePostScheduledStart = (
+  value: string | undefined | null,
+  timezone?: string,
+): PostScheduleValidation => {
+  const date = parsePostScheduledStart(value, timezone);
+
+  if (!date) {
+    return { error: 'Scheduled time is invalid' };
+  }
+
+  if (date.getTime() <= Date.now()) {
+    return { error: 'Scheduled time must be in the future' };
+  }
+
+  if (date.getTime() > Date.now() + MAX_POST_SCHEDULE_MS) {
+    return {
+      error: `Scheduled time must be within ${MAX_POST_SCHEDULE_DAYS} days`,
+    };
+  }
+
+  return { iso: date.toISOString() };
+};

--- a/packages/shared/src/lib/timezones.ts
+++ b/packages/shared/src/lib/timezones.ts
@@ -641,3 +641,10 @@ export const getTimezoneOffsetLabel = (timezone: string): string => {
 
   return `(UTC ${formatTimezoneOffset(timezoneOffset)}) ${resolvedTimezone}`;
 };
+
+export const getTimezoneNameWithOffset = (timezone: string): string => {
+  const resolvedTimezone = timezone || DEFAULT_TIMEZONE;
+  const timezoneOffset = getTimezoneOffsetInMinutes(resolvedTimezone);
+
+  return `${resolvedTimezone} (UTC ${formatTimezoneOffset(timezoneOffset)})`;
+};

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -17,14 +17,20 @@ import TabContainer, {
 import { ShareLink } from '@dailydotdev/shared/src/components/post/write/ShareLink';
 import {
   generateDefaultSquad,
+  generateUserSourceAsSquad,
   MultipleSourceSelect,
 } from '@dailydotdev/shared/src/components/post/write';
+import { moderationRequired } from '@dailydotdev/shared/src/components/squads/utils';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import { useSchedulePost } from '@dailydotdev/shared/src/components/post/schedule/useSchedulePost';
 import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized';
 import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
 import { SourcePermissions } from '@dailydotdev/shared/src/graphql/sources';
 import {
   useActions,
   useConditionalFeature,
+  usePostToSquad,
   useViewSize,
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
@@ -191,14 +197,87 @@ function CreatePost(): ReactElement {
     },
   });
 
+  // Scheduling is single-source and non-moderated only. Share posts keep the
+  // preview-driven flow in ShareLink, so scheduling for them lives in the new
+  // composer; here it covers new posts and polls.
+  const schedule = useSchedulePost();
+  const singleSourceId =
+    selectedSourceIds.length === 1 ? selectedSourceIds[0] : undefined;
+  const selectedSquad = squads?.find(({ id }) => id === singleSourceId);
+  const isOwnSource = !!singleSourceId && singleSourceId === user?.id;
+  // Only schedule when the single target is the user's own source or a real,
+  // non-moderated squad — never the "Create new Squad" placeholder.
+  const canSchedule =
+    !!singleSourceId &&
+    display !== WriteFormTab.Share &&
+    (selectedSquad ? !moderationRequired(selectedSquad) : isOwnSource);
+
+  const {
+    onSubmitFreeformPost,
+    onSubmitPollPost,
+    isPosting: isSchedulePosting,
+  } = usePostToSquad({
+    onPostSuccess: () => {
+      displayToast('✅ Your post has been scheduled!');
+      clearFormOnSuccess();
+      push(`${webappUrl}${user?.username}/posts/`);
+    },
+    onError: (data) => {
+      if (data?.response?.errors?.[0]) {
+        displayToast(data?.response?.errors?.[0].message);
+      }
+      onAskConfirmation(true);
+    },
+  });
+
+  const submitScheduledPost = async (
+    params: Omit<WriteForm, 'image'> & { image?: File },
+    type: Post['type'],
+  ): Promise<boolean> => {
+    const resolved = schedule.resolveScheduledAt();
+    if (resolved.error) {
+      displayToast(resolved.error);
+      return true;
+    }
+    const scheduledAt = resolved.iso;
+    if (!scheduledAt) {
+      return false;
+    }
+
+    const squad = selectedSquad ?? generateUserSourceAsSquad(user);
+    const { options, image, title, content, duration } = params;
+    const validImage =
+      image instanceof File && image.size > 0 ? image : undefined;
+    if (type === PostType.Poll) {
+      await onSubmitPollPost(
+        { title, options: options ?? [], duration, scheduledAt },
+        squad,
+      );
+    } else {
+      await onSubmitFreeformPost(
+        { title, content, image: validImage, scheduledAt },
+        squad,
+      );
+    }
+    return true;
+  };
+
   const onClickSubmit = async (
     e: FormEvent<HTMLFormElement>,
     params: Omit<WriteForm, 'image'> & { image?: File },
+    type: Post['type'],
   ) => {
     e.preventDefault();
 
-    if (isPending || !selectedSourceIds.length) {
+    if (isPending || isSchedulePosting || !selectedSourceIds.length) {
       return;
+    }
+
+    if (canSchedule && schedule.isScheduled) {
+      const handled = await submitScheduledPost(params, type);
+      if (handled) {
+        return;
+      }
     }
 
     const { options, image, ...args } = params;
@@ -303,11 +382,16 @@ function CreatePost(): ReactElement {
       squad={null}
       formRef={formRef}
       isUpdatingDraft={isUpdatingDraft}
-      isPosting={isPending}
+      isPosting={isPending || isSchedulePosting}
       updateDraft={updateDraft}
       onSubmitForm={onClickSubmit}
       formId={WriteFormTabToFormID[display]}
-      rightCopy={getSubmitCopy(display)}
+      rightCopy={
+        canSchedule && schedule.isScheduled
+          ? 'Schedule'
+          : getSubmitCopy(display)
+      }
+      schedule={canSchedule ? schedule : undefined}
       enableUpload
     >
       <WritePageContainer>

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -22,7 +22,12 @@ import {
 } from '@dailydotdev/shared/src/components/post/write';
 import { moderationRequired } from '@dailydotdev/shared/src/components/squads/utils';
 import type { Post } from '@dailydotdev/shared/src/graphql/posts';
-import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import {
+  PostType,
+  submitExternalLink,
+} from '@dailydotdev/shared/src/graphql/posts';
+import { useLogPostCreated } from '@dailydotdev/shared/src/hooks/post/useLogPostCreated';
+import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
 import { useSchedulePost } from '@dailydotdev/shared/src/components/post/schedule/useSchedulePost';
 import Unauthorized from '@dailydotdev/shared/src/components/errors/Unauthorized';
 import { verifyPermission } from '@dailydotdev/shared/src/graphql/squads';
@@ -39,7 +44,7 @@ import {
   WriteFormTab,
   WriteFormTabToFormID,
 } from '@dailydotdev/shared/src/components/fields/form/common';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import CreatePoll from '@dailydotdev/shared/src/components/post/poll/CreatePoll';
 import { CreateLiveRoomForm } from '@dailydotdev/shared/src/components/liveRooms/CreateLiveRoomForm';
 import { featureStandupCreation } from '@dailydotdev/shared/src/lib/featureManagement';
@@ -197,10 +202,9 @@ function CreatePost(): ReactElement {
     },
   });
 
-  // Scheduling is single-source and non-moderated only. Share posts keep the
-  // preview-driven flow in ShareLink, so scheduling for them lives in the new
-  // composer; here it covers new posts and polls.
+  // Scheduling is single-source and non-moderated only.
   const schedule = useSchedulePost();
+  const logPostCreated = useLogPostCreated();
   const singleSourceId =
     selectedSourceIds.length === 1 ? selectedSourceIds[0] : undefined;
   const selectedSquad = squads?.find(({ id }) => id === singleSourceId);
@@ -209,7 +213,6 @@ function CreatePost(): ReactElement {
   // non-moderated squad — never the "Create new Squad" placeholder.
   const canSchedule =
     !!singleSourceId &&
-    display !== WriteFormTab.Share &&
     (selectedSquad ? !moderationRequired(selectedSquad) : isOwnSource);
 
   const {
@@ -230,8 +233,32 @@ function CreatePost(): ReactElement {
     },
   });
 
+  // submitExternalLink returns EmptyResponse, so the shared post-success path
+  // in usePostToSquad can't handle it — schedule external-link shares directly.
+  const { mutateAsync: scheduleExternalLink, isPending: isSchedulingLink } =
+    useMutation({
+      mutationFn: submitExternalLink,
+      onSuccess: () => {
+        logPostCreated({ postType: PostType.Share, sourceCount: 1 });
+        displayToast('✅ Your post has been scheduled!');
+        clearFormOnSuccess();
+        push(`${webappUrl}${user?.username}/posts/`);
+      },
+      onError: (data: ApiErrorResult) => {
+        if (data?.response?.errors?.[0]) {
+          displayToast(data.response.errors[0].message);
+        }
+        onAskConfirmation(true);
+      },
+    });
+
   const submitScheduledPost = async (
-    params: Omit<WriteForm, 'image'> & { image?: File },
+    params: Omit<WriteForm, 'image'> & {
+      image?: File;
+      externalLink?: string;
+      imageUrl?: string;
+      commentary?: string;
+    },
     type: Post['type'],
   ): Promise<boolean> => {
     const resolved = schedule.resolveScheduledAt();
@@ -248,7 +275,20 @@ function CreatePost(): ReactElement {
     const { options, image, title, content, duration } = params;
     const validImage =
       image instanceof File && image.size > 0 ? image : undefined;
-    if (type === PostType.Poll) {
+    if (type === PostType.Share) {
+      if (!params.externalLink || !title) {
+        displayToast('Invalid link');
+        return true;
+      }
+      await scheduleExternalLink({
+        url: params.externalLink,
+        title,
+        image: params.imageUrl,
+        sourceId: squad.id,
+        commentary: params.commentary ?? '',
+        scheduledAt,
+      });
+    } else if (type === PostType.Poll) {
       await onSubmitPollPost(
         { title, options: options ?? [], duration, scheduledAt },
         squad,
@@ -264,12 +304,22 @@ function CreatePost(): ReactElement {
 
   const onClickSubmit = async (
     e: FormEvent<HTMLFormElement>,
-    params: Omit<WriteForm, 'image'> & { image?: File },
+    params: Omit<WriteForm, 'image'> & {
+      image?: File;
+      externalLink?: string;
+      imageUrl?: string;
+      commentary?: string;
+    },
     type: Post['type'],
   ) => {
     e.preventDefault();
 
-    if (isPending || isSchedulePosting || !selectedSourceIds.length) {
+    if (
+      isPending ||
+      isSchedulePosting ||
+      isSchedulingLink ||
+      !selectedSourceIds.length
+    ) {
       return;
     }
 
@@ -382,7 +432,7 @@ function CreatePost(): ReactElement {
       squad={null}
       formRef={formRef}
       isUpdatingDraft={isUpdatingDraft}
-      isPosting={isPending || isSchedulePosting}
+      isPosting={isPending || isSchedulePosting || isSchedulingLink}
       updateDraft={updateDraft}
       onSubmitForm={onClickSubmit}
       formId={WriteFormTabToFormID[display]}


### PR DESCRIPTION
## What

Adds an optional **schedule** to post creation. A calendar button next to the submit button opens a popover (desktop) / drawer (mobile) with a datetime picker; the submit button label flips to **Schedule** once a time is set.

Pairs with the daily-api branch `codex/schedule-all-post-types`.

## Scope

- **Single-source, non-moderated only** — the schedule button is hidden when more than one source is selected or the target requires moderation.
- **New composer** (`SmartComposerModal`): all post types. `scheduledAt` is sent on the dedicated single-source mutations (`createFreeformPost`, `createPollPost`, `submitExternalLink`, `sharePost`). `postInMultipleSources` never carries `scheduledAt`.
- **Legacy composer** (`squads/create`): new posts + polls. The schedule control mirrors the submit button — footer on desktop, `FormWrapper` header on mobile. Share is intentionally left to the new composer (its preview-driven flow makes clean scheduling costly).
- **Validation** matches the backend: must be in the future and within 14 days.

## Notes

- Scheduled posts are invisible until published, so success shows a "scheduled" toast and skips navigating to the not-yet-visible post.
- `scheduledAt` is stripped on all moderation paths.

## Test

- Unit test for the validation helper (`scheduledPost.spec.ts`): future + 14-day cap.
- Manual: in each composer, single non-moderated source → set a schedule → submit → the request carries `scheduledAt` and the post doesn't appear in the feed immediately.

### Preview domain
https://feat-schedule-posts.preview.app.daily.dev