### PR TITLE
fix: don't fetch dailyHeadlines until onboarding is complete

### DIFF
--- a/packages/shared/src/features/daily/CoverTopics.tsx
+++ b/packages/shared/src/features/daily/CoverTopics.tsx
@@ -37,6 +37,7 @@ import {
   channelConfigurationsQueryOptions,
   dailyHeadlinesQueryOptions,
 } from '../../graphql/highlights';
+import { useOnboardingActions } from '../../hooks/auth/useOnboardingActions';
 import { HeadlinesSettingsModal } from './HeadlinesSettingsModal';
 import { DailyPostVotes } from './DailyPostVotes';
 import type { UpdateDailyPost } from './optimisticMutations';
@@ -311,7 +312,11 @@ const HeadlineRowSkeleton = (): ReactElement => (
 export const CoverTopics = (): ReactElement => {
   const { logEvent } = useLogContext();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const { data, isPending } = useQuery(dailyHeadlinesQueryOptions());
+  const { isOnboardingComplete } = useOnboardingActions();
+  const { data, isPending } = useQuery({
+    ...dailyHeadlinesQueryOptions(),
+    enabled: isOnboardingComplete,
+  });
   const { data: channelData } = useQuery(channelConfigurationsQueryOptions());
   const [getHeadlines, setHeadlines] = useUpdateQuery(
     dailyHeadlinesQueryOptions(),


### PR DESCRIPTION
## Problem

The `dailyHeadlines` GraphQL query seeds channel digest follows from the user's onboarding tags on the backend (`seedHeadlineChannelsForUser`). We found a production user where the query fired ~0.5s *before* their onboarding tags were persisted, so the backend resolved zero tags and permanently marked them as backfilled with no follows.

## Fix

Gate the `dailyHeadlines` fetch in `CoverTopics` behind `isOnboardingComplete` (from `useOnboardingActions`), so the query doesn't fire mid-onboarding. While disabled, the existing skeleton placeholders render as before. `CoverTopics` is the only place this query is fetched.

Companion backend fix (stops marking users backfilled on an empty resolve, so affected users self-heal on the next call): dailydotdev/daily-api#3991

### Preview domain
https://fix-gate-daily-headlines-on-onbo.preview.app.daily.dev