### PR TITLE
fix(auth): remove redundant headline from signup modal

### DIFF
--- a/packages/shared/src/components/auth/AuthModal.tsx
+++ b/packages/shared/src/components/auth/AuthModal.tsx
@@ -100,6 +100,7 @@ export default function AuthModal({
     >
       <AuthOptions
         className={{ container: 'h-full' }}
+        hideRegistrationHeadline
         onClose={onClose}
         formRef={formRef!}
         onSuccessfulLogin={onSuccessfulLogin}


### PR DESCRIPTION
## What

Removes the gradient headline (e.g. *"Where developers discover what's next"*) from the **auth signup modal**. The modal already shows a **Sign up** header at the top, so the headline underneath just repeats the message.

## How

Passes `hideRegistrationHeadline` to `AuthOptions` in `AuthModal` — reusing the prop landed in [apps#6307](https://github.com/dailydotdev/apps/pull/6307). The form keeps its **Sign up** title; only the redundant headline is dropped.

## Scope

Modal only. The onboarding funnel and marketing banners render their own headings and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-auth-modal-remove-signup-hea.preview.app.daily.dev