### PR TITLE
fix: stop private squads and gated pages from being indexable

### DIFF
--- a/packages/webapp/__tests__/AppSeoRobots.spec.tsx
+++ b/packages/webapp/__tests__/AppSeoRobots.spec.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { render } from '@testing-library/react';
+import type { NextSeoProps } from 'next-seo/lib/types';
+import { DefaultSeo, NextSeo } from 'next-seo';
+import { HeadManagerContext } from 'next/dist/shared/lib/head-manager-context.shared-runtime';
+import { defaultSeo, defaultSeoTitle, robotsProps } from '../next-seo';
+
+// Mirrors the DefaultSeo + page-level NextSeo render order in `_app.tsx`. The
+// HeadManagerContext captures the deduped set of head elements that next/head
+// would flush, so we can assert exactly one robots tag survives and the
+// page-level noindex wins — the whole point of moving robots off
+// `additionalMetaTags` and onto next-seo's first-class robots handling.
+const renderRobotsTags = (seo?: NextSeoProps): ReactElement[] => {
+  let headState: ReactElement[] = [];
+  const headManager = {
+    mountedInstances: new Set(),
+    updateHead: (state: ReactElement[]) => {
+      headState = state;
+    },
+  } as never;
+
+  render(
+    <HeadManagerContext.Provider value={headManager}>
+      <DefaultSeo
+        {...defaultSeo}
+        title={defaultSeoTitle}
+        robotsProps={robotsProps}
+      />
+      {!!seo && <NextSeo robotsProps={robotsProps} {...seo} />}
+    </HeadManagerContext.Provider>,
+  );
+
+  return headState.filter(
+    (el) => (el?.props as { name?: string })?.name === 'robots',
+  );
+};
+
+const contentOf = (tag: ReactElement): string =>
+  (tag.props as { content: string }).content;
+
+describe('app SEO robots tag', () => {
+  it('emits exactly one robots tag for a public page', () => {
+    const robots = renderRobotsTags({ title: 'Public page' });
+
+    expect(robots).toHaveLength(1);
+  });
+
+  it('keeps the max-* directives on public pages after migrating off additionalMetaTags', () => {
+    const [robots] = renderRobotsTags({ title: 'Public page' });
+
+    expect(contentOf(robots)).toBe(
+      'index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1',
+    );
+  });
+
+  it('makes a private squad noindex,nofollow with no stray index,follow tag', () => {
+    const robots = renderRobotsTags({ noindex: true, nofollow: true });
+
+    expect(robots).toHaveLength(1);
+    expect(contentOf(robots[0])).toMatch(/^noindex,nofollow/);
+    robots.forEach((tag) => expect(contentOf(tag)).not.toContain('index,follow'));
+  });
+
+  it('falls back to a single default robots tag when a page renders no page-level seo', () => {
+    const robots = renderRobotsTags();
+
+    expect(robots).toHaveLength(1);
+    expect(contentOf(robots[0])).toBe(
+      'index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1',
+    );
+  });
+});

--- a/packages/webapp/__tests__/AppSeoRobots.spec.tsx
+++ b/packages/webapp/__tests__/AppSeoRobots.spec.tsx
@@ -11,7 +11,7 @@ import { defaultSeo, defaultSeoTitle, robotsProps } from '../next-seo';
 // would flush, so we can assert exactly one robots tag survives and the
 // page-level noindex wins — the whole point of moving robots off
 // `additionalMetaTags` and onto next-seo's first-class robots handling.
