### PR TITLE
fix(giveback): celebrate first unseen milestone

### DIFF
--- a/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.spec.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import type { RefObject } from 'react';
+import { render } from '@testing-library/react';
+import { useQuery } from '@tanstack/react-query';
+import { GivebackLiveActivityListener } from './GivebackLiveActivityListener';
+import type { GivebackGiftDockHandle } from './GivebackGiftDock';
+import type { ContributionMilestone } from '../types';
+import { APP_KEY_PREFIX } from '../../../lib/storage';
+
+jest.mock('@tanstack/react-query', () => ({
+  ...jest.requireActual('@tanstack/react-query'),
+  useQuery: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useSubscription', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+jest.mock('../../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+const mockUseQuery = useQuery as jest.MockedFunction<typeof useQuery>;
+
+const LAST_MILESTONE_STORAGE_KEY = `${APP_KEY_PREFIX}:giveback:last-milestone`;
+
+const milestone = (id: string, value: number): ContributionMilestone => ({
+  id,
+  value,
+  title: null,
+  reachedAt: '2026-07-14T11:02:21.000Z',
+});
+
+const renderListener = (
+  reached: ContributionMilestone | null,
+): { showPrompt: jest.Mock } => {
+  mockUseQuery.mockReturnValue({
+    data: reached
+      ? { contributionLastReachedMilestone: reached }
+      : { contributionLastReachedMilestone: null },
+  } as unknown as ReturnType<typeof useQuery>);
+
+  const showPrompt = jest.fn();
+  const dock = {
+    current: { showPrompt } as unknown as GivebackGiftDockHandle,
+  } as RefObject<GivebackGiftDockHandle>;
+
+  render(<GivebackLiveActivityListener dock={dock} />);
+  return { showPrompt };
+};
+
+beforeEach(() => {
+  window.localStorage.clear();
+  jest.clearAllMocks();
+});
+
+it('pops on first sight when the visitor has never seen a milestone', () => {
+  const { showPrompt } = renderListener(milestone('m-500', 500));
+
+  expect(showPrompt).toHaveBeenCalledTimes(1);
+  expect(window.localStorage.getItem(LAST_MILESTONE_STORAGE_KEY)).toBe('m-500');
+});
+
+it('does not re-pop a milestone the visitor already saw', () => {
+  window.localStorage.setItem(LAST_MILESTONE_STORAGE_KEY, 'm-500');
+
+  const { showPrompt } = renderListener(milestone('m-500', 500));
+
+  expect(showPrompt).not.toHaveBeenCalled();
+});
+
+it('pops when a new milestone is crossed since the last seen one', () => {
+  window.localStorage.setItem(LAST_MILESTONE_STORAGE_KEY, 'm-100');
+
+  const { showPrompt } = renderListener(milestone('m-500', 500));
+
+  expect(showPrompt).toHaveBeenCalledTimes(1);
+  expect(window.localStorage.getItem(LAST_MILESTONE_STORAGE_KEY)).toBe('m-500');
+});
+
+it('does nothing when no milestone has been reached', () => {
+  const { showPrompt } = renderListener(null);
+
+  expect(showPrompt).not.toHaveBeenCalled();
+  expect(window.localStorage.getItem(LAST_MILESTONE_STORAGE_KEY)).toBeNull();
+});

--- a/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.tsx
+++ b/packages/shared/src/features/giveback/components/GivebackLiveActivityListener.tsx
@@ -131,14 +131,9 @@ export function GivebackLiveActivityListener({
       return;
     }
 
-    // Seed on first sight without popping (the milestone may already be old);
-    // only a genuinely new crossing this session celebrates.
-    if (!lastCelebratedRef.current) {
-      lastCelebratedRef.current = milestone.id;
-      window.localStorage.setItem(LAST_MILESTONE_STORAGE_KEY, milestone.id);
-      return;
-    }
-
+    // Celebrate any milestone the visitor hasn't seen yet, including the first
+    // one they encounter. localStorage records the last celebrated id, so a
+    // reload never re-pops the same milestone.
     if (lastCelebratedRef.current === milestone.id) {
       return;
     }


### PR DESCRIPTION
## Problem
The milestone celebration popover never fired in production. The listener silently seeded `localStorage` on **first sight** of a milestone and returned without popping (`reachedAt` was never consulted). Because milestones only just went live — and 500 was reached ~30 min after 100 — effectively every visitor loaded the page with empty `localStorage`, got seeded straight to the current milestone, and saw nothing.

## Fix
Pop for any milestone id the visitor hasn't seen yet, **including the first one**. `localStorage` is used purely as the already-celebrated record, so a reload never re-pops the same milestone.

## Tests
New `GivebackLiveActivityListener.spec.tsx` covers: first-sight pop, no re-pop of a seen milestone, pop on a new crossing, and the empty (no milestone) state. 4/4 pass, lint clean.

## Note
Visitors who were already silently seeded to milestone 500 during the broken window won't retroactively see the 500 popover (their `localStorage` already holds it); they'll celebrate from the next milestone onward. New/unseeded visitors get 500 once on their next load.

### Preview domain
https://fix-giveback-milestone-celebrati.preview.app.daily.dev