### PR TITLE
feat: add post-signup feed activation

### DIFF
--- a/packages/shared/src/components/LoginButton.tsx
+++ b/packages/shared/src/components/LoginButton.tsx
@@ -5,7 +5,7 @@ import { Button, ButtonVariant } from './buttons/Button';
 import { useLogContext } from '../contexts/LogContext';
 import type { LogEvent } from '../hooks/log/useLogQueue';
 import { TargetType } from '../lib/log';
-import { useAuthContext } from '../contexts/AuthContext';
+import { type LoginState, useAuthContext } from '../contexts/AuthContext';
 import { AuthTriggers } from '../lib/auth';
 
 interface ClassName {
@@ -15,6 +15,7 @@ interface ClassName {
 
 interface LoginButtonProps {
   className?: ClassName;
+  onRegistrationSuccess?: LoginState['onRegistrationSuccess'];
 }
 
 enum ButtonCopy {
@@ -32,6 +33,7 @@ const getLogEvent = (copy: ButtonCopy): LogEvent => ({
 
 export default function LoginButton({
   className = {},
+  onRegistrationSuccess,
 }: LoginButtonProps): ReactElement {
   const { logEvent } = useLogContext();
   const { showLogin } = useAuthContext();
@@ -41,6 +43,7 @@ export default function LoginButton({
       trigger: AuthTriggers.MainButton,
       options: {
         isLogin: copy === ButtonCopy.Login,
+        onRegistrationSuccess,
       },
     });
   };

--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -5,7 +5,7 @@ import classed from '../../lib/classed';
 import { OnboardingHeadline } from './OnboardingHeadline';
 import AuthOptions from './AuthOptions';
 import { AuthTriggers } from '../../lib/auth';
-import { useAuthContext } from '../../contexts/AuthContext';
+import { type LoginState, useAuthContext } from '../../contexts/AuthContext';
 import { authGradientBg, BottomBannerContainer } from '../marketing/banners';
 import { ButtonVariant } from '../buttons/common';
 import { Image } from '../image/Image';
@@ -20,11 +20,13 @@ const Section = classed('div', 'flex flex-col');
 
 interface AuthenticationBannerProps extends PropsWithChildren {
   compact?: boolean;
+  onRegistrationSuccess?: LoginState['onRegistrationSuccess'];
 }
 
 export function AuthenticationBanner({
   children,
   compact,
+  onRegistrationSuccess,
 }: AuthenticationBannerProps): ReactElement {
   const { showLogin } = useAuthContext();
 
@@ -89,6 +91,7 @@ export function AuthenticationBanner({
                   isLogin: !!props.isLoginFlow,
                   defaultDisplay: props.defaultDisplay,
                   formValues: props.email ? { email: props.email } : undefined,
+                  onRegistrationSuccess,
                 },
               });
             }}

--- a/packages/shared/src/components/auth/CustomAuthBanner.tsx
+++ b/packages/shared/src/components/auth/CustomAuthBanner.tsx
@@ -6,6 +6,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useViewSize, ViewSize } from '../../hooks';
 import LoginButton from '../LoginButton';
 import { authGradientBg } from '../marketing/banners';
+import { markPostSignupActivation } from '../../lib/postSignupActivation';
 
 const CustomAuthBanner = (): ReactElement | null => {
   const { shouldShowAuthBanner } = useOnboardingActions();
@@ -21,6 +22,7 @@ const CustomAuthBanner = (): ReactElement | null => {
 
   return (
     <LoginButton
+      onRegistrationSuccess={markPostSignupActivation}
       className={{
         container: classNames(
           authGradientBg,

--- a/packages/shared/src/components/auth/CustomAuthBanner.tsx
+++ b/packages/shared/src/components/auth/CustomAuthBanner.tsx
@@ -1,20 +1,36 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
+import { useRouter } from 'next/router';
 import { useOnboardingActions } from '../../hooks/auth';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useViewSize, ViewSize } from '../../hooks';
 import LoginButton from '../LoginButton';
 import { authGradientBg } from '../marketing/banners';
-import { markPostSignupActivation } from '../../lib/postSignupActivation';
+import {
+  isPostOnboardingPreviewEnabled,
+  markPostSignupActivation,
+  POST_ONBOARDING_PREVIEW_QUERY,
+} from '../../lib/postSignupActivation';
+import { isDevelopment } from '../../lib/constants';
 
 const CustomAuthBanner = (): ReactElement | null => {
   const { shouldShowAuthBanner } = useOnboardingActions();
   const { shouldShowLogin } = useAuthContext();
+  const router = useRouter();
   const isLaptop = useViewSize(ViewSize.Laptop);
   const isTablet = useViewSize(ViewSize.Tablet);
+  const isActivationPreview =
+    router.pathname === '/posts/[id]' &&
+    (isDevelopment ||
+      isPostOnboardingPreviewEnabled(
+        router.query?.[POST_ONBOARDING_PREVIEW_QUERY],
+      ));
   const isValid =
-    shouldShowAuthBanner && !isLaptop && (isTablet || !shouldShowLogin);
+    !isActivationPreview &&
+    shouldShowAuthBanner &&
+    !isLaptop &&
+    (isTablet || !shouldShowLogin);
 
   if (!isValid) {
     return null;

--- a/packages/shared/src/components/auth/PostAuthBanner.tsx
+++ b/packages/shared/src/components/auth/PostAuthBanner.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import { AuthenticationBanner } from './AuthenticationBanner';
 import { getSocialReferrer } from '../../lib/socialMedia';
 import { useAuthContext } from '../../contexts/AuthContext';
+import { markPostSignupActivation } from '../../lib/postSignupActivation';
 
 const UserPersonalizedBanner = dynamic(
   () =>
@@ -36,17 +37,40 @@ export const PostAuthBanner = ({
   const userId = searchParams?.get('userid');
 
   if (userId) {
-    return <UserPersonalizedBanner userId={userId} compact={compact} />;
+    return (
+      <UserPersonalizedBanner
+        userId={userId}
+        compact={compact}
+        onRegistrationSuccess={markPostSignupActivation}
+      />
+    );
   }
 
   const social = getSocialReferrer();
   if (social) {
-    return <SocialPersonalizedBanner site={social} compact={compact} />;
+    return (
+      <SocialPersonalizedBanner
+        site={social}
+        compact={compact}
+        onRegistrationSuccess={markPostSignupActivation}
+      />
+    );
   }
 
   if (geo?.region) {
-    return <GeoPersonalizedBanner geo={geo.region} compact={compact} />;
+    return (
+      <GeoPersonalizedBanner
+        geo={geo.region}
+        compact={compact}
+        onRegistrationSuccess={markPostSignupActivation}
+      />
+    );
   }
 
-  return <AuthenticationBanner compact={compact} />;
+  return (
+    <AuthenticationBanner
+      compact={compact}
+      onRegistrationSuccess={markPostSignupActivation}
+    />
+  );
 };

--- a/packages/shared/src/components/marketing/banners/personalized/GeoPersonalizedBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/personalized/GeoPersonalizedBanner.tsx
@@ -2,19 +2,25 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { geoToCountry, geoToEmoji } from '../../../../lib/geo';
 import { AuthenticationBanner, OnboardingHeadline } from '../../../auth';
+import type { LoginState } from '../../../../contexts/AuthContext';
 
 const GeoPersonalizedBanner = ({
   geo,
   compact,
+  onRegistrationSuccess,
 }: {
   geo: string;
   compact?: boolean;
+  onRegistrationSuccess?: LoginState['onRegistrationSuccess'];
 }): ReactElement => {
   const emoji = geoToEmoji(geo);
   const country = geoToCountry(geo);
 
   return (
-    <AuthenticationBanner compact={compact}>
+    <AuthenticationBanner
+      compact={compact}
+      onRegistrationSuccess={onRegistrationSuccess}
+    >
       <span
         className={
           compact ? 'text-[2.5rem] leading-none' : 'text-[3.5rem] leading-none'

--- a/packages/shared/src/components/marketing/banners/personalized/SocialPersonalizedBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/personalized/SocialPersonalizedBanner.tsx
@@ -11,19 +11,25 @@ import {
 import type { SupportedSocialReferrer } from '../../../../lib/socialMedia';
 import { capitalize } from '../../../../lib/strings';
 import { IconSize } from '../../../Icon';
+import type { LoginState } from '../../../../contexts/AuthContext';
 
 const SocialPersonalizedBanner = ({
   site,
   compact,
+  onRegistrationSuccess,
 }: {
   site: SupportedSocialReferrer;
   compact?: boolean;
+  onRegistrationSuccess?: LoginState['onRegistrationSuccess'];
 }): ReactElement => {
   const Icon = socialIcon[site];
   const gradient = socialGradient[site];
 
   return (
-    <AuthenticationBanner compact={compact}>
+    <AuthenticationBanner
+      compact={compact}
+      onRegistrationSuccess={onRegistrationSuccess}
+    >
       <Icon
         size={compact ? IconSize.Large : IconSize.Size48}
         secondary={site === SocialIconType.Reddit}

--- a/packages/shared/src/components/marketing/banners/personalized/UserPersonalizedBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/personalized/UserPersonalizedBanner.tsx
@@ -5,13 +5,16 @@ import { getBasicUserInfo } from '../../../../graphql/users';
 import { AuthenticationBanner, OnboardingHeadline } from '../../../auth';
 import { ProfilePicture } from '../../../ProfilePicture';
 import { generateQueryKey, RequestKey } from '../../../../lib/query';
+import type { LoginState } from '../../../../contexts/AuthContext';
 
 const UserPersonalizedBanner = ({
   userId,
   compact,
+  onRegistrationSuccess,
 }: {
   userId: string;
   compact?: boolean;
+  onRegistrationSuccess?: LoginState['onRegistrationSuccess'];
 }): ReactElement => {
   const key = generateQueryKey(RequestKey.ReferringUser);
   const { data: user, isError } = useQuery({
@@ -20,13 +23,21 @@ const UserPersonalizedBanner = ({
   });
 
   if (isError) {
-    return <AuthenticationBanner compact={compact} />;
+    return (
+      <AuthenticationBanner
+        compact={compact}
+        onRegistrationSuccess={onRegistrationSuccess}
+      />
+    );
   }
 
   const name = user?.name ? user?.name.split(' ')[0] : user?.username;
 
   return (
-    <AuthenticationBanner compact={compact}>
+    <AuthenticationBanner
+      compact={compact}
+      onRegistrationSuccess={onRegistrationSuccess}
+    >
       {user?.image && <ProfilePicture user={user} />}
       <OnboardingHeadline
         className={{

--- a/packages/shared/src/components/post/PostOnboardingActivation.spec.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PostOnboardingActivation } from './PostOnboardingActivation';
+import {
+  clearPostSignupActivation,
+  hasPostSignupActivation,
+} from '../../lib/postSignupActivation';
+
+const mockPush = jest.fn();
+const mockLogEvent = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: '/posts/post-1?ref=share',
+    push: mockPush,
+  }),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuthContext: () => ({ user: { id: 'new-user' } }),
+}));
+
+jest.mock('../../hooks/auth/useOnboardingActions', () => ({
+  useOnboardingActions: () => ({
+    isOnboardingActionsReady: true,
+    isOnboardingComplete: false,
+  }),
+}));
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: mockLogEvent }),
+}));
+
+jest.mock('../../lib/postSignupActivation', () => ({
+  clearPostSignupActivation: jest.fn(),
+  hasPostSignupActivation: jest.fn(() => true),
+}));
+
+const mockHasPostSignupActivation = jest.mocked(hasPostSignupActivation);
+const mockClearPostSignupActivation = jest.mocked(clearPostSignupActivation);
+
+describe('PostOnboardingActivation', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHasPostSignupActivation.mockReturnValue(true);
+  });
+
+  it('connects the current post topics to the feed value proposition', async () => {
+    render(
+      <PostOnboardingActivation
+        post={{ tags: ['react', 'typescript', 'webdev'] }}
+      />,
+    );
+
+    expect(
+      await screen.findByText(
+        'One good post is luck. Build a feed full of them.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText('#react')).toBeInTheDocument();
+    expect(screen.getByText('#typescript')).toBeInTheDocument();
+    expect(screen.getByText('#webdev')).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Build my feed' }),
+    );
+
+    expect(mockPush).toHaveBeenCalledWith({
+      pathname: '/onboarding',
+      query: { after_auth: '/posts/post-1?ref=share' },
+    });
+  });
+
+  it('dismisses the prompt without completing onboarding', async () => {
+    render(<PostOnboardingActivation post={{ tags: [] }} />);
+
+    await screen.findByRole('complementary', {
+      name: 'Personalize your feed',
+    });
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: 'Dismiss feed personalization',
+      }),
+    );
+
+    expect(mockClearPostSignupActivation).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('complementary', {
+          name: 'Personalize your feed',
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/shared/src/components/post/PostOnboardingActivation.spec.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.spec.tsx
@@ -52,13 +52,13 @@ describe('PostOnboardingActivation', () => {
     render(<PostOnboardingActivation />);
 
     expect(
-      await screen.findByText("Your account is ready. Your feed isn't."),
+      await screen.findByText("You're in. Now make daily.dev yours."),
     ).toBeInTheDocument();
-    expect(screen.getByText('Account created')).toBeInTheDocument();
-    expect(screen.getByText('One step left')).toBeInTheDocument();
+    expect(screen.getByText('Account ready')).toBeInTheDocument();
+    expect(screen.getByText('Final setup')).toBeInTheDocument();
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Choose my topics' }),
+      screen.getByRole('button', { name: 'Personalize my feed' }),
     );
 
     expect(mockPush).toHaveBeenCalledWith({

--- a/packages/shared/src/components/post/PostOnboardingActivation.spec.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.spec.tsx
@@ -35,6 +35,8 @@ jest.mock('../../contexts/LogContext', () => ({
 jest.mock('../../lib/postSignupActivation', () => ({
   clearPostSignupActivation: jest.fn(),
   hasPostSignupActivation: jest.fn(() => true),
+  isPostOnboardingPreviewEnabled: jest.fn(() => false),
+  POST_ONBOARDING_PREVIEW_QUERY: 'postOnboardingPreview',
 }));
 
 const mockHasPostSignupActivation = jest.mocked(hasPostSignupActivation);
@@ -46,24 +48,17 @@ describe('PostOnboardingActivation', () => {
     mockHasPostSignupActivation.mockReturnValue(true);
   });
 
-  it('connects the current post topics to the feed value proposition', async () => {
-    render(
-      <PostOnboardingActivation
-        post={{ tags: ['react', 'typescript', 'webdev'] }}
-      />,
-    );
+  it('frames feed setup as the final step with a clear value proposition', async () => {
+    render(<PostOnboardingActivation />);
 
     expect(
-      await screen.findByText(
-        'One good post is luck. Build a feed full of them.',
-      ),
+      await screen.findByText("Your account is ready. Your feed isn't."),
     ).toBeInTheDocument();
-    expect(screen.getByText('#react')).toBeInTheDocument();
-    expect(screen.getByText('#typescript')).toBeInTheDocument();
-    expect(screen.getByText('#webdev')).toBeInTheDocument();
+    expect(screen.getByText('Account created')).toBeInTheDocument();
+    expect(screen.getByText('One step left')).toBeInTheDocument();
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Build my feed' }),
+      screen.getByRole('button', { name: 'Choose my topics' }),
     );
 
     expect(mockPush).toHaveBeenCalledWith({
@@ -73,7 +68,7 @@ describe('PostOnboardingActivation', () => {
   });
 
   it('dismisses the prompt without completing onboarding', async () => {
-    render(<PostOnboardingActivation post={{ tags: [] }} />);
+    render(<PostOnboardingActivation />);
 
     await screen.findByRole('complementary', {
       name: 'Personalize your feed',

--- a/packages/shared/src/components/post/PostOnboardingActivation.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.tsx
@@ -7,6 +7,7 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { useOnboardingActions } from '../../hooks/auth/useOnboardingActions';
 import { useLogContext } from '../../contexts/LogContext';
 import { TargetType } from '../../lib/log';
+import { isDevelopment } from '../../lib/constants';
 import {
   clearPostSignupActivation,
   hasPostSignupActivation,
@@ -52,6 +53,7 @@ export const PostOnboardingActivation = ({
   const { isOnboardingActionsReady, isOnboardingComplete } =
     useOnboardingActions();
   const [isVisible, setIsVisible] = useState(false);
+  const [isLocalPreviewDismissed, setIsLocalPreviewDismissed] = useState(false);
   const hasLoggedImpression = useRef(false);
   const tags = useMemo(() => post.tags?.slice(0, 3) ?? [], [post.tags]);
 
@@ -69,10 +71,11 @@ export const PostOnboardingActivation = ({
   }, [isOnboardingActionsReady, isOnboardingComplete, user?.id]);
 
   const shouldShow =
-    !!user?.id &&
-    isOnboardingActionsReady &&
-    !isOnboardingComplete &&
-    isVisible;
+    (isDevelopment && !isLocalPreviewDismissed) ||
+    (!!user?.id &&
+      isOnboardingActionsReady &&
+      !isOnboardingComplete &&
+      isVisible);
 
   useEffect(() => {
     if (!shouldShow || hasLoggedImpression.current) {
@@ -92,7 +95,11 @@ export const PostOnboardingActivation = ({
   }
 
   const onDismiss = (): void => {
-    clearPostSignupActivation();
+    if (isDevelopment) {
+      setIsLocalPreviewDismissed(true);
+    } else {
+      clearPostSignupActivation();
+    }
     setIsVisible(false);
     logEvent({
       event_name: 'click',

--- a/packages/shared/src/components/post/PostOnboardingActivation.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.tsx
@@ -114,51 +114,56 @@ export const PostOnboardingActivation = (): ReactElement | null => {
       className="relative mb-4 w-full overflow-hidden border-y border-border-subtlest-secondary bg-surface-float shadow-2 laptop:mx-auto laptop:max-w-[69.25rem] laptop:rounded-16 laptop:border"
     >
       <div className="absolute inset-y-0 left-0 w-1 bg-accent-cabbage-default" />
-      <div className="relative flex w-full flex-col gap-5 px-5 py-5 pr-14 tablet:flex-row tablet:items-center tablet:gap-8 tablet:px-6 tablet:py-6 tablet:pr-14 laptop:px-8">
+      <div className="relative flex w-full flex-col gap-5 px-5 py-5 pr-14 tablet:flex-row tablet:items-center tablet:gap-8 tablet:px-6 tablet:pr-14 laptop:px-8">
         <div className="min-w-0 flex-1">
-          <div className="mb-2 flex items-center gap-2 font-bold uppercase tracking-wide typo-caption1">
+          <div
+            aria-label="Account ready. Final setup step."
+            className="mb-2.5 flex items-center gap-2 font-bold uppercase tracking-wide typo-caption1"
+          >
             <span className="flex size-5 items-center justify-center rounded-full bg-accent-cabbage-default text-white">
               <VIcon secondary size={IconSize.Size16} />
             </span>
-            <span className="text-text-tertiary">Account created</span>
+            <span className="text-text-secondary">Account ready</span>
             <span className="h-px w-6 bg-border-subtlest-secondary" />
-            <span className="text-accent-cabbage-default">One step left</span>
+            <span className="font-mono text-accent-cabbage-default">
+              Final setup
+            </span>
           </div>
           <Typography
             tag={TypographyTag.H2}
-            type={TypographyType.Title2}
+            type={TypographyType.Title3}
             bold
-            className="[text-wrap:balance]"
+            className="[text-wrap:balance] tablet:!typo-title2"
           >
-            Your account is ready. Your feed isn&apos;t.
+            You&apos;re in. Now make daily.dev yours.
           </Typography>
           <Typography
             type={TypographyType.Callout}
             color={TypographyColor.Secondary}
-            className="mt-1 max-w-[42rem] [text-wrap:pretty]"
+            className="mt-1.5 max-w-[42rem] [text-wrap:pretty]"
           >
-            Choose what you care about once. We&apos;ll filter the noise and
-            make daily.dev worth opening every day.
+            Choose a few topics. We&apos;ll cut the noise and build a feed worth
+            coming back to.
           </Typography>
         </div>
 
-        <div className="flex w-full shrink-0 flex-col items-center gap-1.5 tablet:w-auto">
+        <div className="flex w-full shrink-0 flex-col items-center gap-1.5 tablet:w-auto tablet:border-l tablet:border-border-subtlest-secondary tablet:pl-8">
           <Button
             type="button"
             variant={ButtonVariant.Primary}
             color={ButtonColor.Cabbage}
             size={ButtonSize.Large}
-            className="w-full tablet:w-auto"
+            className="w-full transition-[transform,box-shadow] duration-200 ease-out hover:-translate-y-0.5 hover:shadow-2-cabbage active:translate-y-0 motion-reduce:transform-none tablet:min-w-52"
             onClick={onBuildFeed}
           >
-            Choose my topics
+            Personalize my feed
           </Button>
           <Typography
             tag={TypographyTag.Span}
             type={TypographyType.Caption1}
             color={TypographyColor.Secondary}
           >
-            Takes about 1 minute
+            About 1 minute · change it anytime
           </Typography>
         </div>
 

--- a/packages/shared/src/components/post/PostOnboardingActivation.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.tsx
@@ -1,8 +1,6 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import classNames from 'classnames';
+import React, { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
-import type { Post } from '../../graphql/posts';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useOnboardingActions } from '../../hooks/auth/useOnboardingActions';
 import { useLogContext } from '../../contexts/LogContext';
@@ -11,16 +9,13 @@ import { isDevelopment } from '../../lib/constants';
 import {
   clearPostSignupActivation,
   hasPostSignupActivation,
+  isPostOnboardingPreviewEnabled,
+  POST_ONBOARDING_PREVIEW_QUERY,
 } from '../../lib/postSignupActivation';
 import { AFTER_AUTH_PARAM } from '../auth/common';
-import {
-  Button,
-  ButtonIconPosition,
-  ButtonSize,
-  ButtonVariant,
-} from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import CloseButton from '../CloseButton';
-import { ArrowIcon, SparkleIcon } from '../icons';
+import { VIcon } from '../icons/V';
 import { IconSize } from '../Icon';
 import {
   Typography,
@@ -29,31 +24,7 @@ import {
   TypographyType,
 } from '../typography/Typography';
 
-interface PostOnboardingActivationProps {
-  post: Pick<Post, 'tags'>;
-  inline?: boolean;
-}
-
-const previewQueryKey = 'postOnboardingPreview';
-
-const isPreviewQueryEnabled = (value?: string | string[]): boolean =>
-  value === '1' ||
-  value === 'true' ||
-  (Array.isArray(value) && (value.includes('1') || value.includes('true')));
-
-const getSupportingCopy = (tags: string[]): string => {
-  if (!tags.length) {
-    return 'Pick what you care about. We’ll bring you the tech worth knowing — minus the noise.';
-  }
-
-  const topics = tags.slice(0, 2).join(' and ');
-  return `Start with ${topics}, then pick what else you care about. We’ll do the filtering.`;
-};
-
-export const PostOnboardingActivation = ({
-  post,
-  inline = false,
-}: PostOnboardingActivationProps): ReactElement | null => {
+export const PostOnboardingActivation = (): ReactElement | null => {
   const router = useRouter();
   const { user } = useAuthContext();
   const { logEvent } = useLogContext();
@@ -62,9 +33,11 @@ export const PostOnboardingActivation = ({
   const [isVisible, setIsVisible] = useState(false);
   const [isLocalPreviewDismissed, setIsLocalPreviewDismissed] = useState(false);
   const hasLoggedImpression = useRef(false);
-  const tags = useMemo(() => post.tags?.slice(0, 3) ?? [], [post.tags]);
   const isPreviewMode =
-    isDevelopment || isPreviewQueryEnabled(router.query?.[previewQueryKey]);
+    isDevelopment ||
+    isPostOnboardingPreviewEnabled(
+      router.query?.[POST_ONBOARDING_PREVIEW_QUERY],
+    );
 
   useEffect(() => {
     if (!user?.id || !isOnboardingActionsReady) {
@@ -122,7 +95,6 @@ export const PostOnboardingActivation = ({
       event_name: 'click',
       target_type: TargetType.PostSignupActivation,
       target_id: 'build feed from post signup activation',
-      extra: JSON.stringify({ tags }),
     });
 
     router.push({
@@ -134,78 +106,55 @@ export const PostOnboardingActivation = ({
   return (
     <aside
       aria-label="Personalize your feed"
-      className={classNames(
-        'isolate overflow-hidden border border-accent-cabbage-default bg-surface-float shadow-2-cabbage',
-        inline
-          ? 'relative mx-4 mt-6 rounded-16'
-          : 'fixed bottom-0 left-0 z-modal w-full border-x-0 border-b-0',
-      )}
+      className="relative mb-4 w-full overflow-hidden border-y border-border-subtlest-secondary bg-surface-secondary laptop:mx-auto laptop:max-w-[69.25rem] laptop:rounded-16 laptop:border"
     >
-      <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -left-20 -top-24 -z-1 h-56 w-56 rounded-full blur-3xl" />
-      <div className="bg-accent-onion-default/15 pointer-events-none absolute -right-20 -top-20 -z-1 h-48 w-48 rounded-full blur-3xl" />
-      <div
-        className={classNames(
-          'relative mx-auto flex w-full max-w-[63.75rem] flex-col gap-4 px-4 py-5 pr-14 tablet:px-6 tablet:pr-16',
-          !inline &&
-            'laptop:flex-row laptop:items-center laptop:gap-6 laptop:py-4',
-        )}
-      >
-        <div className="flex min-w-0 flex-1 items-start gap-3">
-          <div className="shadow-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-12 bg-accent-cabbage-subtlest text-accent-cabbage-default">
-            <SparkleIcon secondary size={IconSize.Small} />
+      <div className="absolute inset-y-0 left-0 w-1 bg-accent-cabbage-default" />
+      <div className="relative flex w-full flex-col gap-5 px-5 py-5 pr-14 tablet:flex-row tablet:items-center tablet:gap-8 tablet:px-6 tablet:py-6 tablet:pr-14 laptop:px-8">
+        <div className="min-w-0 flex-1">
+          <div className="mb-2 flex items-center gap-2 font-bold uppercase tracking-wide typo-caption1">
+            <span className="flex size-5 items-center justify-center rounded-full bg-accent-cabbage-default text-white">
+              <VIcon secondary size={IconSize.Size16} />
+            </span>
+            <span className="text-text-tertiary">Account created</span>
+            <span className="h-px w-6 bg-border-subtlest-secondary" />
+            <span className="text-accent-cabbage-default">One step left</span>
           </div>
-          <div className="min-w-0 flex-1">
-            <Typography
-              tag={TypographyTag.Span}
-              type={TypographyType.Caption1}
-              color={TypographyColor.Brand}
-              bold
-              className="uppercase tracking-wide"
-            >
-              You&apos;re in
-            </Typography>
-            <Typography
-              tag={TypographyTag.H2}
-              type={TypographyType.Title3}
-              bold
-              className="mt-0.5"
-            >
-              One good post is luck. Build a feed full of them.
-            </Typography>
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Tertiary}
-              className="mt-1"
-            >
-              {getSupportingCopy(tags)}
-            </Typography>
-          </div>
+          <Typography
+            tag={TypographyTag.H2}
+            type={TypographyType.Title2}
+            bold
+            className="[text-wrap:balance]"
+          >
+            Your account is ready. Your feed isn&apos;t.
+          </Typography>
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Tertiary}
+            className="mt-1 max-w-[42rem] [text-wrap:pretty]"
+          >
+            Choose what you care about once. We&apos;ll filter the noise and
+            make daily.dev worth opening every day.
+          </Typography>
         </div>
 
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-1.5 laptop:max-w-64 laptop:justify-end">
-            {tags.map((tag) => (
-              <span
-                key={tag}
-                className="border-accent-cabbage-default/30 rounded-10 border bg-accent-cabbage-subtlest px-2.5 py-1 text-accent-cabbage-default typo-caption1"
-              >
-                #{tag}
-              </span>
-            ))}
-          </div>
-        )}
-
-        <Button
-          type="button"
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Large}
-          className="w-full shrink-0 tablet:w-auto"
-          icon={<ArrowIcon />}
-          iconPosition={ButtonIconPosition.Right}
-          onClick={onBuildFeed}
-        >
-          Build my feed
-        </Button>
+        <div className="flex w-full shrink-0 flex-col items-center gap-1.5 tablet:w-auto">
+          <Button
+            type="button"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Large}
+            className="w-full tablet:w-auto"
+            onClick={onBuildFeed}
+          >
+            Choose my topics
+          </Button>
+          <Typography
+            tag={TypographyTag.Span}
+            type={TypographyType.Caption1}
+            color={TypographyColor.Tertiary}
+          >
+            Takes about 1 minute
+          </Typography>
+        </div>
 
         <CloseButton
           type="button"

--- a/packages/shared/src/components/post/PostOnboardingActivation.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.tsx
@@ -34,6 +34,13 @@ interface PostOnboardingActivationProps {
   inline?: boolean;
 }
 
+const previewQueryKey = 'postOnboardingPreview';
+
+const isPreviewQueryEnabled = (value?: string | string[]): boolean =>
+  value === '1' ||
+  value === 'true' ||
+  (Array.isArray(value) && (value.includes('1') || value.includes('true')));
+
 const getSupportingCopy = (tags: string[]): string => {
   if (!tags.length) {
     return 'Pick what you care about. We’ll bring you the tech worth knowing — minus the noise.';
@@ -56,6 +63,8 @@ export const PostOnboardingActivation = ({
   const [isLocalPreviewDismissed, setIsLocalPreviewDismissed] = useState(false);
   const hasLoggedImpression = useRef(false);
   const tags = useMemo(() => post.tags?.slice(0, 3) ?? [], [post.tags]);
+  const isPreviewMode =
+    isDevelopment || isPreviewQueryEnabled(router.query?.[previewQueryKey]);
 
   useEffect(() => {
     if (!user?.id || !isOnboardingActionsReady) {
@@ -71,7 +80,7 @@ export const PostOnboardingActivation = ({
   }, [isOnboardingActionsReady, isOnboardingComplete, user?.id]);
 
   const shouldShow =
-    (isDevelopment && !isLocalPreviewDismissed) ||
+    (isPreviewMode && !isLocalPreviewDismissed) ||
     (!!user?.id &&
       isOnboardingActionsReady &&
       !isOnboardingComplete &&
@@ -95,7 +104,7 @@ export const PostOnboardingActivation = ({
   }
 
   const onDismiss = (): void => {
-    if (isDevelopment) {
+    if (isPreviewMode) {
       setIsLocalPreviewDismissed(true);
     } else {
       clearPostSignupActivation();

--- a/packages/shared/src/components/post/PostOnboardingActivation.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.tsx
@@ -13,7 +13,12 @@ import {
   POST_ONBOARDING_PREVIEW_QUERY,
 } from '../../lib/postSignupActivation';
 import { AFTER_AUTH_PARAM } from '../auth/common';
-import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/Button';
 import CloseButton from '../CloseButton';
 import { VIcon } from '../icons/V';
 import { IconSize } from '../Icon';
@@ -106,7 +111,7 @@ export const PostOnboardingActivation = (): ReactElement | null => {
   return (
     <aside
       aria-label="Personalize your feed"
-      className="relative mb-4 w-full overflow-hidden border-y border-border-subtlest-secondary bg-surface-secondary laptop:mx-auto laptop:max-w-[69.25rem] laptop:rounded-16 laptop:border"
+      className="relative mb-4 w-full overflow-hidden border-y border-border-subtlest-secondary bg-surface-float shadow-2 laptop:mx-auto laptop:max-w-[69.25rem] laptop:rounded-16 laptop:border"
     >
       <div className="absolute inset-y-0 left-0 w-1 bg-accent-cabbage-default" />
       <div className="relative flex w-full flex-col gap-5 px-5 py-5 pr-14 tablet:flex-row tablet:items-center tablet:gap-8 tablet:px-6 tablet:py-6 tablet:pr-14 laptop:px-8">
@@ -129,7 +134,7 @@ export const PostOnboardingActivation = (): ReactElement | null => {
           </Typography>
           <Typography
             type={TypographyType.Callout}
-            color={TypographyColor.Tertiary}
+            color={TypographyColor.Secondary}
             className="mt-1 max-w-[42rem] [text-wrap:pretty]"
           >
             Choose what you care about once. We&apos;ll filter the noise and
@@ -141,6 +146,7 @@ export const PostOnboardingActivation = (): ReactElement | null => {
           <Button
             type="button"
             variant={ButtonVariant.Primary}
+            color={ButtonColor.Cabbage}
             size={ButtonSize.Large}
             className="w-full tablet:w-auto"
             onClick={onBuildFeed}
@@ -150,7 +156,7 @@ export const PostOnboardingActivation = (): ReactElement | null => {
           <Typography
             tag={TypographyTag.Span}
             type={TypographyType.Caption1}
-            color={TypographyColor.Tertiary}
+            color={TypographyColor.Secondary}
           >
             Takes about 1 minute
           </Typography>

--- a/packages/shared/src/components/post/PostOnboardingActivation.tsx
+++ b/packages/shared/src/components/post/PostOnboardingActivation.tsx
@@ -1,0 +1,204 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { useRouter } from 'next/router';
+import type { Post } from '../../graphql/posts';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useOnboardingActions } from '../../hooks/auth/useOnboardingActions';
+import { useLogContext } from '../../contexts/LogContext';
+import { TargetType } from '../../lib/log';
+import {
+  clearPostSignupActivation,
+  hasPostSignupActivation,
+} from '../../lib/postSignupActivation';
+import { AFTER_AUTH_PARAM } from '../auth/common';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonSize,
+  ButtonVariant,
+} from '../buttons/Button';
+import CloseButton from '../CloseButton';
+import { ArrowIcon, SparkleIcon } from '../icons';
+import { IconSize } from '../Icon';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+
+interface PostOnboardingActivationProps {
+  post: Pick<Post, 'tags'>;
+  inline?: boolean;
+}
+
+const getSupportingCopy = (tags: string[]): string => {
+  if (!tags.length) {
+    return 'Pick what you care about. We’ll bring you the tech worth knowing — minus the noise.';
+  }
+
+  const topics = tags.slice(0, 2).join(' and ');
+  return `Start with ${topics}, then pick what else you care about. We’ll do the filtering.`;
+};
+
+export const PostOnboardingActivation = ({
+  post,
+  inline = false,
+}: PostOnboardingActivationProps): ReactElement | null => {
+  const router = useRouter();
+  const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const { isOnboardingActionsReady, isOnboardingComplete } =
+    useOnboardingActions();
+  const [isVisible, setIsVisible] = useState(false);
+  const hasLoggedImpression = useRef(false);
+  const tags = useMemo(() => post.tags?.slice(0, 3) ?? [], [post.tags]);
+
+  useEffect(() => {
+    if (!user?.id || !isOnboardingActionsReady) {
+      return;
+    }
+
+    if (isOnboardingComplete) {
+      clearPostSignupActivation();
+      return;
+    }
+
+    setIsVisible(hasPostSignupActivation(user.id));
+  }, [isOnboardingActionsReady, isOnboardingComplete, user?.id]);
+
+  const shouldShow =
+    !!user?.id &&
+    isOnboardingActionsReady &&
+    !isOnboardingComplete &&
+    isVisible;
+
+  useEffect(() => {
+    if (!shouldShow || hasLoggedImpression.current) {
+      return;
+    }
+
+    hasLoggedImpression.current = true;
+    logEvent({
+      event_name: 'impression',
+      target_type: TargetType.PostSignupActivation,
+      target_id: 'post signup activation',
+    });
+  }, [logEvent, shouldShow]);
+
+  if (!shouldShow) {
+    return null;
+  }
+
+  const onDismiss = (): void => {
+    clearPostSignupActivation();
+    setIsVisible(false);
+    logEvent({
+      event_name: 'click',
+      target_type: TargetType.PostSignupActivation,
+      target_id: 'dismiss post signup activation',
+    });
+  };
+
+  const onBuildFeed = (): void => {
+    logEvent({
+      event_name: 'click',
+      target_type: TargetType.PostSignupActivation,
+      target_id: 'build feed from post signup activation',
+      extra: JSON.stringify({ tags }),
+    });
+
+    router.push({
+      pathname: '/onboarding',
+      query: { [AFTER_AUTH_PARAM]: router.asPath },
+    });
+  };
+
+  return (
+    <aside
+      aria-label="Personalize your feed"
+      className={classNames(
+        'isolate overflow-hidden border border-accent-cabbage-default bg-surface-float shadow-2-cabbage',
+        inline
+          ? 'relative mx-4 mt-6 rounded-16'
+          : 'fixed bottom-0 left-0 z-modal w-full border-x-0 border-b-0',
+      )}
+    >
+      <div className="bg-accent-cabbage-default/20 pointer-events-none absolute -left-20 -top-24 -z-1 h-56 w-56 rounded-full blur-3xl" />
+      <div className="bg-accent-onion-default/15 pointer-events-none absolute -right-20 -top-20 -z-1 h-48 w-48 rounded-full blur-3xl" />
+      <div
+        className={classNames(
+          'relative mx-auto flex w-full max-w-[63.75rem] flex-col gap-4 px-4 py-5 pr-14 tablet:px-6 tablet:pr-16',
+          !inline &&
+            'laptop:flex-row laptop:items-center laptop:gap-6 laptop:py-4',
+        )}
+      >
+        <div className="flex min-w-0 flex-1 items-start gap-3">
+          <div className="shadow-1 flex h-10 w-10 shrink-0 items-center justify-center rounded-12 bg-accent-cabbage-subtlest text-accent-cabbage-default">
+            <SparkleIcon secondary size={IconSize.Small} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <Typography
+              tag={TypographyTag.Span}
+              type={TypographyType.Caption1}
+              color={TypographyColor.Brand}
+              bold
+              className="uppercase tracking-wide"
+            >
+              You&apos;re in
+            </Typography>
+            <Typography
+              tag={TypographyTag.H2}
+              type={TypographyType.Title3}
+              bold
+              className="mt-0.5"
+            >
+              One good post is luck. Build a feed full of them.
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+              className="mt-1"
+            >
+              {getSupportingCopy(tags)}
+            </Typography>
+          </div>
+        </div>
+
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 laptop:max-w-64 laptop:justify-end">
+            {tags.map((tag) => (
+              <span
+                key={tag}
+                className="border-accent-cabbage-default/30 rounded-10 border bg-accent-cabbage-subtlest px-2.5 py-1 text-accent-cabbage-default typo-caption1"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <Button
+          type="button"
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Large}
+          className="w-full shrink-0 tablet:w-auto"
+          icon={<ArrowIcon />}
+          iconPosition={ButtonIconPosition.Right}
+          onClick={onBuildFeed}
+        >
+          Build my feed
+        </Button>
+
+        <CloseButton
+          type="button"
+          aria-label="Dismiss feed personalization"
+          className="absolute right-3 top-3"
+          size={ButtonSize.Small}
+          onClick={onDismiss}
+        />
+      </div>
+    </aside>
+  );
+};

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -532,6 +532,7 @@ export enum TargetType {
   SpotlightCommand = 'spotlight command',
   MyFeedModal = 'my feed modal',
   ArticleAnonymousCTA = 'article anonymous cta',
+  PostSignupActivation = 'post signup activation',
   EnableNotifications = 'enable notifications',
   OnboardingChecklist = 'onboarding checklist',
   LoginButton = 'login button',

--- a/packages/shared/src/lib/postSignupActivation.spec.ts
+++ b/packages/shared/src/lib/postSignupActivation.spec.ts
@@ -1,0 +1,43 @@
+import {
+  clearPostSignupActivation,
+  hasPostSignupActivation,
+  markPostSignupActivation,
+} from './postSignupActivation';
+
+describe('post signup activation', () => {
+  beforeEach(() => {
+    clearPostSignupActivation();
+    window.history.replaceState({}, '', '/posts/original-post');
+  });
+
+  it('marks the newly registered user on the originating post', () => {
+    markPostSignupActivation({ id: 'new-user' });
+
+    expect(hasPostSignupActivation('new-user')).toBe(true);
+    expect(hasPostSignupActivation('another-user')).toBe(false);
+  });
+
+  it('does not carry the activation prompt to another post', () => {
+    markPostSignupActivation({ id: 'new-user' });
+
+    window.history.replaceState({}, '', '/posts/another-post');
+
+    expect(hasPostSignupActivation('new-user')).toBe(false);
+  });
+
+  it('does not mark registrations outside a post page', () => {
+    window.history.replaceState({}, '', '/sources/javascript');
+
+    markPostSignupActivation({ id: 'new-user' });
+
+    expect(hasPostSignupActivation('new-user')).toBe(false);
+  });
+
+  it('clears the activation prompt', () => {
+    markPostSignupActivation({ id: 'new-user' });
+
+    clearPostSignupActivation();
+
+    expect(hasPostSignupActivation('new-user')).toBe(false);
+  });
+});

--- a/packages/shared/src/lib/postSignupActivation.spec.ts
+++ b/packages/shared/src/lib/postSignupActivation.spec.ts
@@ -1,6 +1,7 @@
 import {
   clearPostSignupActivation,
   hasPostSignupActivation,
+  isPostOnboardingPreviewEnabled,
   markPostSignupActivation,
 } from './postSignupActivation';
 
@@ -39,5 +40,12 @@ describe('post signup activation', () => {
     clearPostSignupActivation();
 
     expect(hasPostSignupActivation('new-user')).toBe(false);
+  });
+
+  it('supports explicit local and hosted preview values', () => {
+    expect(isPostOnboardingPreviewEnabled('1')).toBe(true);
+    expect(isPostOnboardingPreviewEnabled('true')).toBe(true);
+    expect(isPostOnboardingPreviewEnabled(['0', '1'])).toBe(true);
+    expect(isPostOnboardingPreviewEnabled('0')).toBe(false);
   });
 });

--- a/packages/shared/src/lib/postSignupActivation.ts
+++ b/packages/shared/src/lib/postSignupActivation.ts
@@ -8,6 +8,15 @@ const activationStorageKey = generateStorageKey(
 
 const activationTtl = 7 * 24 * 60 * 60 * 1000;
 
+export const POST_ONBOARDING_PREVIEW_QUERY = 'postOnboardingPreview';
+
+export const isPostOnboardingPreviewEnabled = (
+  value?: string | string[],
+): boolean =>
+  value === '1' ||
+  value === 'true' ||
+  (Array.isArray(value) && (value.includes('1') || value.includes('true')));
+
 interface PostSignupActivation {
   userId: string;
   postPath: string;

--- a/packages/shared/src/lib/postSignupActivation.ts
+++ b/packages/shared/src/lib/postSignupActivation.ts
@@ -1,0 +1,81 @@
+import { generateStorageKey, StorageTopic } from './storage';
+import { storageWrapper as storage } from './storageWrapper';
+
+const activationStorageKey = generateStorageKey(
+  StorageTopic.Onboarding,
+  'postSignupActivation',
+);
+
+const activationTtl = 7 * 24 * 60 * 60 * 1000;
+
+interface PostSignupActivation {
+  userId: string;
+  postPath: string;
+  createdAt: number;
+}
+
+interface ActivationUser {
+  id?: string;
+}
+
+const getCurrentPostPath = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const { pathname } = window.location;
+  return pathname.startsWith('/posts/') ? pathname : null;
+};
+
+const readPostSignupActivation = (): PostSignupActivation | null => {
+  const value = storage.getItem(activationStorageKey);
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as PostSignupActivation;
+  } catch {
+    storage.removeItem(activationStorageKey);
+    return null;
+  }
+};
+
+export const markPostSignupActivation = (user?: ActivationUser): void => {
+  const postPath = getCurrentPostPath();
+  if (!user?.id || !postPath) {
+    return;
+  }
+
+  storage.setItem(
+    activationStorageKey,
+    JSON.stringify({
+      userId: user.id,
+      postPath,
+      createdAt: Date.now(),
+    } satisfies PostSignupActivation),
+  );
+};
+
+export const hasPostSignupActivation = (userId?: string): boolean => {
+  const postPath = getCurrentPostPath();
+  if (!userId || !postPath) {
+    return false;
+  }
+
+  const activation = readPostSignupActivation();
+  if (!activation) {
+    return false;
+  }
+
+  if (Date.now() - activation.createdAt > activationTtl) {
+    storage.removeItem(activationStorageKey);
+    return false;
+  }
+
+  return activation.userId === userId && activation.postPath === postPath;
+};
+
+export const clearPostSignupActivation = (): void => {
+  storage.removeItem(activationStorageKey);
+};

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -53,6 +53,11 @@ import { isPostRedesignEligible } from '@dailydotdev/shared/src/hooks/post/usePo
 import { featurePostRedesign } from '@dailydotdev/shared/src/lib/featureManagement';
 import { PostFocusCard } from '@dailydotdev/shared/src/components/post/focus/PostFocusCard';
 import { PostOnboardingActivation } from '@dailydotdev/shared/src/components/post/PostOnboardingActivation';
+import {
+  isPostOnboardingPreviewEnabled,
+  POST_ONBOARDING_PREVIEW_QUERY,
+} from '@dailydotdev/shared/src/lib/postSignupActivation';
+import { isDevelopment } from '@dailydotdev/shared/src/lib/constants';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getLayout } from '../../../components/layouts/MainLayout';
 import FooterNavBarLayout from '../../../components/layouts/FooterNavBarLayout';
@@ -192,6 +197,12 @@ export const PostPage = ({
   const router = useRouter();
   const isFallback = false;
   const { shouldShowAuthBanner } = useOnboardingActions();
+  const isActivationPreview =
+    isDevelopment ||
+    isPostOnboardingPreviewEnabled(
+      router.query?.[POST_ONBOARDING_PREVIEW_QUERY],
+    );
+  const showAuthBanner = shouldShowAuthBanner && !isActivationPreview;
   const isLaptop = useViewSize(ViewSize.Laptop);
   const { post, isError, isLoading } = usePostById({
     id,
@@ -286,6 +297,7 @@ export const PostPage = ({
             <link rel="preload" as="image" href={post?.image} />
           </Head>
           <PostSEOSchema post={post} topComments={topComments} />
+          <PostOnboardingActivation />
           {showRedesign ? (
             <div className="mx-auto w-full max-w-[63.75rem]">
               <PostFocusCard post={post} origin={Origin.ArticlePage} />
@@ -299,7 +311,7 @@ export const PostPage = ({
               backToSquad={!!router?.query?.squad}
               shouldOnboardAuthor={!!router.query?.author}
               origin={Origin.ArticlePage}
-              isBannerVisible={shouldShowAuthBanner && !isLaptop}
+              isBannerVisible={showAuthBanner && !isLaptop}
               className={{
                 container: containerClass,
                 fixedNavigation: { container: 'flex laptop:hidden' },
@@ -310,10 +322,7 @@ export const PostPage = ({
               }}
             />
           )}
-          {!showRedesign && shouldShowAuthBanner && isLaptop && (
-            <PostAuthBanner />
-          )}
-          <PostOnboardingActivation post={post} inline={!isLaptop} />
+          {!showRedesign && showAuthBanner && isLaptop && <PostAuthBanner />}
           <CompanionDemoWidget />
         </FooterNavBarLayout>
       </LogExtraContextProvider>

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -52,6 +52,7 @@ import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditio
 import { isPostRedesignEligible } from '@dailydotdev/shared/src/hooks/post/usePostRedesign';
 import { featurePostRedesign } from '@dailydotdev/shared/src/lib/featureManagement';
 import { PostFocusCard } from '@dailydotdev/shared/src/components/post/focus/PostFocusCard';
+import { PostOnboardingActivation } from '@dailydotdev/shared/src/components/post/PostOnboardingActivation';
 import { getPageSeoTitles } from '../../../components/layouts/utils';
 import { getLayout } from '../../../components/layouts/MainLayout';
 import FooterNavBarLayout from '../../../components/layouts/FooterNavBarLayout';
@@ -312,6 +313,7 @@ export const PostPage = ({
           {!showRedesign && shouldShowAuthBanner && isLaptop && (
             <PostAuthBanner />
           )}
+          <PostOnboardingActivation post={post} inline={!isLaptop} />
           <CompanionDemoWidget />
         </FooterNavBarLayout>
       </LogExtraContextProvider>


### PR DESCRIPTION
## Summary

- add a value-led feed activation strip for users who register from a post page
- connect the prompt to the originating post tags and return users to that post after onboarding
- support responsive placement, dismissal, expiry, completion cleanup, and analytics

## Testing

- node scripts/typecheck-strict-changed.js
- shared and webapp lint
- 6 targeted activation tests
- 48 PostPage tests

### Preview domain
https://codex-post-signup-feed-activatio.preview.app.daily.dev