### PR TITLE
fix: contain YouTube navigation in iOS app

### DIFF
--- a/packages/shared/src/components/video/YoutubeVideo.spec.tsx
+++ b/packages/shared/src/components/video/YoutubeVideo.spec.tsx
@@ -6,6 +6,14 @@ import { QueryClient } from '@tanstack/react-query';
 import YoutubeVideo from './YoutubeVideo';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import { sharePost } from '../../../__tests__/fixture/post';
+import { isIOSNative } from '../../lib/func';
+
+jest.mock('../../lib/func', () => ({
+  ...jest.requireActual('../../lib/func'),
+  isIOSNative: jest.fn(),
+}));
+
+const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>;
 
 const renderComponent = (): RenderResult => {
   const client = new QueryClient();
@@ -25,6 +33,10 @@ const renderComponent = (): RenderResult => {
 };
 
 describe('YoutubeVideo', () => {
+  beforeEach(() => {
+    mockIsIOSNative.mockReturnValue(false);
+  });
+
   it('should add the right title attribute', () => {
     renderComponent();
 
@@ -39,5 +51,22 @@ describe('YoutubeVideo', () => {
       'src',
       'https://www.youtube-nocookie.com/embed/igZCEr3HwCg',
     );
+  });
+
+  it('should prevent the YouTube player from opening popups in the native iOS app', () => {
+    mockIsIOSNative.mockReturnValue(true);
+
+    renderComponent();
+
+    expect(screen.getByTestId('iframeId')).toHaveAttribute(
+      'sandbox',
+      'allow-same-origin allow-scripts allow-presentation',
+    );
+  });
+
+  it('should preserve YouTube popup behavior outside the native iOS app', () => {
+    renderComponent();
+
+    expect(screen.getByTestId('iframeId')).not.toHaveAttribute('sandbox');
   });
 });

--- a/packages/shared/src/components/video/YoutubeVideo.tsx
+++ b/packages/shared/src/components/video/YoutubeVideo.tsx
@@ -1,13 +1,16 @@
 import type { HTMLAttributes, ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { GdprConsentKey } from '../../hooks/useCookieBanner';
 import type { YoutubeVideoWithoutConsentProps } from './YoutubeVideoWithoutConsent';
 import { YoutubeVideoWithoutConsent } from './YoutubeVideoWithoutConsent';
 import { YoutubeVideoBackground, YoutubeVideoContainer } from './common';
 import { useConsentCookie } from '../../hooks/useCookieConsent';
-import { isExtension } from '../../lib/func';
+import { isExtension, isIOSNative } from '../../lib/func';
 import { webappUrl } from '../../lib/constants';
+
+const nativeIOSYouTubeSandbox =
+  'allow-same-origin allow-scripts allow-presentation';
 
 interface YoutubeVideoProps extends HTMLAttributes<HTMLIFrameElement> {
   videoId: string;
@@ -29,8 +32,13 @@ const YoutubeVideo = ({
   const { cookieExists, saveCookies } = useConsentCookie(
     GdprConsentKey.Marketing,
   );
+  const [isNativeIOS, setIsNativeIOS] = useState<boolean>();
 
-  if (!isAuthReady) {
+  useEffect(() => {
+    setIsNativeIOS(isIOSNative());
+  }, []);
+
+  if (!isAuthReady || typeof isNativeIOS === 'undefined') {
     return (
       <YoutubeVideoContainer className={className}>
         <YoutubeVideoBackground />
@@ -60,6 +68,7 @@ const YoutubeVideo = ({
         title={title}
         src={embedSrc}
         allow="autoplay; clipboard-write; encrypted-media; picture-in-picture; web-share"
+        sandbox={isNativeIOS ? nativeIOSYouTubeSandbox : undefined}
         referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
         className="absolute inset-0 aspect-video w-full border-0"


### PR DESCRIPTION
## Summary
- sandbox YouTube embeds only inside the native iOS wrapper
- prevent popup and top-level navigation while retaining inline playback and fullscreen
- preserve existing behavior on web, extension, Android, and mobile Safari
- add native iOS and non-native regression coverage

## Verification
- NODE_ENV=test pnpm --filter shared exec jest src/components/video/YoutubeVideo.spec.tsx --runInBand
- pnpm --filter shared exec eslint src/components/video/YoutubeVideo.tsx src/components/video/YoutubeVideo.spec.tsx --max-warnings 0
- node ./scripts/typecheck-strict-changed.js
- Prettier and git diff checks

### Preview domain
https://codex-fix-ios-youtube-navigation.preview.app.daily.dev