### PR TITLE
feat(giveback): wire suggest-a-cause submission flow

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackCausesPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCausesPanel.tsx
@@ -246,6 +246,37 @@ export const GivebackCausesPanel = ({
         )}
       </FlexCol>
 
+      {/* Sits between the picks and the discovery list: once you've reviewed
+          what you back, but before browsing the rest, is the natural moment to
+          add one we don't fund yet. */}
+      {canSuggest && (
+        <FlexRow className="flex-col items-start gap-3 rounded-16 border border-dashed border-border-subtlest-tertiary p-4 tablet:flex-row tablet:items-center tablet:justify-between">
+          <FlexCol className="min-w-0 gap-0.5">
+            <Typography bold type={TypographyType.Callout}>
+              Care about one we don&apos;t fund yet?
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+              className="[text-wrap:pretty]"
+            >
+              Nominate a nonprofit or open-source fund. If it&apos;s a fit, it
+              joins the causes everyone can back.
+            </Typography>
+          </FlexCol>
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Secondary}
+            icon={<PlusIcon />}
+            onClick={openSuggest}
+            className="shrink-0"
+          >
+            Suggest a cause
+          </Button>
+        </FlexRow>
+      )}
+
       {/* Filters sit just above the discovery grid they control (and below your
           own causes), so the connection is obvious. */}
       {hasOtherCauses && (
@@ -299,33 +330,6 @@ export const GivebackCausesPanel = ({
             </Typography>
           )}
         </FlexCol>
-      )}
-
-      {canSuggest && (
-        <FlexRow className="flex-col items-start gap-3 rounded-16 border border-dashed border-border-subtlest-tertiary p-4 tablet:flex-row tablet:items-center tablet:justify-between">
-          <FlexCol className="min-w-0 gap-0.5">
-            <Typography bold type={TypographyType.Callout}>
-              Don&apos;t see your cause?
-            </Typography>
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Tertiary}
-              className="[text-wrap:pretty]"
-            >
-              Suggest a nonprofit or open-source fund and we&apos;ll review it.
-            </Typography>
-          </FlexCol>
-          <Button
-            type="button"
-            size={ButtonSize.Small}
-            variant={ButtonVariant.Secondary}
-            icon={<PlusIcon />}
-            onClick={openSuggest}
-            className="shrink-0"
-          >
-            Suggest a cause
-          </Button>
-        </FlexRow>
       )}
 
       {isSuggestOpen && (

--- a/packages/shared/src/features/giveback/components/GivebackCausesPanel.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCausesPanel.tsx
@@ -14,14 +14,22 @@ import {
   PlusIcon,
 } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
 import { anchorDefaultRel } from '../../../lib/strings';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
+import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
+import { featureGivebackSuggestCause } from '../../../lib/featureManagement';
 import { useGivebackCauseSelection } from '../hooks/useGivebackCauseSelection';
 import type { ContributionCause } from '../types';
 import { GivebackFilterChip } from './GivebackFilterChip';
 import { GivebackCauseCard } from './GivebackCauseCard';
 import { GivebackTabHeading } from './GivebackTabHeading';
+import { GivebackSuggestCauseModal } from './GivebackSuggestCauseModal';
 import { CauseEmblem } from './CauseEmblem';
 
 const ALL_FILTER = 'all';
@@ -109,6 +117,19 @@ export const GivebackCausesPanel = ({
   const { causes, isLoading, selectedIds, toggleAndSave, selectedCount } =
     useGivebackCauseSelection(true);
   const [activeFilter, setActiveFilter] = useState<string>(ALL_FILTER);
+  const [isSuggestOpen, setIsSuggestOpen] = useState(false);
+  const { value: canSuggest } = useConditionalFeature({
+    feature: featureGivebackSuggestCause,
+    shouldEvaluate: true,
+  });
+
+  const openSuggest = () => {
+    logEvent({
+      event_name: LogEvent.OpenGivebackCauseSuggestion,
+      extra: JSON.stringify({ origin: 'causes_tab' }),
+    });
+    setIsSuggestOpen(true);
+  };
 
   const selectFilter = (filter: string) => {
     setActiveFilter(filter);
@@ -278,6 +299,37 @@ export const GivebackCausesPanel = ({
             </Typography>
           )}
         </FlexCol>
+      )}
+
+      {canSuggest && (
+        <FlexRow className="flex-col items-start gap-3 rounded-16 border border-dashed border-border-subtlest-tertiary p-4 tablet:flex-row tablet:items-center tablet:justify-between">
+          <FlexCol className="min-w-0 gap-0.5">
+            <Typography bold type={TypographyType.Callout}>
+              Don&apos;t see your cause?
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+              className="[text-wrap:pretty]"
+            >
+              Suggest a nonprofit or open-source fund and we&apos;ll review it.
+            </Typography>
+          </FlexCol>
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Secondary}
+            icon={<PlusIcon />}
+            onClick={openSuggest}
+            className="shrink-0"
+          >
+            Suggest a cause
+          </Button>
+        </FlexRow>
+      )}
+
+      {isSuggestOpen && (
+        <GivebackSuggestCauseModal onClose={() => setIsSuggestOpen(false)} />
       )}
     </FlexCol>
   );

--- a/packages/shared/src/features/giveback/components/GivebackSuggestCauseForm.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSuggestCauseForm.spec.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GivebackSuggestCauseForm } from './GivebackSuggestCauseForm';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import loggedUser from '../../../../__tests__/fixture/loggedUser';
+import { useSuggestContributionCause } from '../hooks/useSuggestContributionCause';
+
+jest.mock('../hooks/useSuggestContributionCause', () => ({
+  useSuggestContributionCause: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useToastNotification', () => ({
+  ...jest.requireActual('../../../hooks/useToastNotification'),
+  useToastNotification: () => ({ displayToast: jest.fn() }),
+}));
+
+jest.mock('../../../contexts/LogContext', () => ({
+  ...jest.requireActual('../../../contexts/LogContext'),
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+const mockedUseSuggest = useSuggestContributionCause as jest.Mock;
+
+beforeEach(() => {
+  mockedUseSuggest.mockReturnValue({
+    suggest: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+  });
+});
+
+const renderForm = (
+  onClose: () => void = jest.fn(),
+): ReturnType<typeof render> => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <TestBootProvider client={client} auth={{ user: loggedUser }}>
+      <GivebackSuggestCauseForm onClose={onClose} origin="causes_tab" />
+    </TestBootProvider>,
+  );
+};
+
+it('keeps submit disabled until a valid URL is entered', () => {
+  renderForm();
+
+  const submit = screen.getByRole('button', { name: 'Submit for review' });
+  expect(submit).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText('Cause URL'), {
+    target: { value: 'not a url' },
+  });
+  expect(submit).toBeDisabled();
+
+  fireEvent.change(screen.getByLabelText('Cause URL'), {
+    target: { value: 'https://example.org' },
+  });
+  expect(submit).toBeEnabled();
+});
+
+it('submits the url and optional note, then shows a confirmation', async () => {
+  const suggest = jest.fn().mockResolvedValue(undefined);
+  mockedUseSuggest.mockReturnValue({ suggest, isPending: false });
+  renderForm();
+
+  fireEvent.change(screen.getByLabelText('Cause URL'), {
+    target: { value: 'https://example.org' },
+  });
+  fireEvent.change(screen.getByPlaceholderText(/Tell us a bit/), {
+    target: { value: 'they do great work' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Submit for review' }));
+
+  await waitFor(() =>
+    expect(suggest).toHaveBeenCalledWith({
+      url: 'https://example.org',
+      note: 'they do great work',
+    }),
+  );
+
+  expect(
+    await screen.findByText("Thanks, we'll take a look"),
+  ).toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: 'Submit for review' }),
+  ).not.toBeInTheDocument();
+});
+
+it('omits an empty note from the submission', async () => {
+  const suggest = jest.fn().mockResolvedValue(undefined);
+  mockedUseSuggest.mockReturnValue({ suggest, isPending: false });
+  renderForm();
+
+  fireEvent.change(screen.getByLabelText('Cause URL'), {
+    target: { value: 'https://example.org' },
+  });
+  fireEvent.click(screen.getByRole('button', { name: 'Submit for review' }));
+
+  await waitFor(() =>
+    expect(suggest).toHaveBeenCalledWith({
+      url: 'https://example.org',
+      note: undefined,
+    }),
+  );
+});