-const renderRobotsTags = (seo?: NextSeoProps): ReactElement[] => {
+const getRobotsTags = (seo?: NextSeoProps): ReactElement[] => {
   let headState: ReactElement[] = [];
   const headManager = {
     mountedInstances: new Set(),
@@ -41,13 +41,13 @@ const contentOf = (tag: ReactElement): string =>
 
 describe('app SEO robots tag', () => {
   it('emits exactly one robots tag for a public page', () => {
-    const robots = renderRobotsTags({ title: 'Public page' });
+    const robots = getRobotsTags({ title: 'Public page' });
 
     expect(robots).toHaveLength(1);
   });
 
   it('keeps the max-* directives on public pages after migrating off additionalMetaTags', () => {
-    const [robots] = renderRobotsTags({ title: 'Public page' });
+    const [robots] = getRobotsTags({ title: 'Public page' });
 
     expect(contentOf(robots)).toBe(
       'index,follow,max-snippet:-1,max-image-preview:large,max-video-preview:-1',
@@ -55,15 +55,17 @@ describe('app SEO robots tag', () => {
   });
 
   it('makes a private squad noindex,nofollow with no stray index,follow tag', () => {
-    const robots = renderRobotsTags({ noindex: true, nofollow: true });
+    const robots = getRobotsTags({ noindex: true, nofollow: true });
 
     expect(robots).toHaveLength(1);
     expect(contentOf(robots[0])).toMatch(/^noindex,nofollow/);
-    robots.forEach((tag) => expect(contentOf(tag)).not.toContain('index,follow'));
+    robots.forEach((tag) =>
+      expect(contentOf(tag)).not.toContain('index,follow'),
+    );
   });
 
   it('falls back to a single default robots tag when a page renders no page-level seo', () => {
-    const robots = renderRobotsTags();
+    const robots = getRobotsTags();
 
     expect(robots).toHaveLength(1);
     expect(contentOf(robots[0])).toBe(

--- a/packages/webapp/__tests__/GatedPagesSeo.spec.ts
+++ b/packages/webapp/__tests__/GatedPagesSeo.spec.ts
@@ -1,0 +1,17 @@
+import type { NextSeoProps } from 'next-seo/lib/types';
+import FollowingFeed from '../pages/following';
+
+type WithLayoutProps = {
+  layoutProps?: { seo?: NextSeoProps };
+};
+
+// Regression lock: auth-gated pages must stay noindex,nofollow so private,
+// crawler-inaccessible surfaces are never advertised as indexable.
+describe('gated page seo', () => {
+  it('following feed is noindex and nofollow', () => {
+    const { seo } = (FollowingFeed as WithLayoutProps).layoutProps ?? {};
+
+    expect(seo?.noindex).toBe(true);
+    expect(seo?.nofollow).toBe(true);
+  });
+});

--- a/packages/webapp/__tests__/SquadPageStaticProps.spec.ts
+++ b/packages/webapp/__tests__/SquadPageStaticProps.spec.ts
@@ -1,0 +1,92 @@
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import {
+  getSquad,
+  getSquadStaticFields,
+} from '@dailydotdev/shared/src/graphql/squads';
+import { SourceType } from '@dailydotdev/shared/src/graphql/sources';
+import { getServerSideProps } from '../pages/squads/[handle]/index';
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => {
+  const actual = jest.requireActual('@dailydotdev/shared/src/graphql/common');
+
+  return {
+    ...actual,
+    gqlClient: {
+      request: jest.fn(),
+    },
+  };
+});
+
+jest.mock('@dailydotdev/shared/src/graphql/squads', () => {
+  const actual = jest.requireActual('@dailydotdev/shared/src/graphql/squads');
+
+  return {
+    ...actual,
+    getSquadStaticFields: jest.fn(),
+    getSquad: jest.fn(),
+  };
+});
+
+const mockRequest = gqlClient.request as jest.Mock;
+const mockStaticFields = getSquadStaticFields as jest.Mock;
+const mockGetSquad = getSquad as jest.Mock;
+
+const createSquad = (isPublic: boolean) => ({
+  id: 'squad-id',
+  handle: 'my-squad',
+  name: 'My Squad',
+  permalink: 'https://app.daily.dev/squads/my-squad',
+  description: 'A squad',
+  image: 'https://media.daily.dev/squad.png',
+  membersCount: 3,
+  public: isPublic,
+});
+
+const runGssp = () =>
+  getServerSideProps({
+    params: { handle: 'my-squad' },
+    query: {},
+    res: { setHeader: jest.fn() },
+  } as never);
+
+describe('squad page getServerSideProps seo', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+    mockStaticFields.mockReset();
+    mockGetSquad.mockReset();
+    mockRequest.mockResolvedValue({
+      source: { type: SourceType.Squad, id: 'squad-id' },
+    });
+  });
+
+  it('marks a private squad as noindex and nofollow', async () => {
+    mockStaticFields.mockResolvedValue(createSquad(false));
+
+    const result = await runGssp();
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          noindex: true,
+          nofollow: true,
+        },
+      },
+    });
+  });
+
+  it('keeps a public squad indexable', async () => {
+    mockStaticFields.mockResolvedValue(createSquad(true));
+    mockGetSquad.mockResolvedValue(createSquad(true));
+
+    const result = await runGssp();
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          noindex: false,
+          nofollow: false,
+        },
+      },
+    });
+  });
+});

