### PR TITLE
feat(giveback): wire real reveal assets + dedicated OG image

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackCampaignVideo.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCampaignVideo.tsx
@@ -1,21 +1,11 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import React, { useState } from 'react';
 import { FlexCol } from '../../../components/utilities';
 import { PlayIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
+import { cloudinaryGivebackCampaignVideoPoster } from '../../../lib/image';
 
 const VIDEO_ID = 'kDTf2R-OMnM';
-
-const CHARM_IMAGE_SRC =
-  'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)';
-
-// A dark, on-brand backdrop (page background + a soft cabbage glow from the top)
-// so the charm - rendered with `mix-blend-screen` - reads as floating, exactly
-// like it does elsewhere on the dark page.
-const posterBackdrop: CSSProperties = {
-  background:
-    'radial-gradient(120% 95% at 50% 0%, color-mix(in srgb, var(--theme-accent-cabbage-default) 22%, transparent), transparent 68%), var(--theme-background-default)',
-};
 
 export const GivebackCampaignVideo = (): ReactElement => {
   const [isPlaying, setIsPlaying] = useState(false);
@@ -38,27 +28,14 @@ export const GivebackCampaignVideo = (): ReactElement => {
             aria-label="Play the Giveback campaign video"
             className="absolute inset-0 size-full"
           >
-            <span
+            {/* Full-bleed poster: the composed thumbnail fills the 16:9 frame. */}
+            <img
+              src={cloudinaryGivebackCampaignVideoPoster}
+              alt=""
               aria-hidden
-              className="absolute inset-0"
-              style={posterBackdrop}
+              loading="lazy"
+              className="absolute inset-0 size-full select-none object-cover transition-transform duration-500 motion-safe:group-hover:scale-105"
             />
-
-            {/* The charm as the poster: a soft glow behind it, then the artwork
-                with the black baked-in background dropped via mix-blend-screen. */}
-            <span className="absolute inset-0 flex items-center justify-center">
-              <span
-                aria-hidden
-                className="bg-accent-cabbage-default/20 absolute size-1/2 rounded-full blur-3xl motion-safe:animate-glow-pulse"
-              />
-              <img
-                src={CHARM_IMAGE_SRC}
-                alt=""
-                aria-hidden
-                loading="lazy"
-                className="relative max-h-[80%] w-auto select-none object-contain mix-blend-screen transition-transform duration-500 motion-safe:group-hover:scale-105"
-              />
-            </span>
 
             <span className="absolute inset-0 flex items-center justify-center">
               {/* Dark halo so the button keeps strong contrast even over the

--- a/packages/shared/src/features/giveback/components/GivebackCampaignVideo.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCampaignVideo.tsx
@@ -39,7 +39,7 @@ export const GivebackCampaignVideo = (): ReactElement => {
 
             <span className="absolute inset-0 flex items-center justify-center">
               {/* Dark halo so the button keeps strong contrast even over the
-                  bright parts of the charm. */}
+                  bright parts of the poster. */}
               <span
                 aria-hidden
                 className="absolute size-24 rounded-full bg-overlay-primary-pepper blur-2xl"

--- a/packages/shared/src/features/giveback/components/GivebackFunnelSteps.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFunnelSteps.tsx
@@ -9,7 +9,7 @@ import {
   TypographyType,
 } from '../../../components/typography/Typography';
 import { CoinIcon, GiftIcon, VIcon } from '../../../components/icons';
-import { cloudinaryCharmBookmarks } from '../../../lib/image';
+import { cloudinaryGivebackFunnelImpact } from '../../../lib/image';
 import { GivebackMascot } from './GivebackMascot';
 import { GivebackCauseSelection } from './GivebackCauseSelection';
 import { GivebackReveal as Reveal } from './GivebackReveal';
@@ -196,8 +196,8 @@ export const GivebackFunnelStep = ({
               <GivebackMascot
                 imageClassName="h-28 tablet:h-36"
                 image={{
-                  src: cloudinaryCharmBookmarks,
-                  alt: 'daily.dev charm celebrating your causes',
+                  src: cloudinaryGivebackFunnelImpact,
+                  alt: 'Patchy holding a Cores coin, celebrating your causes',
                 }}
               />
             </Stage>

--- a/packages/shared/src/features/giveback/components/rewards/revealScenes.tsx
+++ b/packages/shared/src/features/giveback/components/rewards/revealScenes.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
   Typography,
@@ -14,12 +14,18 @@ import {
 } from '../../../../components/buttons/Button';
 import {
   DevPlusIcon,
+  SlackIcon,
   SparkleIcon,
-  UserIcon,
   VIcon,
 } from '../../../../components/icons';
 import LogoText from '../../../../svg/LogoText';
-import { getCoreCurrencyImage } from '../../../../lib/image';
+import {
+  cloudinaryGivebackCouncilMembers,
+  cloudinaryGivebackPatchyCardFrame,
+  cloudinaryGivebackPatchySelfieMov,
+  cloudinaryGivebackPatchySelfieWebm,
+  getCoreCurrencyImage,
+} from '../../../../lib/image';
 import { anchorDefaultRel } from '../../../../lib/strings';
 import { getDomainFromUrl } from '../../../../lib/links';
 import { FlexCol, FlexRow } from '../../../../components/utilities';
@@ -145,25 +151,35 @@ export const PlusCard = ({ duration }: { duration?: string }): ReactElement => (
   </div>
 );
 
-// A ring of teammate tiles with the visitor standing out in a gradient frame —
-// used by the Council seat reveal so it reads as "you're in the room". The
-// teammates are neutral tiles (no fabricated faces); the visitor is the one real
-// avatar.
-const TEAMMATE_TILES = 3;
+// A ring of real teammate avatars (Slack profile photos) with the visitor
+// standing out in a gradient frame — so the Council seat reveal reads as
+// "you're in the room" with the actual team.
 export const MemberRing = ({
   user,
 }: {
   user: LoggedUser | null;
 }): ReactElement => (
   <FlexCol className="items-center gap-4">
+    {/* A Slack pill above the ring — signals this is a real space you're
+        joining, not just a badge. */}
+    <FlexRow className="items-center gap-2 rounded-10 bg-surface-float px-3 py-1.5 motion-safe:animate-reward-pop [&_svg]:size-5">
+      <SlackIcon />
+      <Typography bold type={TypographyType.Footnote}>
+        daily.dev Council
+      </Typography>
+    </FlexRow>
     <FlexRow className="items-center">
-      {Array.from({ length: TEAMMATE_TILES }).map((_, index) => (
+      {cloudinaryGivebackCouncilMembers.map((src) => (
         <span
-          // eslint-disable-next-line react/no-array-index-key
-          key={index}
-          className="-ml-2.5 flex size-10 items-center justify-center rounded-12 bg-surface-float text-text-tertiary ring-2 ring-background-default first:ml-0 [&_svg]:size-5"
+          key={src}
+          className="-ml-2.5 size-10 overflow-hidden rounded-12 bg-surface-float ring-2 ring-background-default first:ml-0"
         >
-          <UserIcon />
+          <img
+            src={src}
+            alt=""
+            loading="lazy"
+            className="size-full object-cover"
+          />
         </span>
       ))}
       {/* The visitor stands out with a colorful gradient ring. Inner picture is
@@ -229,10 +245,13 @@ export const CouncilReveal = ({
   </FlexCol>
 );
 
-// Picture with Patchy → an asset-light 2-stage flow. "Take a selfie" plays a
-// brief beat, then Patchy poses beside the visitor's photo.
-// PLACEHOLDER: uses the invite-friends charm until the bespoke animated selfie
-// asset is uploaded to the CDN.
+// Picture with Patchy → a 3-stage flow built on the bespoke selfie video. A
+// single transparent <video> (WebM for most browsers, HEVC-alpha .mov for
+// Safari — the PersonaMascot source-order pattern) stays mounted across idle and
+// playing: idle shows it paused on its first frame, "Take a selfie" plays it
+// once, and onEnded advances to the result — Patchy holding a card frame with
+// the visitor's photo dropped in. Reduced motion skips playback straight to the
+// framed result.
 export const PatchyPictureReveal = ({
   reveal,
   levelNumber,
@@ -245,14 +264,33 @@ export const PatchyPictureReveal = ({
   onClose: () => void;
 }): ReactElement => {
   const [stage, setStage] = useState<'idle' | 'playing' | 'result'>('idle');
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const reducedMotion = usePrefersReducedMotion();
 
+  // Fail-safe: `onEnded` is the normal path to the result, but if it never
+  // fires (a source that can't decode, or a browser that drops the event),
+  // don't strand the user on the playing stage. The clip is ~6s; this generous
+  // cap only trips on a genuine fault, so it won't truncate normal playback.
   useEffect(() => {
     if (stage !== 'playing') {
       return undefined;
     }
-    const done = setTimeout(() => setStage('result'), 1100);
+    const done = setTimeout(() => setStage('result'), 12000);
     return () => clearTimeout(done);
   }, [stage]);
+
+  const play = () => {
+    if (reducedMotion) {
+      setStage('result');
+      return;
+    }
+    setStage('playing');
+    // A rejected play() (autoplay policy, not-yet-ready) must not leave the
+    // user staring at a frozen frame — jump straight to the result. `play()`
+    // returns undefined outside modern browsers (jsdom, legacy), so guard the
+    // `.catch` with optional chaining too.
+    videoRef.current?.play()?.catch(() => setStage('result'));
+  };
 
   if (stage === 'result') {
     return (
@@ -261,31 +299,36 @@ export const PatchyPictureReveal = ({
           <LevelChip levelNumber={levelNumber} />
         </Reveal>
         <Reveal delay={STAGGER_STEP} className="w-full">
-          <FlexRow className="items-end justify-center gap-3 motion-safe:animate-reward-pop">
-            {reveal.image && (
-              <img
-                src={reveal.image}
-                alt="Patchy"
-                loading="lazy"
-                className="h-40 w-auto select-none object-contain"
-              />
-            )}
-            <span className="mb-2 rounded-16 bg-gradient-to-br from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default p-0.5">
-              <span className="block size-24 overflow-hidden rounded-[14px]">
-                {user?.image ? (
-                  <img
-                    src={user.image}
-                    alt=""
-                    className="size-full object-cover"
-                  />
-                ) : (
-                  <span className="flex size-full items-center justify-center bg-accent-cabbage-default text-white [&_svg]:size-10">
-                    <VIcon />
-                  </span>
-                )}
-              </span>
+          <div className="relative mx-auto w-full max-w-xs motion-safe:animate-reward-pop">
+            <img
+              src={cloudinaryGivebackPatchyCardFrame}
+              alt="Patchy holding a frame with you in it"
+              loading="lazy"
+              className="w-full select-none object-contain"
+            />
+            {/* The visitor's photo dropped into the card frame Patchy holds. */}
+            <span
+              className="absolute overflow-hidden rounded-[10%]"
+              style={{
+                left: '45.5%',
+                top: '42%',
+                width: '39.5%',
+                height: '39.5%',
+              }}
+            >
+              {user?.image ? (
+                <img
+                  src={user.image}
+                  alt=""
+                  className="size-full object-cover"
+                />
+              ) : (
+                <span className="flex size-full items-center justify-center bg-accent-cabbage-default text-white [&_svg]:size-10">
+                  <VIcon />
+                </span>
+              )}
             </span>
-          </FlexRow>
+          </div>
         </Reveal>
         <RevealCopy reveal={reveal} delayBase={STAGGER_STEP * 3} />
         <Reveal delay={STAGGER_STEP * 6}>
@@ -295,76 +338,71 @@ export const PatchyPictureReveal = ({
     );
   }
 
-  if (stage === 'playing') {
-    return (
-      <FlexCol className="items-center gap-6">
-        <Reveal delay={0}>
-          <LevelChip levelNumber={levelNumber} />
-        </Reveal>
-        {reveal.image && (
-          <img
-            src={reveal.image}
-            alt="Patchy taking a selfie with you"
-            loading="lazy"
-            className="h-48 w-auto select-none object-contain motion-safe:animate-mascot-bob"
-          />
-        )}
+  return (
+    <FlexCol className="items-center gap-6">
+      <Reveal delay={0}>
+        <LevelChip levelNumber={levelNumber} />
+      </Reveal>
+      <video
+        ref={videoRef}
+        muted
+        playsInline
+        preload="auto"
+        onEnded={() => setStage('result')}
+        onError={() => setStage('result')}
+        aria-label="Patchy taking a selfie with you"
+        className="h-48 w-auto select-none object-contain"
+      >
+        {/* WebM first: every browser that can plays VP9 alpha uses it; Safari
+            can't, so it falls through to the HEVC-alpha .mov. */}
+        <source src={cloudinaryGivebackPatchySelfieWebm} type="video/webm" />
+        <source
+          src={cloudinaryGivebackPatchySelfieMov}
+          type='video/quicktime; codecs="hvc1"'
+        />
+      </video>
+      {stage === 'playing' ? (
         <Typography
           type={TypographyType.Callout}
           color={TypographyColor.Secondary}
         >
           Say cheese…
         </Typography>
-      </FlexCol>
-    );
-  }
-
-  return (
-    <FlexCol className="items-center gap-6">
-      <Reveal delay={0}>
-        <LevelChip levelNumber={levelNumber} />
-      </Reveal>
-      {reveal.image && (
-        <Reveal delay={STAGGER_STEP}>
-          <img
-            src={reveal.image}
-            alt="Patchy"
-            loading="lazy"
-            className="h-48 w-auto select-none object-contain"
-          />
-        </Reveal>
+      ) : (
+        <>
+          <FlexCol className="items-center gap-1.5 text-center">
+            <Reveal delay={STAGGER_STEP * 2}>
+              <Typography
+                tag={TypographyTag.H3}
+                bold
+                type={TypographyType.Title1}
+                className="[text-wrap:balance]"
+              >
+                Say cheese with Patchy
+              </Typography>
+            </Reveal>
+            <Reveal delay={STAGGER_STEP * 3}>
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Secondary}
+                className="max-w-sm [text-wrap:pretty]"
+              >
+                Patchy wants a photo with you. Grab yours to keep forever.
+              </Typography>
+            </Reveal>
+          </FlexCol>
+          <Reveal delay={STAGGER_STEP * 5}>
+            <Button
+              type="button"
+              size={ButtonSize.Medium}
+              variant={ButtonVariant.Primary}
+              onClick={play}
+            >
+              Take a selfie
+            </Button>
+          </Reveal>
+        </>
       )}
-      <FlexCol className="items-center gap-1.5 text-center">
-        <Reveal delay={STAGGER_STEP * 2}>
-          <Typography
-            tag={TypographyTag.H3}
-            bold
-            type={TypographyType.Title1}
-            className="[text-wrap:balance]"
-          >
-            Say cheese with Patchy
-          </Typography>
-        </Reveal>
-        <Reveal delay={STAGGER_STEP * 3}>
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Secondary}
-            className="max-w-sm [text-wrap:pretty]"
-          >
-            Patchy wants a photo with you. Grab yours to keep forever.
-          </Typography>
-        </Reveal>
-      </FlexCol>
-      <Reveal delay={STAGGER_STEP * 5}>
-        <Button
-          type="button"
-          size={ButtonSize.Medium}
-          variant={ButtonVariant.Primary}
-          onClick={() => setStage('playing')}
-        >
-          Take a selfie
-        </Button>
-      </Reveal>
     </FlexCol>
   );
 };

--- a/packages/shared/src/features/giveback/components/rewards/rewardReveal.ts
+++ b/packages/shared/src/features/giveback/components/rewards/rewardReveal.ts
@@ -1,6 +1,6 @@
 import type { ContributionRewardTier } from '../../types';
 import { ContributionRewardType } from '../../types';
-import { cloudinaryCharmInviteFriends } from '../../../../lib/image';
+import { cloudinaryGivebackPatchyFounding } from '../../../../lib/image';
 
 // The reward-claim "reveal": the cinematic pop-up shown after a contributor
 // claims a reward tier on the journey. Each reward gets a bespoke payoff moment
@@ -33,8 +33,6 @@ export interface RewardReveal {
   duration?: string;
   // swagDiscount: discount percent.
   percent?: number;
-  // an anchor illustration where one helps (e.g. Patchy).
-  image?: string;
 }
 
 // Format a Plus grant's day count into the human label the reveal shows.
@@ -102,7 +100,6 @@ export const resolveRewardReveal = (
         kind: 'mascotHug',
         headline: 'You and Patchy, official.',
         body: 'Save it, share it, make it your profile picture.',
-        image: cloudinaryCharmInviteFriends,
       };
     case ContributionRewardType.Trivia:
       return {
@@ -156,7 +153,7 @@ export interface FoundingAward {
 
 export const PATCHY_FOUNDING_AWARD: FoundingAward = {
   name: 'Founding Patchy',
-  image: cloudinaryCharmInviteFriends,
+  image: cloudinaryGivebackPatchyFounding,
   coresValue: 1000,
 };
 

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -479,3 +479,46 @@ export const cloudinaryCharmNotEnoughTags =
 // `mix-blend-screen` on a dark surface so the black drops out.
 export const cloudinaryCharmGiveback =
   'https://media.daily.dev/image/upload/s--d1dldAty--/f_auto,q_auto/v1780848838/public/daily.dev%20Charm%20-%20Giveback%20(1)';
+
+// Bespoke Patchy assets for the Giveback "Picture with Patchy" reward reveal.
+// The selfie is a transparent video played once — a VP9-alpha .webm for most
+// browsers and an HEVC-alpha .mov for Safari (the same source-order trick as
+// PersonaMascot); both carry real alpha, so Patchy floats cleanly on any
+// surface. The card frame is the still Patchy holds with the visitor's photo
+// dropped in.
+export const cloudinaryGivebackPatchySelfieWebm =
+  'https://media.daily.dev/video/upload/v1783860990/patchy-wave_n8a6ve.webm';
+
+export const cloudinaryGivebackPatchySelfieMov =
+  'https://media.daily.dev/video/upload/v1783860588/patchy-wave_gniigo.mov';
+
+export const cloudinaryGivebackPatchyCardFrame =
+  'https://media.daily.dev/image/upload/s--mId_6LSG--/f_auto,q_auto/v1783860198/public/daily.dev%20-%20Patchy%20picture%20frame%20(1)';
+
+// The founding-award Patchy (IMPACT AMBASSADOR sash) — the real asset from the
+// award library, used by the giveback journey's founding first step.
+export const cloudinaryGivebackPatchyFounding =
+  'https://media.daily.dev/image/upload/s--BxFWArbd--/f_auto,q_auto/v1783344577/public/Color%3DDefault';
+
+// Dedicated Open Graph / social share image for the giveback pages (1280×800).
+export const cloudinaryGivebackOpenGraph =
+  'https://media.daily.dev/image/upload/s--lQzU56yU--/f_auto,q_auto/v1783863597/public/daily.dev%20Givevback%20-%201280x800%20(1)';
+
+// Poster/thumbnail for the giveback campaign video on the warm-up funnel's
+// first step. A full-bleed composed scene (its own background), so it fills the
+// 16:9 frame with `object-cover` — no charm/blend treatment needed.
+export const cloudinaryGivebackCampaignVideoPoster =
+  'https://media.daily.dev/image/upload/s--XBh2vl9j--/f_auto,q_auto/v1783865279/public/daily.dev%20Givevback%20only%20dog%20-%201280x800%20(1)';
+
+// Patchy holding a Cores coin — the giveback warm-up funnel's impact finale
+// ("You're in. Now every action funds them.").
+export const cloudinaryGivebackFunnelImpact =
+  'https://media.daily.dev/image/upload/s--1mdwPltz--/f_auto,q_auto/v1783863973/public/ChatGPT%20Image%20Jun%2028%2C%202026%2C%2004_55_41%20PM%201%20(1)';
+
+// Real daily.dev teammate avatars (Slack profile photos) shown in the Council
+// seat reveal's member ring, so the seat reads as joining an actual room.
+export const cloudinaryGivebackCouncilMembers = [
+  'https://media.daily.dev/image/upload/s--xaoZnUa4--/f_auto,q_auto/v1783862580/public/T0A1ABR3B6W-U0A1C8X742J-9eed239f3f57-72',
+  'https://media.daily.dev/image/upload/s--AoszePMr--/f_auto,q_auto/v1783862580/public/T0A1ABR3B6W-U0A2A2AATAN-b3dcdb7512bb-72',
+  'https://media.daily.dev/image/upload/s--gVjCf-uB--/f_auto,q_auto/v1783862580/public/T0A1ABR3B6W-U0BC6FM8SFQ-15d342d0d5da-72',
+];

--- a/packages/storybook/stories/features/giveback/GivebackRevealAssetsRestore.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackRevealAssetsRestore.stories.tsx
@@ -1,0 +1,262 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import type { ContributionRewardTier } from '@dailydotdev/shared/src/features/giveback/types';
+import { ContributionRewardType } from '@dailydotdev/shared/src/features/giveback/types';
+import {
+  RevealSurface,
+  RewardRevealContent,
+} from '@dailydotdev/shared/src/features/giveback/components/rewards/GivebackRewardReveal';
+import { resolveRewardReveal } from '@dailydotdev/shared/src/features/giveback/components/rewards/rewardReveal';
+import { GivebackFoundingAward } from '@dailydotdev/shared/src/features/giveback/components/rewards/GivebackFoundingAward';
+import { GivebackMascot } from '@dailydotdev/shared/src/features/giveback/components/GivebackMascot';
+import { GivebackCampaignVideo } from '@dailydotdev/shared/src/features/giveback/components/GivebackCampaignVideo';
+import { cloudinaryGivebackFunnelImpact } from '@dailydotdev/shared/src/lib/image';
+import { FlexCol } from '@dailydotdev/shared/src/components/utilities';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import { MOCK_USER, withGiveback } from './giveback.mocks';
+
+// Dedicated review surface for the reveal-asset restoration PR: the bespoke
+// assets that were dropped to placeholders in the merged reveals PR (#6289) are
+// wired back to their real media.daily.dev URLs. These stories render the REAL
+// production components (`RewardRevealContent`, `GivebackFoundingAward`) on the
+// real pop-up surface, so what you review is what ships.
+//
+// What changed in this PR:
+// • Picture with Patchy — static charm placeholder → the bespoke transparent
+//   selfie VIDEO (PersonaMascot pattern: VP9-alpha WebM for most browsers, an
+//   HEVC-alpha .mov for Safari — both transparent). Idle shows the video on its
+//   first frame; "Take a selfie" plays it once; the result composites your photo
+//   into the card Patchy holds.
+// • Founding award — placeholder charm → the real "IMPACT AMBASSADOR" Patchy
+//   from the award library.
+// • Council seat — neutral grey tiles → real teammate Slack avatars + a
+//   "daily.dev Council" Slack pill above the ring.
+// • Warm-up funnel finale ("You're in. Now every action funds them.") — the
+//   bookmarks charm → Patchy holding a Cores coin.
+// • Campaign video poster (funnel first step) — the charm-with-glow poster →
+//   the composed "Community Impact" thumbnail, full-bleed.
+
+const user = MOCK_USER as unknown as LoggedUser;
+
+const tier = (
+  id: string,
+  rewardType: ContributionRewardType,
+  title: string,
+  {
+    description = null,
+    metadata = {},
+  }: Partial<Pick<ContributionRewardTier, 'description' | 'metadata'>> = {},
+): ContributionRewardTier => ({
+  id,
+  title,
+  description,
+  thresholdPoints: 100,
+  rewardType,
+  metadata,
+});
+
+const PATCHY_TIER = tier(
+  'picture-with-patchy',
+  ContributionRewardType.PatchyPicture,
+  'Picture with Patchy',
+);
+
+const COUNCIL_TIER = tier(
+  'council-seat',
+  ContributionRewardType.Council,
+  'Seat on the daily.dev council',
+  {
+    description: 'Join the daily.dev council and help steer the product.',
+  },
+);
+
+const RevealCard = ({
+  reveal,
+  levelNumber,
+}: {
+  reveal: ReturnType<typeof resolveRewardReveal>;
+  levelNumber?: number;
+}): ReactElement => (
+  <RevealSurface>
+    <div className="px-6 py-8">
+      <RewardRevealContent
+        reveal={reveal}
+        levelNumber={levelNumber}
+        user={user}
+      />
+    </div>
+  </RevealSurface>
+);
+
+const SectionHeading = ({
+  title,
+  note,
+}: {
+  title: string;
+  note: string;
+}): ReactElement => (
+  <FlexCol className="gap-1">
+    <Typography tag={TypographyTag.H2} bold type={TypographyType.Title3}>
+      {title}
+    </Typography>
+    <Typography type={TypographyType.Callout} color={TypographyColor.Secondary}>
+      {note}
+    </Typography>
+  </FlexCol>
+);
+
+const meta: Meta = {
+  title: 'Features/Giveback/PR — Restored assets',
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Review surface for the giveback asset PR. Restores/updates the bespoke Patchy selfie video (transparent VP9-alpha WebM + HEVC-alpha .mov), the founding-award Patchy, the council teammate avatars + Slack pill, the warm-up funnel finale image, and the campaign video poster — all placeholders in the merged reveals PR. Real components, real surfaces.',
+      },
+    },
+  },
+  decorators: [withGiveback()],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const PatchySelfie: Story = {
+  render: () => (
+    <FlexCol className="gap-4">
+      <SectionHeading
+        title="Picture with Patchy — selfie video"
+        note='Click "Take a selfie" to play the video, then see your photo composited into the card Patchy holds. WebM for most browsers, HEVC-alpha .mov for Safari.'
+      />
+      <div className="max-w-md">
+        <RevealCard reveal={resolveRewardReveal(PATCHY_TIER)} levelNumber={6} />
+      </div>
+    </FlexCol>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Both sources are transparent — a VP9-alpha WebM for most browsers and an HEVC-alpha .mov for Safari — so Patchy floats cleanly on the pop-up surface in every browser.',
+      },
+    },
+  },
+};
+
+export const FoundingAward: Story = {
+  render: () => (
+    <FlexCol className="gap-4">
+      <SectionHeading
+        title="Founding award — IMPACT AMBASSADOR Patchy"
+        note='Click "Claim your award" for the celebration. The award art is now the real asset from the award library.'
+      />
+      <div className="mx-auto max-w-2xl">
+        <GivebackFoundingAward initialState="claimable" />
+      </div>
+    </FlexCol>
+  ),
+};
+
+export const CouncilSeat: Story = {
+  render: () => (
+    <FlexCol className="gap-4">
+      <SectionHeading
+        title="Council seat — real teammate avatars + Slack pill"
+        note='Real daily.dev teammate Slack avatars in the ring (you stand out in the gradient frame), under a "daily.dev Council" Slack pill.'
+      />
+      <div className="max-w-md">
+        <RevealCard reveal={resolveRewardReveal(COUNCIL_TIER)} levelNumber={9} />
+      </div>
+    </FlexCol>
+  ),
+};
+
+export const FunnelFinale: Story = {
+  render: () => (
+    <FlexCol className="gap-4">
+      <SectionHeading
+        title="Warm-up funnel finale — Patchy with a Cores coin"
+        note={`Shown at "You're in. Now every action funds them." — swapped from the bookmarks charm to Patchy holding a Cores coin.`}
+      />
+      <div className="flex justify-center rounded-16 bg-surface-float p-10">
+        <GivebackMascot
+          imageClassName="h-28 tablet:h-36"
+          image={{
+            src: cloudinaryGivebackFunnelImpact,
+            alt: 'Patchy holding a Cores coin, celebrating your causes',
+          }}
+        />
+      </div>
+    </FlexCol>
+  ),
+};
+
+export const CampaignVideoPoster: Story = {
+  render: () => (
+    <FlexCol className="gap-4">
+      <SectionHeading
+        title="Campaign video poster — funnel first step"
+        note='The video thumbnail on the intro step, swapped from the charm-with-glow poster to the composed "Community Impact" scene. Click to play the embed.'
+      />
+      <div className="mx-auto w-full max-w-xl">
+        <GivebackCampaignVideo />
+      </div>
+    </FlexCol>
+  ),
+};
+
+export const AllRestoredAssets: Story = {
+  render: () => (
+    <FlexCol className="gap-6">
+      <FlexCol className="gap-1">
+        <Typography tag={TypographyTag.H2} bold type={TypographyType.Title2}>
+          Restored reveal assets
+        </Typography>
+        <Typography
+          type={TypographyType.Callout}
+          color={TypographyColor.Secondary}
+        >
+          Everything this PR wires back from placeholder to the real asset.
+        </Typography>
+      </FlexCol>
+      <div className="grid items-start gap-6 laptop:grid-cols-2">
+        <div className="max-w-md">
+          <RevealCard
+            reveal={resolveRewardReveal(PATCHY_TIER)}
+            levelNumber={6}
+          />
+        </div>
+        <div className="max-w-md">
+          <RevealCard
+            reveal={resolveRewardReveal(COUNCIL_TIER)}
+            levelNumber={9}
+          />
+        </div>
+        <div className="flex justify-center rounded-16 bg-surface-float p-10">
+          <GivebackMascot
+            imageClassName="h-28 tablet:h-36"
+            image={{
+              src: cloudinaryGivebackFunnelImpact,
+              alt: 'Patchy holding a Cores coin, celebrating your causes',
+            }}
+          />
+        </div>
+        <div className="laptop:col-span-2">
+          <GivebackCampaignVideo />
+        </div>
+        <div className="laptop:col-span-2">
+          <GivebackFoundingAward initialState="claimable" />
+        </div>
+      </div>
+    </FlexCol>
+  ),
+};

--- a/packages/webapp/pages/giveback/index.tsx
+++ b/packages/webapp/pages/giveback/index.tsx
@@ -6,6 +6,7 @@ import { useConditionalFeature } from '@dailydotdev/shared/src/hooks';
 import { featureGiveback } from '@dailydotdev/shared/src/lib/featureManagement';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import { cloudinaryGivebackOpenGraph } from '@dailydotdev/shared/src/lib/image';
 import { GivebackPage } from '@dailydotdev/shared/src/features/giveback/components/GivebackPage';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../../components/layouts/MainLayout';
@@ -18,6 +19,15 @@ const seo: NextSeoProps = {
   openGraph: {
     ...defaultOpenGraph,
     ...seoTitles.openGraph,
+    // Dedicated giveback share card, overriding the site-wide default OG image.
+    images: [
+      {
+        url: cloudinaryGivebackOpenGraph,
+        width: 1280,
+        height: 800,
+        alt: 'daily.dev Giveback — ad budgets buy clicks, ours funds real causes',
+      },
+    ],
   },
   ...defaultSeo,
   description:


### PR DESCRIPTION
## Changes

Restores the bespoke giveback assets that shipped as placeholders in the reveals PR ([#6289](https://github.com/dailydotdev/apps/pull/6289)) — now wired to their real `media.daily.dev` URLs — and adds a dedicated Open Graph image for the giveback page. All behind the existing **`giveback`** flag, so flag-off preserves `main`.

- **Picture with Patchy** — placeholder charm → the bespoke **transparent selfie video** (VP9-alpha WebM for most browsers, HEVC-alpha `.mov` for Safari, via ordered `<source>`s like `PersonaMascot`). Idle shows the video on its first frame; "Take a selfie" plays it once; the result composites the visitor's photo into the card Patchy holds. Fail-safes (`onError` / timeout / `play().catch`) so a decode or play failure can't strand the user.
- **Founding award** — placeholder charm → the real **IMPACT AMBASSADOR** Patchy from the award library.
- **Council seat** — neutral tiles → real teammate Slack avatars + a **"daily.dev Council"** Slack pill above the ring.
- **Warm-up funnel finale** ("You're in. Now every action funds them.") → Patchy holding a Cores coin.
- **Campaign video poster** (funnel first step) → the composed "Community Impact" thumbnail, full-bleed.
- **Dedicated Open Graph image** for `/giveback`, overriding the site-wide default.

Removed the now-dead `image` field on the reveal type and the placeholder charm wiring.

## Events

No new tracking events.

## Experiment

No new experiment — reuses the existing `giveback` flag.

## Manual Testing

- Review Storybook: **Features/Giveback/PR — Restored assets** (renders the real components).
- `pnpm --filter shared test src/features/giveback` — 80 passing.
- Strict typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-cranky-benz-2b5130.preview.app.daily.dev