### PR TITLE
fix: track focus post views

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import type { ComponentProps, ReactElement } from 'react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import dynamic from 'next/dynamic';
 import type { Post } from '../../graphql/posts';
 import { isVideoPost } from '../../graphql/posts';
@@ -15,8 +15,7 @@ import { combinedClicks } from '../../lib/click';
 import type { PostContentProps, PostNavigationProps } from './common';
 import { PostContainer } from './common';
 import YoutubeVideo from '../video/YoutubeVideo';
-import { useAuthContext } from '../../contexts/AuthContext';
-import { useViewPost } from '../../hooks/post';
+import { useTrackPostView } from '../../hooks/post/useTrackPostView';
 import { TruncateText } from '../utilities';
 import { useFeature } from '../GrowthBookProvider';
 import { feature } from '../../lib/featureManagement';
@@ -83,7 +82,6 @@ export function PostContentRaw({
   isBannerVisible,
   isPostPage,
 }: PostContentRawProps): ReactElement {
-  const { user } = useAuthContext();
   const { subject } = useToastNotification();
   const engagementActions = usePostContent({
     origin,
@@ -104,7 +102,6 @@ export function PostContentRaw({
     }
     onReadArticle();
   };
-  const onSendViewPost = useViewPost();
   const showCodeSnippets = useFeature(feature.showCodeSnippets);
   const { title } = useSmartTitle(post);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
@@ -137,14 +134,7 @@ export function PostContentRaw({
     hideSubscribeAction,
   };
 
-  // Only send view post if the post is a video type
-  useEffect(() => {
-    if (!isVideoType || !post?.id || !user?.id) {
-      return;
-    }
-
-    onSendViewPost(post.id);
-  }, [isVideoType, onSendViewPost, post.id, user?.id]);
+  useTrackPostView({ post, shouldTrack: isVideoType });
 
   const postMainColumn = (
     <PostContainer

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import classNames from 'classnames';
 import PostContentContainer from './PostContentContainer';
 import usePostContent from '../../hooks/usePostContent';
@@ -14,10 +14,9 @@ import SquadPostAuthor from './SquadPostAuthor';
 import SharePostContent from './SharePostContent';
 import MarkdownPostContent from './MarkdownPostContent';
 import { SquadPostWidgets } from './SquadPostWidgets';
-import { useAuthContext } from '../../contexts/AuthContext';
 import type { PostContentProps, PostNavigationProps } from './common';
 import ShareYouTubeContent from './ShareYouTubeContent';
-import { useViewPost } from '../../hooks/post';
+import { useTrackPostView } from '../../hooks/post/useTrackPostView';
 import { withPostById } from './withPostById';
 import PostSourceInfo from './PostSourceInfo';
 import { isSourceUserSource } from '../../graphql/sources';
@@ -67,7 +66,6 @@ function SquadPostContentRaw({
   isPostPage,
 }: SquadPostContentRawProps): ReactElement {
   const isBoostButtonVisible = useShowBoostButton({ post });
-  const { user } = useAuthContext();
   const { checkHasCompleted, isActionsFetched } = useActions();
   const hasClosedBanner = checkHasCompleted(
     ActionType.ClosedNewPostBoostBanner,
@@ -79,7 +77,6 @@ function SquadPostContentRaw({
     isBoostButtonVisible &&
     !post?.flags?.campaignId;
   const isLaptop = useViewSize(ViewSize.Laptop);
-  const onSendViewPost = useViewPost();
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const isCompactModalSpacing = !isPostPage;
   const engagementActions = usePostContent({ origin, post });
@@ -106,13 +103,7 @@ function SquadPostContentRaw({
     }
   }
 
-  useEffect(() => {
-    if (!post?.id || !user?.id) {
-      return;
-    }
-
-    onSendViewPost(post.id);
-  }, [post.id, onSendViewPost, user?.id]);
+  useTrackPostView({ post });
 
   const socialTwitterType = getSocialTwitterPostType(post);
   const finalType = isVideoPost(post)

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import type { ReactElement } from 'react';
-import React, { useEffect } from 'react';
+import React from 'react';
 import Link from '../../utilities/Link';
 import { LazyImage } from '../../LazyImage';
 import { ToastSubject, useToastNotification } from '../../../hooks';
@@ -16,9 +16,8 @@ import type { PostContentProps, PostNavigationProps } from '../common';
 import { PostContainer } from '../common';
 import { Pill } from '../../Pill';
 import { CollectionsIntro } from '../widgets';
-import { useAuthContext } from '../../../contexts/AuthContext';
 import { webappUrl } from '../../../lib/constants';
-import { useViewPost } from '../../../hooks/post/useViewPost';
+import { useTrackPostView } from '../../../hooks/post/useTrackPostView';
 import { DateFormat } from '../../utilities';
 import { withPostById } from '../withPostById';
 import { PostTagList } from '../tags/PostTagList';
@@ -50,7 +49,6 @@ const CollectionPostContentRaw = ({
   isBannerVisible,
   isPostPage,
 }: CollectionPostContentRawProps): ReactElement => {
-  const { user } = useAuthContext();
   const { subject } = useToastNotification();
   const engagementActions = usePostContent({
     origin,
@@ -80,15 +78,7 @@ const CollectionPostContentRaw = ({
     inlineActions,
   };
 
-  const onSendViewPost = useViewPost();
-
-  useEffect(() => {
-    if (!post?.id || !user?.id) {
-      return;
-    }
-
-    onSendViewPost(post.id);
-  }, [post?.id, onSendViewPost, user?.id]);
+  useTrackPostView({ post });
 
   return (
     <PostContentContainer

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -16,6 +16,7 @@ import type { PostOrigin } from '../../../hooks/log/useLogContextData';
 import usePostContent from '../../../hooks/usePostContent';
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
 import { useUpvoteQuery } from '../../../hooks/useUpvoteQuery';
+import { useViewPost } from '../../../hooks/post/useViewPost';
 import { useReaderInstallPromptGate } from '../../../hooks/useReaderInstallPromptGate';
 import { useReaderModalEligibility } from '../reader/hooks/useReaderModalEligibility';
 import { EarthIcon } from '../../icons';
@@ -50,6 +51,7 @@ import { PostMenuOptions } from '../PostMenuOptions';
 import { FocusCardActionBar } from './FocusCardActionBar';
 import { PostDiscussionPanel } from './PostDiscussionPanel';
 import { CollectionSources } from './CollectionSources';
+import { useAuthContext } from '../../../contexts/AuthContext';
 
 const PostCodeSnippets = dynamic(() =>
   import(/* webpackChunkName: "postCodeSnippets" */ '../PostCodeSnippets').then(
@@ -58,6 +60,13 @@ const PostCodeSnippets = dynamic(() =>
 );
 
 export type FocusCardLeftVariant = 'lean' | 'rich';
+
+const viewTrackedPostTypes = [
+  PostType.Share,
+  PostType.Collection,
+  PostType.Freeform,
+  PostType.Welcome,
+];
 
 interface PostFocusCardProps {
   post: Post;
@@ -233,6 +242,8 @@ export const PostFocusCard = ({
       ? post.author
       : undefined;
   const isVideoType = isVideoPost(article);
+  const { user } = useAuthContext();
+  const onSendViewPost = useViewPost();
   const { title } = useSmartTitle(article);
   const { onCopyPostLink, onReadArticle } = usePostContent({ origin, post });
   const { openModal } = useLazyModal();
@@ -252,6 +263,17 @@ export const PostFocusCard = ({
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
   const readHref = getReadArticleHref(post);
+
+  useEffect(() => {
+    if (
+      !user?.id ||
+      (!isVideoPost(post) && !viewTrackedPostTypes.includes(post.type))
+    ) {
+      return;
+    }
+
+    onSendViewPost(post.id);
+  }, [onSendViewPost, post.id, post.type, user?.id]);
 
   useEffect(() => {
     if (!isVideoType || isVideoExpanded) {

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -16,7 +16,7 @@ import type { PostOrigin } from '../../../hooks/log/useLogContextData';
 import usePostContent from '../../../hooks/usePostContent';
 import { useSmartTitle } from '../../../hooks/post/useSmartTitle';
 import { useUpvoteQuery } from '../../../hooks/useUpvoteQuery';
-import { useViewPost } from '../../../hooks/post/useViewPost';
+import { useTrackPostView } from '../../../hooks/post/useTrackPostView';
 import { useReaderInstallPromptGate } from '../../../hooks/useReaderInstallPromptGate';
 import { useReaderModalEligibility } from '../reader/hooks/useReaderModalEligibility';
 import { EarthIcon } from '../../icons';
@@ -51,7 +51,6 @@ import { PostMenuOptions } from '../PostMenuOptions';
 import { FocusCardActionBar } from './FocusCardActionBar';
 import { PostDiscussionPanel } from './PostDiscussionPanel';
 import { CollectionSources } from './CollectionSources';
-import { useAuthContext } from '../../../contexts/AuthContext';
 
 const PostCodeSnippets = dynamic(() =>
   import(/* webpackChunkName: "postCodeSnippets" */ '../PostCodeSnippets').then(
@@ -242,8 +241,6 @@ export const PostFocusCard = ({
       ? post.author
       : undefined;
   const isVideoType = isVideoPost(article);
-  const { user } = useAuthContext();
-  const onSendViewPost = useViewPost();
   const { title } = useSmartTitle(article);
   const { onCopyPostLink, onReadArticle } = usePostContent({ origin, post });
   const { openModal } = useLazyModal();
@@ -264,16 +261,10 @@ export const PostFocusCard = ({
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
   const readHref = getReadArticleHref(post);
 
-  useEffect(() => {
-    if (
-      !user?.id ||
-      (!isVideoPost(post) && !viewTrackedPostTypes.includes(post.type))
-    ) {
-      return;
-    }
-
-    onSendViewPost(post.id);
-  }, [onSendViewPost, post.id, post.type, user?.id]);
+  useTrackPostView({
+    post,
+    shouldTrack: isVideoPost(post) || viewTrackedPostTypes.includes(post.type),
+  });
 
   useEffect(() => {
     if (!isVideoType || isVideoExpanded) {

--- a/packages/shared/src/hooks/post/useTrackPostView.ts
+++ b/packages/shared/src/hooks/post/useTrackPostView.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import type { Post } from '../../graphql/posts';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useViewPost } from './useViewPost';
+
+interface UseTrackPostViewProps {
+  post?: Pick<Post, 'id'>;
+  shouldTrack?: boolean;
+}
+
+export const useTrackPostView = ({
+  post,
+  shouldTrack = true,
+}: UseTrackPostViewProps): void => {
+  const { user } = useAuthContext();
+  const onSendViewPost = useViewPost();
+
+  useEffect(() => {
+    if (!shouldTrack || !post?.id || !user?.id) {
+      return;
+    }
+
+    onSendViewPost(post.id);
+  }, [onSendViewPost, post?.id, shouldTrack, user?.id]);
+};

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -1057,6 +1057,42 @@ describe('post redesign', () => {
     expect(screen.queryByTestId('postContainer')).not.toBeInTheDocument();
   });
 
+  it('should log a view for tracked posts when the focus card is on', async () => {
+    mockRedesignOn = true;
+    let viewPostMutationCalled = false;
+    renderPost(
+      {},
+      [
+        createPostMock({ type: PostType.Collection }),
+        createCommentsMock(),
+        {
+          request: {
+            query: VIEW_POST_MUTATION,
+            variables: {
+              id: '0e4005b2d3cf191f8c44c2718a457a1e',
+            },
+          },
+          result: () => {
+            viewPostMutationCalled = true;
+
+            return {
+              data: {
+                viewPost: {
+                  _: true,
+                },
+              },
+            };
+          },
+        },
+      ],
+      defaultUser,
+    );
+
+    await waitFor(() => {
+      expect(viewPostMutationCalled).toBe(true);
+    });
+  });
+
   it('should keep the classic layout when the flag is off', async () => {
     mockRedesignOn = false;
     renderPost();


### PR DESCRIPTION
## What changed

- Record post views from the focus-card variation for the same post types as the control layout.
- Add coverage for the redesigned collection post path.

## Why

The focus-card variation rendered without invoking the view mutation, so eligible post views were not tracked.

## Validation

- `NODE_ENV=test pnpm --filter webapp exec jest __tests__/PostPage.tsx --runInBand`
- `node ./scripts/typecheck-strict-changed.js`
- Targeted ESLint
- `git diff --check`


### Preview domain
https://agent-fix-focus-post-views.preview.app.daily.dev