--- a/packages/webapp/next-seo.ts
+++ b/packages/webapp/next-seo.ts
@@ -31,13 +31,23 @@ export default config;
 export const defaultSeo: Partial<NextSeoProps> = {
   description:
     'daily.dev is the easiest way to stay updated on the latest programming news. Get the best content from the top tech publications on any topic you want.',
-  additionalMetaTags: [
-    {
-      name: 'robots',
-      content:
-        'index, follow, max-snippet:-1, max-image-preview:large, max-video-preview:-1',
-    },
-  ],
+};
+
+// Robots directives must flow through next-seo's first-class robots handling
+// (noindex/nofollow/robotsProps) so exactly one key="robots" tag is emitted per
+// page and page-level noindex always wins. Do NOT reintroduce robots via
+// additionalMetaTags — those are keyed by meta name, escape next-seo's dedupe,
+// and silently override every page's noindex.
+export const robotsProps: NextSeoProps['robotsProps'] = {
+  maxSnippet: -1,
+  maxImagePreview: 'large',
+  maxVideoPreview: -1,
+};
+
+// Spread into a page's `seo` when it is auth-gated / crawler-inaccessible.
+export const noindexSeoProps: Pick<NextSeoProps, 'nofollow' | 'noindex'> = {
+  nofollow: true,
+  noindex: true,
 };
 
 export const getSquadOpenGraph = ({

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -56,7 +56,7 @@ import {
   WebKitMessageHandlers,
 } from '@dailydotdev/shared/src/lib/ios';
 import { useCheckLocation } from '@dailydotdev/shared/src/hooks/useCheckLocation';
-import Seo, { defaultSeo, defaultSeoTitle } from '../next-seo';
+import Seo, { defaultSeo, defaultSeoTitle, robotsProps } from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 import { getAppOrigin, getSiteOrigin } from '../lib/seo';
 import { PixelsProvider } from '../context/PixelsContext';
@@ -470,8 +470,9 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
             url: canonical,
           }}
           titleTemplate={unreadCount ? `(${unreadText}) %s` : '%s'}
+          robotsProps={robotsProps}
         />
-        {!!seo && <NextSeo {...seo} />}
+        {!!seo && <NextSeo robotsProps={robotsProps} {...seo} />}
         <LazyModalElement />
         <DndContextProvider>
           {getLayout(<Component {...pageProps} />, pageProps, layoutProps)}

--- a/packages/webapp/pages/bookmarks/[folderId].tsx
+++ b/packages/webapp/pages/bookmarks/[folderId].tsx
@@ -5,7 +5,7 @@ import { useBookmarkFolder } from '@dailydotdev/shared/src/hooks/bookmark/useBoo
 import { useRouter } from 'next/router';
 import { usePlusSubscription } from '@dailydotdev/shared/src/hooks';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
