### PR TITLE
fix: rename giveback impact tab to Rewards and show all levels

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackImpactPanel.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackImpactPanel.spec.tsx
@@ -145,6 +145,33 @@ beforeEach(() => {
   >);
 });
 
+it('renders every reward level without a show-more toggle', () => {
+  const manyTiers: ContributionRewardTier[] = Array.from(
+    { length: 12 },
+    (_, index) => ({
+      id: `tier-${index + 1}`,
+      title: `Reward ${index + 1}`,
+      description: null,
+      thresholdPoints: (index + 1) * 25,
+      rewardType: ContributionRewardType.Custom,
+      metadata: {},
+    }),
+  );
+  mockRewards.mockReturnValue({ rewardTiers: manyTiers, isPending: false });
+
+  render(<GivebackImpactPanel onTakeAction={jest.fn()} />);
+
+  manyTiers.forEach((tier) => {
+    expect(screen.getByText(tier.title)).toBeInTheDocument();
+  });
+  expect(
+    screen.queryByRole('button', { name: /Show \d+ more levels?/ }),
+  ).not.toBeInTheDocument();
+  expect(
+    screen.queryByRole('button', { name: /Show \d+ completed levels?/ }),
+  ).not.toBeInTheDocument();
+});
+
 it('renders the reward-ladder journey with the current level', () => {
   render(<GivebackImpactPanel onTakeAction={jest.fn()} />);
 

--- a/packages/shared/src/features/giveback/components/GivebackPersonalRoadmap.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackPersonalRoadmap.tsx
@@ -12,7 +12,7 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '../../../components/buttons/Button';
-import { ArrowIcon, GiftIcon } from '../../../components/icons';
+import { GiftIcon } from '../../../components/icons';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
@@ -26,7 +26,6 @@ import { useContributionCausePicker } from '../hooks/useContributionCausePicker'
 import { useContributionActions } from '../hooks/useContributionActions';
 import { formatDonationAmount } from '../utils';
 import { GivebackTabHeading } from './GivebackTabHeading';
-import { RailToggle } from './GivebackRoadmapRail';
 import { NodeRow } from './GivebackRoadmapNode';
 import type {
   ConnectorFill,
@@ -53,10 +52,6 @@ const formatCauseNames = (names: string[]): string | null => {
   const suffix = names.length > 3 ? ', and more' : '';
   return `${head}, and ${tail}${suffix}`;
 };
-
-// How many upcoming levels to reveal after the one you're on. The ladder can be
-// long, so we only ever render a window of it.
-const DEFAULT_UPCOMING = 4;
 
 interface GivebackPersonalRoadmapProps {
   onTakeAction: () => void;
@@ -85,9 +80,6 @@ export const GivebackPersonalRoadmap = ({
   const [claimingId, setClaimingId] = useState<string | null>(null);
   // The tier whose reward reveal is open (set after a successful claim).
   const [revealTierId, setRevealTierId] = useState<string | null>(null);
-  const [showCompleted, setShowCompleted] = useState(true);
-  const [showAllUpcoming, setShowAllUpcoming] = useState(false);
-
   const levels = useMemo<RoadmapLevel[]>(
     () =>
       [...rewardTiers]
@@ -260,29 +252,18 @@ export const GivebackPersonalRoadmap = ({
     await claimFoundingAward();
   };
 
-  // Window: current level + the next few. "Show more" extends it; "Show
-  // completed" reveals everything already cleared above.
-  const upcomingEnd = showAllUpcoming
-    ? total - 1
-    : Math.min(total - 1, focusIndex + DEFAULT_UPCOMING);
-  const visibleStart = showCompleted ? 0 : focusIndex;
-  const hiddenUpcoming = total - 1 - upcomingEnd;
-  const canCollapseUpcoming = total - 1 > focusIndex + DEFAULT_UPCOMING;
-
-  const visibleNodes: RoadmapNode[] = levels
-    .slice(visibleStart, upcomingEnd + 1)
-    .map((level) => {
-      const index = level.levelNumber - 1;
-      return {
-        level,
-        isLast: index === total - 1,
-        isReached: approved >= level.requiredApprovedAmount,
-        isCurrent: level.levelNumber === focusIndex + 1,
-        isNext: level.id === nextLevel?.id,
-        isClaimed: claimedIds.has(level.id),
-        connector: getConnector(index),
-      };
-    });
+  const roadmapNodes: RoadmapNode[] = levels.map((level) => {
+    const index = level.levelNumber - 1;
+    return {
+      level,
+      isLast: index === total - 1,
+      isReached: approved >= level.requiredApprovedAmount,
+      isCurrent: level.levelNumber === focusIndex + 1,
+      isNext: level.id === nextLevel?.id,
+      isClaimed: claimedIds.has(level.id),
+      connector: getConnector(index),
+    };
+  });
 
   const revealTier = revealTierId
     ? rewardTiers.find((tier) => tier.id === revealTierId)
@@ -387,26 +368,7 @@ export const GivebackPersonalRoadmap = ({
             </Typography>
 
             <FlexCol>
-              {focusIndex > 0 && (
-                <RailToggle
-                  icon={
-                    <ArrowIcon
-                      className={showCompleted ? 'rotate-180' : undefined}
-                    />
-                  }
-                  label={
-                    showCompleted
-                      ? 'Hide completed levels'
-                      : `Show ${focusIndex} completed ${
-                          focusIndex === 1 ? 'level' : 'levels'
-                        }`
-                  }
-                  onClick={() => setShowCompleted((value) => !value)}
-                  connectorBelow={{ type: 'full' }}
-                />
-              )}
-
-              {visibleNodes.map((node) => (
+              {roadmapNodes.map((node) => (
                 <NodeRow
                   key={node.level.id}
                   node={node}
@@ -418,31 +380,7 @@ export const GivebackPersonalRoadmap = ({
                   onTakeAction={handleTakeAction}
                 />
               ))}
-
-              {hiddenUpcoming > 0 && (
-                <RailToggle
-                  icon={<ArrowIcon className="rotate-180" />}
-                  label={`Show ${hiddenUpcoming} more ${
-                    hiddenUpcoming === 1 ? 'level' : 'levels'
-                  }`}
-                  onClick={() => setShowAllUpcoming(true)}
-                />
-              )}
             </FlexCol>
-
-            {showAllUpcoming && canCollapseUpcoming && (
-              <FlexRow className="justify-center">
-                <Button
-                  type="button"
-                  size={ButtonSize.Small}
-                  variant={ButtonVariant.Float}
-                  icon={<ArrowIcon />}
-                  onClick={() => setShowAllUpcoming(false)}
-                >
-                  Show less
-                </Button>
-              </FlexRow>
-            )}
           </FlexCol>
         </FlexCol>
       </section>

--- a/packages/shared/src/features/giveback/components/GivebackRoadmapRail.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackRoadmapRail.tsx
@@ -1,11 +1,5 @@
 import type { ReactElement } from 'react';
 import React from 'react';
-import classNames from 'classnames';
-import {
-  Typography,
-  TypographyColor,
-  TypographyType,
-} from '../../../components/typography/Typography';
 import type { ConnectorFill } from './givebackRoadmapTypes';
 
 // A straight 3px track between nodes. Cleared segments are green; the live
@@ -24,52 +18,4 @@ export const Connector = ({ fill }: { fill: ConnectorFill }): ReactElement => (
       />
     )}
   </div>
-);
-
-interface RailToggleProps {
-  icon: ReactElement;
-  label: string;
-  onClick: () => void;
-  connectorBelow?: ConnectorFill;
-}
-
-// A dashed node that expands/collapses a stretch of the rail (completed levels
-// above, upcoming levels below), styled like a node so it sits on the same track.
-export const RailToggle = ({
-  icon,
-  label,
-  onClick,
-  connectorBelow,
-}: RailToggleProps): ReactElement => (
-  <button
-    type="button"
-    onClick={onClick}
-    className="group flex w-full gap-4 text-left"
-  >
-    <div className="relative flex w-10 shrink-0 flex-col items-center">
-      <span className="z-1 flex size-10 items-center justify-center rounded-14 border border-dashed border-border-subtlest-secondary bg-background-default text-text-tertiary transition-colors group-hover:border-accent-cabbage-default group-hover:text-accent-cabbage-default [&_svg]:size-4">
-        {icon}
-      </span>
-      {connectorBelow && <Connector fill={connectorBelow} />}
-    </div>
-    <div
-      className={classNames(
-        'flex min-w-0 flex-1 flex-col',
-        connectorBelow ? 'pb-8' : 'pb-1',
-      )}
-    >
-      {/* Match the icon's height so the label centers against the node, not the
-          full icon + connector run. */}
-      <div className="flex h-10 items-center">
-        <Typography
-          type={TypographyType.Footnote}
-          bold
-          color={TypographyColor.Tertiary}
-          className="transition-colors group-hover:text-text-primary"
-        >
-          {label}
-        </Typography>
-      </div>
-    </div>
-  </button>
 );

--- a/packages/shared/src/features/giveback/components/GivebackTabHeading.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackTabHeading.tsx
@@ -13,7 +13,7 @@ interface GivebackTabHeadingProps {
   description?: ReactNode;
 }
 
-// One shared header for every onboarded tab (Take action / Your impact / Causes
+// One shared header for every onboarded tab (Take action / Rewards / Causes
 // / FAQ) so the title and subtitle always share the exact same size, color, gap
 // and width. Keeping this in one place stops the per-tab styling from drifting.
 export const GivebackTabHeading = ({

--- a/packages/shared/src/features/giveback/components/GivebackTabNav.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackTabNav.spec.tsx
@@ -6,7 +6,7 @@ it('renders the tabs from the shared tab list', () => {
   render(<GivebackTabNav activeTab="actions" onSelect={jest.fn()} />);
 
   expect(screen.getByText('Take action')).toBeInTheDocument();
-  expect(screen.getByText('Your impact')).toBeInTheDocument();
+  expect(screen.getByText('Rewards')).toBeInTheDocument();
   expect(screen.getByText('Causes')).toBeInTheDocument();
   expect(screen.getByText('FAQ')).toBeInTheDocument();
 });

--- a/packages/shared/src/features/giveback/components/GivebackTabNav.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackTabNav.tsx
@@ -11,7 +11,7 @@ interface GivebackTab {
 
 export const givebackTabs: GivebackTab[] = [
   { id: 'actions', label: 'Take action' },
-  { id: 'impact', label: 'Your impact' },
+  { id: 'impact', label: 'Rewards' },
   { id: 'causes', label: 'Causes' },
   { id: 'faq', label: 'FAQ' },
 ];

--- a/packages/storybook/stories/features/giveback/GivebackTabNav.stories.tsx
+++ b/packages/storybook/stories/features/giveback/GivebackTabNav.stories.tsx
@@ -4,7 +4,7 @@ import { GivebackTabNav } from '@dailydotdev/shared/src/features/giveback/compon
 import type { GivebackTabId } from '@dailydotdev/shared/src/features/giveback/components/GivebackTabNav';
 import { withGiveback } from './giveback.mocks';
 
-// The sticky tab navigation that switches between Take action / Impact /
+// The sticky tab navigation that switches between Take action / Rewards /
 // Campaign. Prop-driven (activeTab + onSelect); this story keeps the active tab
 // in local state so the tabs are clickable.
 const meta: Meta<typeof GivebackTabNav> = {


### PR DESCRIPTION
## Summary
- Rename the `/giveback` "Your impact" tab label to "Rewards" (tab id stays `impact` for analytics/routing).
- Show the full reward ladder upfront by removing completed/upcoming level pagination toggles.
- Remove unused `RailToggle` and add a regression test covering 12 tiers with no show-more controls.

## Test plan
- [x] `pnpm --filter shared exec jest GivebackTabNav.spec.tsx GivebackImpactPanel.spec.tsx`
- [ ] Open `/giveback` and confirm the tab reads "Rewards"
- [ ] On the Rewards tab, verify all reward levels render without "Show more levels" or "Show completed levels"
- [ ] Confirm claim flow and founding award still work on the Rewards tab


Made with [Cursor](https://cursor.com)

### Preview domain
https://fix-giveback-rewards-tab-all-lev.preview.app.daily.dev