### PR TITLE
feat(giveback): wire causes breakdown to real by-category endpoint

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackCausesBreakdown.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCausesBreakdown.spec.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { GivebackCausesBreakdown } from './GivebackCausesBreakdown';
-import type { GivebackCauseAllocation } from './GivebackCausesBreakdown';
-import type { ContributionCause } from '../types';
+import type { ContributionCauseCategoryBreakdown } from '../types';
 
 // Resolve the reveal/count-up animations synchronously so assertions read the
 // final values instead of mid-animation frames.
@@ -11,31 +10,23 @@ jest.mock('../useGivebackMotion', () => ({
   useCountUp: (target: number) => target,
 }));
 
-const cause = (id: string, title: string): ContributionCause => ({
-  id,
-  title,
-  url: null,
-  description: null,
-  category: null,
-  logoUrl: null,
-});
-
-// Total 10,800 → 39% / 24% / 17% / 10% / 6% / 4% (rounded).
-const allocations: GivebackCauseAllocation[] = [
-  { cause: cause('oss', 'Open-source maintainers'), amount: 4200 },
-  { cause: cause('scholar', 'Dev scholarships'), amount: 2600 },
-  { cause: cause('access', 'Access to tech'), amount: 1800 },
-  { cause: cause('climate', 'Climate tech'), amount: 1100 },
-  { cause: cause('mentor', 'Mentorship programs'), amount: 700 },
-  { cause: cause('docs', 'Better docs'), amount: 400 },
+// Total 10,800 → 39% / 24% / 17% / 10% / 6% / 4% (rounded). The backend already
+// groups the pool by category, so each row is one category.
+const breakdown: ContributionCauseCategoryBreakdown[] = [
+  { category: 'Open source', points: 4200 },
+  { category: 'Education', points: 2600 },
+  { category: 'Accessibility', points: 1800 },
+  { category: 'Climate', points: 1100 },
+  { category: 'Mentorship', points: 700 },
+  { category: 'Docs', points: 400 },
 ];
 
 describe('GivebackCausesBreakdown', () => {
-  it('renders each cause with its share and formatted amount', () => {
-    render(<GivebackCausesBreakdown allocations={allocations} />);
+  it('renders each category with its share and formatted amount', () => {
+    render(<GivebackCausesBreakdown breakdown={breakdown} />);
 
-    expect(screen.getByText('Open-source maintainers')).toBeInTheDocument();
-    expect(screen.getByText('Better docs')).toBeInTheDocument();
+    expect(screen.getByText('Open source')).toBeInTheDocument();
+    expect(screen.getByText('Docs')).toBeInTheDocument();
     // Biggest slice: 4200 / 10800 ≈ 39%.
     expect(screen.getByText('39%')).toBeInTheDocument();
     expect(screen.getByText('$4,200')).toBeInTheDocument();
@@ -44,7 +35,7 @@ describe('GivebackCausesBreakdown', () => {
   it('renders a custom title and an optional description', () => {
     render(
       <GivebackCausesBreakdown
-        allocations={allocations}
+        breakdown={breakdown}
         title="Where the money will go"
         description="The pool you are growing, by cause."
       />,
@@ -57,22 +48,35 @@ describe('GivebackCausesBreakdown', () => {
   });
 
   it('renders the pool total in the donut hole', () => {
-    render(<GivebackCausesBreakdown allocations={allocations} />);
+    render(<GivebackCausesBreakdown breakdown={breakdown} />);
 
     // Total 4200+2600+1800+1100+700+400 = 10,800.
     expect(screen.getByText('$10,800')).toBeInTheDocument();
   });
 
-  it('renders nothing when there are no allocations', () => {
-    const { container } = render(<GivebackCausesBreakdown allocations={[]} />);
+  it('labels the uncategorised bucket', () => {
+    render(
+      <GivebackCausesBreakdown
+        breakdown={[
+          { category: 'Open source', points: 3000 },
+          { category: null, points: 1000 },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Other causes')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is no breakdown', () => {
+    const { container } = render(<GivebackCausesBreakdown breakdown={[]} />);
 
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders nothing when every allocation is zero', () => {
+  it('renders nothing when every category is zero', () => {
     const { container } = render(
       <GivebackCausesBreakdown
-        allocations={[{ cause: cause('oss', 'Open source'), amount: 0 }]}
+        breakdown={[{ category: 'Open source', points: 0 }]}
       />,
     );
 

--- a/packages/shared/src/features/giveback/components/GivebackCausesBreakdown.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCausesBreakdown.tsx
@@ -8,23 +8,15 @@ import {
   TypographyTag,
   TypographyType,
 } from '../../../components/typography/Typography';
-import type { ContributionCause } from '../types';
+import type { ContributionCauseCategoryBreakdown } from '../types';
 import { formatDonationAmount } from '../utils';
 import { useCountUp, useInView } from '../useGivebackMotion';
 
-// A slice of the community pool directed at one cause. `amount` is in whole
-// currency units, matching the funding meter (points map 1:1 to dollars), so it
-// formats straight through `formatDonationAmount`.
-export interface GivebackCauseAllocation {
-  cause: ContributionCause;
-  amount: number;
-}
-
-// One stable food-palette accent per cause, pinned by the cause's sorted
-// position so a cause keeps the same colour across the donut arc and its legend
-// dot. `fill` paints the legend dot; `text` drives `currentColor` for the SVG
-// arc stroke.
-const CAUSE_COLORS = [
+// One stable food-palette accent per slice, pinned by the slice's sorted
+// position so a category keeps the same colour across the donut arc and its
+// legend dot. `fill` paints the legend dot; `text` drives `currentColor` for
+// the SVG arc stroke.
+const SLICE_COLORS = [
   { fill: 'bg-accent-cabbage-default', text: 'text-accent-cabbage-default' },
   { fill: 'bg-accent-avocado-default', text: 'text-accent-avocado-default' },
   { fill: 'bg-accent-cheese-default', text: 'text-accent-cheese-default' },
@@ -33,26 +25,34 @@ const CAUSE_COLORS = [
   { fill: 'bg-accent-bun-default', text: 'text-accent-bun-default' },
 ] as const;
 
+// The label for the bucket of causes without a category (`category: null`).
+const UNCATEGORISED_LABEL = 'Other causes';
+
 interface Slice {
-  cause: ContributionCause;
+  key: string;
+  label: string;
   amount: number;
   percentage: number;
-  color: (typeof CAUSE_COLORS)[number];
+  color: (typeof SLICE_COLORS)[number];
 }
 
-// Sort biggest-first so the donut leads with the causes the community backs
-// most, and pin a stable colour to each by its sorted position.
+// The backend already groups the pool by cause category (points map 1:1 to
+// dollars), so we only sort biggest-first, compute each share and pin a stable
+// colour by sorted position. Zero rows are dropped so the donut never renders an
+// empty "$0 / 0%" slice.
 const toSlices = (
-  allocations: GivebackCauseAllocation[],
+  breakdown: ContributionCauseCategoryBreakdown[],
   total: number,
 ): Slice[] =>
-  [...allocations]
-    .sort((a, b) => b.amount - a.amount)
-    .map((allocation, index) => ({
-      cause: allocation.cause,
-      amount: allocation.amount,
-      percentage: total > 0 ? (allocation.amount / total) * 100 : 0,
-      color: CAUSE_COLORS[index % CAUSE_COLORS.length],
+  [...breakdown]
+    .filter(({ points }) => points > 0)
+    .sort((a, b) => b.points - a.points)
+    .map(({ category, points }, index) => ({
+      key: category ?? UNCATEGORISED_LABEL,
+      label: category ?? UNCATEGORISED_LABEL,
+      amount: points,
+      percentage: total > 0 ? (points / total) * 100 : 0,
+      color: SLICE_COLORS[index % SLICE_COLORS.length],
     }));
 
 const formatPercentage = (percentage: number): string =>
@@ -69,17 +69,14 @@ const Dot = ({ className }: { className: string }): ReactElement => (
 const Legend = ({ slices }: { slices: Slice[] }): ReactElement => (
   <div className="grid grid-cols-1 gap-x-6 gap-y-2.5 tablet:grid-cols-2">
     {slices.map((slice) => (
-      <FlexRow
-        key={slice.cause.id}
-        className="w-full max-w-72 items-center gap-2"
-      >
+      <FlexRow key={slice.key} className="w-full max-w-72 items-center gap-2">
         <Dot className={slice.color.fill} />
         <Typography
           tag={TypographyTag.Span}
           type={TypographyType.Footnote}
           className="min-w-0 flex-1 truncate"
         >
-          {slice.cause.title}
+          {slice.label}
         </Typography>
         <FlexRow className="shrink-0 items-center gap-1">
           <Typography
@@ -147,7 +144,7 @@ const Donut = ({
             cumulative += slice.percentage;
             return (
               <circle
-                key={slice.cause.id}
+                key={slice.key}
                 cx="18"
                 cy="18"
                 r="15.915"
@@ -189,7 +186,7 @@ const Donut = ({
 };
 
 interface GivebackCausesBreakdownProps {
-  allocations: GivebackCauseAllocation[];
+  breakdown: ContributionCauseCategoryBreakdown[];
   title?: ReactNode;
   description?: ReactNode;
   // Drops the card chrome (border, surface fill, padding, glow) so the block
@@ -205,19 +202,19 @@ interface GivebackCausesBreakdownProps {
 // `flat` renders it open in the page flow; the default is a framed card with a
 // soft brand glow for standalone use.
 export const GivebackCausesBreakdown = ({
-  allocations,
+  breakdown,
   title = 'Where the money will go',
   description,
   flat = false,
   className,
 }: GivebackCausesBreakdownProps): ReactElement | null => {
-  const total = allocations.reduce((sum, { amount }) => sum + amount, 0);
+  const total = breakdown.reduce((sum, { points }) => sum + points, 0);
 
-  if (allocations.length === 0 || total === 0) {
+  if (total === 0) {
     return null;
   }
 
-  const slices = toSlices(allocations, total);
+  const slices = toSlices(breakdown, total);
 
   return (
     <section

--- a/packages/shared/src/features/giveback/components/GivebackPage.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPage.tsx
@@ -12,48 +12,18 @@ import { GivebackTabHeading } from './GivebackTabHeading';
 import { GivebackImpactPanel } from './GivebackImpactPanel';
 import { GivebackCausesPanel } from './GivebackCausesPanel';
 import { GivebackCausesBreakdown } from './GivebackCausesBreakdown';
-import type { GivebackCauseAllocation } from './GivebackCausesBreakdown';
 import { GivebackFaq } from './GivebackFaq';
 import type { GivebackTabId } from './GivebackTabNav';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 import { useContributionStatus } from '../hooks/useContributionStatus';
+import { useContributionCauseBreakdown } from '../hooks/useContributionCauseBreakdown';
 import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
-import type { ContributionCause } from '../types';
 
 // Single source of truth for the page gutter, shared by the hero, the tab
 // content and the footer so every row lines up at the exact same left/right
 // padding. Scales up on wider screens so content isn't edge-tight.
 const column = 'mx-auto w-full max-w-6xl px-4 tablet:px-8 laptop:px-12';
-
-// Placeholder split for the "Where the money will go" breakdown. The
-// contribution API has no per-cause amounts yet, so we spread the current cycle
-// pool across the campaign causes with a stable descending weight purely to
-// visualize the block in context. Swap this for real per-cause figures once the
-// backend exposes them.
-const BREAKDOWN_WEIGHTS = [42, 26, 18, 11, 7, 4];
-
-const buildCausesBreakdown = (
-  causes: ContributionCause[],
-  pool: number,
-): GivebackCauseAllocation[] => {
-  if (pool <= 0 || causes.length === 0) {
-    return [];
-  }
-
-  const used = causes.slice(0, BREAKDOWN_WEIGHTS.length);
-  const weights = used.map((_, index) => BREAKDOWN_WEIGHTS[index] ?? 3);
-  const weightSum = weights.reduce((sum, weight) => sum + weight, 0);
-
-  // Drop slivers that round to $0 on a tiny pool so the breakdown never renders
-  // an empty "$0 / 0%" row.
-  return used
-    .map((cause, index) => ({
-      cause,
-      amount: Math.round((pool * weights[index]) / weightSum),
-    }))
-    .filter(({ amount }) => amount > 0);
-};
 
 const scrollIntoView = (node: HTMLElement | null): void => {
   if (!node || typeof node.scrollIntoView !== 'function') {
@@ -65,6 +35,7 @@ const scrollIntoView = (node: HTMLElement | null): void => {
 export const GivebackPage = (): ReactElement => {
   const { logEvent } = useLogContext();
   const { status } = useContributionStatus();
+  const { breakdown } = useContributionCauseBreakdown();
   // Eligibility gates the cause picker query (backend-gated), so only eligible
   // visitors load their picks - which also tells us whether to show the tabs.
   const isEligible = status?.eligible === true;
@@ -151,11 +122,6 @@ export const GivebackPage = (): ReactElement => {
 
   const activeLabel = givebackTabs.find((tab) => tab.id === activeTab)?.label;
 
-  const causesBreakdown = buildCausesBreakdown(
-    selection.causes,
-    status?.currentCyclePoints ?? 0,
-  );
-
   // No `overflow-x-clip` on the root: it would clip GivebackBackground's
   // `laptop:-inset-1` corner bleed and leave a dark crescent inside the app
   // card's rounded corner. Stray horizontal bleed is still caught by the global
@@ -174,9 +140,9 @@ export const GivebackPage = (): ReactElement => {
             <GivebackHero onHowItWorks={handleHowItWorks} />
           </div>
 
-          {showTabs && causesBreakdown.length > 0 && (
+          {showTabs && breakdown.length > 0 && (
             <div className={column}>
-              <GivebackCausesBreakdown flat allocations={causesBreakdown} />
+              <GivebackCausesBreakdown flat breakdown={breakdown} />
             </div>
           )}
 

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -1,7 +1,13 @@
-// Public campaign data shown on load: the funding status and the sponsor wall
-// come back in a single request so the hero renders from one round trip.
+// Public campaign data shown on load: the funding status and the by-category
+// pool breakdown come back in a single request so the hero and the causes
+// breakdown render from one round trip.
+//
+// The sponsor wall (contributionSponsors) is commented out for now: nothing on
+// the page renders GivebackSponsorTiers yet, so fetching it here just wastes a
+// round trip. Re-enable the block and the $first variable once the sponsor wall
+// is mounted.
 export const CONTRIBUTION_OVERVIEW_QUERY = `
-  query ContributionOverview($first: Int) {
+  query ContributionOverview {
     contributionStatus {
       enabled
       eligible
@@ -12,20 +18,30 @@ export const CONTRIBUTION_OVERVIEW_QUERY = `
       contributorsCount
       userPoints
     }
-    contributionSponsors(first: $first) {
-      edges {
-        node {
-          id
-          name
-          amountCents
-          url
-          logoUrl
-          tier
-        }
-      }
+    contributionCauseBreakdown {
+      category
+      points
     }
   }
 `;
+
+// export const CONTRIBUTION_OVERVIEW_QUERY = `
+//   query ContributionOverview($first: Int) {
+//     ...
+//     contributionSponsors(first: $first) {
+//       edges {
+//         node {
+//           id
+//           name
+//           amountCents
+//           url
+//           logoUrl
+//           tier
+//         }
+//       }
+//     }
+//   }
+// `;
 
 // The cause picker needs the catalog and the visitor's saved picks together, so
 // they share one request fired when the visitor opts in.

--- a/packages/shared/src/features/giveback/hooks/useContributionCauseBreakdown.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionCauseBreakdown.ts
@@ -1,0 +1,20 @@
+import { useContributionOverview } from './useContributionOverview';
+import type { ContributionCauseCategoryBreakdown } from '../types';
+
+interface UseContributionCauseBreakdown {
+  breakdown: ContributionCauseCategoryBreakdown[];
+  isPending: boolean;
+}
+
+// The projected pool split across cause categories, powering the causes
+// breakdown donut. Public campaign data, so it rides the shared overview query
+// (see `useContributionOverview`) rather than firing its own request.
+export const useContributionCauseBreakdown =
+  (): UseContributionCauseBreakdown => {
+    const { data, isPending } = useContributionOverview();
+
+    return {
+      breakdown: data?.contributionCauseBreakdown ?? [],
+      isPending,
+    };
+  };

--- a/packages/shared/src/features/giveback/hooks/useContributionOverview.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionOverview.ts
@@ -6,19 +6,24 @@ import { gqlClient } from '../../../graphql/common';
 import { disabledRefetch } from '../../../lib/func';
 import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
 import { CONTRIBUTION_OVERVIEW_QUERY } from '../graphql';
-import type { ContributionSponsor, ContributionStatus } from '../types';
+import type {
+  ContributionCauseCategoryBreakdown,
+  ContributionSponsor,
+  ContributionStatus,
+} from '../types';
 
 interface ContributionOverview {
   contributionStatus: ContributionStatus;
-  contributionSponsors: Connection<ContributionSponsor>;
+  // Optional while the sponsor wall is disabled in the query (see
+  // CONTRIBUTION_OVERVIEW_QUERY); the field isn't fetched today.
+  contributionSponsors?: Connection<ContributionSponsor>;
+  contributionCauseBreakdown: ContributionCauseCategoryBreakdown[];
 }
 
-const MAX_SPONSORS = 100;
-
-// Shared query behind the funding summary and the sponsor wall. Both surfaces
-// load together on the hero, so they read from one request: the two public
-// hooks call this with the same key and React Query dedupes them. Keyed by user
-// because the status carries user-specific fields.
+// Shared query behind the funding summary and the causes breakdown. Both
+// surfaces load together on the hero, so they read from one request: the public
+// facade hooks call this with the same key and React Query dedupes them. Keyed
+// by user because the status carries user-specific fields.
 export const useContributionOverview =
   (): UseQueryResult<ContributionOverview> => {
     const { user, isAuthReady } = useAuthContext();
@@ -26,9 +31,7 @@ export const useContributionOverview =
     return useQuery({
       queryKey: generateQueryKey(RequestKey.ContributionOverview, user),
       queryFn: () =>
-        gqlClient.request<ContributionOverview>(CONTRIBUTION_OVERVIEW_QUERY, {
-          first: MAX_SPONSORS,
-        }),
+        gqlClient.request<ContributionOverview>(CONTRIBUTION_OVERVIEW_QUERY),
       enabled: isAuthReady,
       staleTime: StaleTime.Default,
       ...disabledRefetch,

--- a/packages/shared/src/features/giveback/hooks/useContributionSponsors.ts
+++ b/packages/shared/src/features/giveback/hooks/useContributionSponsors.ts
@@ -12,7 +12,7 @@ export const useContributionSponsors = (): UseContributionSponsors => {
   const { data, isPending } = useContributionOverview();
 
   return {
-    sponsors: data?.contributionSponsors.edges.map((edge) => edge.node) ?? [],
+    sponsors: data?.contributionSponsors?.edges.map((edge) => edge.node) ?? [],
     isPending,
   };
 };

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -70,6 +70,15 @@ export interface ContributionActionCategory {
   title: string;
 }
 
+// The community pool's projected current-cycle points, grouped by cause
+// category, as returned by `contributionCauseBreakdown`. Points map 1:1 to
+// currency, so the causes breakdown donut renders them straight as dollars.
+// `category` is null for the bucket of causes without one.
+export interface ContributionCauseCategoryBreakdown {
+  category: string | null;
+  points: number;
+}
+
 // The kind of perk a reward tier grants, used to pick the roadmap node's icon.
 export enum ContributionRewardType {
   Cores = 'cores',

--- a/packages/storybook/stories/features/giveback/GivebackCausesBreakdown.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackCausesBreakdown.stories.tsx
@@ -2,31 +2,28 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { ReactElement } from 'react';
 import React from 'react';
 import { GivebackCausesBreakdown } from '@dailydotdev/shared/src/features/giveback/components/GivebackCausesBreakdown';
-import type { GivebackCauseAllocation } from '@dailydotdev/shared/src/features/giveback/components/GivebackCausesBreakdown';
-import { mockCauses, withGiveback } from './giveback.mocks';
+import type { ContributionCauseCategoryBreakdown } from '@dailydotdev/shared/src/features/giveback/types';
+import { withGiveback } from './giveback.mocks';
 
-// Pair the shared mock causes with a plausible, uneven split of the community
-// pool (whole dollars, biggest-first) so the donut has real proportions to draw.
-const allocations: GivebackCauseAllocation[] = mockCauses().map(
-  (cause, index) => ({
-    cause,
-    amount: [4200, 2600, 1800, 1100, 700, 400][index] ?? 300,
-  }),
-);
+// A plausible, uneven split of the community pool by cause category (whole
+// dollars, biggest-first), matching the shape the `contributionCauseBreakdown`
+// query returns, so the donut has real proportions to draw.
+const breakdown: ContributionCauseCategoryBreakdown[] = [
+  { category: 'Open source', points: 4200 },
+  { category: 'Education', points: 2600 },
+  { category: 'Accessibility', points: 1800 },
+  { category: 'Climate', points: 1100 },
+  { category: 'Mentorship', points: 700 },
+  { category: 'Better docs', points: 400 },
+];
 
-const fewAllocations: GivebackCauseAllocation[] = allocations.slice(0, 3);
+const fewCategories: ContributionCauseCategoryBreakdown[] = breakdown.slice(0, 3);
 
-// A deliberately long cause name so the capped, truncating legend title stays
+// A deliberately long category name so the capped, truncating legend label stays
 // visible alongside the normal roster.
-const longTitleAllocations: GivebackCauseAllocation[] = [
-  {
-    cause: {
-      ...mockCauses()[0],
-      title: 'Open-source maintainers, docs & tooling grants',
-    },
-    amount: 4200,
-  },
-  ...allocations.slice(1),
+const longLabelBreakdown: ContributionCauseCategoryBreakdown[] = [
+  { category: 'Open-source maintainers, docs & tooling grants', points: 4200 },
+  ...breakdown.slice(1),
 ];
 
 // Constrain to the page column width so the donut reads the way it would
@@ -43,7 +40,7 @@ const meta: Meta<typeof GivebackCausesBreakdown> = {
     docs: {
       description: {
         component:
-          'The causes breakdown block that sits below the hero and above the tabs, turning "the pool you are growing" into a picture: an SVG donut with the pool total counting up in the hole and a legend of causes with their share and amount, all sharing the giveback food-palette accents.',
+          'The causes breakdown block that sits below the hero and above the tabs, turning "the pool you are growing" into a picture: an SVG donut with the pool total counting up in the hole and a legend of cause categories with their share and amount, all sharing the giveback food-palette accents. The backend groups the pool by category (via `contributionCauseBreakdown`) so the donut stays a handful of slices instead of one sliver per nonprofit.',
       },
     },
   },
@@ -58,7 +55,7 @@ type Story = StoryObj<typeof GivebackCausesBreakdown>;
 export const Default: Story = {
   render: () => (
     <Frame>
-      <GivebackCausesBreakdown allocations={allocations} />
+      <GivebackCausesBreakdown breakdown={breakdown} />
     </Frame>
   ),
 };
@@ -77,27 +74,27 @@ export const FlatOnPage: Story = {
   },
   render: () => (
     <Frame>
-      <GivebackCausesBreakdown allocations={allocations} flat />
+      <GivebackCausesBreakdown breakdown={breakdown} flat />
     </Frame>
   ),
 };
 
-// A leaner three-cause pool, so the donut holds up before the community spreads
-// across the full roster.
-export const FewCauses: Story = {
+// A leaner three-category pool, so the donut holds up before the community
+// spreads across the full roster.
+export const FewCategories: Story = {
   render: () => (
     <Frame>
-      <GivebackCausesBreakdown allocations={fewAllocations} />
+      <GivebackCausesBreakdown breakdown={fewCategories} />
     </Frame>
   ),
 };
 
-// A long cause name to confirm the legend title caps and truncates cleanly while
-// the share and amount stay right-aligned.
-export const LongTitle: Story = {
+// A long category name to confirm the legend label caps and truncates cleanly
+// while the share and amount stay right-aligned.
+export const LongLabel: Story = {
   render: () => (
     <Frame>
-      <GivebackCausesBreakdown allocations={longTitleAllocations} />
+      <GivebackCausesBreakdown breakdown={longLabelBreakdown} />
     </Frame>
   ),
 };


### PR DESCRIPTION
## What

The `/giveback` causes breakdown donut was rendering a **synthetic** split (`BREAKDOWN_WEIGHTS = [42, 26, 18, 11, 7, 4]` spread across causes) — its own comment said to swap it for real data once the backend exposed it.

The backend already exposes it: `contributionCauseBreakdown` is a public query returning `[{ category, points }]`, grouped and aggregated by cause **category** server-side (points map 1:1 to dollars). This wires the UI to it, so the pie shows a handful of category slices instead of one sliver per nonprofit.

## Changes

- **Real data**: `GivebackCausesBreakdown` now takes `breakdown={[{ category, points }]}` directly; removed the client-side grouping and the synthetic `buildCausesBreakdown`/`BREAKDOWN_WEIGHTS` from `GivebackPage`.
- **Grouped the request**: folded `contributionCauseBreakdown` into the shared `CONTRIBUTION_OVERVIEW_QUERY`, so it rides the hero's existing round trip. `useContributionCauseBreakdown` is a facade over `useContributionOverview` (same pattern as status/sponsors) — no new network call.
- **Dropped wasted fetch**: commented out `contributionSponsors` in the overview query — nothing on the page renders `GivebackSponsorTiers` yet, so it was fetched and discarded on every load. Easy to restore when the sponsor wall ships.

Net: `/giveback` loads on a single overview round trip carrying status + the by-category breakdown.

## Test

- Rewrote `GivebackCausesBreakdown` spec + Storybook story to the new prop.
- All 64 giveback tests pass; strict typecheck clean.

### Preview domain
https://feat-giveback-causes-breakdown-e.preview.app.daily.dev