### PR TITLE
fix(giveback): don't mark repeatable actions done after one approval

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.spec.tsx
@@ -64,10 +64,37 @@ it('labels a referral action as an invite rather than a proof submission', () =>
   expect(onSubmit).toHaveBeenCalledWith(action);
 });
 
-it('locks an approved action into a non-interactive Done state', () => {
+it('keeps an uncapped action actionable after an approval', () => {
   render(
     <GivebackActionCard
       action={makeAction({
+        maxPerUser: null,
+        userCompletions: 1,
+        latestUserSubmission: {
+          id: 's1',
+          actionId: 'a1',
+          status: ContributionSubmissionStatus.Approved,
+          awardedPoints: 5,
+          createdAt: '2026-01-01',
+          reviewedAt: '2026-01-02',
+        },
+      })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.queryByText('Done')).not.toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Submit proof for Post about us on X' }),
+  ).toBeInTheDocument();
+});
+
+it('locks a one-shot approved action into a non-interactive Done state', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({
+        maxPerUser: 1,
+        userCompletions: 1,
         latestUserSubmission: {
           id: 's1',
           actionId: 'a1',
@@ -115,6 +142,40 @@ it('treats reaching the per-user cap as Done', () => {
   );
 
   expect(screen.getByText('Done')).toBeInTheDocument();
+});
+
+it('keeps a repeatable action actionable after an approval until the cap is hit', () => {
+  render(
+    <GivebackActionCard
+      action={makeAction({
+        title: 'Invite a friend',
+        maxPerUser: 10,
+        userCompletions: 1,
+        metadata: {
+          platform: null,
+          instructions: null,
+          externalUrl: null,
+          isLoveAction: false,
+          assistType: ContributionAssistType.ReferralLink,
+        },
+        latestUserSubmission: {
+          id: 's1',
+          actionId: 'a1',
+          status: ContributionSubmissionStatus.Approved,
+          awardedPoints: 15,
+          createdAt: '2026-01-01',
+          reviewedAt: '2026-01-02',
+        },
+      })}
+      onSubmit={onSubmit}
+    />,
+  );
+
+  expect(screen.queryByText('Done')).not.toBeInTheDocument();
+  expect(screen.getByText('9 left')).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', { name: 'Invite friends: Invite a friend' }),
+  ).toBeInTheDocument();
 });
 
 it('keeps a rejected action submittable for a retry', () => {

--- a/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackActionCard.tsx
@@ -54,13 +54,16 @@ export const GivebackActionCard = ({
 
   const reachedMax =
     action.maxPerUser != null && action.userCompletions >= action.maxPerUser;
-  const isApproved =
-    latestUserSubmission?.status === ContributionSubmissionStatus.Approved;
   const isInReview =
     latestUserSubmission?.status === ContributionSubmissionStatus.Flagged;
-  // "Done" = approved or you've hit the per-user cap. A rejected submission
-  // stays clickable to retry.
-  const isDone = isApproved || reachedMax;
+  // "Done" = the action is exhausted, i.e. its per-user cap is reached. A capped
+  // action (maxPerUser set) latches once completions hit the cap - a one-shot
+  // (cap 1) after its single approval, a repeatable one only at its ceiling. An
+  // uncapped action (maxPerUser null) is unlimited, matching the backend, so a
+  // single approval never marks it done (e.g. "Invite a friend" stays open). A
+  // pending submission still reads as "In review", and a rejected one stays
+  // clickable to retry.
+  const isDone = !isInReview && reachedMax;
   // Cooldown only gates an action that would otherwise be actionable.
   const onCooldown =
     !isDone &&


### PR DESCRIPTION
## Bug

"Invite a friend" (and any repeatable action) was marked **Done** after a single completion, even with runs left. Referral invites approve instantly, so the card latched to Done right after the first invite.

## Root cause

Two parts:

1. **Card logic** — `isDone = isApproved || reachedMax` treated *any* approved submission as terminal, ignoring the per-user cap.
2. **Production data** — the invite action's `contribution_action` row had `maxPerUser = NULL`. Every other action sets it explicitly (one-shot = 1, repeatable = 3/5/10/20/30), so the card fell back to one-shot behavior.

## Fix

**Code** (this PR): align the card with the backend, where `maxPerUser = null` already means *unlimited*. An action is "Done" only when it reaches its cap:
- capped (`maxPerUser` set) → latches at the ceiling (one-shot latches after its single approval)
- uncapped (`null`) → unlimited, never latches from an approval (invite stays open)
- pending stays "In review", rejected stays retryable

**Data** (already applied to prod `daily`): the invite action stays uncapped. The 4 app-store review actions (Chrome/Edge/Play/App Store) were *also* `null` — under the null=unlimited semantics they'd wrongly become repeatable, so they were given `maxPerUser = 1` to stay one-shot.

## Test

Card spec updated: uncapped-approved stays actionable, one-shot-approved shows Done, repeatable-approved shows "N left" and stays clickable. 13/13 pass, strict typecheck clean.

### Preview domain
https://fix-giveback-repeatable-action-d.preview.app.daily.dev