### PR TITLE
fix: don't request tag chip feeds until onboarding is complete

### DIFF
--- a/packages/shared/src/hooks/feed/useFeeds.spec.tsx
+++ b/packages/shared/src/hooks/feed/useFeeds.spec.tsx
@@ -14,6 +14,13 @@ import {
 import { mockGraphQL } from '../../../__tests__/helpers/graphql';
 import { BootApp } from '../../lib/boot';
 import { GrowthBookProvider } from '../../components/GrowthBookProvider';
+import { useOnboardingActions } from '../auth/useOnboardingActions';
+
+jest.mock('../auth/useOnboardingActions', () => ({
+  useOnboardingActions: jest.fn(),
+}));
+
+const mockUseOnboardingActions = useOnboardingActions as jest.Mock;
 
 const client = new QueryClient();
 const noop = jest.fn();
@@ -82,6 +89,7 @@ const feeds = [
 describe('useFeeds hook', () => {
   beforeEach(() => {
     client.clear();
+    mockUseOnboardingActions.mockReturnValue({ isOnboardingComplete: true });
 
     mockGraphQL({
       request: {
@@ -250,5 +258,35 @@ describe('useFeeds hook', () => {
     expect(
       result.current.feeds!.edges.find((f) => f.node.id === 'cf1'),
     ).toBeFalsy();
+  });
+
+  it('should not request tag chip feeds until onboarding is complete', async () => {
+    mockUseOnboardingActions.mockReturnValue({ isOnboardingComplete: false });
+
+    let withoutChipsCalled = false;
+    mockGraphQL({
+      request: {
+        query: FEED_LIST_QUERY,
+        variables: {
+          includeTagChipFeeds: false,
+        },
+      },
+      result: () => {
+        withoutChipsCalled = true;
+
+        return {
+          data: {
+            feedList: {
+              pageInfo: { endCursor: expect.any(String), hasNextPage: false },
+              edges: feeds,
+            },
+          },
+        };
+      },
+    });
+
+    renderHook(() => useFeeds(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(withoutChipsCalled).toBe(true));
   });
 });

--- a/packages/shared/src/hooks/feed/useFeeds.ts
+++ b/packages/shared/src/hooks/feed/useFeeds.ts
@@ -17,6 +17,7 @@ import {
   FeedChipsVariant,
   featureFeedChips,
 } from '../../lib/featureManagement';
+import { useOnboardingActions } from '../auth/useOnboardingActions';
 
 export type CreateFeedProps = {
   name: string;
@@ -38,13 +39,18 @@ export const useFeeds = (): UseFeeds => {
   const queryClient = useQueryClient();
   const { displayToast } = useToastNotification();
   const { user, feeds: bootFeeds } = useAuthContext();
-  const queryKey = generateQueryKey(RequestKey.Feeds, user);
+  const { isOnboardingComplete } = useOnboardingActions();
 
   const { value: feedChipsVariant } = useConditionalFeature({
     feature: featureFeedChips,
     shouldEvaluate: !!user,
   });
-  const includeTagChipFeeds = feedChipsVariant === FeedChipsVariant.V2;
+  const includeTagChipFeeds =
+    feedChipsVariant === FeedChipsVariant.V2 && isOnboardingComplete;
+
+  const queryKey = generateQueryKey(RequestKey.Feeds, user, {
+    includeTagChipFeeds,
+  });
 
   const initialData: FeedList['feedList'] | undefined = useMemo(() => {
     if (!bootFeeds) {


### PR DESCRIPTION
Tag-chip feed seeding on the server is one-shot: the first feedList query with includeTagChipFeeds burns the seed slot even if the user has no tags yet. Requesting it before onboarding completes leaves new users with permanently empty chips. Gate includeTagChipFeeds on isOnboardingComplete and include it in the query key so chips are fetched once onboarding is done.

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://fix-chips-empty-new-users.preview.app.daily.dev