-import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+import { defaultOpenGraph, defaultSeo, noindexSeoProps } from '../../next-seo';
 import {
   getBookmarkFeedLayout,
   bookmarkFeedLayoutProps,
@@ -15,6 +15,7 @@ const seo: NextSeoProps = {
   title: `Your daily.dev bookmarks`,
   openGraph: { ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 const BookmarksPage = (): ReactElement | null => {

--- a/packages/webapp/pages/bookmarks/index.tsx
+++ b/packages/webapp/pages/bookmarks/index.tsx
@@ -5,12 +5,13 @@ import {
   getBookmarkFeedLayout,
   bookmarkFeedLayoutProps,
 } from '../../components/layouts/BookmarkFeedPage';
-import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+import { defaultOpenGraph, defaultSeo, noindexSeoProps } from '../../next-seo';
 
 const seo: NextSeoProps = {
   title: `Your daily.dev bookmarks`,
   openGraph: { ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 const BookmarksPage = (): ReactElement => <></>;

--- a/packages/webapp/pages/bookmarks/later.tsx
+++ b/packages/webapp/pages/bookmarks/later.tsx
@@ -5,12 +5,13 @@ import {
   getBookmarkFeedLayout,
   bookmarkFeedLayoutProps,
 } from '../../components/layouts/BookmarkFeedPage';
-import { defaultOpenGraph, defaultSeo } from '../../next-seo';
+import { defaultOpenGraph, defaultSeo, noindexSeoProps } from '../../next-seo';
 
 const seo: NextSeoProps = {
   title: `Your daily.dev read it later bookmarks`,
   openGraph: { ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 const BookmarksPage = (): ReactElement => <></>;

--- a/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
+++ b/packages/webapp/pages/feeds/[slugOrId]/edit.tsx
@@ -20,7 +20,11 @@ import {
   getMainFeedLayout,
   mainFeedLayoutProps,
 } from '../../../components/layouts/MainFeedPage';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 
 const seoTitles = getPageSeoTitles('Edit feed');
@@ -28,6 +32,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 const EditFeedPage = (): ReactElement | null => {

--- a/packages/webapp/pages/following.tsx
+++ b/packages/webapp/pages/following.tsx
@@ -5,7 +5,7 @@ import {
   getMainFeedLayout,
   mainFeedLayoutProps,
 } from '../components/layouts/MainFeedPage';
-import { defaultOpenGraph } from '../next-seo';
+import { defaultOpenGraph, noindexSeoProps } from '../next-seo';
 import ProtectedPage from '../components/ProtectedPage';
 import { getPageSeoTitles } from '../components/layouts/utils';
 
@@ -15,6 +15,7 @@ const seo: NextSeoProps = {
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   description:
     'Explore a personalized feed featuring posts from the sources, Squads, and users you follow. Stay updated with content that matches your interests on daily.dev.',
+  ...noindexSeoProps,
 };
 
 const FollowingFeed = (): ReactElement => (

--- a/packages/webapp/pages/my-feed.tsx
+++ b/packages/webapp/pages/my-feed.tsx
@@ -5,12 +5,13 @@ import {
   getMainFeedLayout,
   mainFeedLayoutProps,
 } from '../components/layouts/MainFeedPage';
-import { defaultOpenGraph, defaultSeo } from '../next-seo';
+import { defaultOpenGraph, defaultSeo, noindexSeoProps } from '../next-seo';
 
 const seo: NextSeoProps = {
   title: 'For You',
   openGraph: { ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 const MyFeed = (): ReactElement => <></>;

--- a/packages/webapp/pages/settings/api.tsx
+++ b/packages/webapp/pages/settings/api.tsx
@@ -44,12 +44,13 @@ import {
 } from '@dailydotdev/shared/src/lib/dateFormat';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('API Access'),
+  ...noindexSeoProps,
 };
 
 const OPENAPI_URL = 'https://api.daily.dev/public/v1/docs/json';

--- a/packages/webapp/pages/settings/appearance.tsx
+++ b/packages/webapp/pages/settings/appearance.tsx
@@ -26,7 +26,7 @@ import { FlexCol } from '@dailydotdev/shared/src/components/utilities';
 import { iOSSupportsAppIconChange } from '@dailydotdev/shared/src/lib/ios';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import { SettingsSwitch } from '../../components/layouts/SettingsLayout/common';
 
@@ -206,6 +206,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Appearance'),
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getSettingsLayout;

--- a/packages/webapp/pages/settings/composition.tsx
+++ b/packages/webapp/pages/settings/composition.tsx
@@ -14,7 +14,7 @@ import { WriteFormTab } from '@dailydotdev/shared/src/components/fields/form/com
 import { FlexCol } from '@dailydotdev/shared/src/components/utilities';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const defaultWriteTabs: RadioItemProps[] = Object.keys(WriteFormTab).map(
@@ -61,6 +61,7 @@ const PostingSettingsPage = (): ReactElement => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Posting'),
+  ...noindexSeoProps,
 };
 
 PostingSettingsPage.getLayout = getSettingsLayout;

--- a/packages/webapp/pages/settings/customization/devcard.tsx
+++ b/packages/webapp/pages/settings/customization/devcard.tsx
@@ -9,7 +9,7 @@ import { useActions } from '@dailydotdev/shared/src/hooks';
 import { ActionType } from '@dailydotdev/shared/src/graphql/actions';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { LogEvent } from '@dailydotdev/shared/src/lib/log';
-import { defaultOpenGraph } from '../../../next-seo';
+import { defaultOpenGraph, noindexSeoProps } from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getSettingsLayout } from '../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
@@ -37,6 +37,7 @@ const seo: NextSeoProps = {
     type: 'website',
     site_name: 'daily.dev',
   },
+  ...noindexSeoProps,
 };
 
 const Page = (): ReactElement | null => {

--- a/packages/webapp/pages/settings/customization/gamification.tsx
+++ b/packages/webapp/pages/settings/customization/gamification.tsx
@@ -8,7 +8,7 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../next-seo';
 import { getTemplatedTitle } from '../../../components/layouts/utils';
 import { SettingsSwitch } from '../../../components/layouts/SettingsLayout/common';
 
@@ -112,6 +112,7 @@ const GamificationSettingsPage = (): ReactElement => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   title: getTemplatedTitle('Feature visibility'),
+  ...noindexSeoProps,
 };
 
 GamificationSettingsPage.getLayout = getSettingsLayout;

--- a/packages/webapp/pages/settings/customization/integrations.tsx
+++ b/packages/webapp/pages/settings/customization/integrations.tsx
@@ -17,12 +17,13 @@ import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { LogEvent, Origin } from '@dailydotdev/shared/src/lib/log';
 import { getSettingsLayout } from '../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultSeo } from '../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Integrations'),
+  ...noindexSeoProps,
 };
 
 const AccountIntegrationsPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/customization/streaks.tsx
+++ b/packages/webapp/pages/settings/customization/streaks.tsx
@@ -17,7 +17,7 @@ import { getUserInitialTimezone } from '@dailydotdev/shared/src/lib/timezones';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { SettingsSwitch } from '../../../components/layouts/SettingsLayout/common';
 
@@ -105,6 +105,7 @@ const AccountManageSubscriptionPage = (): ReactElement => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Streaks'),
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getSettingsLayout;

--- a/packages/webapp/pages/settings/feed/ai.tsx
+++ b/packages/webapp/pages/settings/feed/ai.tsx
@@ -4,7 +4,11 @@ import type { NextSeoProps } from 'next-seo';
 
 import { FeedSettingsAISection } from '@dailydotdev/shared/src/components/feeds/FeedSettings/sections/FeedSettingsAISection';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getFeedSettingsLayout } from '../../../components/layouts/SettingsLayout/FeedSettingsLayout';
 
@@ -23,6 +27,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getFeedSettingsLayout;

--- a/packages/webapp/pages/settings/feed/blocked.tsx
+++ b/packages/webapp/pages/settings/feed/blocked.tsx
@@ -4,7 +4,11 @@ import type { NextSeoProps } from 'next-seo';
 
 import { FeedSettingsBlockingSection } from '@dailydotdev/shared/src/components/feeds/FeedSettings/sections/FeedSettingsBlockingSection';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getFeedSettingsLayout } from '../../../components/layouts/SettingsLayout/FeedSettingsLayout';
 
@@ -23,6 +27,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getFeedSettingsLayout;

--- a/packages/webapp/pages/settings/feed/general.tsx
+++ b/packages/webapp/pages/settings/feed/general.tsx
@@ -4,7 +4,11 @@ import type { NextSeoProps } from 'next-seo';
 
 import { FeedSettingsGeneralSection } from '@dailydotdev/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getFeedSettingsLayout } from '../../../components/layouts/SettingsLayout/FeedSettingsLayout';
 
@@ -23,6 +27,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getFeedSettingsLayout;

--- a/packages/webapp/pages/settings/feed/preferences.tsx
+++ b/packages/webapp/pages/settings/feed/preferences.tsx
@@ -4,7 +4,11 @@ import type { NextSeoProps } from 'next-seo';
 
 import { FeedSettingsContentPreferencesSection } from '@dailydotdev/shared/src/components/feeds/FeedSettings/sections/FeedSettingsContentPreferencesSection';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getFeedSettingsLayout } from '../../../components/layouts/SettingsLayout/FeedSettingsLayout';
 
@@ -23,6 +27,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getFeedSettingsLayout;

--- a/packages/webapp/pages/settings/feed/sources.tsx
+++ b/packages/webapp/pages/settings/feed/sources.tsx
@@ -4,7 +4,11 @@ import type { NextSeoProps } from 'next-seo';
 
 import { FeedSettingsContentSourcesSection } from '@dailydotdev/shared/src/components/feeds/FeedSettings/sections/FeedSettingsContentSourcesSection';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getFeedSettingsLayout } from '../../../components/layouts/SettingsLayout/FeedSettingsLayout';
 
@@ -23,6 +27,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getFeedSettingsLayout;

--- a/packages/webapp/pages/settings/feed/tags.tsx
+++ b/packages/webapp/pages/settings/feed/tags.tsx
@@ -4,7 +4,11 @@ import type { NextSeoProps } from 'next-seo';
 
 import { FeedSettingsTagsSection } from '@dailydotdev/shared/src/components/feeds/FeedSettings/sections/FeedSettingsTagsSection';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultOpenGraph, defaultSeo } from '../../../next-seo';
+import {
+  defaultOpenGraph,
+  defaultSeo,
+  noindexSeoProps,
+} from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getFeedSettingsLayout } from '../../../components/layouts/SettingsLayout/FeedSettingsLayout';
 
@@ -23,6 +27,7 @@ const seo: NextSeoProps = {
   title: seoTitles.title,
   openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
   ...defaultSeo,
+  ...noindexSeoProps,
 };
 
 AccountManageSubscriptionPage.getLayout = getFeedSettingsLayout;

--- a/packages/webapp/pages/settings/feedback.tsx
+++ b/packages/webapp/pages/settings/feedback.tsx
@@ -19,12 +19,13 @@ import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import { useUserFeedback } from '@dailydotdev/shared/src/graphql/feedback';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getTemplatedTitle } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   title: getTemplatedTitle('Your Feedback'),
+  ...noindexSeoProps,
 };
 
 const AccountFeedbackPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/invite.tsx
