### PR TITLE
feat(giveback): drive reward reveals from rewardType + metadata

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackImpactPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackImpactPanel.spec.tsx
@@ -59,6 +59,7 @@ const tiers: ContributionRewardTier[] = [
     description: 'A pack of daily.dev stickers',
     thresholdPoints: 25,
     rewardType: ContributionRewardType.Custom,
+    metadata: {},
   },
   {
     id: 't2',
@@ -66,6 +67,7 @@ const tiers: ContributionRewardTier[] = [
     description: null,
     thresholdPoints: 100,
     rewardType: ContributionRewardType.PlusDays,
+    metadata: { days: 30 },
   },
   {
     id: 't3',
@@ -73,6 +75,7 @@ const tiers: ContributionRewardTier[] = [
     description: null,
     thresholdPoints: 250,
     rewardType: ContributionRewardType.Custom,
+    metadata: {},
   },
 ];
 

--- a/packages/shared/src/features/giveback/components/GivebackRoadmapNode.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackRoadmapNode.tsx
@@ -35,13 +35,16 @@ import { GivebackMeterShine } from './GivebackMeterShine';
 import { Connector } from './GivebackRoadmapRail';
 import type { RoadmapNode } from './givebackRoadmapTypes';
 
-const rewardIconByType: Record<ContributionRewardType, ReactElement> = {
-  [ContributionRewardType.Cores]: <CoreIcon />,
-  [ContributionRewardType.PlusDays]: <DevPlusIcon />,
-  [ContributionRewardType.Call]: <StarIcon />,
-  [ContributionRewardType.Privilege]: <MedalBadgeIcon />,
-  [ContributionRewardType.Custom]: <GiftIcon />,
-};
+// Content and unmapped reward types fall back to the gift icon (see usage).
+const rewardIconByType: Partial<Record<ContributionRewardType, ReactElement>> =
+  {
+    [ContributionRewardType.Cores]: <CoreIcon />,
+    [ContributionRewardType.PlusDays]: <DevPlusIcon />,
+    [ContributionRewardType.StoreDiscount]: <GiftIcon />,
+    [ContributionRewardType.Council]: <MedalBadgeIcon />,
+    [ContributionRewardType.Call]: <StarIcon />,
+    [ContributionRewardType.Privilege]: <MedalBadgeIcon />,
+  };
 
 // Directions the celebration confetti flies when a reward is claimed, fed to the
 // reaction-burst keyframe via CSS custom properties. A fuller spread of brand
@@ -190,7 +193,7 @@ export const NodeRow = ({
             'border-accent-cheese-default/50 border bg-surface-float text-accent-cheese-default',
           )}
         >
-          {rewardIconByType[reward.type]}
+          {rewardIconByType[reward.type] ?? <GiftIcon />}
         </span>
       );
     }
@@ -203,7 +206,7 @@ export const NodeRow = ({
             'bg-accent-cabbage-default text-white',
           )}
         >
-          {rewardIconByType[reward.type]}
+          {rewardIconByType[reward.type] ?? <GiftIcon />}
         </span>
       );
     }

