### PR TITLE
fix(extension): point Find Squads link to webapp URL

### DIFF
--- a/packages/shared/src/components/sidebar/sections/NetworkSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/NetworkSection.tsx
@@ -41,10 +41,11 @@ export const NetworkSection = ({
           <ListIcon Icon={() => <SourceIcon secondary={active} />} />
         ),
         title: 'Find Squads',
-        // Point at the actual landing page (`/squads` redirects here)
-        // so the active-state highlight matches the URL the user
-        // actually navigates to.
-        path: squadCategoriesPaths.discover,
+        // Absolute webapp URL so the extension's new tab links out to
+        // daily.dev instead of resolving against the chrome-extension://
+        // origin. Active-state matching strips the origin, so the webapp
+        // highlight still works.
+        path: `${webappUrl}${squadCategoriesPaths.discover.substring(1)}`,
         isForcedLink: true,
       },
       isModeratorInAnySquad && {


### PR DESCRIPTION
## Changes

The sidebar **Find Squads** item (`NetworkSection`) used the bare relative path `/squads/discover`. On the webapp this is fine, but in the extension new tab a relative href resolves against the `chrome-extension://` origin, producing a broken URL like `chrome-extension://<id>/squads/discover` instead of `https://daily.dev/squads/discover`.

- Prefix the path with `webappUrl` (stripping the duplicate leading slash), matching the sibling **Pending Posts** item and the existing `SidebarTablet` pattern.

**Why it's safe for the webapp:** active-state highlighting runs the href through `isSidebarItemActive`, which strips the `https?://host` origin before comparing to the current page — so the absolute webapp URL still matches `/squads/discover` and highlights correctly.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

- Extension new tab: **Find Squads** now navigates to `https://daily.dev/squads/discover`.
- Webapp: link and active-state highlight unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-chrome-extension-squad-ur.preview.app.daily.dev