### PR TITLE
fix: update Giveback terms link

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
@@ -15,7 +15,10 @@ import { anchorDefaultRel } from '../../../lib/strings';
 // purpose since the global cookie banner already covers it.
 const legalLinks: { label: string; href: string }[] = [
   { label: 'Campaign rules', href: termsOfService },
-  { label: 'Terms of Service', href: termsOfService },
+  {
+    label: 'Terms of Service',
+    href: 'https://daily.dev/giveback-program-terms/',
+  },
   { label: 'Privacy Policy', href: privacyPolicy },
 ];
 

--- a/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLegalFooter.tsx
@@ -7,14 +7,13 @@ import {
   TypographyTag,
   TypographyType,
 } from '../../../components/typography/Typography';
-import { privacyPolicy, termsOfService } from '../../../lib/constants';
+import { privacyPolicy } from '../../../lib/constants';
 import { anchorDefaultRel } from '../../../lib/strings';
 
 // Legal/footer home for the campaign. One quiet line: funding disclaimer on the
-// left, the terms/rules/privacy links on the right. Cookie policy is omitted on
+// left, the terms/privacy links on the right. Cookie policy is omitted on
 // purpose since the global cookie banner already covers it.
 const legalLinks: { label: string; href: string }[] = [
-  { label: 'Campaign rules', href: termsOfService },
   {
     label: 'Terms of Service',
     href: 'https://daily.dev/giveback-program-terms/',


### PR DESCRIPTION
## Summary
- point the Giveback Terms of Service link to the Giveback program terms page

## Validation
- `node ./scripts/typecheck-strict-changed.js`

### Preview domain
https://agent-update-giveback-terms-link.preview.app.daily.dev