### PR TITLE
feat(cards): replace collection pill with source stack

### DIFF
--- a/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
@@ -1,8 +1,7 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
-import { CollectionPillSources } from '../../post/collection/CollectionPillSources';
-import { getCollectionPillLabel } from '../../post/collection/common';
+import { CollectionSourceStack } from '../../post/collection/CollectionSourceStack';
 import {
   BookmakProviderHeader,
   headerHiddenClassName,
@@ -31,23 +30,22 @@ export const CollectionCardHeader = ({
   return (
     <>
       {highlightBookmarkedPost && <BookmakProviderHeader />}
-      <CollectionPillSources
-        className={{
-          main: classNames(
-            'mb-1 mt-3',
-            highlightBookmarkedPost && headerHiddenClassName,
-          ),
-        }}
-        sources={sources ?? []}
-        totalSources={totalSources ?? 0}
-        label={getCollectionPillLabel(post)}
+      <div
+        className={classNames(
+          'mb-1 mt-3 flex flex-row items-center',
+          highlightBookmarkedPost && headerHiddenClassName,
+        )}
       >
+        <CollectionSourceStack
+          sources={sources ?? []}
+          totalSources={totalSources ?? 0}
+        />
         <div className="flex-1" />
         <PostOptionButton
           post={post}
           triggerClassName="laptop:mouse:invisible laptop:mouse:group-hover:visible"
         />
-      </CollectionPillSources>
+      </div>
     </>
   );
 };

--- a/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionCardHeader.tsx
@@ -32,7 +32,9 @@ export const CollectionCardHeader = ({
       {highlightBookmarkedPost && <BookmakProviderHeader />}
       <div
         className={classNames(
-          'mb-1 mt-3 flex flex-row items-center',
+          // mt-4 matches the article card's CardHeader top margin so the title
+          // (and the tags/date below it) start on the same row.
+          'mb-1 mt-4 flex flex-row items-center',
           highlightBookmarkedPost && headerHiddenClassName,
         )}
       >

--- a/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
@@ -107,20 +107,31 @@ it('should hide read time when not available', async () => {
   expect(screen.queryByTestId('readTime')).not.toBeInTheDocument();
 });
 
-it('should display the `collection` pill in the header', async () => {
-  renderComponent();
-  await screen.findByText('Collection');
-});
-
-it('should display the `Trend` pill when the post source is trends', async () => {
+it('should display the collection source stack in the header', async () => {
   renderComponent({
     post: {
       ...post,
-      source: { ...post.source, id: 'trends' } as Post['source'],
-    },
+      collectionSources: [
+        {
+          id: 'src1',
+          handle: 'src1',
+          name: 'Source One',
+          image: 'https://daily.dev/src1.png',
+          permalink: 'https://daily.dev/sources/src1',
+        },
+        {
+          id: 'src2',
+          handle: 'src2',
+          name: 'Source Two',
+          image: 'https://daily.dev/src2.png',
+          permalink: 'https://daily.dev/sources/src2',
+        },
+      ],
+      numCollectionSources: 2,
+    } as Post,
   });
-  await screen.findByText('Trend');
-  expect(screen.queryByText('Collection')).not.toBeInTheDocument();
+  await screen.findByAltText('Avatar of src1');
+  await screen.findByAltText('Avatar of src2');
 });
 
 it('should show options button on hover when in laptop size', async () => {

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -9,6 +9,7 @@ import {
   getPostClassNames,
   FreeformCardTitle,
   CardTextContainer,
+  CardSpace,
 } from '../common/Card';
 import { WelcomePostCardFooter } from '../common/WelcomePostCardFooter';
 import ActionButtons from '../common/ActionButtons';
@@ -69,6 +70,17 @@ export const CollectionGrid = forwardRef(function CollectionCard(
     );
   }
 
+  const postMetadata = (
+    <PostMetadata
+      createdAt={wasUpdated ? post.updatedAt : post.createdAt}
+      dateLabel={wasUpdated ? 'Updated' : undefined}
+      dateType={wasUpdated ? TimeFormatType.PostUpdated : TimeFormatType.Post}
+      readTime={post.readTime}
+      numSources={post.numCollectionSources}
+      className={classNames('mx-4', !image && 'mb-4')}
+    />
+  );
+
   return (
     <FeedItemContainer
       domProps={{
@@ -100,16 +112,21 @@ export const CollectionGrid = forwardRef(function CollectionCard(
         >
           {post.title}
         </FreeformCardTitle>
-        <PostTags post={post} />
+        {/* Freeform (text) cards keep the tags directly under the title. */}
+        {!image && <PostTags post={post} />}
       </CardTextContainer>
-      <PostMetadata
-        createdAt={wasUpdated ? post.updatedAt : post.createdAt}
-        dateLabel={wasUpdated ? 'Updated' : undefined}
-        dateType={wasUpdated ? TimeFormatType.PostUpdated : TimeFormatType.Post}
-        readTime={post.readTime}
-        numSources={post.numCollectionSources}
-        className={classNames('mx-4', post.image ? 'my-0' : 'mb-4')}
-      />
+      {image ? (
+        // With a cover image, push the tags + date to the bottom of the text
+        // area so they rest just above the image — the same placement as the
+        // default article card, independent of the title length.
+        <Container>
+          <CardSpace />
+          <PostTags post={post} className="mx-4" />
+          {postMetadata}
+        </Container>
+      ) : (
+        postMetadata
+      )}
       <Container className={useGlass && image ? 'flex-none' : undefined}>
         <WelcomePostCardFooter
           image={image}

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -77,7 +77,7 @@ export const CollectionGrid = forwardRef(function CollectionCard(
       dateType={wasUpdated ? TimeFormatType.PostUpdated : TimeFormatType.Post}
       readTime={post.readTime}
       numSources={post.numCollectionSources}
-      className={classNames('mx-4', !image && 'mb-4')}
+      className="mx-4"
     />
   );
 
@@ -112,21 +112,15 @@ export const CollectionGrid = forwardRef(function CollectionCard(
         >
           {post.title}
         </FreeformCardTitle>
-        {/* Freeform (text) cards keep the tags directly under the title. */}
-        {!image && <PostTags post={post} />}
       </CardTextContainer>
-      {image ? (
-        // With a cover image, push the tags + date to the bottom of the text
-        // area so they rest just above the image — the same placement as the
-        // default article card, independent of the title length.
-        <Container>
-          <CardSpace />
-          <PostTags post={post} className="mx-4" />
-          {postMetadata}
-        </Container>
-      ) : (
-        postMetadata
-      )}
+      {/* Push the tags + date to the bottom of the text area, just above the
+          footer (cover image or freeform text preview), matching the default
+          article card so they align regardless of title length. */}
+      <Container>
+        <CardSpace />
+        <PostTags post={post} className="mx-4" />
+        {postMetadata}
+      </Container>
       <Container className={useGlass && image ? 'flex-none' : undefined}>
         <WelcomePostCardFooter
           image={image}

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -112,7 +112,7 @@ export const CollectionGrid = forwardRef(function CollectionCard(
         dateType={wasUpdated ? TimeFormatType.PostUpdated : TimeFormatType.Post}
         readTime={post.readTime}
         numSources={post.numCollectionSources}
-        className={classNames('mx-4', post.image ? 'my-0' : 'mb-4 mt-2')}
+        className={classNames('mx-4', post.image ? 'my-0' : 'mb-4')}
       />
       <Container className={useGlass && image ? 'flex-none' : undefined}>
         <WelcomePostCardFooter

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -9,7 +9,6 @@ import {
   getPostClassNames,
   FreeformCardTitle,
   CardTextContainer,
-  CardSpace,
 } from '../common/Card';
 import { WelcomePostCardFooter } from '../common/WelcomePostCardFooter';
 import ActionButtons from '../common/ActionButtons';
@@ -89,7 +88,7 @@ export const CollectionGrid = forwardRef(function CollectionCard(
         onPostCardClick={onPostCardClick}
         onPostCardAuxClick={onPostCardAuxClick}
       />
-      <CardTextContainer className="mx-4 flex-1">
+      <CardTextContainer className="mx-4">
         <CollectionCardHeader post={post} />
         <FreeformCardTitle
           className={classNames(
@@ -102,8 +101,6 @@ export const CollectionGrid = forwardRef(function CollectionCard(
         >
           {post.title}
         </FreeformCardTitle>
-
-        <CardSpace />
         <PostTags post={post} />
       </CardTextContainer>
       <PostMetadata

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -2,7 +2,7 @@ import type { Ref } from 'react';
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import type { PostCardProps } from '../common/common';
-import { Container, generateTitleClamp } from '../common/common';
+import { Container } from '../common/common';
 import FeedItemContainer from '../common/FeedItemContainer';
 import { CollectionCardHeader } from './CollectionCardHeader';
 import {
@@ -92,10 +92,9 @@ export const CollectionGrid = forwardRef(function CollectionCard(
         <CollectionCardHeader post={post} />
         <FreeformCardTitle
           className={classNames(
-            generateTitleClamp({
-              hasImage: !!image,
-              hasHtmlContent: !!post.contentHtml,
-            }),
+            // Match the default article card's title guideline: clamp to 3 lines
+            // at natural height (no fixed reserve).
+            'line-clamp-3',
             'font-bold text-text-primary typo-title3',
           )}
         >

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -9,6 +9,7 @@ import {
   getPostClassNames,
   FreeformCardTitle,
   CardTextContainer,
+  CardSpace,
 } from '../common/Card';
 import { WelcomePostCardFooter } from '../common/WelcomePostCardFooter';
 import ActionButtons from '../common/ActionButtons';
@@ -102,7 +103,8 @@ export const CollectionGrid = forwardRef(function CollectionCard(
           {post.title}
         </FreeformCardTitle>
 
-        <PostTags post={post} className="!items-end" />
+        <CardSpace />
+        <PostTags post={post} />
       </CardTextContainer>
       <PostMetadata
         createdAt={wasUpdated ? post.updatedAt : post.createdAt}

--- a/packages/shared/src/components/cards/collection/CollectionGrid.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.tsx
@@ -131,6 +131,11 @@ export const CollectionGrid = forwardRef(function CollectionCard(
           imageClassName={
             useGlass && image ? glassCoverImageClassName : undefined
           }
+          // Give the freeform text preview the same footer height as the cover
+          // image slot (h-40 image + its mt-2/mb-1 margins = 10.5rem) so the
+          // tags/date bottom-anchor to the same row as the image cards and the
+          // default article card.
+          contentClassName="min-h-[10.5rem]"
         />
         {useGlass ? (
           <FeedCardGlassActions

--- a/packages/shared/src/components/cards/collection/CollectionList.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionList.tsx
@@ -13,8 +13,7 @@ import {
 import ActionButtons from '../common/ActionButtons';
 import { usePostImage } from '../../../hooks/post/usePostImage';
 import { PostCardHeader } from '../common/list/PostCardHeader';
-import { CollectionPillSources } from '../../post/collection/CollectionPillSources';
-import { getCollectionPillLabel } from '../../post/collection/common';
+import { CollectionSourceStack } from '../../post/collection/CollectionSourceStack';
 import { useTruncatedSummary, useViewSize, ViewSize } from '../../../hooks';
 import PostTags from '../common/PostTags';
 import { CardCoverList } from '../common/list/CardCover';
@@ -111,15 +110,14 @@ export const CollectionList = forwardRef(function CollectionCard(
             numSources: post.numCollectionSources,
           }}
         >
-          <CollectionPillSources
-            className={{
-              main: classNames(!!post.collectionSources?.length && '-my-0.5'),
-              avatar: 'group-hover:border-background-subtle',
-            }}
+          <CollectionSourceStack
+            className={classNames(
+              !!post.collectionSources?.length && '-my-0.5',
+            )}
             sources={post.collectionSources ?? []}
             totalSources={post.numCollectionSources ?? 0}
-            alwaysShowSources
-            label={getCollectionPillLabel(post)}
+            alwaysExpanded
+            enableHoverCard={false}
           />
         </PostCardHeader>
 

--- a/packages/shared/src/components/cards/common/WelcomePostCardFooter.tsx
+++ b/packages/shared/src/components/cards/common/WelcomePostCardFooter.tsx
@@ -13,6 +13,7 @@ interface WelcomePostCardFooterProps {
   contentHtml?: string;
   onShare?: (post: Post) => void;
   imageClassName?: string;
+  contentClassName?: string;
   glassActions?: boolean;
 }
 
@@ -22,6 +23,7 @@ export const WelcomePostCardFooter = ({
   onShare,
   contentHtml,
   imageClassName,
+  contentClassName,
   glassActions = false,
 }: WelcomePostCardFooterProps): ReactElement | null => {
   const { overlay } = useCardCover({
@@ -74,6 +76,7 @@ export const WelcomePostCardFooter = ({
           // The glass action bar floats over the card bottom. Clamp one line
           // tighter and reserve its height (pb-12) so text never sits under it.
           glassActions ? 'line-clamp-5 pb-12' : 'line-clamp-6',
+          contentClassName,
         )}
       >
         {decodedText}

--- a/packages/shared/src/components/post/collection/CollectionSourceStack.tsx
+++ b/packages/shared/src/components/post/collection/CollectionSourceStack.tsx
@@ -1,0 +1,155 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import dynamic from 'next/dynamic';
+import { SourceAvatar } from '../../profile/source/SourceAvatar';
+import { ProfileImageSize, sizeClasses } from '../../ProfilePicture';
+import HoverCard from '../../cards/common/HoverCard';
+import type { SourceTooltip } from '../../../graphql/sources';
+import { SourceType } from '../../../graphql/sources';
+import { Origin } from '../../../lib/log';
+import { useViewSize, ViewSize } from '../../../hooks';
+
+const SquadEntityCard = dynamic(
+  /* webpackChunkName: "squadEntityCard" */ () =>
+    import('../../cards/entity/SquadEntityCard'),
+);
+
+const SourceEntityCard = dynamic(
+  /* webpackChunkName: "sourceEntityCard" */ () =>
+    import('../../cards/entity/SourceEntityCard'),
+);
+
+// Resting stack shows at most 3 avatars + one "+N" counter = 4 circles.
+const MAX_AVATARS = 3;
+// Open spacing matches how sources sit today (~6px overlap, i.e. -ml-1.5).
+const OPEN_OVERLAP_PX = 6;
+// While resting the circles overlap ~62% of their width for a compact mark.
+const REST_OVERLAP_RATIO = 0.62;
+
+const avatarPx: Partial<Record<ProfileImageSize, number>> = {
+  [ProfileImageSize.Small]: 24,
+  [ProfileImageSize.Medium]: 32,
+  [ProfileImageSize.Large]: 40,
+};
+
+interface CollectionSourceStackProps {
+  sources: SourceTooltip[];
+  totalSources: number;
+  size?: ProfileImageSize;
+  className?: string;
+  /**
+   * Force the stack open (no hover needed). Defaults to true on touch/mobile
+   * where there is no cursor to hover.
+   */
+  alwaysExpanded?: boolean;
+  /**
+   * Show the rich source hover card per avatar. Defaults to true on desktop
+   * only — touch surfaces have no hover.
+   */
+  enableHoverCard?: boolean;
+}
+
+export const CollectionSourceStack = ({
+  sources,
+  totalSources,
+  size = ProfileImageSize.Medium,
+  className,
+  alwaysExpanded: alwaysExpandedProp,
+  enableHoverCard: enableHoverCardProp,
+}: CollectionSourceStackProps): ReactElement | null => {
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const alwaysExpanded = alwaysExpandedProp ?? !isLaptop;
+  const enableHoverCard = enableHoverCardProp ?? isLaptop;
+
+  if (!sources?.length) {
+    return null;
+  }
+
+  const shown = sources.slice(0, MAX_AVATARS);
+  const remaining = Math.max(totalSources - shown.length, 0);
+  const px = avatarPx[size] ?? 32;
+  const restStep = alwaysExpanded
+    ? OPEN_OVERLAP_PX
+    : Math.round(px * REST_OVERLAP_RATIO);
+
+  // margin-left is applied through a class reading a CSS var (never inline), so
+  // the group-hover variant can win. Inline margin would always beat the class.
+  const marginClass =
+    'ml-[var(--ml-rest)] group-hover/srcstack:ml-[var(--ml-open)]';
+
+  const circleStyle = (index: number): React.CSSProperties =>
+    ({
+      '--ml-rest': `${index === 0 ? 0 : -restStep}px`,
+      '--ml-open': `${index === 0 ? 0 : -OPEN_OVERLAP_PX}px`,
+      transitionProperty: 'margin-left',
+      transitionDuration: '260ms',
+      transitionTimingFunction: 'cubic-bezier(0.22, 1, 0.36, 1)',
+    } as React.CSSProperties);
+
+  const withHoverCard = (
+    source: SourceTooltip,
+    avatar: ReactElement,
+  ): ReactElement => {
+    if (!enableHoverCard) {
+      return <React.Fragment key={source.handle}>{avatar}</React.Fragment>;
+    }
+
+    return (
+      <HoverCard
+        key={source.handle}
+        appendTo={globalThis?.document?.body}
+        side="bottom"
+        align="start"
+        sideOffset={10}
+        trigger={avatar}
+      >
+        {source.type === SourceType.Squad ? (
+          <SquadEntityCard handle={source.handle} origin={Origin.Feed} />
+        ) : (
+          <SourceEntityCard source={source} />
+        )}
+      </HoverCard>
+    );
+  };
+
+  return (
+    // `pointer-events-auto` re-enables hover: the card's text container is
+    // `pointer-events-none` so post clicks fall through to the card link, and
+    // that inherits down to the stack.
+    <div
+      className={classNames(
+        'group/srcstack pointer-events-auto relative flex w-fit flex-row items-center',
+        className,
+      )}
+    >
+      {shown.map((source, index) =>
+        withHoverCard(
+          source,
+          <div
+            style={{ ...circleStyle(index), zIndex: shown.length - index }}
+            className={classNames('relative rounded-full', marginClass)}
+          >
+            <SourceAvatar
+              className="!mr-0 box-content ring-2 ring-background-default"
+              source={source}
+              size={size}
+            />
+          </div>,
+        ),
+      )}
+      {remaining > 0 && (
+        <div
+          style={{ ...circleStyle(shown.length), zIndex: 0 }}
+          className={classNames(
+            'flex items-center justify-center rounded-full bg-surface-float font-bold tabular-nums text-text-secondary ring-2 ring-background-default typo-caption1',
+            sizeClasses[size],
+            marginClass,
+          )}
+        >
+          +{remaining}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -670,8 +670,17 @@ export const FEED_POST_FRAGMENT = gql`
     trending
     feedMeta
     collectionSources {
+      id
       handle
+      name
       image
+      permalink
+      type
+      description
+      membersCount
+      flags {
+        totalUpvotes
+      }
     }
     numCollectionSources
     updatedAt

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -408,8 +408,17 @@ export const POST_BY_ID_QUERY = gql`
       updatedAt
       numCollectionSources
       collectionSources {
+        id
         handle
+        name
         image
+        permalink
+        type
+        description
+        membersCount
+        flags {
+          totalUpvotes
+        }
       }
     }
     relatedCollectionPosts: relatedPosts(
@@ -495,8 +504,17 @@ export const POST_BY_ID_STATIC_FIELDS_QUERY = gql`
       updatedAt
       numCollectionSources
       collectionSources {
+        id
         handle
+        name
         image
+        permalink
+        type
+        description
+        membersCount
+        flags {
+          totalUpvotes
+        }
       }
       sharedPost {
         ...SharedPostInfo


### PR DESCRIPTION
## What

Two related changes to collection feed cards (which also render **trend** posts):

**1. Source stack replaces the pill.** Replaces the "Collection"/"Trend" pill with the collection's own **source avatars**.
- **Desktop (grid):** the stack rests tight (≤3 avatars + a "+N" counter) and **expands on hover**; hovering a specific source shows that source's **rich hover card** — the same `HoverCard`/`SourceEntityCard` used elsewhere.
- **Mobile (list):** rendered **expanded by default**, no hover card.

**2. Tag & date placement fix.** On collection/trend grid cards, `PostTags` rendered directly after the title with no spacer, pinning the tags to the top of the text area while the date drifted to the bottom. Added a `CardSpace` spacer before the tags so they sit at the bottom of the text area, **directly above the date** — matching the default `ArticleGrid`, which uses the same `CardSpace` pattern.

The shared `CollectionPillSources` is intentionally **left untouched** — digest and brief still use the pill.

## How

- New shared `CollectionSourceStack` — viewport-aware (`useViewSize`), overridable via `alwaysExpanded` / `enableHoverCard`. Expansion is pure CSS `group-hover` (CSS-var margins applied through classes, never inline) and the container is `pointer-events-auto` so it works inside the card's `pointer-events-none` text container. Hover-card wiring mirrors the canonical `SourceButton` pattern.
- Wired into `CollectionCardHeader` (grid — also feeds the featured wide card) and `CollectionList` (list).
- `CollectionGrid`: added `CardSpace` before `PostTags` (dropped the `!items-end` hack) to align tag/date placement with `ArticleGrid`.
- Expanded the `collectionSources` GraphQL selections (`fragments.ts`, `posts.ts`) with the fields the hover card needs (`id`, `name`, `permalink`, `type`, `description`, `membersCount`, `flags.totalUpvotes`) — all valid `Source` fields.

## Notes

- Grid/list collection cards no longer render the `Collection`/`Trend` pill label; the source stack replaces it. `getCollectionPillLabel`/`CollectionPillSources` remain in use by the collection post view, digest, and brief.

## Testing

- `CollectionGrid.spec.tsx` updated (pill-label assertions → source-stack render). Collection + posts GraphQL specs pass; strict typecheck + lint clean.
- Tag/date placement verified in Storybook with a before/after against the default article card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-collection-card-pr-migrat.preview.app.daily.dev