### PR TITLE
feat(ads): add measurement tags to Ad contract

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -332,6 +332,17 @@ export interface Ad {
   adDomain?: string;
   companyLogo?: string;
   callToAction?: string;
+  tags?: AdMeasurementTag[];
+}
+
+// Third-party measurement tags (CM360 JS/iframe, DoubleVerify) that cannot run
+// natively under the extension's MV3 CSP. Executed inline on web; inside a single
+// web-origin frame on the extension. `markup` arrives with macros unsubstituted
+// (${GDPR}, [timestamp], ...) because the client fills them at fire time.
+export interface AdMeasurementTag {
+  markup: string;
+  // true when the frame must cover the creative to measure it (e.g. DV viewability)
+  overlay?: boolean;
 }
 
 export type ReadHistoryPost = Pick<

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -335,13 +335,8 @@ export interface Ad {
   tags?: AdMeasurementTag[];
 }
 
-// Third-party measurement tags (CM360 JS/iframe, DoubleVerify) that cannot run
-// natively under the extension's MV3 CSP. Executed inline on web; inside a single
-// web-origin frame on the extension. `markup` arrives with macros unsubstituted
-// (${GDPR}, [timestamp], ...) because the client fills them at fire time.
 export interface AdMeasurementTag {
   markup: string;
-  // true when the frame must cover the creative to measure it (e.g. DV viewability)
   overlay?: boolean;
 }
 


### PR DESCRIPTION
## What

Extends the skadi \`Ad\` signature with third-party measurement support for enterprise advertisers (CM360 JS/iframe tags, DoubleVerify viewability/IVT/suitability).

\`\`\`ts
export interface Ad {
  // ...
  tags?: AdMeasurementTag[];
}

export interface AdMeasurementTag {
  markup: string;      // raw tag HTML, macros unsubstituted
  overlay?: boolean;   // frame must cover the creative (e.g. DV viewability)
}
\`\`\`

## Why this shape

- **Server describes, client decides execution.** No ad-level \`renderMode\` — the same DV ad runs inline on webapp but inside a web-origin frame on the extension (MV3 CSP forbids remote JS in the extension page). Framing is a per-surface decision, not a property of the ad.
- **\`pixel[]\` stays the native path.** skadi sends image impression trackers in the existing \`pixel[]\` whenever available, so the common CM360 advertiser is fully native and frameless on every surface. \`tags[]\` is the escape hatch only for JS-based measurement.
- **No vendor field.** Client behavior is identical regardless of vendor: inject markup, substitute macros, fire.
- **One frame per ad.** On the extension all of an ad's \`tags[]\` load into a single web-origin frame; \`overlay\` is ORed across them — card-sized only when geometry is actually required, otherwise 0×0 hidden.
- **\`markup\` unsubstituted.** Cachebuster/consent macros (\`\${GDPR}\`, \`[timestamp]\`) are filled client-side at fire time.

## Scope

Signature only. Rendering (native macro substitution on web, the web-origin measurement frame on the extension) lands in follow-ups. Coordinate with the ad-server team so skadi populates \`tags[]\` accordingly.

Ref: \`plans/cm360-doubleverify-support.md\`

### Preview domain
https://feat-ad-measurement-tags-signatu.preview.app.daily.dev