### PR TITLE
fix(giveback): show two decimal places on funding percentage

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackFundingSummary.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingSummary.spec.tsx
@@ -45,8 +45,18 @@ it('renders campaign points as dollars against the cycle goal with contributors'
 
   expect(screen.getByText('$5,000')).toBeInTheDocument();
   expect(screen.getByText('unlocked of $10,000 goal')).toBeInTheDocument();
-  expect(screen.getByText('50%')).toBeInTheDocument();
+  expect(screen.getByText('50.00%')).toBeInTheDocument();
   expect(screen.getByText(/12,480 contributors/)).toBeInTheDocument();
+});
+
+it('shows two decimal places for small funding percentages', () => {
+  renderSummary({
+    currentCyclePoints: 1,
+    currentCycleTargetPoints: 10000,
+    contributorsCount: 1,
+  });
+
+  expect(screen.getByText('0.01%')).toBeInTheDocument();
 });
 
 it('shows a goal-forward empty state when nothing is unlocked yet', () => {

--- a/packages/shared/src/features/giveback/components/GivebackFundingSummary.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingSummary.tsx
@@ -11,11 +11,20 @@ import {
 import { ProgressBar } from '../../../components/fields/ProgressBar';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useCountUp, useInView } from '../useGivebackMotion';
-import { formatDonationAmount, getGoalProgressPercentage } from '../utils';
+import {
+  formatDonationAmount,
+  getGoalProgressPercentage,
+} from '../utils';
 import { GivebackMeterShine } from './GivebackMeterShine';
 
 const barColor =
   'bg-gradient-to-r from-accent-avocado-default via-accent-cabbage-default to-accent-cheese-default';
+
+const formatFundingPercentage = (percentage: number): string =>
+  `${new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(percentage)}%`;
 
 // Quarter-way milestone markers sit on the track (like the impact roadmap's
 // nodes) so the goal reads as a journey with checkpoints, not one long fill.
@@ -167,7 +176,7 @@ export const GivebackFundingSummary = (): ReactElement => {
           color={TypographyColor.StatusSuccess}
           bold
         >
-          {Math.round(percentage)}%
+          {formatFundingPercentage(percentage)}
         </Typography>
         <Typography
           tag={TypographyTag.Span}

--- a/packages/shared/src/features/giveback/components/GivebackFundingSummary.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackFundingSummary.tsx
@@ -11,10 +11,7 @@ import {
 import { ProgressBar } from '../../../components/fields/ProgressBar';
 import { useContributionStatus } from '../hooks/useContributionStatus';
 import { useCountUp, useInView } from '../useGivebackMotion';
-import {
-  formatDonationAmount,
-  getGoalProgressPercentage,
-} from '../utils';
+import { formatDonationAmount, getGoalProgressPercentage } from '../utils';
 import { GivebackMeterShine } from './GivebackMeterShine';
 
 const barColor =


### PR DESCRIPTION
## Summary
- Show the `/giveback` hero "% funded" label with two decimal places (e.g. `0.01%`, `50.00%`) instead of rounding to whole numbers
- Keep formatting scoped to `GivebackFundingSummary` only; other giveback percentage displays are unchanged

## Test plan
- [x] `pnpm --filter shared exec jest packages/shared/src/features/giveback/components/GivebackFundingSummary.spec.tsx`
- [ ] Open `/giveback` and confirm the funding label shows two decimals for partial progress
- [ ] Confirm the progress bar animation and causes breakdown percentages are unchanged

Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-giveback-funding-percentage.preview.app.daily.dev