+++ b/packages/webapp/pages/settings/invite.tsx
@@ -44,12 +44,13 @@ import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import AccountContentSection from '../../components/layouts/SettingsLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Invite Friends'),
+  ...noindexSeoProps,
 };
 
 const AccountInvitePage = (): ReactElement => {

--- a/packages/webapp/pages/settings/job-preferences.tsx
+++ b/packages/webapp/pages/settings/job-preferences.tsx
@@ -55,13 +55,14 @@ import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { UploadEmploymentAgreementButton } from '@dailydotdev/shared/src/features/opportunity/components/UploadEmploymentAgreementButton';
 import { ClearEmploymentAgreementButton } from '@dailydotdev/shared/src/features/opportunity/components/ClearEmploymentAgreementButton';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Job preferences'),
+  ...noindexSeoProps,
 };
 
 const options = [

--- a/packages/webapp/pages/settings/notifications.tsx
+++ b/packages/webapp/pages/settings/notifications.tsx
@@ -16,7 +16,7 @@ import EmailNotificationsTab from '@dailydotdev/shared/src/components/notificati
 import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
 
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import { AccountPageContent } from '../../components/layouts/SettingsLayout/common';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
@@ -24,6 +24,7 @@ import { AccountPageContainer } from '../../components/layouts/SettingsLayout/Ac
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Notifications'),
+  ...noindexSeoProps,
 };
 
 type NotificationsTab = 'in-app' | 'email';

