### PR TITLE
feat(posts): view and edit scheduled posts

### DIFF
--- a/packages/shared/src/components/modals/post/SmartComposerModal.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import classNames from 'classnames';
+import { useRouter } from 'next/router';
 import { useQueryClient } from '@tanstack/react-query';
 import type { LazyModalCommonProps } from '../common/Modal';
 import { Modal } from '../common/Modal';
@@ -26,6 +27,7 @@ import { Tooltip } from '../../tooltip/Tooltip';
 import { Switch } from '../../fields/Switch';
 import { Drawer, DrawerPosition } from '../../drawers/Drawer';
 import { labels } from '../../../lib/labels';
+import { scheduledPostsUrl } from '../../../lib/constants';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useSettingsContext } from '../../../contexts/SettingsContext';
@@ -56,6 +58,7 @@ import { useComposerSubmit } from '../../post/composer/useComposerSubmit';
 import { useStandupCreation } from '../../../hooks/liveRooms/useStandupCreation';
 import { useSchedulePost } from '../../post/schedule/useSchedulePost';
 import { SchedulePostButton } from '../../post/schedule/SchedulePostButton';
+import { ScheduledPostsNavButton } from '../../post/schedule/ScheduledPostsNavButton';
 import {
   DEFAULT_LINK,
   DEFAULT_POLL,
@@ -110,6 +113,7 @@ export function SmartComposerModal({
 }: SmartComposerModalProps): ReactElement {
   const { user } = useAuthContext();
   const { logEvent } = useLogContext();
+  const router = useRouter();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const queryClient = useQueryClient();
   const { showPrompt } = usePrompt();
@@ -204,36 +208,47 @@ export function SmartComposerModal({
     return false;
   }, [cover, text, link, poll, standup, editPost]);
 
+  const confirmDiscardIfDirty = useCallback(async () => {
+    if (!isDirty) {
+      return true;
+    }
+
+    return showPrompt({
+      title: isEditing ? 'Discard changes?' : 'Discard draft?',
+      description:
+        'You have unsaved changes. Are you sure you want to discard them?',
+      okButton: {
+        title: 'Discard',
+        variant: ButtonVariant.Primary,
+        color: ButtonColor.Ketchup,
+      },
+      cancelButton: { title: 'Keep editing' },
+    });
+  }, [isDirty, isEditing, showPrompt]);
+
   const handleClose = useCallback(
     async (event?: React.MouseEvent | React.KeyboardEvent) => {
-      const closeAndLog = () => {
-        logEvent({
-          event_name: LogEvent.CloseSmartComposer,
-          extra: JSON.stringify({ kind, isDirty }),
-        });
-        onRequestClose?.(event);
-      };
-      if (!isDirty) {
-        closeAndLog();
+      if (!(await confirmDiscardIfDirty())) {
         return;
       }
-      const confirmed = await showPrompt({
-        title: isEditing ? 'Discard changes?' : 'Discard draft?',
-        description:
-          'You have unsaved changes. Are you sure you want to discard them?',
-        okButton: {
-          title: 'Discard',
-          variant: ButtonVariant.Primary,
-          color: ButtonColor.Ketchup,
-        },
-        cancelButton: { title: 'Keep editing' },
+
+      logEvent({
+        event_name: LogEvent.CloseSmartComposer,
+        extra: JSON.stringify({ kind, isDirty }),
       });
-      if (confirmed) {
-        closeAndLog();
-      }
+      onRequestClose?.(event);
     },
-    [isDirty, kind, logEvent, onRequestClose, showPrompt, isEditing],
+    [confirmDiscardIfDirty, isDirty, kind, logEvent, onRequestClose],
   );
+
+  const handleViewScheduled = useCallback(async () => {
+    if (!(await confirmDiscardIfDirty())) {
+      return;
+    }
+
+    onRequestClose?.();
+    router.push(scheduledPostsUrl);
+  }, [confirmDiscardIfDirty, onRequestClose, router]);
 
   useEffect(() => {
     logEvent({
@@ -460,6 +475,10 @@ export function SmartComposerModal({
           )}
         </div>
         <div className="flex shrink-0 items-center gap-1">
+          <ScheduledPostsNavButton
+            onClick={handleViewScheduled}
+            disabled={isInFlight}
+          />
           {kind === 'text' && (
             <Tooltip
               content={

--- a/packages/shared/src/components/post/schedule/SchedulePostButton.tsx
+++ b/packages/shared/src/components/post/schedule/SchedulePostButton.tsx
@@ -27,6 +27,7 @@ interface SchedulePostButtonProps {
   scheduledStart: string;
   timezone: string;
   error?: string | null;
+  clearLabel?: string;
   disabled?: boolean;
   onScheduledStartChange: (value: string) => void;
   onSeedDefault: () => void;
@@ -39,6 +40,7 @@ export function SchedulePostButton({
   scheduledStart,
   timezone,
   error,
+  clearLabel = 'Publish now',
   disabled,
   onScheduledStartChange,
   onSeedDefault,
@@ -59,6 +61,20 @@ export function SchedulePostButton({
       onSeedDefault();
     }
   };
+
+  const clearNode = isScheduled ? (
+    <Button
+      type="button"
+      variant={ButtonVariant.Subtle}
+      size={ButtonSize.Small}
+      onClick={() => {
+        onClear();
+        setOpen(false);
+      }}
+    >
+      {clearLabel}
+    </Button>
+  ) : null;
 
   const pickerBody = (
     <>
@@ -109,21 +125,7 @@ export function SchedulePostButton({
         )}
       </div>
       <div className="flex items-center justify-between gap-2">
-        {isScheduled ? (
-          <Button
-            type="button"
-            variant={ButtonVariant.Subtle}
-            size={ButtonSize.Small}
-            onClick={() => {
-              onClear();
-              setOpen(false);
-            }}
-          >
-            Publish now
-          </Button>
-        ) : (
-          <span />
-        )}
+        {clearNode || <span />}
         <Button
           type="button"
           variant={ButtonVariant.Primary}

--- a/packages/shared/src/components/post/schedule/SchedulePostControl.tsx
+++ b/packages/shared/src/components/post/schedule/SchedulePostControl.tsx
@@ -18,6 +18,7 @@ export function SchedulePostControl({
       scheduledStart={schedule.scheduledStart}
       timezone={schedule.timezone}
       error={schedule.error}
+      clearLabel={schedule.clearLabel}
       disabled={disabled}
       onScheduledStartChange={schedule.setScheduledStart}
       onSeedDefault={schedule.seedDefault}

--- a/packages/shared/src/components/post/schedule/ScheduledPostItem.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostItem.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import Link from '../../utilities/Link';
+import { SourceAvatar } from '../../profile/source/SourceAvatar';
+import { ProfileImageSize } from '../../ProfilePicture';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import type { ScheduledPost } from '../../../graphql/posts';
+import { webappUrl } from '../../../lib/constants';
+import { formatScheduleDelta } from '../../../lib/scheduledPost';
+import { dateFormatInTimezone } from '../../../lib/timezones';
+
+interface ScheduledPostItemProps {
+  post: ScheduledPost;
+}
+
+export function ScheduledPostItem({
+  post,
+}: ScheduledPostItemProps): ReactElement | null {
+  const { user } = useAuthContext();
+  const scheduledAt = post.flags?.scheduledAt;
+
+  if (!scheduledAt) {
+    return null;
+  }
+
+  const scheduledDate = new Date(scheduledAt);
+  const absolute = dateFormatInTimezone(
+    scheduledDate,
+    'MMM d, yyyy · HH:mm',
+    user?.timezone,
+  );
+  const delta = formatScheduleDelta(scheduledDate);
+
+  return (
+    <Link href={`${webappUrl}posts/${post.id}/edit`} passHref>
+      <a className="flex items-center gap-3 border-b border-border-subtlest-tertiary px-4 py-3 hover:bg-surface-hover">
+        <SourceAvatar
+          source={post.source}
+          size={ProfileImageSize.Medium}
+          className="!mr-0"
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <Typography type={TypographyType.Body} bold truncate>
+            {post.title || 'Untitled post'}
+          </Typography>
+          {post.source?.name && (
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+              truncate
+            >
+              {post.source.name}
+            </Typography>
+          )}
+        </div>
+        <div className="flex shrink-0 flex-col items-end text-text-tertiary">
+          <Typography type={TypographyType.Caption1}>{absolute}</Typography>
+          {delta && (
+            <Typography
+              type={TypographyType.Caption2}
+              color={TypographyColor.Tertiary}
+            >
+              {delta}
+            </Typography>
+          )}
+        </div>
+      </a>
+    </Link>
+  );
+}

--- a/packages/shared/src/components/post/schedule/ScheduledPostList.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostList.tsx
@@ -1,0 +1,76 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { useScheduledPosts } from './useScheduledPosts';
+import { ScheduledPostItem } from './ScheduledPostItem';
+import InfiniteScrolling from '../../containers/InfiniteScrolling';
+import { Loader } from '../../Loader';
+import { MyProfileEmptyScreen } from '../../profile/MyProfileEmptyScreen';
+import { cloudinaryCharmNoPosts } from '../../../lib/image';
+import { link } from '../../../lib/links';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+
+export function ScheduledPostList(): ReactElement {
+  const {
+    posts,
+    isLoading,
+    isFetched,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useScheduledPosts();
+
+  if (isLoading && !isFetched) {
+    return (
+      <div className="flex justify-center py-10">
+        <Loader />
+      </div>
+    );
+  }
+
+  if (isFetched && posts.length === 0) {
+    return (
+      <MyProfileEmptyScreen
+        className="items-center px-4 py-6 text-center tablet:px-6"
+        image={cloudinaryCharmNoPosts}
+        imageAlt="daily.dev charm waiting for a scheduled post"
+        text="You have no scheduled posts. Schedule a post and it will show up here until it goes live."
+        cta="New post"
+        buttonProps={{ tag: 'a', href: link.post.create }}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div className="flex flex-col gap-1 px-4 py-4">
+        <Typography type={TypographyType.Title3} bold>
+          Scheduled posts
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Tertiary}
+        >
+          Posts waiting to go live. Select one to edit or reschedule it.
+        </Typography>
+      </div>
+      <InfiniteScrolling
+        canFetchMore={hasNextPage && !isFetchingNextPage}
+        isFetchingNextPage={isFetchingNextPage}
+        fetchNextPage={fetchNextPage}
+        placeholder={
+          <div className="flex justify-center py-6">
+            <Loader />
+          </div>
+        }
+      >
+        {posts.map((post) => (
+          <ScheduledPostItem key={post.id} post={post} />
+        ))}
+      </InfiniteScrolling>
+    </div>
+  );
+}

--- a/packages/shared/src/components/post/schedule/ScheduledPostsNavButton.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostsNavButton.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { TimerIcon } from '../../icons';
+import { Tooltip } from '../../tooltip/Tooltip';
+
+interface ScheduledPostsNavButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function ScheduledPostsNavButton({
+  onClick,
+  disabled,
+  className,
+}: ScheduledPostsNavButtonProps): ReactElement {
+  return (
+    <Tooltip content="Scheduled posts">
+      <Button
+        type="button"
+        size={ButtonSize.Small}
+        variant={ButtonVariant.Tertiary}
+        icon={<TimerIcon />}
+        onClick={onClick}
+        disabled={disabled}
+        className={className}
+        aria-label="Scheduled posts"
+      />
+    </Tooltip>
+  );
+}

--- a/packages/shared/src/components/post/schedule/useSchedulePost.ts
+++ b/packages/shared/src/components/post/schedule/useSchedulePost.ts
@@ -1,7 +1,8 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { DEFAULT_TIMEZONE } from '../../../lib/timezones';
 import {
+  formatScheduledAtInput,
   getDefaultPostScheduledStart,
   validatePostScheduledStart,
 } from '../../../lib/scheduledPost';
@@ -11,11 +12,20 @@ export interface ResolvedScheduledAt {
   error?: string;
 }
 
+export interface UseSchedulePostProps {
+  // When editing an already-scheduled post, seed the picker with its time.
+  initialScheduledAt?: string | null;
+  // Label for the clear action. Composer: "Publish now" (post immediately on
+  // submit). Editor: "Cancel scheduling" (publish with edits on submit).
+  clearLabel?: string;
+}
+
 export interface UseSchedulePost {
   isScheduled: boolean;
   scheduledStart: string;
   timezone: string;
   error: string | null;
+  clearLabel: string;
   setScheduledStart: (value: string) => void;
   seedDefault: () => void;
   confirmSchedule: () => boolean;
@@ -23,12 +33,31 @@ export interface UseSchedulePost {
   resolveScheduledAt: () => ResolvedScheduledAt;
 }
 
-export const useSchedulePost = (): UseSchedulePost => {
+export const useSchedulePost = ({
+  initialScheduledAt,
+  clearLabel = 'Publish now',
+}: UseSchedulePostProps = {}): UseSchedulePost => {
   const { user } = useAuthContext();
   const timezone = user?.timezone || DEFAULT_TIMEZONE;
   const [isScheduled, setIsScheduled] = useState(false);
   const [scheduledStart, setScheduledStartState] = useState('');
   const [error, setError] = useState<string | null>(null);
+
+  // Seed once when an existing schedule becomes available (post loads async).
+  // Wait for the user so we format against their real timezone, not the default
+  // (seeding early would lock in a wrong-tz value that resolves to a wrong instant).
+  const hasSeeded = useRef(false);
+  useEffect(() => {
+    if (hasSeeded.current || !initialScheduledAt || !user) {
+      return;
+    }
+
+    hasSeeded.current = true;
+    setScheduledStartState(
+      formatScheduledAtInput(initialScheduledAt, timezone),
+    );
+    setIsScheduled(true);
+  }, [initialScheduledAt, timezone, user]);
 
   const setScheduledStart = useCallback((value: string) => {
     setScheduledStartState(value);
@@ -81,6 +110,7 @@ export const useSchedulePost = (): UseSchedulePost => {
     scheduledStart,
     timezone,
     error,
+    clearLabel,
     setScheduledStart,
     seedDefault,
     confirmSchedule,

--- a/packages/shared/src/components/post/schedule/useScheduledPosts.ts
+++ b/packages/shared/src/components/post/schedule/useScheduledPosts.ts
@@ -1,0 +1,82 @@
+import { useCallback } from 'react';
+import type {
+  InfiniteData,
+  UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import type { Connection } from '../../../graphql/common';
+import { gqlClient } from '../../../graphql/common';
+import type { ScheduledPost } from '../../../graphql/posts';
+import {
+  SCHEDULED_POSTS_PER_PAGE_DEFAULT,
+  SCHEDULED_POSTS_QUERY,
+} from '../../../graphql/posts';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import {
+  generateQueryKey,
+  getNextPageParam,
+  RequestKey,
+  StaleTime,
+} from '../../../lib/query';
+
+type ScheduledPostsData = Connection<ScheduledPost>;
+
+export interface UseScheduledPosts {
+  posts: ScheduledPost[];
+  isLoading: boolean;
+  isFetched: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: UseInfiniteQueryResult['fetchNextPage'];
+  isFetchingNextPage: boolean;
+}
+
+export const useScheduledPosts = (): UseScheduledPosts => {
+  const { user } = useAuthContext();
+
+  const {
+    data,
+    isPending,
+    isFetched,
+    hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  } = useInfiniteQuery({
+    queryKey: generateQueryKey(RequestKey.ScheduledPosts, user),
+    queryFn: async ({ pageParam }) => {
+      const result = await gqlClient.request<{
+        scheduledPosts: ScheduledPostsData;
+      }>(SCHEDULED_POSTS_QUERY, {
+        first: SCHEDULED_POSTS_PER_PAGE_DEFAULT,
+        after: pageParam,
+      });
+
+      return result.scheduledPosts;
+    },
+    initialPageParam: '',
+    enabled: !!user,
+    getNextPageParam: (lastPage) => getNextPageParam(lastPage?.pageInfo),
+    select: useCallback((result: InfiniteData<ScheduledPostsData>) => {
+      if (!result) {
+        return undefined;
+      }
+
+      return {
+        ...result,
+        pages: result.pages.filter((page) => !!page?.edges.length),
+      };
+    }, []),
+    staleTime: StaleTime.Default,
+  });
+
+  const posts =
+    data?.pages.flatMap((page) => page.edges.map((edge) => edge.node)) ?? [];
+
+  return {
+    posts,
+    isLoading: isPending,
+    isFetched,
+    hasNextPage: !!hasNextPage,
+    fetchNextPage,
+    isFetchingNextPage,
+  };
+};

--- a/packages/shared/src/contexts/WritePostContext.tsx
+++ b/packages/shared/src/contexts/WritePostContext.tsx
@@ -3,6 +3,7 @@ import type {
   MutableRefObject,
   PropsWithChildren,
   ReactElement,
+  ReactNode,
 } from 'react';
 import React, { useContext } from 'react';
 import { useRouter } from 'next/router';
@@ -59,6 +60,8 @@ export interface WritePostProps {
   formId?: string;
   // When provided, the schedule control is offered next to the submit button.
   schedule?: UseSchedulePost;
+  // Extra actions rendered in the mobile header (e.g. the scheduled-posts link).
+  headerExtraActions?: ReactNode;
 }
 
 export const WritePostContext = React.createContext<WritePostProps>({
@@ -100,11 +103,16 @@ export const WritePostContextProvider = ({
             rightButtonProps={{ disabled: props.isPosting }}
             leftButtonProps={{ onClick: () => router.back() }}
             headerActions={
-              props.schedule ? (
-                <SchedulePostControl
-                  schedule={props.schedule}
-                  disabled={props.isPosting}
-                />
+              props.headerExtraActions || props.schedule ? (
+                <>
+                  {props.headerExtraActions}
+                  {props.schedule ? (
+                    <SchedulePostControl
+                      schedule={props.schedule}
+                      disabled={props.isPosting}
+                    />
+                  ) : null}
+                </>
               ) : undefined
             }
             form={formId}

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -418,6 +418,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
       savedTime
       generatedAt
       digestPostIds
+      scheduledAt
       ad {
         type
         index

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -1220,6 +1220,45 @@ export const RELATED_POSTS_QUERY = gql`
   ${RELATED_POST_FRAGMENT}
 `;
 
+export const SCHEDULED_POSTS_PER_PAGE_DEFAULT = 20;
+
+export type ScheduledPost = Pick<
+  Post,
+  'id' | 'title' | 'image' | 'type' | 'createdAt' | 'flags'
+> & {
+  source: Pick<Source, 'id' | 'handle' | 'name' | 'image' | 'type'>;
+};
+
+export const SCHEDULED_POSTS_QUERY = gql`
+  query ScheduledPosts($after: String, $first: Int) {
+    scheduledPosts(after: $after, first: $first) {
+      edges {
+        node {
+          id
+          title
+          image
+          type
+          createdAt
+          flags {
+            scheduledAt
+          }
+          source {
+            id
+            handle
+            name
+            image
+            type
+          }
+        }
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+`;
+
 export const POST_CODE_SNIPPETS_PER_PAGE_DEFAULT = 5;
 
 export type PostCodeSnippet = {

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -67,6 +67,7 @@ export const plusSuccessUrl = `${plusUrl}/success`;
 export const walletUrl = `${webappUrl}wallet`;
 export const settingsUrl = `${webappUrl}settings`;
 export const briefingUrl = `${webappUrl}briefing`;
+export const scheduledPostsUrl = `${webappUrl}scheduled`;
 export const opportunityUrl = `${webappUrl}jobs`;
 export const recruiterUrl = `${webappUrl}recruiter`;
 export const boostOpportunityLink = 'https://r.daily.dev/boost-opportunity';

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -177,6 +177,7 @@ export enum RequestKey {
   SquadStatus = 'squad_status',
   PublicSquadRequests = 'public_squad_requests',
   Feeds = 'feeds',
+  ScheduledPosts = 'scheduled_posts',
   FeedSettings = 'feedSettings',
   Ads = 'ads',
   FeedByIds = 'feedByIds',

--- a/packages/shared/src/lib/scheduledPost.ts
+++ b/packages/shared/src/lib/scheduledPost.ts
@@ -16,6 +16,14 @@ export const getDefaultPostScheduledStart = (timezone?: string): string =>
     timezone,
   );
 
+// Convert a stored ISO/UTC scheduledAt into the `datetime-local` string the
+// picker expects, rendered in the given timezone.
+export const formatScheduledAtInput = (
+  iso: string,
+  timezone?: string,
+): string =>
+  dateFormatInTimezone(new Date(iso), "yyyy-MM-dd'T'HH:mm", timezone);
+
 export const parsePostScheduledStart = (
   value: string | undefined | null,
   timezone?: string,

--- a/packages/webapp/pages/posts/[id]/edit.tsx
+++ b/packages/webapp/pages/posts/[id]/edit.tsx
@@ -36,7 +36,11 @@ import {
 import { useSourcePostModerationById } from '@dailydotdev/shared/src/hooks/source/useSourcePostModerationById';
 import useSourcePostModeration from '@dailydotdev/shared/src/hooks/source/useSourcePostModeration';
 import { generateUserSourceAsSquad } from '@dailydotdev/shared/src/components/post/write';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import { useSchedulePost } from '@dailydotdev/shared/src/components/post/schedule/useSchedulePost';
+import {
+  scheduledPostsUrl,
+  webappUrl,
+} from '@dailydotdev/shared/src/lib/constants';
 import { getLayout as getMainLayout } from '../../../components/layouts/MainLayout';
 import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
 
@@ -74,6 +78,16 @@ function EditPost(): ReactElement {
   const isVerified =
     !isUserSource && verifyPermission(squad, SourcePermissions.Post);
   const { displayToast } = useToastNotification();
+
+  // Scheduling can only be changed on a still-scheduled freeform post: the API
+  // rejects schedule changes once a post is published and only allows freeform.
+  const initialScheduledAt = post?.flags?.scheduledAt;
+  const canReschedule =
+    !!initialScheduledAt && post?.type === PostType.Freeform;
+  const schedule = useSchedulePost({
+    initialScheduledAt,
+    clearLabel: 'Cancel scheduling',
+  });
   const {
     onAskConfirmation,
     draft,
@@ -94,7 +108,11 @@ function EditPost(): ReactElement {
         completeAction(ActionType.EditWelcomePost);
       }
 
-      onSuccess(data.commentsPermalink);
+      // A still-scheduled post is invisible, so its permalink 404s — send the
+      // author back to their scheduled list instead of the (hidden) post.
+      onSuccess(
+        data.flags?.scheduledAt ? scheduledPostsUrl : data.commentsPermalink,
+      );
     },
     onSourcePostModerationSuccess: (data) => onSuccess(data.source.permalink),
     onError: (data: ApiErrorResult) => {
@@ -126,6 +144,28 @@ function EditPost(): ReactElement {
         id: moderated.id,
         sourceId: squad.id,
       });
+    }
+
+    if (canReschedule) {
+      if (schedule.isScheduled) {
+        const resolved = schedule.resolveScheduledAt();
+
+        if (resolved.error) {
+          displayToast(resolved.error);
+          return null;
+        }
+
+        return onEditFreeformPost(
+          { ...params, id: post.id, scheduledAt: resolved.iso },
+          squad,
+        );
+      }
+
+      // Scheduling was cancelled: publish immediately together with the edits.
+      return onEditFreeformPost(
+        { ...params, id: post.id, scheduledAt: null },
+        squad,
+      );
     }
 
     return onEditFreeformPost({ ...params, id: post.id }, squad);
@@ -176,6 +216,7 @@ function EditPost(): ReactElement {
       updateDraft={updateDraft}
       onSubmitForm={onClickSubmit}
       formId={formId}
+      schedule={canReschedule ? schedule : undefined}
       enableUpload
     >
       <NextSeo {...seo} noindex nofollow />

--- a/packages/webapp/pages/scheduled/index.tsx
+++ b/packages/webapp/pages/scheduled/index.tsx
@@ -1,0 +1,39 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { NextSeoProps } from 'next-seo';
+import { useRouter } from 'next/router';
+import { ResponsivePageContainer } from '@dailydotdev/shared/src/components/utilities';
+import { ScheduledPostList } from '@dailydotdev/shared/src/components/post/schedule/ScheduledPostList';
+import ProtectedPage from '../../components/ProtectedPage';
+import { getLayout } from '../../components/layouts/MainLayout';
+import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
+
+const ScheduledPostsPage = (): ReactElement | null => {
+  const router = useRouter();
+
+  if (!router.isReady) {
+    return null;
+  }
+
+  return (
+    <ProtectedPage>
+      <ResponsivePageContainer className="relative !p-0" role="main">
+        <ScheduledPostList />
+      </ResponsivePageContainer>
+    </ProtectedPage>
+  );
+};
+
+const getScheduledLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+const seo: NextSeoProps = {
+  title: 'Scheduled posts',
+  nofollow: true,
+  noindex: true,
+};
+
+ScheduledPostsPage.getLayout = getScheduledLayout;
+ScheduledPostsPage.layoutProps = { seo };
+
+export default ScheduledPostsPage;

--- a/packages/webapp/pages/squads/create.tsx
+++ b/packages/webapp/pages/squads/create.tsx
@@ -50,7 +50,12 @@ import { CreateLiveRoomForm } from '@dailydotdev/shared/src/components/liveRooms
 import { featureStandupCreation } from '@dailydotdev/shared/src/lib/featureManagement';
 import { Pill, PillSize } from '@dailydotdev/shared/src/components/Pill';
 import { useMultipleSourcePost } from '@dailydotdev/shared/src/features/squads/hooks/useMultipleSourcePost';
-import { settingsUrl, webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import {
+  scheduledPostsUrl,
+  settingsUrl,
+  webappUrl,
+} from '@dailydotdev/shared/src/lib/constants';
+import { ScheduledPostsNavButton } from '@dailydotdev/shared/src/components/post/schedule/ScheduledPostsNavButton';
 import type { WriteForm } from '@dailydotdev/shared/src/contexts';
 import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { useDisableSpotlightShortcut } from '@dailydotdev/shared/src/components/spotlight/SpotlightContext';
@@ -442,6 +447,13 @@ function CreatePost(): ReactElement {
           : getSubmitCopy(display)
       }
       schedule={canSchedule ? schedule : undefined}
+      headerExtraActions={
+        // Desktop/tablet render the button in the TabContainer header
+        // (extraHeaderContent); only mobile relies on the FormWrapper header.
+        isMobile ? (
+          <ScheduledPostsNavButton onClick={() => push(scheduledPostsUrl)} />
+        ) : undefined
+      }
       enableUpload
     >
       <WritePageContainer>
@@ -453,24 +465,30 @@ function CreatePost(): ReactElement {
           showHeader={isTablet}
           extraHeaderContent={
             !isMobile && (
-              <LinkWithTooltip
-                tooltip={{
-                  content: (
-                    <div className="max-w-48">
-                      You can change the default post type settings
-                    </div>
-                  ),
-                  placement: 'left',
-                }}
-                href={`${settingsUrl}/composition`}
-                passHref
-              >
-                <Button
-                  icon={<SettingsIcon />}
-                  size={ButtonSize.Small}
-                  className="ml-auto mr-3 self-center text-text-quaternary"
+              <div className="ml-auto mr-3 flex items-center gap-1 self-center">
+                <ScheduledPostsNavButton
+                  onClick={() => push(scheduledPostsUrl)}
+                  className="text-text-quaternary"
                 />
-              </LinkWithTooltip>
+                <LinkWithTooltip
+                  tooltip={{
+                    content: (
+                      <div className="max-w-48">
+                        You can change the default post type settings
+                      </div>
+                    ),
+                    placement: 'left',
+                  }}
+                  href={`${settingsUrl}/composition`}
+                  passHref
+                >
+                  <Button
+                    icon={<SettingsIcon />}
+                    size={ButtonSize.Small}
+                    className="self-center text-text-quaternary"
+                  />
+                </LinkWithTooltip>
+              </div>
             )
           }
         >

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -151,6 +151,12 @@ const strictSkipList = new Set([
   // null user arg) live on unrelated lines and should be addressed in a
   // dedicated cleanup PR.
   'packages/webapp/__tests__/SourcePage.tsx',
+  // Schedule-posts branch — edit.tsx was touched only to seed the schedule
+  // control from an existing scheduled post and thread `scheduledAt` through
+  // the edit submit. Pre-existing strict violations (squad/user optionality,
+  // mutable formRef typing on unrelated lines) predate this change and should
+  // be addressed in a dedicated cleanup PR.
+  'packages/webapp/pages/posts/[id]/edit.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
Stacked on #6283 (creates the schedule components this builds on). Pairs with daily-api #3979.

## What
Lets authors **see and manage their scheduled posts**.

- **`/scheduled` page** — lists the author's scheduled posts (`useScheduledPosts` infinite query), each row shows the publish time (absolute + relative) and links to the editor.
- **Editor** — seeds a schedule control from `post.flags.scheduledAt`; the author can **reschedule** or **Cancel scheduling** to publish immediately with their edits (sends `scheduledAt: null` to `editPost`). On save it navigates back to `/scheduled` if still scheduled, or to the post if published.
- **Entry point** — a 'Scheduled posts' button in both composers (new `SmartComposerModal` + legacy `squads/create`), desktop and mobile. The new composer routes it through the discard-guard.
- Adds `flags { scheduledAt }` to `SHARED_POST_INFO_FRAGMENT` so the editor can read the scheduled time.

## Review fixes applied
- Fixed a duplicate entry-point button on tablet in the legacy composer.
- Gated the schedule-seed effect on the user being resolved (avoids a wrong-timezone seed).
- Null-guarded `source` in the list row.
- daily-api (#3979): guarded publish-now so only actually-scheduled posts can be published.

## Known limitation
The editor's reschedule/cancel is freeform-only (the backend `editPost` only edits freeform/welcome). Scheduled poll/share posts appear in the list but full edit/reschedule is a follow-up.

### Preview domain
https://feat-view-edit-scheduled-posts.preview.app.daily.dev