### PR TITLE
fix(notifications): honor global dismiss across all push prompts

### DIFF
--- a/packages/shared/src/hooks/notifications/useEnableNotification.ts
+++ b/packages/shared/src/hooks/notifications/useEnableNotification.ts
@@ -69,11 +69,6 @@ export const useEnableNotification = ({
     DISMISS_PERMISSION_BANNER,
     false,
   );
-  const shouldIgnoreDismissStateForSource =
-    source === NotificationPromptSource.SquadPage;
-  const effectiveIsDismissed = shouldIgnoreDismissStateForSource
-    ? false
-    : isDismissed;
   useEffect(() => {
     setHasCompletedEnableAction(!onEnableAction);
   }, [onEnableAction]);
@@ -121,7 +116,7 @@ export const useEnableNotification = ({
       (conditions.every(Boolean) ||
         (enabledJustNow &&
           source !== NotificationPromptSource.SquadPostModal)) &&
-      !effectiveIsDismissed
+      !isDismissed
     );
   };
 

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -268,7 +268,7 @@ const SquadPage = ({
     () => createSquadNotificationToastStateStore(user?.id),
     [user?.id],
   );
-  const { shouldShowCta, onEnable } = useEnableNotification({
+  const { shouldShowCta, onEnable, onDismiss } = useEnableNotification({
     source: NotificationPromptSource.SquadPage,
   });
 
@@ -316,12 +316,13 @@ const SquadPage = ({
         },
       },
       onClose: () => {
-        squadNotificationToastState.dismissUntilTomorrow({ squadId });
+        onDismiss();
       },
     });
   }, [
     displayToast,
     isFetched,
+    onDismiss,
     onEnable,
     shouldShowCta,
     squad?.currentMember,


### PR DESCRIPTION
## Problem

Since #5738 (contextual notification CTAs), the enable-push prompts stopped respecting user intent. `useEnableNotification` forced `effectiveIsDismissed = false` for the `SquadPage` source, so the global `DISMISS_PERMISSION_BANNER` was bypassed there. On top of that the squad page never called `onDismiss` — its toast close only set a local *daily* flag, so it reappeared every day regardless of how many times the user dismissed it. (`NewComment` had the same bug until #6XXX / May, when it was removed from the ignore list.)

## Fix

- **`useEnableNotification.ts`**: dropped the `shouldIgnoreDismissStateForSource` hardcode. Every source now reads the single global `DISMISS_PERMISSION_BANNER`, so a dismiss on any surface persists everywhere.
- **`squads/[handle]/index.tsx`**: the squad toast close now calls `onDismiss()` (sets the global key) instead of a daily-only flag. The daily-throttle store is kept only for the *enable-failure* path (a declined browser permission is a retry-tomorrow case, not a dismiss).

Comments and composer opt-in toggles already read and set the global key, so no change needed there — they stay opt-in, but dismissing now suppresses the prompt permanently across the app.

## Behavior

Dismiss the prompt once, on any surface (notifications page, squad toast, comment prompt, composer toggle) → it never shows again anywhere.

### Preview domain
https://fix-notification-prompt-global-d.preview.app.daily.dev