--- a/packages/webapp/pages/settings/organization/[orgId]/billing.tsx
+++ b/packages/webapp/pages/settings/organization/[orgId]/billing.tsx
@@ -27,7 +27,7 @@ import { useLazyModal } from '@dailydotdev/shared/src/hooks/useLazyModal';
 import { useOrganizationSubscription } from '@dailydotdev/shared/src/features/organizations/hooks/useOrganizationSubscription';
 import { PlusPriceType } from '@dailydotdev/shared/src/lib/featureValues';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
 import { getOrganizationLayout } from '../../../../components/layouts/OrganizationLayout';
 
@@ -201,6 +201,7 @@ const Page = (): ReactElement | null => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Billing'),
+  ...noindexSeoProps,
 };
 
 Page.getLayout = getOrganizationLayout;

--- a/packages/webapp/pages/settings/organization/[orgId]/general.tsx
+++ b/packages/webapp/pages/settings/organization/[orgId]/general.tsx
@@ -36,7 +36,7 @@ import type { PromptOptions } from '@dailydotdev/shared/src/hooks/usePrompt';
 import { usePrompt } from '@dailydotdev/shared/src/hooks/usePrompt';
 import { getOrganizationLayout } from '../../../../components/layouts/OrganizationLayout';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const Page = (): ReactElement | null => {
@@ -218,6 +218,7 @@ const Page = (): ReactElement | null => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('General'),
+  ...noindexSeoProps,
 };
 
 Page.getLayout = getOrganizationLayout;

--- a/packages/webapp/pages/settings/organization/[orgId]/members.tsx
+++ b/packages/webapp/pages/settings/organization/[orgId]/members.tsx
@@ -65,7 +65,7 @@ import {
 } from '@dailydotdev/shared/src/components/dropdown/DropdownMenu';
 import type { MenuItemProps } from '@dailydotdev/shared/src/components/dropdown/common';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
 import { getOrganizationLayout } from '../../../../components/layouts/OrganizationLayout';
 
@@ -478,6 +478,7 @@ const Page = (): ReactElement | null => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Members'),
+  ...noindexSeoProps,
 };
 
 Page.getLayout = getOrganizationLayout;

--- a/packages/webapp/pages/settings/organization/index.tsx
+++ b/packages/webapp/pages/settings/organization/index.tsx
@@ -45,7 +45,7 @@ import UserBadge from '@dailydotdev/shared/src/components/UserBadge';
 import { getOrganizationSettingsUrl } from '@dailydotdev/shared/src/features/organizations/utils';
 import { AccountPageContainer } from '../../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../next-seo';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 
 const NoOrganizations = () => {
@@ -177,6 +177,7 @@ const Page = (): ReactElement => {
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Organizations'),
+  ...noindexSeoProps,
 };
 
 Page.getLayout = getSettingsLayout;

--- a/packages/webapp/pages/settings/privacy.tsx
+++ b/packages/webapp/pages/settings/privacy.tsx
@@ -20,12 +20,13 @@ import { useConsentCookie } from '@dailydotdev/shared/src/hooks/useCookieConsent
 import AccountContentSection from '../../components/layouts/SettingsLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Privacy'),
+  ...noindexSeoProps,
 };
 
 const AccountInvitePage = (): ReactElement | null => {

--- a/packages/webapp/pages/settings/profile.tsx
+++ b/packages/webapp/pages/settings/profile.tsx
@@ -4,12 +4,13 @@ import React from 'react';
 import type { NextSeoProps } from 'next-seo';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
 import ProfileIndex from '../../components/layouts/SettingsLayout/Profile';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Profile details'),
+  ...noindexSeoProps,
 };
 
 const AccountProfilePage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/certification.tsx