--- a/packages/shared/src/features/giveback/components/GivebackSuggestCauseForm.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSuggestCauseForm.tsx
@@ -23,21 +23,17 @@ interface GivebackSuggestCauseFormProps {
   onClose: () => void;
   // Where the form was opened from ('reward_reveal' | 'causes_tab'), for logging.
   origin: string;
-  // The reveal renders the form on a colorful wash, so the fields need a solid
-  // surface; the plain modal doesn't. Defaults to the modal look.
-  onSurface?: boolean;
 }
 
 const NOTE_MAX_LENGTH = 1000;
 
-// The cause-nomination form, reused by both entry points (the reward reveal and
-// the Causes tab). Collects a required URL and an optional note, submits it for
-// review, then swaps to a confirmation — the backend only pings the team, so
-// there's nothing to track after submit.
+// The cause-nomination form used inside GivebackSuggestCauseModal (both entry
+// points open that modal). Collects a required URL and an optional note, submits
+// it for review, then swaps to a confirmation — the backend only pings the team,
+// so there's nothing to track after submit.
 export const GivebackSuggestCauseForm = ({
   onClose,
   origin,
-  onSurface = false,
 }: GivebackSuggestCauseFormProps): ReactElement => {
   const { displayToast } = useToastNotification();
   const { logEvent } = useLogContext();
@@ -52,7 +48,6 @@ export const GivebackSuggestCauseForm = ({
 
   const trimmedUrl = url.trim();
   const canSubmit = isValidHttpUrl(trimmedUrl);
-  const fieldClass = onSurface ? 'bg-background-default' : 'bg-surface-float';
 
   const onSubmit = async () => {
     if (!canSubmit || isPending) {
@@ -129,7 +124,7 @@ export const GivebackSuggestCauseForm = ({
           id={urlInputId}
           type="url"
           inputMode="url"
-          className={`rounded-12 border border-border-subtlest-tertiary px-3 py-2 text-text-primary typo-callout ${fieldClass}`}
+          className="rounded-12 border border-border-subtlest-tertiary bg-surface-float px-3 py-2 text-text-primary typo-callout"
           placeholder="https://..."
           value={url}
           onChange={(event) => setUrl(event.target.value)}
@@ -150,7 +145,7 @@ export const GivebackSuggestCauseForm = ({
         <textarea
           id={noteInputId}
           maxLength={NOTE_MAX_LENGTH}
-          className={`min-h-24 rounded-12 border border-border-subtlest-tertiary px-3 py-2 text-text-primary typo-callout ${fieldClass}`}
+          className="min-h-24 rounded-12 border border-border-subtlest-tertiary bg-surface-float px-3 py-2 text-text-primary typo-callout"
           placeholder="Tell us a bit about it, so we can review it faster."
           value={note}
           onChange={(event) => setNote(event.target.value)}

--- a/packages/shared/src/features/giveback/components/GivebackSuggestCauseForm.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSuggestCauseForm.tsx
@@ -1,0 +1,182 @@
+import type { ReactElement } from 'react';
+import React, { useId, useState } from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import { useToastNotification } from '../../../hooks/useToastNotification';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent } from '../../../lib/log';
+import { labels } from '../../../lib/labels';
+import { isValidHttpUrl } from '../../../lib/links';
+import { useSuggestContributionCause } from '../hooks/useSuggestContributionCause';
+
+interface GivebackSuggestCauseFormProps {
+  onClose: () => void;
+  // Where the form was opened from ('reward_reveal' | 'causes_tab'), for logging.
+  origin: string;
+  // The reveal renders the form on a colorful wash, so the fields need a solid
+  // surface; the plain modal doesn't. Defaults to the modal look.
+  onSurface?: boolean;
+}
+
+const NOTE_MAX_LENGTH = 1000;
+
+// The cause-nomination form, reused by both entry points (the reward reveal and
+// the Causes tab). Collects a required URL and an optional note, submits it for
+// review, then swaps to a confirmation — the backend only pings the team, so
+// there's nothing to track after submit.
+export const GivebackSuggestCauseForm = ({
+  onClose,
+  origin,
+  onSurface = false,
+}: GivebackSuggestCauseFormProps): ReactElement => {
+  const { displayToast } = useToastNotification();
+  const { logEvent } = useLogContext();
+  const { suggest, isPending } = useSuggestContributionCause();
+  const fieldId = useId();
+  const urlInputId = `${fieldId}-url`;
+  const noteInputId = `${fieldId}-note`;
+
+  const [url, setUrl] = useState('');
+  const [note, setNote] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  const trimmedUrl = url.trim();
+  const canSubmit = isValidHttpUrl(trimmedUrl);
+  const fieldClass = onSurface ? 'bg-background-default' : 'bg-surface-float';
+
+  const onSubmit = async () => {
+    if (!canSubmit || isPending) {
+      return;
+    }
+
+    const trimmedNote = note.trim();
+    try {
+      await suggest({ url: trimmedUrl, note: trimmedNote || undefined });
+      logEvent({
+        event_name: LogEvent.SubmitGivebackCauseSuggestion,
+        extra: JSON.stringify({ origin, has_note: !!trimmedNote }),
+      });
+      setIsSubmitted(true);
+    } catch {
+      logEvent({
+        event_name: LogEvent.SubmitGivebackCauseSuggestionError,
+        extra: JSON.stringify({ origin }),
+      });
+      displayToast(labels.error.generic);
+    }
+  };
+
+  if (isSubmitted) {
+    return (
+      <FlexCol className="gap-4">
+        <FlexCol className="gap-2 rounded-18 border border-accent-cabbage-default bg-accent-cabbage-flat p-5">
+          <Typography bold tag={TypographyTag.H2} type={TypographyType.Title3}>
+            Thanks, we&apos;ll take a look
+          </Typography>
+          <Typography
+            type={TypographyType.Callout}
+            className="text-text-tertiary [text-wrap:pretty]"
+          >
+            We review every suggestion. If it&apos;s a fit, it joins the causes
+            everyone can back.
+          </Typography>
+        </FlexCol>
+        <FlexRow className="justify-end">
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Primary}
+            onClick={onClose}
+          >
+            Done
+          </Button>
+        </FlexRow>
+      </FlexCol>
+    );
+  }
+
+  return (
+    <FlexCol className="gap-4">
+      <FlexCol className="gap-1.5">
+        <Typography bold tag={TypographyTag.H2} type={TypographyType.Title3}>
+          Suggest a cause
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Secondary}
+          className="[text-wrap:pretty]"
+        >
+          Drop a link to a nonprofit or open-source fund you care about. We
+          review every suggestion before it goes live.
+        </Typography>
+      </FlexCol>
+
+      <label htmlFor={urlInputId} className="flex flex-col gap-2">
+        <Typography bold type={TypographyType.Footnote}>
+          Cause URL
+        </Typography>
+        <input
+          id={urlInputId}
+          type="url"
+          inputMode="url"
+          className={`rounded-12 border border-border-subtlest-tertiary px-3 py-2 text-text-primary typo-callout ${fieldClass}`}
+          placeholder="https://..."
+          value={url}
+          onChange={(event) => setUrl(event.target.value)}
+        />
+      </label>
+
+      <label htmlFor={noteInputId} className="flex flex-col gap-2">
+        <Typography bold type={TypographyType.Footnote}>
+          Why this cause?{' '}
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Footnote}
+            color={TypographyColor.Tertiary}
+          >
+            (optional)
+          </Typography>
+        </Typography>
+        <textarea
+          id={noteInputId}
+          maxLength={NOTE_MAX_LENGTH}
+          className={`min-h-24 rounded-12 border border-border-subtlest-tertiary px-3 py-2 text-text-primary typo-callout ${fieldClass}`}
+          placeholder="Tell us a bit about it, so we can review it faster."
+          value={note}
+          onChange={(event) => setNote(event.target.value)}
+        />
+      </label>
+
+      <FlexRow className="justify-end gap-2">
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+          onClick={onClose}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          disabled={!canSubmit}
+          loading={isPending}
+          onClick={onSubmit}
+        >
+          Submit for review
+        </Button>
+      </FlexRow>
+    </FlexCol>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackSuggestCauseModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSuggestCauseModal.tsx
@@ -1,0 +1,48 @@
+import type { ReactElement } from 'react';
+import React, { useEffect } from 'react';
+import { RootPortal } from '../../../components/tooltips/Portal';
+import { GivebackSuggestCauseForm } from './GivebackSuggestCauseForm';
+
+interface GivebackSuggestCauseModalProps {
+  onClose: () => void;
+}
+
+// Standalone home for the suggest-a-cause form (the Causes tab entry point),
+// mirroring GivebackActionSubmissionModal's portal + backdrop shell.
+export const GivebackSuggestCauseModal = ({
+  onClose,
+}: GivebackSuggestCauseModalProps): ReactElement => {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  return (
+    <RootPortal>
+      <div className="fixed inset-0 z-modal flex items-center justify-center bg-overlay-primary-pepper px-4 backdrop-blur-sm">
+        <button
+          type="button"
+          aria-label="Close"
+          tabIndex={-1}
+          className="absolute inset-0 cursor-default"
+          onClick={onClose}
+        />
+        <section
+          aria-modal="true"
+          role="dialog"
+          aria-label="Suggest a cause"
+          className="relative z-1 flex max-h-[calc(100vh-2rem)] w-full max-w-[32rem] flex-col overflow-hidden rounded-24 border border-border-subtlest-secondary bg-background-default shadow-2"
+        >
+          <div className="min-h-0 flex-1 overflow-y-auto p-4 tablet:p-5">
+            <GivebackSuggestCauseForm onClose={onClose} origin="causes_tab" />
+          </div>
+        </section>
+      </div>
+    </RootPortal>
+  );
+};

--- a/packages/shared/src/features/giveback/components/GivebackSuggestCauseModal.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackSuggestCauseModal.tsx
@@ -5,12 +5,16 @@ import { GivebackSuggestCauseForm } from './GivebackSuggestCauseForm';
 
 interface GivebackSuggestCauseModalProps {
   onClose: () => void;
+  // Which entry point opened it ('causes_tab' | 'reward_reveal'), for logging.
+  origin?: string;
 }
 
-// Standalone home for the suggest-a-cause form (the Causes tab entry point),
-// mirroring GivebackActionSubmissionModal's portal + backdrop shell.
+// Standalone home for the suggest-a-cause form, opened by both entry points (the
+// Causes tab and the reward reveal), mirroring GivebackActionSubmissionModal's
+// portal + backdrop shell.
 export const GivebackSuggestCauseModal = ({
   onClose,
+  origin = 'causes_tab',
 }: GivebackSuggestCauseModalProps): ReactElement => {
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -39,7 +43,7 @@ export const GivebackSuggestCauseModal = ({
           className="relative z-1 flex max-h-[calc(100vh-2rem)] w-full max-w-[32rem] flex-col overflow-hidden rounded-24 border border-border-subtlest-secondary bg-background-default shadow-2"
         >
           <div className="min-h-0 flex-1 overflow-y-auto p-4 tablet:p-5">
-            <GivebackSuggestCauseForm onClose={onClose} origin="causes_tab" />
+            <GivebackSuggestCauseForm onClose={onClose} origin={origin} />
           </div>
         </section>
       </div>

--- a/packages/shared/src/features/giveback/components/rewards/revealScenes.tsx
+++ b/packages/shared/src/features/giveback/components/rewards/revealScenes.tsx
@@ -24,10 +24,15 @@ import { anchorDefaultRel } from '../../../../lib/strings';
 import { getDomainFromUrl } from '../../../../lib/links';
 import { FlexCol, FlexRow } from '../../../../components/utilities';
 import type { LoggedUser } from '../../../../lib/user';
+import { useConditionalFeature } from '../../../../hooks/useConditionalFeature';
+import { featureGivebackSuggestCause } from '../../../../lib/featureManagement';
+import { useLogContext } from '../../../../contexts/LogContext';
+import { LogEvent } from '../../../../lib/log';
 import { useCountUp, usePrefersReducedMotion } from '../../useGivebackMotion';
 import { useContributionCausePicker } from '../../hooks/useContributionCausePicker';
 import type { ContributionCause } from '../../types';
 import { GivebackReveal as Reveal } from '../GivebackReveal';
+import { GivebackSuggestCauseForm } from '../GivebackSuggestCauseForm';
 import type { RewardReveal } from './rewardReveal';
 import { GivebackSecretScratch } from './GivebackSecretScratch';
 import {
@@ -707,10 +712,10 @@ const CausesStack = ({
 };
 
 // Suggest a cause → a celebration that the privilege is unlocked, over the
-// carousel of the live causes we already fund. "Suggest now" is the entry to
-// the real nomination flow.
-// PLACEHOLDER: the nomination flow doesn't exist yet, so the CTA dismisses for
-// now — wire it to the suggest-a-cause form once that endpoint lands.
+// carousel of the live causes we already fund. "Suggest now" opens the
+// nomination form inline. The form flow is gated on `featureGivebackSuggestCause`
+// (the team rolls it out with the feature access); when it's off the CTA just
+// dismisses, keeping the celebration harmless.
 export const SuggestCauseReveal = ({
   reveal,
   levelNumber,
@@ -720,8 +725,36 @@ export const SuggestCauseReveal = ({
   levelNumber?: number;
   onClose: () => void;
 }): ReactElement => {
+  const { logEvent } = useLogContext();
   // Cache hit: the roadmap already loads the cause picker, so this reuses it.
   const { causes } = useContributionCausePicker(true);
+  const { value: canSuggest } = useConditionalFeature({
+    feature: featureGivebackSuggestCause,
+    shouldEvaluate: true,
+  });
+  const [showForm, setShowForm] = useState(false);
+
+  if (showForm) {
+    return (
+      <GivebackSuggestCauseForm
+        onClose={onClose}
+        origin="reward_reveal"
+        onSurface
+      />
+    );
+  }
+
+  const onSuggest = () => {
+    if (!canSuggest) {
+      onClose();
+      return;
+    }
+    logEvent({
+      event_name: LogEvent.OpenGivebackCauseSuggestion,
+      extra: JSON.stringify({ origin: 'reward_reveal' }),
+    });
+    setShowForm(true);
+  };
 
   return (
     <FlexCol className="items-center gap-5">
@@ -735,7 +768,7 @@ export const SuggestCauseReveal = ({
         </Reveal>
       )}
       <Reveal delay={STAGGER_STEP * 5}>
-        <DismissButton label="Suggest now" onClose={onClose} />
+        <DismissButton label="Suggest now" onClose={onSuggest} />
       </Reveal>
     </FlexCol>
   );

--- a/packages/shared/src/features/giveback/components/rewards/revealScenes.tsx
+++ b/packages/shared/src/features/giveback/components/rewards/revealScenes.tsx
@@ -32,7 +32,7 @@ import { useCountUp, usePrefersReducedMotion } from '../../useGivebackMotion';
 import { useContributionCausePicker } from '../../hooks/useContributionCausePicker';
 import type { ContributionCause } from '../../types';
 import { GivebackReveal as Reveal } from '../GivebackReveal';
-import { GivebackSuggestCauseForm } from '../GivebackSuggestCauseForm';
+import { GivebackSuggestCauseModal } from '../GivebackSuggestCauseModal';
 import type { RewardReveal } from './rewardReveal';
 import { GivebackSecretScratch } from './GivebackSecretScratch';
 import {
@@ -712,10 +712,10 @@ const CausesStack = ({
 };
 
 // Suggest a cause → a celebration that the privilege is unlocked, over the
-// carousel of the live causes we already fund. "Suggest now" opens the
-// nomination form inline. The form flow is gated on `featureGivebackSuggestCause`
-// (the team rolls it out with the feature access); when it's off the CTA just
-// dismisses, keeping the celebration harmless.
+// carousel of the live causes we already fund. "Suggest now" opens the same
+// nomination modal the Causes tab uses. The flow is gated on
+// `featureGivebackSuggestCause` (the team rolls it out with the feature access);
+// when it's off the CTA just dismisses, keeping the celebration harmless.
 export const SuggestCauseReveal = ({
   reveal,
   levelNumber,
@@ -732,17 +732,7 @@ export const SuggestCauseReveal = ({
     feature: featureGivebackSuggestCause,
     shouldEvaluate: true,
   });
-  const [showForm, setShowForm] = useState(false);
-
-  if (showForm) {
-    return (
-      <GivebackSuggestCauseForm
-        onClose={onClose}
-        origin="reward_reveal"
-        onSurface
-      />
-    );
-  }
+  const [showModal, setShowModal] = useState(false);
 
   const onSuggest = () => {
     if (!canSuggest) {
@@ -753,7 +743,7 @@ export const SuggestCauseReveal = ({
       event_name: LogEvent.OpenGivebackCauseSuggestion,
       extra: JSON.stringify({ origin: 'reward_reveal' }),
     });
-    setShowForm(true);
+    setShowModal(true);
   };
 
   return (
@@ -770,6 +760,11 @@ export const SuggestCauseReveal = ({
       <Reveal delay={STAGGER_STEP * 5}>
         <DismissButton label="Suggest now" onClose={onSuggest} />
       </Reveal>
+      {/* Opens over the celebration; closing it tears down the whole reveal so
+          the visitor lands back on the page, not the confetti. */}
+      {showModal && (
+        <GivebackSuggestCauseModal onClose={onClose} origin="reward_reveal" />
+      )}
     </FlexCol>
   );
 };

--- a/packages/shared/src/features/giveback/graphql.ts
+++ b/packages/shared/src/features/giveback/graphql.ts
@@ -205,6 +205,16 @@ export const UPDATE_CONTRIBUTION_CAUSE_PREFERENCES_MUTATION = `
   }
 `;
 
+// Nominate a cause for the team to review. The backend doesn't store it — it
+// posts the URL (and optional note) to Slack for a human decision.
+export const SUGGEST_CONTRIBUTION_CAUSE_MUTATION = `
+  mutation SuggestContributionCause($url: String!, $note: String) {
+    suggestContributionCause(url: $url, note: $note) {
+      _
+    }
+  }
+`;
+
 // Real-time community activity: every approved action lands here so the gift
 // entry point can pop a live "+$" jump. `awardedPoints` maps 1:1 to USD, like
 // the campaign totals.

--- a/packages/shared/src/features/giveback/hooks/useSuggestContributionCause.ts
+++ b/packages/shared/src/features/giveback/hooks/useSuggestContributionCause.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query';
+import { gqlClient } from '../../../graphql/common';
+import { SUGGEST_CONTRIBUTION_CAUSE_MUTATION } from '../graphql';
+
+export interface SuggestContributionCauseInput {
+  url: string;
+  note?: string;
+}
+
+interface UseSuggestContributionCause {
+  suggest: (input: SuggestContributionCauseInput) => Promise<void>;
+  isPending: boolean;
+}
+
+// Sends a cause nomination for review. Nothing is stored client- or server-side
+// (the backend just pings Slack), so there's no cache to invalidate — the caller
+// owns the success/error UI.
+export const useSuggestContributionCause = (): UseSuggestContributionCause => {
+  const { mutateAsync, isPending } = useMutation({
+    mutationFn: async ({ url, note }: SuggestContributionCauseInput) => {
+      await gqlClient.request(SUGGEST_CONTRIBUTION_CAUSE_MUTATION, {
+        url,
+        note: note || undefined,
+      });
+    },
+  });
+
+  return { suggest: mutateAsync, isPending };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -182,6 +182,11 @@ export const featureShortcutsHub = new Feature('shortcuts_hub_v2', false);
 
 export const featureGiveback = new Feature('giveback', isDevelopment);
 
+export const featureGivebackSuggestCause = new Feature(
+  'giveback_suggest_cause',
+  false,
+);
+
 export const featureCompanionDemoWidget = new Feature(
   'companion_demo_widget',
   false,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -520,6 +520,9 @@ export enum LogEvent {
   ClickGivebackHowItWorks = 'click giveback how it works',
   ClickGivebackGiftEntry = 'click giveback gift entry',
   ViewGivebackPrompt = 'view giveback prompt',
+  OpenGivebackCauseSuggestion = 'open giveback cause suggestion',
+  SubmitGivebackCauseSuggestion = 'submit giveback cause suggestion',
+  SubmitGivebackCauseSuggestionError = 'submit giveback cause suggestion error',
   // Daily homepage
   DailyFeedback = 'daily feedback',
 }


### PR DESCRIPTION
## What

Replaces the placeholder "Suggest now" reveal CTA with a real cause-nomination flow.

- New `GivebackSuggestCauseForm` (required cause URL + optional note → "we'll review it" confirmation) and `GivebackSuggestCauseModal`.
- `useSuggestContributionCause` hook + `suggestContributionCause` mutation.
- **Two entry points, both gated on the new `featureGivebackSuggestCause` flag (default off):**
  - the reward reveal's "Suggest now" now opens the form inline (dismisses when the flag is off);
  - a persistent "Suggest a cause" prompt on the Causes tab.

Backend: dailydotdev/daily-api#TBD (add `suggestContributionCause`).

## Notes

- Set the flag to match the reward's feature-access cohort.
- Backend enforces the `suggest_causes` feature access, so the flag leaking can't bypass authorization.

## Test plan

- [x] Form spec (submit disabled until valid URL, submits url+note, omits empty note)
- [x] Strict typecheck + lint clean

### Preview domain
https://feat-giveback-suggest-cause.preview.app.daily.dev