### PR TITLE
fix(profile): expand experience description textareas

### DIFF
--- a/packages/shared/src/components/fields/ControlledTextarea.tsx
+++ b/packages/shared/src/components/fields/ControlledTextarea.tsx
@@ -3,12 +3,17 @@ import { Controller, useFormContext } from 'react-hook-form';
 import Textarea from './Textarea';
 import type { BaseFieldProps } from './BaseFieldContainer';
 
+type ControlledTextareaProps = Pick<
+  BaseFieldProps<HTMLTextAreaElement>,
+  'label' | 'maxLength' | 'rows'
+> & {
+  name: string;
+};
+
 const ControlledTextarea = ({
   name,
   ...restProps
-}: Pick<BaseFieldProps<HTMLTextAreaElement>, 'name' | 'label' | 'maxLength'> & {
-  name: string;
-}) => {
+}: ControlledTextareaProps) => {
   const { control } = useFormContext();
 
   return (

--- a/packages/shared/src/features/profile/components/experience/forms/UserCertificationForm.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserCertificationForm.tsx
@@ -93,6 +93,7 @@ const UserCertificationForm = ({ company }: UserCertificationFormProps) => {
             name="description"
             label="Key topics covered, skills validated"
             maxLength={5000}
+            rows={6}
           />
         </div>
       </div>

--- a/packages/shared/src/features/profile/components/experience/forms/UserEducationForm.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserEducationForm.tsx
@@ -100,6 +100,7 @@ const UserEducationForm = ({ company }: UserEducationFormProps) => {
             name="description"
             label="Relevant projects, hackathons, technical clubs"
             maxLength={5000}
+            rows={6}
           />
         </div>
       </div>

--- a/packages/shared/src/features/profile/components/experience/forms/UserProjectExperienceForm.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserProjectExperienceForm.tsx
@@ -147,6 +147,7 @@ const UserProjectExperienceForm = ({
             name="description"
             label="Summary of the work, focus area"
             maxLength={5000}
+            rows={6}
           />
         </div>
       </div>

--- a/packages/shared/src/features/profile/components/experience/forms/UserWorkExperienceForm.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserWorkExperienceForm.tsx
@@ -104,6 +104,7 @@ const UserWorkExperienceForm = ({
             name="description"
             label="Key technologies, projects, and achievements"
             maxLength={5000}
+            rows={6}
           />
         </div>
         <ProfileSkills name="skills" />


### PR DESCRIPTION
Updates the profile experience Description textareas to open at six visible rows, so long descriptions are easier to review before saving.

Key decisions:
- Forward `rows` through `ControlledTextarea`; the shared `Textarea` already supports the prop.
- Apply `rows={6}` consistently to Open Source/Project, Work, Certification, and Education description fields.
- Leave max length, character counter, validation, and `resize-none` behavior unchanged.

Verification:
- Targeted Jest form specs: 4 suites, 50 tests passed
- `node ./scripts/typecheck-strict-changed.js`
- Targeted eslint on changed `.tsx` files
- `git diff --check main...HEAD`

Closes ENG-1815

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1815-feedback-ux-issue-descr.preview.app.daily.dev