+++ b/packages/webapp/pages/settings/profile/experience/certification.tsx
@@ -12,13 +12,14 @@ import { ExperienceSettings } from '@dailydotdev/shared/src/components/profile/E
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Certifications'),
+  ...noindexSeoProps,
 };
 
 const CertificationsPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/edit.tsx
+++ b/packages/webapp/pages/settings/profile/experience/edit.tsx
@@ -26,12 +26,13 @@ import { useRouter } from 'next/router';
 import { getCookiesAndHeadersFromRequest } from '@dailydotdev/shared/src/features/onboarding/lib/utils';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Edit experience'),
+  ...noindexSeoProps,
 };
 
 const titleCopy = {

--- a/packages/webapp/pages/settings/profile/experience/education.tsx
+++ b/packages/webapp/pages/settings/profile/experience/education.tsx
@@ -12,13 +12,14 @@ import { ExperienceSettings } from '@dailydotdev/shared/src/components/profile/E
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Education'),
+  ...noindexSeoProps,
 };
 
 const EducationPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/opensource.tsx
+++ b/packages/webapp/pages/settings/profile/experience/opensource.tsx
@@ -12,13 +12,14 @@ import { ExperienceSettings } from '@dailydotdev/shared/src/components/profile/E
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Open Source'),
+  ...noindexSeoProps,
 };
 
 const OpenSourcePage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/project.tsx
+++ b/packages/webapp/pages/settings/profile/experience/project.tsx
@@ -12,13 +12,14 @@ import { ExperienceSettings } from '@dailydotdev/shared/src/components/profile/E
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Projects & Publications'),
+  ...noindexSeoProps,
 };
 
 const ProjectsPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/volunteering.tsx
+++ b/packages/webapp/pages/settings/profile/experience/volunteering.tsx
@@ -12,13 +12,14 @@ import { ExperienceSettings } from '@dailydotdev/shared/src/components/profile/E
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Volunteering'),
+  ...noindexSeoProps,
 };
 
 const VolunteeringPage = (): ReactElement => {

--- a/packages/webapp/pages/settings/profile/experience/work.tsx
+++ b/packages/webapp/pages/settings/profile/experience/work.tsx
@@ -12,13 +12,14 @@ import { ExperienceSettings } from '@dailydotdev/shared/src/components/profile/E
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../../components/layouts/utils';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getSettingsLayout } from '../../../../components/layouts/SettingsLayout';
 import { AccountPageContainer } from '../../../../components/layouts/SettingsLayout/AccountPageContainer';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Work Experience'),
+  ...noindexSeoProps,
 };
 
 const WorkExperiencePage = (): ReactElement => {

--- a/packages/webapp/pages/settings/security.tsx
+++ b/packages/webapp/pages/settings/security.tsx
@@ -32,12 +32,13 @@ import type {
 } from '../../components/layouts/SettingsLayout/Security';
 import AccountSecurityDefault from '../../components/layouts/SettingsLayout/Security';
 import EmailFormPage from '../../components/layouts/SettingsLayout/Security/EmailFormPage';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Account & Security'),
+  ...noindexSeoProps,
 };
 
 const BETTER_AUTH_CHANGE_EMAIL_MESSAGE =