--- a/packages/shared/src/features/giveback/components/rewards/GivebackRewardReveal.tsx
+++ b/packages/shared/src/features/giveback/components/rewards/GivebackRewardReveal.tsx
@@ -15,16 +15,12 @@ import {
 import CloseButton from '../../../../components/CloseButton';
 import {
   DevPlusIcon,
-  SlackIcon,
   SparkleIcon,
   UserIcon,
   VIcon,
 } from '../../../../components/icons';
 import LogoText from '../../../../svg/LogoText';
-import {
-  cloudinaryCharm404,
-  getCoreCurrencyImage,
-} from '../../../../lib/image';
+import { getCoreCurrencyImage } from '../../../../lib/image';
 import { anchorDefaultRel } from '../../../../lib/strings';
 import { FlexCol, FlexRow } from '../../../../components/utilities';
 import type { LoggedUser } from '../../../../lib/user';
@@ -262,26 +258,12 @@ const PlusCard = ({ duration }: { duration?: string }): ReactElement => (
 );
 
 // A ring of teammate tiles with the visitor standing out in a gradient frame —
-// used by both the Council seat and the team-call reveals so they read as
-// "you're in the room". The teammates are neutral tiles (no fabricated faces);
-// the visitor is the one real avatar.
+// used by the Council seat reveal so it reads as "you're in the room". The
+// teammates are neutral tiles (no fabricated faces); the visitor is the one real
+// avatar.
 const TEAMMATE_TILES = 3;
-const MemberRing = ({
-  channel,
-  user,
-}: {
-  channel?: string;
-  user: LoggedUser | null;
-}): ReactElement => (
+const MemberRing = ({ user }: { user: LoggedUser | null }): ReactElement => (
   <FlexCol className="items-center gap-4">
-    {channel && (
-      <FlexRow className="items-center gap-2 rounded-10 bg-surface-float px-3 py-1.5 motion-safe:animate-reward-pop [&_svg]:size-5">
-        <SlackIcon />
-        <Typography bold type={TypographyType.Footnote}>
-          {channel}
-        </Typography>
-      </FlexRow>
-    )}
     <FlexRow className="items-center">
       {Array.from({ length: TEAMMATE_TILES }).map((_, index) => (
         <span
@@ -664,165 +646,6 @@ const SwagReveal = ({
   );
 };
 
-// Roast → user hits "Roast me", we "generate" it (a few-second loading beat with
-// rotating status lines), then type the burn out live. In the real flow the text
-// comes from the backend; here it's placeholder copy typed the same way.
-const TYPE_MS = 15;
-const ROAST_LOADING_STEPS = [
-  'Scanning your reading history…',
-  'Counting your unopened bookmarks…',
-  'Cooking up something painful…',
-];
-const ROAST_STEP_MS = 850;
-
-const RoastReveal = ({
-  reveal,
-  levelNumber,
-  onClose,
-}: {
-  reveal: RewardReveal;
-  levelNumber?: number;
-  onClose: () => void;
-}): ReactElement => {
-  const full = reveal.roastText ?? '';
-  const reduced = usePrefersReducedMotion();
-  const [stage, setStage] = useState<'idle' | 'loading' | 'typing'>('idle');
-  const [loadingStep, setLoadingStep] = useState(0);
-  const [typed, setTyped] = useState('');
-
-  useEffect(() => {
-    if (stage !== 'loading') {
-      return undefined;
-    }
-    const stepper = setInterval(() => {
-      setLoadingStep((step) =>
-        Math.min(step + 1, ROAST_LOADING_STEPS.length - 1),
-      );
-    }, ROAST_STEP_MS);
-    const finish = setTimeout(
-      () => setStage('typing'),
-      ROAST_STEP_MS * ROAST_LOADING_STEPS.length,
-    );
-    return () => {
-      clearInterval(stepper);
-      clearTimeout(finish);
-    };
-  }, [stage]);
-
-  useEffect(() => {
-    if (stage !== 'typing') {
-      return undefined;
-    }
-    if (reduced) {
-      setTyped(full);
-      return undefined;
-    }
-    let index = 0;
-    const interval = setInterval(() => {
-      index += 1;
-      setTyped(full.slice(0, index));
-      if (index >= full.length) {
-        clearInterval(interval);
-      }
-    }, TYPE_MS);
-    return () => clearInterval(interval);
-  }, [stage, full, reduced]);
-
-  const done = typed.length >= full.length;
-
-  return (
-    <FlexCol className="items-center gap-6">
-      <Reveal delay={0}>
-        <LevelChip levelNumber={levelNumber} />
-      </Reveal>
-      {/* Patchy calmly getting roasted in the flames (the daily.dev "404" charm
-          — a dog on fire, perfect for a roast). */}
-      <Reveal delay={STAGGER_STEP}>
-        <span className="relative flex items-center justify-center">
-          <span
-            aria-hidden
-            className="bg-accent-ketchup-default/25 absolute inset-0 m-auto size-24 rounded-full blur-2xl motion-safe:animate-glow-pulse"
-          />
-          <img
-            src={cloudinaryCharm404}
-            alt="Patchy getting roasted"
-            loading="lazy"
-            className={classNames(
-              'relative h-32 w-auto select-none object-contain',
-              stage === 'loading'
-                ? 'motion-safe:animate-mascot-bob'
-                : 'motion-safe:animate-reward-pop',
-            )}
-          />
-        </span>
-      </Reveal>
-      {stage === 'idle' && (
-        <>
-          <RevealCopy reveal={reveal} delayBase={STAGGER_STEP * 2} />
-          <Reveal delay={STAGGER_STEP * 5}>
-            <Button
-              type="button"
-              size={ButtonSize.Medium}
-              variant={ButtonVariant.Primary}
-              onClick={() => setStage('loading')}
-            >
-              Roast me
-            </Button>
-          </Reveal>
-        </>
-      )}
-      {stage === 'loading' && (
-        <FlexCol className="items-center gap-4 py-2">
-          {/* Heat gauge climbs mild → charred as the burn is generated. */}
-          <div className="h-3 w-52 overflow-hidden rounded-8 bg-surface-float ring-1 ring-inset ring-border-subtlest-tertiary">
-            <div
-              className="h-full rounded-8 bg-gradient-to-r from-accent-cheese-default via-accent-bun-default to-accent-ketchup-default transition-[width] duration-700 ease-out"
-              style={{
-                width: `${
-                  ((loadingStep + 1) / ROAST_LOADING_STEPS.length) * 100
-                }%`,
-              }}
-            />
-          </div>
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Secondary}
-            className="text-center"
-          >
-            {ROAST_LOADING_STEPS[loadingStep]}
-          </Typography>
-        </FlexCol>
-      )}
-      {stage === 'typing' && (
-        <>
-          <div className="min-h-24 w-full rounded-16 border border-border-subtlest-tertiary bg-background-default p-4 text-left">
-            <span className="bg-gradient-to-r from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default bg-clip-text font-black uppercase tracking-widest text-transparent typo-caption2">
-              Fresh burn
-            </span>
-            <Typography
-              type={TypographyType.Footnote}
-              className="mt-2 italic [text-wrap:pretty]"
-            >
-              {typed}
-              {!done && (
-                <span
-                  aria-hidden
-                  className="ml-px inline-block h-4 w-0.5 translate-y-0.5 bg-text-primary motion-safe:animate-glow-pulse"
-                />
-              )}
-            </Typography>
-          </div>
-          {done && (
-            <Reveal delay={0}>
-              <DismissButton label="Ouch. Fair." onClose={onClose} />
-            </Reveal>
-          )}
-        </>
-      )}
-    </FlexCol>
-  );
-};
-
 // The causes we already fund, rendered as a looping conveyor of cards so
 // "suggest a cause" reads as joining a real, curated list.
 const CAUSES: ReadonlyArray<{
@@ -1014,13 +837,6 @@ const TriviaReveal = ({
   </FlexCol>
 );
 
-// A medal emblem for a generic privilege perk.
-const PrivilegeEmblem = (): ReactElement => (
-  <span className="relative flex size-32 items-center justify-center rounded-full bg-gradient-to-br from-accent-cabbage-default to-accent-onion-default text-white shadow-2-cabbage motion-safe:animate-reward-pop [&_svg]:size-16">
-    <SparkleIcon />
-  </span>
-);
-
 interface RevealBodyProps {
   reveal: RewardReveal;
   levelNumber?: number;
@@ -1038,14 +854,6 @@ const revealBody = ({
     case 'note':
       return (
         <NoteReveal
-          reveal={reveal}
-          levelNumber={levelNumber}
-          onClose={onClose}
-        />
-      );
-    case 'roast':
-      return (
-        <RoastReveal
           reveal={reveal}
           levelNumber={levelNumber}
           onClose={onClose}
@@ -1088,15 +896,6 @@ const revealBody = ({
           }
         />
       );
-    case 'call':
-      return (
-        <Scene
-          reveal={reveal}
-          levelNumber={levelNumber}
-          object={<MemberRing user={user} />}
-          action={<DismissButton label="Book your call" onClose={onClose} />}
-        />
-      );
     case 'swagDiscount':
       return <SwagReveal reveal={reveal} levelNumber={levelNumber} />;
     case 'suggestCause':
@@ -1112,17 +911,8 @@ const revealBody = ({
         <Scene
           reveal={reveal}
           levelNumber={levelNumber}
-          object={<MemberRing channel={reveal.channel} user={user} />}
+          object={<MemberRing user={user} />}
           action={<DismissButton label="Take your seat" onClose={onClose} />}
-        />
-      );
-    case 'privilege':
-      return (
-        <Scene
-          reveal={reveal}
-          levelNumber={levelNumber}
-          object={<PrivilegeEmblem />}
-          action={<DismissButton label="Awesome" onClose={onClose} />}
         />
       );
     default:

--- a/packages/shared/src/features/giveback/components/rewards/rewardReveal.spec.ts
+++ b/packages/shared/src/features/giveback/components/rewards/rewardReveal.spec.ts
@@ -1,6 +1,6 @@
 import type { ContributionRewardTier } from '../../types';
 import { ContributionRewardType } from '../../types';
-import { resolveRewardReveal, RevealSlug } from './rewardReveal';
+import { resolveRewardReveal } from './rewardReveal';
 
 const tier = (
   overrides: Partial<ContributionRewardTier> = {},
@@ -10,77 +10,91 @@ const tier = (
   description: null,
   thresholdPoints: 100,
   rewardType: ContributionRewardType.Custom,
+  metadata: {},
   ...overrides,
 });
 
 describe('resolveRewardReveal', () => {
-  it('matches a bespoke preset by tier id', () => {
-    const reveal = resolveRewardReveal(
-      tier({ id: RevealSlug.Roast, rewardType: ContributionRewardType.Custom }),
-    );
-    expect(reveal.kind).toBe('roast');
-    expect(reveal.roastText).toBeTruthy();
-  });
-
-  it('fills a trivia fact per tier so different secret levels differ', () => {
-    const first = resolveRewardReveal(
-      tier({ id: RevealSlug.Secret, thresholdPoints: 200 }),
-    );
-    const second = resolveRewardReveal(
-      tier({ id: RevealSlug.Secret, thresholdPoints: 201 }),
-    );
-    expect(first.kind).toBe('trivia');
-    expect(first.fact).toBeTruthy();
-    expect(first.fact).not.toBe(second.fact);
-  });
-
-  it('derives Cores reveals and parses the amount from the title', () => {
+  it('derives Cores reveals and reads the amount from metadata', () => {
     const reveal = resolveRewardReveal(
       tier({
-        id: 'cores-1000',
         title: '1,000 Cores',
         rewardType: ContributionRewardType.Cores,
+        metadata: { amount: 1000 },
       }),
     );
     expect(reveal.kind).toBe('cores');
     expect(reveal.amount).toBe(1000);
   });
 
-  it('derives Plus reveals and parses the duration from the title', () => {
-    const reveal = resolveRewardReveal(
-      tier({
-        id: 'plus-year',
-        title: '1 year of Plus',
-        rewardType: ContributionRewardType.PlusDays,
-      }),
-    );
-    expect(reveal.kind).toBe('plus');
-    expect(reveal.duration).toBe('1 year');
+  it('derives Plus reveals and formats the duration from metadata days', () => {
+    expect(
+      resolveRewardReveal(
+        tier({
+          rewardType: ContributionRewardType.PlusDays,
+          metadata: { days: 365 },
+        }),
+      ).duration,
+    ).toBe('1 year');
+    expect(
+      resolveRewardReveal(
+        tier({
+          rewardType: ContributionRewardType.PlusDays,
+          metadata: { days: 14 },
+        }),
+      ).duration,
+    ).toBe('2 weeks');
   });
 
-  it('falls back to a note reveal for an unmatched custom reward', () => {
+  it('derives a store-discount reveal and reads the percent from metadata', () => {
     const reveal = resolveRewardReveal(
       tier({
-        id: 't-thanks',
+        rewardType: ContributionRewardType.StoreDiscount,
+        metadata: { percent: 50 },
+      }),
+    );
+    expect(reveal.kind).toBe('swagDiscount');
+    expect(reveal.percent).toBe(50);
+  });
+
+  it('reveals the trivia fact from the tier description', () => {
+    const reveal = resolveRewardReveal(
+      tier({
+        rewardType: ContributionRewardType.Trivia,
+        description: 'The mascot is a dog named Patchy.',
+      }),
+    );
+    expect(reveal.kind).toBe('trivia');
+    expect(reveal.fact).toBe('The mascot is a dog named Patchy.');
+  });
+
+  it('maps the content and access reward types to their reveals', () => {
+    expect(
+      resolveRewardReveal(
+        tier({ rewardType: ContributionRewardType.PatchyPicture }),
+      ).kind,
+    ).toBe('mascotHug');
+    expect(
+      resolveRewardReveal(tier({ rewardType: ContributionRewardType.Council }))
+        .kind,
+    ).toBe('council');
+    expect(
+      resolveRewardReveal(
+        tier({ rewardType: ContributionRewardType.SuggestCauses }),
+      ).kind,
+    ).toBe('suggestCause');
+  });
+
+  it('falls back to a note reveal for a joke and any unmapped type', () => {
+    const reveal = resolveRewardReveal(
+      tier({
         title: 'Thanks!',
         description: 'You are the best.',
-        rewardType: ContributionRewardType.Custom,
+        rewardType: ContributionRewardType.Joke,
       }),
     );
     expect(reveal.kind).toBe('note');
     expect(reveal.headline).toBe('Thanks!');
     expect(reveal.body).toBe('You are the best.');
-  });
-
-  it('maps the remaining reward types to their reveals', () => {
-    expect(
-      resolveRewardReveal(tier({ rewardType: ContributionRewardType.Call }))
-        .kind,
-    ).toBe('call');
-    expect(
-      resolveRewardReveal(
-        tier({ rewardType: ContributionRewardType.Privilege }),
-      ).kind,
-    ).toBe('privilege');
   });
 });

--- a/packages/shared/src/features/giveback/components/rewards/rewardReveal.ts
+++ b/packages/shared/src/features/giveback/components/rewards/rewardReveal.ts
@@ -1,32 +1,22 @@
 import type { ContributionRewardTier } from '../../types';
 import { ContributionRewardType } from '../../types';
-import {
-  cloudinaryCharm404,
-  cloudinaryCharmInviteFriends,
-} from '../../../../lib/image';
+import { cloudinaryCharmInviteFriends } from '../../../../lib/image';
 
 // The reward-claim "reveal": the cinematic pop-up shown after a contributor
 // claims a reward tier on the journey. Each reward gets a bespoke payoff moment
-// instead of a generic toast.
-//
-// The backend reward contract only carries a coarse `rewardType` (see
-// `ContributionRewardType`), so the finer "fun" reveals (roast, trivia, Patchy,
-// swag, council, suggest-a-cause) are matched here by a stable slug that the
-// seeded reward tiers use as their id. `resolveRewardReveal` is the single place
-// to extend when the backend starts sending an explicit reveal discriminator.
+// instead of a generic toast, resolved from the tier's `rewardType` and its
+// per-type `metadata` (amount → cores, days → plus, percent → discount). The
+// tier's own title/description carry the copy.
 
 export type RevealKind =
-  | 'note' // grateful/funny "note from daily.dev" card
-  | 'roast' // "get roasted"
+  | 'note' // grateful/funny "note from daily.dev" card (joke + fallback)
   | 'mascotHug' // "picture with Patchy"
-  | 'trivia' // scratch-to-reveal secret about daily.dev
+  | 'trivia' // scratch-to-reveal fact about daily.dev
   | 'cores' // parameterized by amount
   | 'plus' // parameterized by duration
-  | 'call' // a 1:1 with the team
-  | 'swagDiscount' // parameterized by percent
+  | 'swagDiscount' // store discount, parameterized by percent
   | 'suggestCause' // right to nominate a cause
-  | 'council' // seat in the private Slack
-  | 'privilege'; // generic access/prestige perk
+  | 'council'; // seat in the private Slack
 
 export interface RewardReveal {
   kind: RevealKind;
@@ -35,125 +25,39 @@ export interface RewardReveal {
   // note: rubber-stamp word + a big sticker emoji.
   stamp?: string;
   emoji?: string;
-  // trivia: the single secret revealed at this level.
+  // trivia: the single fact revealed on the scratch card.
   fact?: string;
-  // roast: canned roast text (backend-generated in the real flow).
-  roastText?: string;
   // cores: how many.
   amount?: number;
   // plus: duration label ("1 week", "1 year").
   duration?: string;
-  // swag: discount percent.
+  // swagDiscount: discount percent.
   percent?: number;
-  // council: the private channel.
-  channel?: string;
-  // an anchor illustration where one helps.
+  // an anchor illustration where one helps (e.g. Patchy).
   image?: string;
 }
 
-// The devil-emoji art the Roast page already uses.
-const ROAST_EMOJI_IMAGE =
-  'https://media.daily.dev/image/upload/s--bLTH_SfU--/f_auto/v1707242870/public/Roast-emoji.png.png';
-
-// Placeholder roast copy. In the live flow this is generated server-side from
-// the contributor's reading history; kept here so the reveal is demoable behind
-// the flag until that endpoint exists.
-const PLACEHOLDER_ROAST_TEXT =
-  'Your profile says "senior engineer." Your bookmarks say "saved 400 articles, opened 3." You star repos the way other people hoard tote bags: great intentions, zero follow-through. You have named three different side projects "final" and shipped precisely zero of them. You have strong opinions about tabs versus spaces but none about your unit tests, which do not exist. You came here to donate to a good cause, got distracted by the feed for 45 minutes, and called it "research." We see all of it. And honestly? We funded a cause anyway. You are still one of the good ones.';
-
-// The pool of secrets — one is revealed per trivia level (picked deterministically
-// per tier below). Org rules: brand stays lowercase, never an explicit user count.
-const TRIVIA_FACTS: ReadonlyArray<string> = [
-  'daily.dev began as a browser extension that took over your new-tab page.',
-  'The mascot is a dog named Patchy. He does not, and will not, fetch.',
-  'The color palette is food-themed. There is genuinely a shade called "bacon".',
-  'The whole product runs on one belief: your feed should respect your time.',
-  'Millions of developers open daily.dev to start the day. You help fund where that goes.',
-];
-
-// Slugs the seeded reward tiers align their ids to, so the bespoke reveals can
-// be matched without a backend discriminator. Adding a reward here (or aligning
-// a tier id to one) is all engineering needs to wire a new payoff.
-export const RevealSlug = {
-  Roast: 'roast',
-  PatchyPicture: 'picture-with-patchy',
-  Secret: 'daily-dev-secret',
-  Swag: 'swag-discount',
-  SuggestCause: 'suggest-a-cause',
-  Council: 'council',
-} as const;
-
-const PRESETS: Record<string, RewardReveal> = {
-  [RevealSlug.Roast]: {
-    kind: 'roast',
-    headline: 'Brace yourself.',
-    body: 'Built from your reading history. You asked for this.',
-    image: ROAST_EMOJI_IMAGE,
-    roastText: PLACEHOLDER_ROAST_TEXT,
-  },
-  [RevealSlug.PatchyPicture]: {
-    kind: 'mascotHug',
-    headline: "Patchy's got you.",
-    body: 'Save it, post it, make it your PFP. Patchy already signed the model release.',
-    image: cloudinaryCharmInviteFriends,
-  },
-  [RevealSlug.Secret]: {
-    kind: 'trivia',
-    headline: 'A secret, unlocked.',
-    body: 'Scratch the card to reveal it.',
-    // `fact` is filled in per tier by resolveRewardReveal so different secret
-    // levels reveal different facts.
-  },
-  [RevealSlug.Swag]: {
-    kind: 'swagDiscount',
-    headline: 'A little surprise is waiting.',
-    body: "You've unlocked a contributor reward. Open the gift to see what's inside.",
-    percent: 50,
-  },
-  [RevealSlug.SuggestCause]: {
-    kind: 'suggestCause',
-    headline: 'You can suggest causes.',
-    body: 'Nominate a nonprofit or open-source fund. If it fits, it joins the causes everyone can donate to.',
-  },
-  [RevealSlug.Council]: {
-    kind: 'council',
-    headline: 'Welcome to the Council.',
-    body: "This is our internal Slack. You've got a seat next to the daily.dev team, in the same channels where we decide what to build next.",
-    channel: '#council',
-  },
+// Format a Plus grant's day count into the human label the reveal shows.
+const formatPlusDuration = (days?: number): string | undefined => {
+  if (!days) {
+    return undefined;
+  }
+  const units: ReadonlyArray<[number, string]> = [
+    [365, 'year'],
+    [30, 'month'],
+    [7, 'week'],
+    [1, 'day'],
+  ];
+  const [size, label] = units.find(([unit]) => days % unit === 0) ?? [1, 'day'];
+  const count = days / size;
+  return `${count} ${label}${count > 1 ? 's' : ''}`;
 };
 
-// Pull the leading number out of a reward title like "1,000 Cores" so the Cores
-// reveal can size its coin art and count-up. Falls back to a sensible default.
-const parseAmount = (title: string, fallback: number): number => {
-  const match = title.replace(/,/g, '').match(/\d+/);
-  return match ? Number(match[0]) : fallback;
-};
-
-// Pull a human duration ("1 week", "1 year", "3-month") out of a Plus reward
-// title — the number and unit may be separated by spaces, a hyphen, or nothing.
-const parseDuration = (title: string): string | undefined => {
-  const match = title.match(/\d+[\s-]*(day|week|month|year)s?/i);
-  return match?.[0];
-};
-
-// Resolve the reveal for a reward tier. Bespoke presets win (matched by tier
-// id/slug); everything else derives from the coarse reward type, with the
-// tier's own title/description as the copy.
+// Resolve the reveal for a claimed reward tier from its type + metadata. `note`
+// is the safe fallback for jokes and any unmapped type.
 export const resolveRewardReveal = (
   reward: ContributionRewardTier,
 ): RewardReveal => {
-  const preset = PRESETS[reward.id];
-  if (preset) {
-    if (preset.kind === 'trivia') {
-      // Pick a fact deterministically from the tier so different secret levels
-      // reveal different facts (and it stays stable across re-renders).
-      const index = reward.thresholdPoints % TRIVIA_FACTS.length;
-      return { ...preset, fact: TRIVIA_FACTS[index] };
-    }
-    return preset;
-  }
-
   const body =
     reward.description ?? 'A little something from us for backing the causes.';
 
@@ -161,30 +65,47 @@ export const resolveRewardReveal = (
     case ContributionRewardType.Cores:
       return {
         kind: 'cores',
-        amount: parseAmount(reward.title, 500),
+        amount: reward.metadata.amount,
         headline: `+${reward.title}, landed.`,
         body: 'Yours to spend across daily.dev. Keep them coming.',
       };
     case ContributionRewardType.PlusDays:
       return {
         kind: 'plus',
-        duration: parseDuration(reward.title),
+        duration: formatPlusDuration(reward.metadata.days),
         headline: 'Plus, unlocked.',
         body: 'Ad-free, custom feeds, the works. Starts the moment you claim.',
       };
-    case ContributionRewardType.Call:
+    case ContributionRewardType.StoreDiscount:
       return {
-        kind: 'call',
-        headline: reward.title,
-        body,
-        image: cloudinaryCharm404,
+        kind: 'swagDiscount',
+        percent: reward.metadata.percent,
+        headline: 'A little surprise is waiting.',
+        body: "You've unlocked a contributor discount. Open the gift to see what's inside.",
       };
-    case ContributionRewardType.Privilege:
-      return { kind: 'privilege', headline: reward.title, body };
+    case ContributionRewardType.PatchyPicture:
+      return {
+        kind: 'mascotHug',
+        headline: "Patchy's got you.",
+        body: 'Save it, post it, make it your PFP. Patchy already signed the model release.',
+        image: cloudinaryCharmInviteFriends,
+      };
+    case ContributionRewardType.Trivia:
+      return {
+        kind: 'trivia',
+        headline: reward.title,
+        body: 'Scratch the card to reveal it.',
+        fact: reward.description ?? undefined,
+      };
+    case ContributionRewardType.SuggestCauses:
+      return { kind: 'suggestCause', headline: reward.title, body };
+    case ContributionRewardType.Council:
+      return { kind: 'council', headline: reward.title, body };
+    case ContributionRewardType.Joke:
     case ContributionRewardType.Custom:
     default:
       // A grateful/funny "note from daily.dev" — the safe, always-available
-      // payoff for a custom reward with no bespoke preset.
+      // payoff for a joke reward or any unmapped type.
       return {
         kind: 'note',
         emoji: '💛',

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -124,6 +124,7 @@ export const CONTRIBUTION_ACTIONS_QUERY = `
           description
           thresholdPoints
           rewardType
+          metadata
         }
       }
     }

--- a/packages/shared/src/features/giveback/hooks/useGivebackContribution.spec.tsx
+++ b/packages/shared/src/features/giveback/hooks/useGivebackContribution.spec.tsx
@@ -21,6 +21,7 @@ const tier = (id: string, thresholdPoints: number) => ({
   description: null,
   thresholdPoints,
   rewardType: ContributionRewardType.Custom,
+  metadata: {},
 });
 
 const setStatus = (userPoints: number | null, isPending = false) =>

--- a/packages/shared/src/features/giveback/types.ts
+++ b/packages/shared/src/features/giveback/types.ts
@@ -79,13 +79,29 @@ export interface ContributionCauseCategoryBreakdown {
   points: number;
 }
 
-// The kind of perk a reward tier grants, used to pick the roadmap node's icon.
+// The kind of perk a reward tier grants. Drives both the roadmap node's icon and
+// the claim reveal (see `resolveRewardReveal`). Mirrors the daily-api enum.
 export enum ContributionRewardType {
   Cores = 'cores',
   PlusDays = 'plus_days',
+  StoreDiscount = 'store_discount',
+  SuggestCauses = 'suggest_causes',
+  Council = 'council',
+  PatchyPicture = 'patchy_picture',
+  Joke = 'joke',
+  Trivia = 'trivia',
   Call = 'call',
   Privilege = 'privilege',
   Custom = 'custom',
+}
+
+// Per-type reward parameters carried on the tier's `metadata` jsonb. Only the
+// grant/reveal-driving fields are typed; each is present only for its reward
+// type (amount → cores, days → plus_days, percent → store_discount).
+export interface ContributionRewardMetadata {
+  amount?: number;
+  days?: number;
+  percent?: number;
 }
 
 // A milestone reward unlocked once a contributor's points cross its threshold.
@@ -97,6 +113,7 @@ export interface ContributionRewardTier {
   description: string | null;
   thresholdPoints: number;
   rewardType: ContributionRewardType;
+  metadata: ContributionRewardMetadata;
 }
 
 // Review outcome for a submitted action. A fresh submission lands `flagged`

--- a/packages/storybook/stories/features/giveback/GivebackRewardReveal.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackRewardReveal.stories.tsx
@@ -8,10 +8,7 @@ import {
   RevealSurface,
   RewardRevealContent,
 } from '@dailydotdev/shared/src/features/giveback/components/rewards/GivebackRewardReveal';
-import {
-  resolveRewardReveal,
-  RevealSlug,
-} from '@dailydotdev/shared/src/features/giveback/components/rewards/rewardReveal';
+import { resolveRewardReveal } from '@dailydotdev/shared/src/features/giveback/components/rewards/rewardReveal';
 import { GivebackFoundingAward } from '@dailydotdev/shared/src/features/giveback/components/rewards/GivebackFoundingAward';
 import { FlexCol } from '@dailydotdev/shared/src/components/utilities';
 import {
@@ -29,95 +26,105 @@ import { MOCK_USER, withGiveback } from './giveback.mocks';
 
 const user = MOCK_USER as unknown as LoggedUser;
 
-// Sample reward tiers, one per reveal. Bespoke reveals are matched by the tier
-// id (see `RevealSlug`); the rest derive from the reward type + copy.
+// Sample reward tiers, one per reveal. Each resolves from its reward type and
+// per-type metadata (see `resolveRewardReveal`).
 const tier = (
   id: string,
   rewardType: ContributionRewardType,
   title: string,
-  description: string | null = null,
+  {
+    description = null,
+    metadata = {},
+  }: Partial<Pick<ContributionRewardTier, 'description' | 'metadata'>> = {},
 ): ContributionRewardTier => ({
   id,
   title,
   description,
   thresholdPoints: 100,
   rewardType,
+  metadata,
 });
 
-const SAMPLE_TIERS: ReadonlyArray<{ label: string; tier: ContributionRewardTier }> =
-  [
-    {
-      label: 'Custom note',
-      tier: tier(
-        'parents-proud',
-        ContributionRewardType.Custom,
-        'Your parents will be proud of you.',
-        'You turned everyday scrolling into real donations. Somewhere, a parent is telling a neighbor about you right now.',
-      ),
-    },
-    {
-      label: 'Roast',
-      tier: tier(RevealSlug.Roast, ContributionRewardType.Custom, 'Get roasted'),
-    },
-    {
-      label: 'Picture with Patchy',
-      tier: tier(
-        RevealSlug.PatchyPicture,
-        ContributionRewardType.Custom,
-        'Picture with Patchy',
-      ),
-    },
-    {
-      label: 'daily.dev secret',
-      tier: tier(RevealSlug.Secret, ContributionRewardType.Custom, 'daily.dev secret'),
-    },
-    {
-      label: 'Cores',
-      tier: tier('cores-1000', ContributionRewardType.Cores, '1,000 Cores'),
-    },
-    {
-      label: 'Plus',
-      tier: tier('plus-1-year', ContributionRewardType.PlusDays, '1 year of Plus'),
-    },
-    {
-      label: 'Call with the team',
-      tier: tier(
-        'team-call',
-        ContributionRewardType.Call,
-        'A call with the team',
-        'Shape the product with a 1:1.',
-      ),
-    },
-    {
-      label: 'Swag discount',
-      tier: tier(
-        RevealSlug.Swag,
-        ContributionRewardType.Custom,
-        '50% off the swag store',
-      ),
-    },
-    {
-      label: 'Suggest a cause',
-      tier: tier(
-        RevealSlug.SuggestCause,
-        ContributionRewardType.Privilege,
-        'Suggest a cause',
-      ),
-    },
-    {
-      label: 'Council',
-      tier: tier(RevealSlug.Council, ContributionRewardType.Privilege, 'daily.dev Council'),
-    },
-    {
-      label: 'Privilege',
-      tier: tier(
-        'founding-badge',
-        ContributionRewardType.Privilege,
-        'Founding contributor badge',
-        'A permanent mark on your profile.',
-      ),
-    },
-  ];
+const SAMPLE_TIERS: ReadonlyArray<{
+  label: string;
+  tier: ContributionRewardTier;
+}> = [
+  {
+    label: 'Joke note',
+    tier: tier(
+      'parents-proud',
+      ContributionRewardType.Joke,
+      'Your parents will be proud of you.',
+      {
+        description:
+          'You turned everyday scrolling into real donations. Somewhere, a parent is telling a neighbor about you right now.',
+      },
+    ),
+  },
+  {
+    label: 'Picture with Patchy',
+    tier: tier(
+      'picture-with-patchy',
+      ContributionRewardType.PatchyPicture,
+      'Picture with Patchy',
+    ),
+  },
+  {
+    label: 'daily.dev secret',
+    tier: tier(
+      'daily-dev-secret',
+      ContributionRewardType.Trivia,
+      'A secret, unlocked',
+      {
+        description:
+          'The color palette is food-themed. There is genuinely a shade called "bacon".',
+      },
+    ),
+  },
+  {
+    label: 'Cores',
+    tier: tier('cores-1000', ContributionRewardType.Cores, '1,000 Cores', {
+      metadata: { amount: 1000 },
+    }),
+  },
+  {
+    label: 'Plus',
+    tier: tier(
+      'plus-1-year',
+      ContributionRewardType.PlusDays,
+      '1 year of Plus',
+      { metadata: { days: 365 } },
+    ),
+  },
+  {
+    label: 'Store discount',
+    tier: tier(
+      'store-discount',
+      ContributionRewardType.StoreDiscount,
+      '50% off the swag store',
+      { metadata: { percent: 50 } },
+    ),
+  },
+  {
+    label: 'Suggest a cause',
+    tier: tier(
+      'suggest-a-cause',
+      ContributionRewardType.SuggestCauses,
+      'Suggest a cause',
+      {
+        description:
+          'Nominate a nonprofit or open-source fund. If it fits, it joins the causes everyone can donate to.',
+      },
+    ),
+  },
+  {
+    label: 'Council',
+    tier: tier('council', ContributionRewardType.Council, 'daily.dev Council', {
+      description:
+        'A seat next to the daily.dev team, in the channels where we decide what to build next.',
+    }),
+  },
+];
 
 const meta: Meta = {
   title: 'Features/Giveback/Reward reveals',
@@ -146,7 +153,11 @@ const RevealCard = ({
 }): ReactElement => (
   <RevealSurface>
     <div className="px-6 py-8">
-      <RewardRevealContent reveal={reveal} levelNumber={levelNumber} user={user} />
+      <RewardRevealContent
+        reveal={reveal}
+        levelNumber={levelNumber}
+        user={user}
+      />
     </div>
   </RevealSurface>
 );
@@ -158,7 +169,10 @@ export const Gallery: Story = {
         <Typography tag={TypographyTag.H2} bold type={TypographyType.Title2}>
           Every claim reveal
         </Typography>
-        <Typography type={TypographyType.Callout} color={TypographyColor.Secondary}>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Secondary}
+        >
           The payoff behind each Claim button.
         </Typography>
       </FlexCol>

--- a/packages/storybook/stories/features/giveback/giveback.mocks.tsx
+++ b/packages/storybook/stories/features/giveback/giveback.mocks.tsx
@@ -4,7 +4,10 @@ import type { Decorator } from '@storybook/react-vite';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AuthContextProvider } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
-import { generateQueryKey, RequestKey } from '@dailydotdev/shared/src/lib/query';
+import {
+  generateQueryKey,
+  RequestKey,
+} from '@dailydotdev/shared/src/lib/query';
 import type {
   ContributionAction,
   ContributionActionCategory,
@@ -160,7 +163,9 @@ export const mockCategories = (): ContributionActionCategory[] => [
   { id: 'cat-content', title: 'Content' },
 ];
 
-const action = (overrides: Partial<ContributionAction>): ContributionAction => ({
+const action = (
+  overrides: Partial<ContributionAction>,
+): ContributionAction => ({
   id: 'a-default',
   categoryId: 'cat-content',
   title: 'Action',
@@ -172,6 +177,7 @@ const action = (overrides: Partial<ContributionAction>): ContributionAction => (
     instructions: null,
     externalUrl: null,
     isLoveAction: false,
+    assistType: null,
   },
   cooldownSeconds: null,
   maxPerUser: null,
@@ -193,6 +199,7 @@ export const mockActions = (): ContributionAction[] => [
       instructions: 'Share photos and the event link.',
       externalUrl: null,
       isLoveAction: false,
+      assistType: null,
     },
   }),
   action({
@@ -213,6 +220,7 @@ export const mockActions = (): ContributionAction[] => [
       instructions: null,
       externalUrl: null,
       isLoveAction: false,
+      assistType: null,
     },
   }),
   action({
@@ -226,6 +234,7 @@ export const mockActions = (): ContributionAction[] => [
       instructions: null,
       externalUrl: null,
       isLoveAction: false,
+      assistType: null,
     },
     // An in-review submission so the catalog shows the "in review" state.
     userCompletions: 1,
@@ -267,6 +276,7 @@ export const mockActions = (): ContributionAction[] => [
       instructions: null,
       externalUrl: null,
       isLoveAction: true,
+      assistType: null,
     },
   }),
 ];
@@ -278,6 +288,7 @@ export const mockRewardTiers = (): ContributionRewardTier[] => [
     description: 'Spend them on the daily.dev store.',
     thresholdPoints: 100,
     rewardType: ContributionRewardType.Cores,
+    metadata: { amount: 500 },
   },
   {
     id: 't-plus',
@@ -285,27 +296,31 @@ export const mockRewardTiers = (): ContributionRewardTier[] => [
     description: 'Unlock the full daily.dev experience.',
     thresholdPoints: 250,
     rewardType: ContributionRewardType.PlusDays,
+    metadata: { days: 30 },
   },
   {
-    id: 't-call',
-    title: 'A call with the team',
-    description: 'Shape the product with a 1:1.',
+    id: 't-discount',
+    title: '50% off the swag store',
+    description: 'A contributor-only discount, emailed to you.',
     thresholdPoints: 500,
-    rewardType: ContributionRewardType.Call,
+    rewardType: ContributionRewardType.StoreDiscount,
+    metadata: { percent: 50 },
   },
   {
-    id: 't-privilege',
-    title: 'Founding contributor badge',
-    description: 'A permanent mark on your profile.',
+    id: 't-council',
+    title: 'daily.dev Council',
+    description: 'A seat next to the team, where we decide what to build.',
     thresholdPoints: 1000,
-    rewardType: ContributionRewardType.Privilege,
+    rewardType: ContributionRewardType.Council,
+    metadata: {},
   },
   {
-    id: 't-custom',
-    title: 'Limited-edition swag',
-    description: 'The drop only contributors get.',
+    id: 't-joke',
+    title: 'Your parents will be proud of you.',
+    description: 'You turned everyday scrolling into real donations.',
     thresholdPoints: 2000,
-    rewardType: ContributionRewardType.Custom,
+    rewardType: ContributionRewardType.Joke,
+    metadata: {},
   },
 ];
 
@@ -354,7 +369,8 @@ const GivebackProviders = ({
     client.setQueryData(
       generateQueryKey(RequestKey.ContributionOverview, MOCK_USER),
       {
-        contributionStatus: status ?? mockStatus({ currentCycleTargetPoints: 0 }),
+        contributionStatus:
+          status ?? mockStatus({ currentCycleTargetPoints: 0 }),
         contributionSponsors: {
           pageInfo: { hasNextPage: false, endCursor: null },
           edges: sponsors.map((node) => ({ node })),


### PR DESCRIPTION
## Changes

Stacked on #6289. Replaces the reveal-matching hacks in that PR with the real backend contract now that daily-api (dailydotdev/daily-api#3985) sends explicit reward types + per-type `metadata`.

- `resolveRewardReveal` is now a `rewardType`-driven switch reading `metadata` (`amount`/`days`/`percent`) instead of matching bespoke reveals by tier-id slug and regex-parsing the title.
- Adds the new reward types to `ContributionRewardType` and selects `metadata` in the reward-tiers query.
- Drops the `roast`, `call` and `privilege` reveals + their placeholder copy (`RevealSlug`, `TRIVIA_FACTS`, canned roast text) — none map to a shipping reward.

Each of the 8 rewards maps to an existing reveal component: cores, plus, store discount (`swagDiscount`), suggest-a-cause, council, picture-with-Patchy (`mascotHug`), joke (`note`), trivia.

## Notes for reviewers
- Treat #6289 as a designer draft — this PR is the adjustment layer. The suggest-a-cause *submission* flow and founding-award live data remain follow-ups.
- `metadata` flows through the shared `useContributionActions` query untouched (nodes map directly).

## Manual testing
- `pnpm --filter @dailydotdev/shared test src/features/giveback` — 72 passing (resolver spec rewritten to the metadata contract).
- Strict typecheck-changed + eslint clean; storybook gallery updated to the new taxonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-giveback-reward-contract.preview.app.daily.dev