### PR TITLE
fix(notifications): stop follow-back button layout shift and gap

### DIFF
--- a/packages/shared/src/components/notifications/NotificationFollowUserButton.tsx
+++ b/packages/shared/src/components/notifications/NotificationFollowUserButton.tsx
@@ -38,7 +38,11 @@ export const NotificationFollowUserButton = ({
   }, [avatars, referenceId]);
 
   return (
-    <div ref={ref}>
+    // Reserve the button's height (Small button = h-8) up front so the row
+    // keeps a constant height whether or not the button has mounted/resolved.
+    // Without this the button pops in as each row scrolls into view and jerks
+    // the rows below it.
+    <div ref={ref} className="flex min-h-8 items-center">
       {inView && (
         <FollowButton
           entityId={referenceId}
@@ -47,10 +51,13 @@ export const NotificationFollowUserButton = ({
           status={followPreference?.status}
           entityName={referenceUserName}
           followedVariant={ButtonVariant.Primary}
-          className="mt-3"
           buttonClassName={classNames(
+            // Not-following "Follow back": render as a plain text link — drop
+            // the button's horizontal padding so the label sits on the row's
+            // content edge, and swap the ghost hover fill for an underline so
+            // there's no offset highlight box.
             !followPreference?.status &&
-              '-ml-3.5 flex min-w-min text-text-link',
+              '!px-0 text-text-link hover:!bg-transparent hover:underline',
           )}
           copyType={CopyType.NiceGuy}
           origin={Origin.Notification}

--- a/packages/shared/src/components/notifications/NotificationItem.tsx
+++ b/packages/shared/src/components/notifications/NotificationItem.tsx
@@ -369,7 +369,7 @@ function NotificationItem(props: NotificationItemProps): ReactElement | null {
           </div>
         )}
         {type === NotificationType.UserFollow && (
-          <span className="relative z-1 mt-1">
+          <span className="relative z-1">
             <NotificationFollowUserButton {...props} />
           </span>
         )}


### PR DESCRIPTION
## Changes

Fixes the "Follow back" row in the Activity/notifications feed, which caused layout shift on scroll and left a large gap under the headline.

- **Layout shift on scroll**: the button was gated behind `{inView && ...}` inside a zero-height container, so each row's follow-status query fired only once the row entered view — then the `h-8` button popped in, grew the row, and jerked the rows below it. Now the button's height is reserved up front (`flex min-h-8 items-center`, matching `ButtonSize.Small` = `h-8`), so the row height stays constant whether or not the button has mounted/resolved. The lazy `inView` query is preserved.
- **Huge gap**: dropped the redundant stacked margins (`mt-1` on the wrapper span + `mt-3` on the button) so the button sits tight under the headline, relying on the parent `flex-col gap-1` for spacing.

## Manual Testing

The notifications page is auth-gated, so worth a visual sanity check on a real feed. The reserved-height value matches the button's actual height exactly, so there should be no residual shift.

### Preview domain
https://claude-follow-back-layout-shift.preview.app.daily.dev