### PR TITLE
fix(giveback): stop causes-breakdown slices sharing a colour

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackCausesBreakdown.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackCausesBreakdown.tsx
@@ -15,14 +15,17 @@ import { useCountUp, useInView } from '../useGivebackMotion';
 // One stable food-palette accent per slice, pinned by the slice's sorted
 // position so a category keeps the same colour across the donut arc and its
 // legend dot. `fill` paints the legend dot; `text` drives `currentColor` for
-// the SVG arc stroke.
+// the SVG arc stroke. Ordered so the earliest slices are maximally distinct
+// hues and the two magenta-family tones (cabbage purple, bacon pink) sit at
+// opposite ends - a typical 4-5 slice chart never shows both, so no two slices
+// read as the same colour.
 const SLICE_COLORS = [
   { fill: 'bg-accent-cabbage-default', text: 'text-accent-cabbage-default' },
-  { fill: 'bg-accent-avocado-default', text: 'text-accent-avocado-default' },
   { fill: 'bg-accent-cheese-default', text: 'text-accent-cheese-default' },
-  { fill: 'bg-accent-bacon-default', text: 'text-accent-bacon-default' },
   { fill: 'bg-accent-water-default', text: 'text-accent-water-default' },
+  { fill: 'bg-accent-avocado-default', text: 'text-accent-avocado-default' },
   { fill: 'bg-accent-bun-default', text: 'text-accent-bun-default' },
+  { fill: 'bg-accent-bacon-default', text: 'text-accent-bacon-default' },
 ] as const;
 
 // The label for the bucket of causes without a category (`category: null`).


### PR DESCRIPTION
## Problem

In the "Where the money will go" donut (`GivebackCausesBreakdown`), two slices could render in near-identical magenta tones — e.g. **Open source** (cabbage, purple `#BA56E1`) and **Mental health** (bacon, pink `#F25D82`) looked like the same colour.

Cause: `SLICE_COLORS` listed cabbage and bacon close together (positions 1 and 4), so a typical 4-slice chart painted both.

## Fix

Reorder the palette so the earliest slices are maximally distinct hues (purple → yellow → blue → green) and the two magenta-family tones (cabbage, bacon) sit at opposite ends. A typical 4–5 slice chart now never shows both, so no two slices read alike. Colours and tokens are unchanged — only their order.

## Notes

- Pure reorder of the readonly palette array; no logic/type changes.
- `GivebackCausesBreakdown.spec.tsx` passes (it doesn't assert specific colours).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-giveback-breakdown-colors.preview.app.daily.dev