### PR TITLE
fix: keep profile back navigation available

### DIFF
--- a/packages/shared/src/components/post/GoBackHeaderMobile.spec.tsx
+++ b/packages/shared/src/components/post/GoBackHeaderMobile.spec.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import { GoBackButton } from './GoBackHeaderMobile';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../../hooks/utils/useFeatureTheme', () => ({
+  useFeatureTheme: jest.fn(),
+}));
+
+describe('GoBackButton', () => {
+  it('uses the fallback path when there is no browser history', () => {
+    const push = jest.fn();
+    const back = jest.fn();
+    jest.mocked(useRouter).mockReturnValue({ push, back } as never);
+
+    render(<GoBackButton showLogo={false} fallbackPath="/" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go back' }));
+
+    expect(push).toHaveBeenCalledWith('/');
+    expect(back).not.toHaveBeenCalled();
+  });
+
+  it('goes back when the referrer is another page on the same site', () => {
+    const push = jest.fn();
+    const back = jest.fn();
+    jest.mocked(useRouter).mockReturnValue({ push, back } as never);
+    Object.defineProperty(document, 'referrer', {
+      configurable: true,
+      value: `${window.location.origin}/posts/internal-post`,
+    });
+    window.history.pushState({}, '', '/profile');
+
+    render(<GoBackButton showLogo={false} fallbackPath="/" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go back' }));
+
+    expect(back).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/components/post/GoBackHeaderMobile.tsx
+++ b/packages/shared/src/components/post/GoBackHeaderMobile.tsx
@@ -19,16 +19,24 @@ const checkSameSite = () => {
     return true; // empty referrer means you are from the same site or from blank tab or no-referrer header was used :/
   }
 
-  return (
-    referrer === origin || origin === referrer.substring(0, referrer.length - 1) // remove trailing slash
-  );
+  if (!origin) {
+    return false;
+  }
+
+  try {
+    return new URL(referrer).origin === origin;
+  } catch {
+    return false;
+  }
 };
 
 export const GoBackButton = ({
   className,
   showLogo = true,
+  fallbackPath,
 }: WithClassNameProps & {
   showLogo?: boolean;
+  fallbackPath?: string;
 }): JSX.Element | null => {
   const router = useRouter();
   const goHome = useCallback(() => router.push('/'), [router]);
@@ -36,6 +44,17 @@ export const GoBackButton = ({
 
   const canGoBack =
     globalThis?.history?.length > 1 && (checkSameSite() || isDevelopment);
+
+  const goBack = useCallback(() => {
+    if (canGoBack) {
+      router.back();
+      return;
+    }
+
+    if (fallbackPath) {
+      router.push(fallbackPath);
+    }
+  }, [canGoBack, fallbackPath, router]);
 
   const logoButton = showLogo ? (
     <Logo
@@ -46,12 +65,12 @@ export const GoBackButton = ({
     />
   ) : null;
 
-  return canGoBack ? (
+  return canGoBack || fallbackPath ? (
     <Button
       icon={<ArrowIcon className="-rotate-90" />}
       size={ButtonSize.Small}
       variant={ButtonVariant.Tertiary}
-      onClick={router.back}
+      onClick={goBack}
       className={className}
       type="button"
       aria-label="Go back"

--- a/packages/shared/src/components/profile/ProfileBackButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileBackButton.spec.tsx
@@ -23,8 +23,18 @@ jest.mock('../../lib/func', () => ({
 }));
 
 jest.mock('../post/GoBackHeaderMobile', () => ({
-  GoBackButton: ({ className }: { className?: string }) => (
-    <button type="button" className={className}>
+  GoBackButton: ({
+    className,
+    fallbackPath,
+  }: {
+    className?: string;
+    fallbackPath?: string;
+  }) => (
+    <button
+      type="button"
+      className={className}
+      data-fallback-path={fallbackPath}
+    >
       Go back
     </button>
   ),
@@ -49,6 +59,7 @@ describe('ProfileMobileBackButton', () => {
     const button = screen.getByRole('button', { name: 'Go back' });
     expect(button).toBeInTheDocument();
     expect(button).toHaveClass('mr-3');
+    expect(button).toHaveAttribute('data-fallback-path', '/');
   });
 
   it('does not render at laptop widths', () => {
@@ -88,6 +99,10 @@ describe('ProfileDesktopPwaBackButton', () => {
       'absolute',
       'left-4',
       'top-4',
+    );
+    expect(screen.getByRole('button', { name: 'Go back' })).toHaveAttribute(
+      'data-fallback-path',
+      '/',
     );
   });
 

--- a/packages/shared/src/components/profile/ProfileBackButton.tsx
+++ b/packages/shared/src/components/profile/ProfileBackButton.tsx
@@ -15,7 +15,9 @@ export const ProfileMobileBackButton = ({
     return null;
   }
 
-  return <GoBackButton showLogo={false} className={className} />;
+  return (
+    <GoBackButton showLogo={false} fallbackPath="/" className={className} />
+  );
 };
 
 export const ProfileDesktopPwaBackButton = ({
@@ -35,6 +37,7 @@ export const ProfileDesktopPwaBackButton = ({
   return (
     <GoBackButton
       showLogo={false}
+      fallbackPath="/"
       className={classNames('hidden laptop:flex', className)}
     />
   );


### PR DESCRIPTION
## Summary
- keep the profile back control visible when browser history is unavailable
- return to same-site history when possible and fall back to the main feed
- cover mobile and desktop PWA profile navigation with regression tests

## Testing
- focused Jest tests: 7 passed
- shared ESLint
- strict changed-file typecheck

### Preview domain
https://codex-fix-profile-back-navigatio.preview.app.daily.dev