--- a/packages/webapp/pages/settings/subscription.tsx
+++ b/packages/webapp/pages/settings/subscription.tsx
@@ -36,7 +36,7 @@ import {
 import AccountContentSection from '../../components/layouts/SettingsLayout/AccountContentSection';
 import { AccountPageContainer } from '../../components/layouts/SettingsLayout/AccountPageContainer';
 import { getSettingsLayout } from '../../components/layouts/SettingsLayout';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
 const UpgradeToPlus = dynamic(() =>
@@ -54,6 +54,7 @@ const PlusList = dynamic(() =>
 const seo: NextSeoProps = {
   ...defaultSeo,
   ...getPageSeoTitles('Subscriptions'),
+  ...noindexSeoProps,
 };
 
 const PlusInfo = (): ReactElement => {

--- a/packages/webapp/pages/squads/discover/my.tsx
+++ b/packages/webapp/pages/squads/discover/my.tsx
@@ -31,7 +31,7 @@ import {
 import { getLayout } from '../../../components/layouts/FeedLayout';
 import { mainFeedLayoutProps } from '../../../components/layouts/MainFeedPage';
 import { SquadDirectoryLayout } from '../../../../shared/src/components/squads/layout/SquadDirectoryLayout';
-import { defaultSeo } from '../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../next-seo';
 
 interface SquadSectionProps {
   squads: Squad[];
@@ -135,7 +135,11 @@ function MySquadsPage(): ReactElement | null {
   );
 }
 
-const seo: NextSeoProps = { ...defaultSeo, title: 'My Squads' };
+const seo: NextSeoProps = {
+  ...defaultSeo,
+  title: 'My Squads',
+  ...noindexSeoProps,
+};
 
 MySquadsPage.getLayout = getLayout;
 MySquadsPage.layoutProps = { ...mainFeedLayoutProps, seo };

--- a/packages/webapp/pages/team/feedback.tsx
+++ b/packages/webapp/pages/team/feedback.tsx
@@ -33,11 +33,12 @@ import {
 } from '@dailydotdev/shared/src/lib/feedback';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { getTemplatedTitle } from '../../components/layouts/utils';
-import { defaultSeo } from '../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../next-seo';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   title: getTemplatedTitle('Open Feedback'),
+  ...noindexSeoProps,
 };
 
 const OPEN_FEEDBACK_STATUSES = [
@@ -121,7 +122,12 @@ const TeamFeedbackUser = ({
     <Link href={`/team/users/${item.user.id}/feedback`}>
       <a className="mb-3 flex items-center gap-3 rounded-12 px-1 transition-colors hover:bg-surface-hover">
         <ProfilePicture
-          user={{ ...item.user, image: item.user.image ?? '' }}
+          user={{
+            ...item.user,
+            image: item.user.image ?? '',
+            name: item.user.name ?? undefined,
+            username: item.user.username ?? undefined,
+          }}
           size={ProfileImageSize.Small}
         />
         <div className="flex min-w-0 flex-col">

--- a/packages/webapp/pages/team/users/[id]/feedback.tsx
+++ b/packages/webapp/pages/team/users/[id]/feedback.tsx
@@ -13,12 +13,13 @@ import InfiniteScrolling from '@dailydotdev/shared/src/components/containers/Inf
 import { Loader } from '@dailydotdev/shared/src/components/Loader';
 import { FeedbackCard } from '@dailydotdev/shared/src/components/feedback/FeedbackCard';
 import { getLayout } from '../../../../components/layouts/MainLayout';
-import { defaultSeo } from '../../../../next-seo';
+import { defaultSeo, noindexSeoProps } from '../../../../next-seo';
 import { getTemplatedTitle } from '../../../../components/layouts/utils';
 
 const seo: NextSeoProps = {
   ...defaultSeo,
   title: getTemplatedTitle('User Feedback'),
+  ...noindexSeoProps,
 };
 
 const TeamUserFeedbackPage = (): ReactElement | null => {


### PR DESCRIPTION
## What

Private squads (and other auth-gated pages) were emitting `index, follow` despite the squad page already setting `noindex`/`nofollow`.

## Root cause

`defaultSeo` injected a global `robots` tag via `additionalMetaTags`. next-seo keys those by meta name, not `key="robots"`, so next/head never deduped it against the page-level native robots tag. Every noindex page therefore rendered **two** robots tags — the correct `noindex,nofollow` and a stray `index, follow, max-snippet…` — and the stray one won in practice.

## Changes

- **Migrate robots off `additionalMetaTags`** onto next-seo's first-class handling: add a shared `robotsProps` (the `max-*` directives) and pass it to both `DefaultSeo` and the page-level `NextSeo` in `_app.tsx`. Now exactly one `robots` tag is emitted per page and page-level `noindex` always wins.
- Add a shared `noindexSeoProps` constant and spread it into the `seo` of auth-gated / crawler-inaccessible pages: `following`, all `settings/**`, `bookmarks/**`, `my-feed`, `squads/discover/my`, `feeds/[slugOrId]/edit`, and `team/**` feedback.
- Regression tests: single robots tag + `max-*` survival (via `HeadManagerContext` to exercise the real next/head dedupe), squad GSSP noindex flags, and a gated-page seo lock.

## Key decisions

- **noindex stays per-page (via `_app`'s server-rendered `NextSeo`), not in `SettingsLayout`.** A single `NextSeo` in the shared layout looked tempting, but `SettingsLayout` returns `null`/an auth wall for unauthenticated requests and settings pages have no `getServerSideProps` — so during SSR (what crawlers receive) it wouldn't render, dropping noindex from the initial HTML.
- **Public pages untouched** (feeds, sources, tags, posts, public squads, public profiles) so they stay `index,follow` with the `max-*` directives byte-preserved.
- Kept a small `null → undefined` coercion in `team/feedback.tsx` required by the strict typecheck guard once the file entered scope.

Closes ENG-1862

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1862-private-squads-still-ha.preview.app.daily.dev