### PR TITLE
fix: remove stale cursor feed refresh in useFeed

### DIFF
--- a/packages/shared/src/graphql/common.ts
+++ b/packages/shared/src/graphql/common.ts
@@ -16,7 +16,6 @@ export interface PageInfo {
   hasPreviousPage?: boolean | null;
   hasNextPage?: boolean | null;
   totalCount?: number | null;
-  staleCursor?: boolean;
 }
 
 export interface Connection<T> {

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -297,7 +297,6 @@ const getFeedPostFragment = (fields = '') => gql`
     pageInfo {
       hasNextPage
       endCursor
-      staleCursor
     }
     edges {
       node {
@@ -404,7 +403,6 @@ export const FEED_V2_QUERY = gql`
       pageInfo {
         hasNextPage
         endCursor
-        staleCursor
       }
       edges {
         node {

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -1,4 +1,4 @@
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 import type {
   InfiniteData,
   QueryKey,
@@ -301,8 +301,6 @@ export default function useFeed<T>(
   const { value: isHighlightCardsOptedOut } = useSettingsBooleanFlag(
     'highlightCardsOptOut',
   );
-  // Track if we're currently resetting due to stale cursor to prevent infinite loops
-  const isResettingRef = useRef(false);
   const { fetchTranslations } = useTranslation({
     queryKey: feedQueryKey,
     queryType: 'feed',
@@ -375,23 +373,6 @@ export default function useFeed<T>(
     initialPageParam: '',
     getNextPageParam: ({ page }) => getNextPageParam(page?.pageInfo),
   });
-
-  // Reset feed when staleCursor is detected (feed cache regenerated mid-session)
-  useEffect(() => {
-    const pages = feedQuery.data?.pages;
-    if (!pages?.length || isResettingRef.current) {
-      return;
-    }
-
-    // Check if any page has staleCursor set
-    const hasStaleCursor = pages.some((p) => p.page.pageInfo.staleCursor);
-    if (hasStaleCursor) {
-      isResettingRef.current = true;
-      queryClient.resetQueries({ queryKey: feedQueryKey }).finally(() => {
-        isResettingRef.current = false;
-      });
-    }
-  }, [feedQuery.data?.pages, feedQueryKey, queryClient]);
 
   const clientError = feedQuery?.error as ClientError;
   const adPostLength = settings?.adPostLength;


### PR DESCRIPTION
## Changes

`useFeed` watched feed pages for a `staleCursor` flag and called `queryClient.resetQueries` when it appeared, which refreshed the feed mid-session and caused it to jump/refresh unexpectedly while scrolling (ENG-1832).

- Remove the `staleCursor` reset `useEffect` and its `isResettingRef` guard from `useFeed`.
- Drop the now-unused `staleCursor` field from the feed GraphQL queries (`FeedPostConnection` fragment and `FEED_V2_QUERY`) and from the `PageInfo` type.

## Key decisions

- Since removing the effect left `staleCursor` with no readers anywhere, the field was fully orphaned — removed it from the queries and type rather than leaving dead code.

## Verification

- Strict typecheck guard and ESLint clean on impacted files.
- `Feed.spec.tsx` passes (43/43).

Closes ENG-1838

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1838-remove-the-stale-cursor.preview.app.daily.dev