### PR TITLE
feat(share): sharing-visibility foundation (PR 1)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "storybook",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "storybook", "dev"],
+      "port": 6006
+    }
+  ]
+}

--- a/packages/shared/src/components/CustomFeedOptionsMenu.spec.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.spec.tsx
@@ -1,0 +1,70 @@
+import type { ComponentProps } from 'react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import CustomFeedOptionsMenu from './CustomFeedOptionsMenu';
+import AuthContext from '../contexts/AuthContext';
+import type { AuthContextData } from '../contexts/AuthContext';
+
+jest.mock('../hooks', () => ({
+  ...jest.requireActual('../hooks'),
+  useFeeds: () => ({ feeds: { edges: [] } }),
+}));
+
+const shareProps = {
+  text: "Check out Ido Shamun's profile on daily.dev",
+  link: 'https://app.daily.dev/idoshamun',
+};
+
+const renderMenu = (
+  props: Partial<ComponentProps<typeof CustomFeedOptionsMenu>> = {},
+) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthContext.Provider
+        value={
+          {
+            user: null,
+            isAuthReady: true,
+            tokenRefreshed: true,
+            squads: [],
+          } as unknown as AuthContextData
+        }
+      >
+        <CustomFeedOptionsMenu
+          onAdd={jest.fn()}
+          shareProps={shareProps}
+          {...props}
+        />
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('CustomFeedOptionsMenu', () => {
+  it('should list the share option by default', async () => {
+    renderMenu({ shareProps });
+
+    // Radix opens the menu on keydown; jsdom lacks the pointer-event support
+    // its click path relies on.
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+
+    expect(await screen.findByText('Share')).toBeInTheDocument();
+    expect(screen.getByText('Add to custom feed')).toBeInTheDocument();
+  });
+
+  it('should drop the share option when the surface promotes it elsewhere', async () => {
+    renderMenu({ shareProps, hideShare: true });
+
+    // Radix opens the menu on keydown; jsdom lacks the pointer-event support
+    // its click path relies on.
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' });
+
+    expect(await screen.findByText('Add to custom feed')).toBeInTheDocument();
+    expect(screen.queryByText('Share')).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/CustomFeedOptionsMenu.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.tsx
@@ -28,6 +28,8 @@ type CustomFeedOptionsMenuProps = {
   buttonVariant?: ButtonVariant;
   shareProps: UseShareOrCopyLinkProps;
   additionalOptions?: MenuItemProps[];
+  /** Drop the in-menu share entry when the surface renders a visible one. */
+  hideShare?: boolean;
 };
 
 const CustomFeedOptionsMenu = ({
@@ -38,13 +40,14 @@ const CustomFeedOptionsMenu = ({
   onCreateNewFeed,
   additionalOptions = [],
   buttonVariant = ButtonVariant.Float,
+  hideShare = false,
 }: CustomFeedOptionsMenuProps): ReactElement => {
   const { openModal } = useLazyModal();
   const [, onShareOrCopyLink] = useShareOrCopyLink(shareProps);
   const { feeds } = useFeeds();
 
   const handleOpenModal = () => {
-    if (feeds?.edges?.length > 0) {
+    if ((feeds?.edges?.length ?? 0) > 0) {
       return openModal({
         type: LazyModal.AddToCustomFeed,
         props: {
@@ -59,11 +62,15 @@ const CustomFeedOptionsMenu = ({
   };
 
   const options: MenuItemProps[] = [
-    {
-      icon: <MenuIcon Icon={ShareIcon} />,
-      label: 'Share',
-      action: () => onShareOrCopyLink(),
-    },
+    ...(hideShare
+      ? []
+      : [
+          {
+            icon: <MenuIcon Icon={ShareIcon} />,
+            label: 'Share',
+            action: () => onShareOrCopyLink(),
+          },
+        ]),
     {
       icon: <MenuIcon Icon={HashtagIcon} />,
       label: 'Add to custom feed',

--- a/packages/shared/src/components/ShareMobile.tsx
+++ b/packages/shared/src/components/ShareMobile.tsx
@@ -1,7 +1,8 @@
 import type { ReactElement } from 'react';
 import React, { useContext } from 'react';
-import { LinkIcon, ShareIcon } from './icons';
+import { CopyIcon, LinkIcon, ShareIcon } from './icons';
 import { useCopyPostLink } from '../hooks/useCopyPostLink';
+import { useShareCopyIcon } from '../hooks/useShareCopyIcon';
 import {
   Button,
   ButtonColor,
@@ -35,6 +36,7 @@ export function ShareMobile({
   const { openSharePost } = useSharePost(origin);
   const { logEvent } = useLogContext();
   const { logOpts } = useContext(ActiveFeedContext);
+  const showCopyIcon = useShareCopyIcon();
 
   const onShare = () => {
     logEvent(
@@ -51,7 +53,7 @@ export function ShareMobile({
         size={ButtonSize.Small}
         onClick={onCopyPostLink}
         pressed={copying}
-        icon={<LinkIcon />}
+        icon={showCopyIcon ? <CopyIcon secondary={copying} /> : <LinkIcon />}
         variant={ButtonVariant.Tertiary}
         color={ButtonColor.Avocado}
       >

--- a/packages/shared/src/components/cards/common/ActionButtons.v2.tsx
+++ b/packages/shared/src/components/cards/common/ActionButtons.v2.tsx
@@ -7,6 +7,7 @@ import { CardActionBar } from '../../buttons/CardActionBar';
 import {
   AnalyticsIcon,
   DiscussIcon as CommentIcon,
+  CopyIcon,
   LinkIcon,
   DownvoteIcon,
 } from '../../icons';
@@ -21,6 +22,7 @@ import { PostTagsPanel } from '../../post/block/PostTagsPanel';
 import { LinkWithTooltip } from '../../tooltips/LinkWithTooltip';
 import { useCardActions } from '../../../hooks/cards/useCardActions';
 import { useBrandSponsorship } from '../../../hooks/useBrandSponsorship';
+import { useShareCopyIcon } from '../../../hooks/useShareCopyIcon';
 import { usePostImpressionsModal } from '../../../hooks/post/usePostImpressionsModal';
 import { usePostImpressions } from '../../../hooks/post/usePostImpressions';
 
@@ -73,6 +75,7 @@ const ActionButtons = ({
 }: ActionButtonsProps): ReactElement | null => {
   const config = variantConfig[variant];
   const isFeedPreview = useFeedPreviewMode();
+  const showCopyIcon = useShareCopyIcon();
   // When impressions are enabled, awards are hidden below laptop (tablet +
   // mobile) to make room for the extra action.
   const isLaptop = useViewSize(ViewSize.Laptop);
@@ -227,7 +230,7 @@ const ActionButtons = ({
           <CardAction
             id="copy-post-btn"
             density={FEED_CARD_DENSITY}
-            icon={<LinkIcon />}
+            icon={showCopyIcon ? <CopyIcon /> : <LinkIcon />}
             label="Copy link"
             onClick={onCopyLink}
             color={ButtonColor.Cabbage}

--- a/packages/shared/src/components/post/brief/BriefPostHeaderActions.tsx
+++ b/packages/shared/src/components/post/brief/BriefPostHeaderActions.tsx
@@ -6,8 +6,9 @@ import type { PostHeaderActionsProps } from '../common';
 import Link from '../../utilities/Link';
 import { Button, ButtonSize } from '../../buttons/Button';
 import { settingsUrl } from '../../../lib/constants';
-import { LinkIcon, SettingsIcon } from '../../icons';
+import { CopyIcon, LinkIcon, SettingsIcon } from '../../icons';
 import { useSharePost } from '../../../hooks/useSharePost';
+import { useShareCopyIcon } from '../../../hooks/useShareCopyIcon';
 import type { Origin } from '../../../lib/log';
 
 const Container = classed('div', 'flex flex-row items-center');
@@ -27,15 +28,17 @@ export const BriefPostHeaderActions = ({
   showShareButton?: boolean;
 }): ReactElement => {
   const { copyLink } = useSharePost(origin);
+  const showCopyIcon = useShareCopyIcon();
 
   return (
     <Container {...props} className={classNames('gap-2', className)}>
       <div className="hidden laptop:block">
         {showShareButton && (
           <Button
-            icon={<LinkIcon />}
+            icon={showCopyIcon ? <CopyIcon /> : <LinkIcon />}
             size={ButtonSize.Medium}
             onClick={() => copyLink({ post })}
+            aria-label="Copy link"
           />
         )}
         <Link passHref href={`${settingsUrl}/notifications`}>

--- a/packages/shared/src/components/profile/Header.tsx
+++ b/packages/shared/src/components/profile/Header.tsx
@@ -45,6 +45,7 @@ import {
 import Link from '../utilities/Link';
 import type { MenuItemProps } from '../dropdown/common';
 import { ProfileMobileBackButton } from './ProfileBackButton';
+import { ProfileShareButton } from './ProfileShareButton';
 
 export interface HeaderProps {
   user: PublicProfile;
@@ -218,6 +219,20 @@ export function Header({
             variant={ButtonVariant.Float}
           />
         )}
+        {/* Only while pinned: unpinned, the profile card right below owns the
+            share control, and two identical copy buttons on one screen read as
+            a mistake. `ml-1` keeps this utility icon out of the Follow group. */}
+        {sticky && (
+          <ProfileShareButton
+            user={user}
+            isSameUser={isSameUser}
+            // Float, not the header card's Subtle: in this bar the control
+            // sits among Float icons (award, options) and a bordered button
+            // would read as a different kind of action.
+            buttonVariant={ButtonVariant.Float}
+            className="ml-1"
+          />
+        )}
         {!isSameUser && (
           <CustomFeedOptionsMenu
             onAdd={(feedId) =>
@@ -241,6 +256,8 @@ export function Header({
                 `/feeds/new?entityId=${user.id}&entityType=${ContentPreferenceType.User}`,
               )
             }
+            // Promoted out of the menu into the dedicated control above.
+            hideShare
             shareProps={{
               text: `Check out ${user.name}'s profile on daily.dev`,
               link: user.permalink,

--- a/packages/shared/src/components/profile/ProfileActions.tsx
+++ b/packages/shared/src/components/profile/ProfileActions.tsx
@@ -67,7 +67,7 @@ const ProfileActions = ({ user, isPreviewMode }: HeaderProps): ReactElement => {
         props: {
           offendingUser: {
             id: user.id,
-            username: user.username,
+            username: user.username || '',
           },
           defaultBlockUser: defaultBlocked,
         },
@@ -87,12 +87,12 @@ const ProfileActions = ({ user, isPreviewMode }: HeaderProps): ReactElement => {
           ? unblock({
               id: user.id,
               entity: ContentPreferenceType.User,
-              entityName: user.username,
+              entityName: user.username || '',
             })
           : block({
               id: user.id,
               entity: ContentPreferenceType.User,
-              entityName: user.username,
+              entityName: user.username || '',
             }),
     },
     {
@@ -178,7 +178,7 @@ const ProfileActions = ({ user, isPreviewMode }: HeaderProps): ReactElement => {
             follow({
               id: user.id,
               entity: ContentPreferenceType.User,
-              entityName: user.username,
+              entityName: user.username || '',
               feedId,
             })
           }
@@ -186,7 +186,7 @@ const ProfileActions = ({ user, isPreviewMode }: HeaderProps): ReactElement => {
             unfollow({
               id: user.id,
               entity: ContentPreferenceType.User,
-              entityName: user.username,
+              entityName: user.username || '',
               feedId,
             })
           }
@@ -195,6 +195,8 @@ const ProfileActions = ({ user, isPreviewMode }: HeaderProps): ReactElement => {
               `/feeds/new?entityId=${user.id}&entityType=${ContentPreferenceType.User}`,
             )
           }
+          // Promoted out of the menu into the header's share control.
+          hideShare
           shareProps={{
             text: `Check out ${user.name}'s profile on daily.dev`,
             link: user.permalink,

--- a/packages/shared/src/components/profile/ProfileHeader.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.spec.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProfileHeader from './ProfileHeader';
+import AuthContext from '../../contexts/AuthContext';
+import type { AuthContextData } from '../../contexts/AuthContext';
+import { getLogContextStatic } from '../../contexts/LogContext';
+import type { PublicProfile } from '../../lib/user';
+import { LogEvent, Origin, TargetType } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+jest.mock('./ProfileActions', () => ({
+  __esModule: true,
+  default: () => <div data-testid="profile-actions" />,
+}));
+
+const user = {
+  id: 'u1',
+  name: 'Ido Shamun',
+  username: 'idoshamun',
+  permalink: 'https://app.daily.dev/idoshamun',
+  reputation: 10,
+  createdAt: '2020-01-01T00:00:00.000Z',
+  bio: 'Building daily.dev',
+  image: 'https://daily.dev/image.jpg',
+  cover: 'https://daily.dev/cover.jpg',
+} as PublicProfile;
+
+const userStats = { upvotes: 1, numFollowers: 2, numFollowing: 3 };
+
+const logEvent = jest.fn();
+
+const renderHeader = (isSameUser: boolean) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const LogContext = getLogContextStatic();
+
+  return render(
+    <QueryClientProvider client={client}>
+      <AuthContext.Provider
+        value={
+          {
+            user: null,
+            isAuthReady: true,
+            tokenRefreshed: true,
+            squads: [],
+          } as unknown as AuthContextData
+        }
+      >
+        <LogContext.Provider
+          value={{
+            logEvent,
+            logEventStart: jest.fn(),
+            logEventEnd: jest.fn(),
+            sendBeacon: () => false,
+          }}
+        >
+          <ProfileHeader
+            user={user}
+            userStats={userStats}
+            isSameUser={isSameUser}
+          />
+        </LogContext.Provider>
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('ProfileHeader share control', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('should fill the edit slot with the share control on a public profile', () => {
+    renderHeader(false);
+
+    expect(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    ).toBeInTheDocument();
+    // The invisible edit placeholder that used to hold the row height is gone.
+    expect(screen.queryByLabelText('Edit profile')).not.toBeInTheDocument();
+  });
+
+  it('should sit next to the edit button on the owner profile', () => {
+    renderHeader(true);
+
+    expect(
+      screen.getByLabelText('Copy link to your profile'),
+    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Edit profile')).toBeInTheDocument();
+  });
+
+  it('should log share profile from the header control', async () => {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: jest.fn().mockResolvedValue(undefined) },
+    });
+
+    renderHeader(false);
+
+    await userEvent.click(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    );
+
+    await waitFor(() =>
+      expect(logEvent).toHaveBeenCalledWith({
+        event_name: LogEvent.ShareProfile,
+        target_id: 'u1',
+        target_type: TargetType.ProfilePage,
+        extra: JSON.stringify({
+          provider: ShareProvider.CopyLink,
+          origin: Origin.Profile,
+        }),
+      }),
+    );
+  });
+
+  it('should render both controls at the same size and variant', () => {
+    renderHeader(true);
+
+    [
+      screen.getByLabelText('Copy link to your profile'),
+      screen.getByLabelText('Edit profile'),
+    ].forEach((control) => {
+      expect(control).toHaveClass('btn-subtle');
+      expect(control).toHaveClass('h-8');
+    });
+  });
+});

--- a/packages/shared/src/components/profile/ProfileHeader.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import dynamic from 'next/dynamic';
-import classNames from 'classnames';
 import { Image } from '../image/Image';
 import {
   Typography,
@@ -13,7 +12,7 @@ import type { UserStatsProps } from './UserStats';
 import { UserStats } from './UserStats';
 import JoinedDate from './JoinedDate';
 import { Separator } from '../cards/common/common';
-import { Button, ButtonVariant } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { webappUrl } from '../../lib/constants';
 import Link from '../utilities/Link';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -23,6 +22,7 @@ import { locationToString } from '../../lib/utils';
 import { IconSize } from '../Icon';
 import { fallbackImages } from '../../lib/config';
 import { ProfileDesktopPwaBackButton } from './ProfileBackButton';
+import { ProfileShareButton } from './ProfileShareButton';
 
 import { ElementPlaceholder } from '../ElementPlaceholder';
 
@@ -75,19 +75,27 @@ const ProfileHeader = ({
         className="absolute left-6 top-16 h-[7.5rem] w-[7.5rem] rounded-16 object-cover"
       />
       <div className="flex flex-col gap-3 px-6">
-        <Link passHref href={`${webappUrl}settings/profile`}>
-          <Button
-            className={classNames(
-              'mb-4 ml-auto mt-2 text-text-secondary',
-              !isSameUser && 'invisible',
-            )}
-            tag="a"
-            disabled={!isSameUser}
-            variant={ButtonVariant.Float}
-            icon={<EditIcon />}
-            aria-label="Edit profile"
-          />
-        </Link>
+        {/* Bottom-anchored to the avatar rather than spaced off the cover:
+            the cover is h-36 (9rem) and the avatar hangs down to 11.5rem, so
+            a 2.5rem row ending flush puts the controls on the avatar's bottom
+            edge at any button height. */}
+        <div className="mb-4 ml-auto flex h-10 items-end gap-2">
+          <ProfileShareButton user={user} isSameUser={isSameUser} />
+          {/* Public profiles used to render an invisible edit button purely to
+              hold this row's height; the share control fills it now. */}
+          {isSameUser && (
+            <Link passHref href={`${webappUrl}settings/profile`}>
+              <Button
+                tag="a"
+                // Matches the share control beside it.
+                variant={ButtonVariant.Subtle}
+                size={ButtonSize.Small}
+                icon={<EditIcon />}
+                aria-label="Edit profile"
+              />
+            </Link>
+          )}
+        </div>
         <div className="flex items-center gap-1">
           <Typography type={TypographyType.Title2} bold>
             {name}

--- a/packages/shared/src/components/profile/ProfileShareButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileShareButton.spec.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ProfileShareButton } from './ProfileShareButton';
+import { getLogContextStatic } from '../../contexts/LogContext';
+import AuthContext from '../../contexts/AuthContext';
+import type { AuthContextData } from '../../contexts/AuthContext';
+import type { PublicProfile } from '../../lib/user';
+import { TOAST_NOTIF_KEY } from '../../hooks/useToastNotification';
+import type { ToastNotification } from '../../hooks/useToastNotification';
+import { shouldUseNativeShare } from '../../lib/func';
+import { LogEvent, Origin, TargetType } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+jest.mock('../../lib/func', () => ({
+  ...jest.requireActual('../../lib/func'),
+  shouldUseNativeShare: jest.fn(),
+}));
+
+const mockShouldUseNativeShare = jest.mocked(shouldUseNativeShare);
+
+const user = {
+  id: 'u1',
+  name: 'Ido Shamun',
+  username: 'idoshamun',
+  permalink: 'https://app.daily.dev/idoshamun',
+} as PublicProfile;
+
+const logEvent = jest.fn();
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const setupButton = (
+  props: Partial<React.ComponentProps<typeof ProfileShareButton>> = {},
+) => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const LogContext = getLogContextStatic();
+
+  render(
+    <QueryClientProvider client={client}>
+      <AuthContext.Provider
+        value={
+          {
+            user: null,
+            isAuthReady: true,
+            tokenRefreshed: true,
+            squads: [],
+          } as unknown as AuthContextData
+        }
+      >
+        <LogContext.Provider
+          value={{
+            logEvent,
+            logEventStart: jest.fn(),
+            logEventEnd: jest.fn(),
+            sendBeacon: () => false,
+          }}
+        >
+          <ProfileShareButton user={user} {...props} />
+        </LogContext.Provider>
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  );
+
+  return client;
+};
+
+describe('ProfileShareButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockShouldUseNativeShare.mockReturnValue(false);
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+  });
+
+  it('should label the control for the profile being copied', () => {
+    setupButton();
+
+    expect(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    ).toBeInTheDocument();
+  });
+
+  it('should label the control for the logged-in owner', () => {
+    setupButton({ isSameUser: true });
+
+    expect(
+      screen.getByLabelText('Copy link to your profile'),
+    ).toBeInTheDocument();
+  });
+
+  it('should copy the profile link and name it in the toast', async () => {
+    const client = setupButton();
+
+    await userEvent.click(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    );
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith('https://app.daily.dev/idoshamun'),
+    );
+    await waitFor(() => {
+      const toast = client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY);
+      expect(toast?.message).toEqual("✅ Copied link to @idoshamun's profile");
+    });
+    // Exact payload: `share profile` already ships from the profile menus and
+    // the owner share widget, and the post copy-link path uses the same
+    // target_id / target_type / stringified {provider, origin} shape. Pin it so
+    // the dashboards keep matching.
+    expect(logEvent).toHaveBeenCalledTimes(1);
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.ShareProfile,
+      target_id: 'u1',
+      target_type: TargetType.ProfilePage,
+      extra: JSON.stringify({
+        provider: ShareProvider.CopyLink,
+        origin: Origin.Profile,
+      }),
+    });
+  });
+
+  it('should say "your profile" in the owner toast', async () => {
+    const client = setupButton({ isSameUser: true });
+
+    await userEvent.click(screen.getByLabelText('Copy link to your profile'));
+
+    await waitFor(() => {
+      const toast = client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY);
+      expect(toast?.message).toEqual('✅ Copied link to your profile');
+    });
+  });
+
+  it('should flip the glyph to a green check while copying', async () => {
+    setupButton();
+
+    const button = screen.getByLabelText("Copy link to @idoshamun's profile");
+    expect(button.querySelector('.text-status-success')).toBeNull();
+
+    await userEvent.click(button);
+
+    await waitFor(() =>
+      expect(button.querySelector('.text-status-success')).toBeInTheDocument(),
+    );
+  });
+
+  it('should open the native share sheet on mobile when available', async () => {
+    mockShouldUseNativeShare.mockReturnValue(true);
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis.navigator, 'share', {
+      configurable: true,
+      value: share,
+    });
+
+    setupButton();
+
+    await userEvent.click(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    );
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        text: "Check out Ido Shamun's profile on daily.dev\nhttps://app.daily.dev/idoshamun",
+      }),
+    );
+    expect(writeText).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledTimes(1);
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.ShareProfile,
+      target_id: 'u1',
+      target_type: TargetType.ProfilePage,
+      extra: JSON.stringify({
+        provider: ShareProvider.Native,
+        origin: Origin.Profile,
+      }),
+    });
+  });
+
+  it('should not log when the native share sheet is dismissed', async () => {
+    mockShouldUseNativeShare.mockReturnValue(true);
+    Object.defineProperty(globalThis.navigator, 'share', {
+      configurable: true,
+      value: jest.fn().mockRejectedValue(new Error('AbortError')),
+    });
+
+    setupButton();
+
+    await userEvent.click(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    );
+
+    await waitFor(() => expect(logEvent).not.toHaveBeenCalled());
+  });
+
+  it('should not open a share popover on desktop', async () => {
+    setupButton();
+
+    await userEvent.click(
+      screen.getByLabelText("Copy link to @idoshamun's profile"),
+    );
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    expect(screen.queryByText('LinkedIn')).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/profile/ProfileShareButton.tsx
+++ b/packages/shared/src/components/profile/ProfileShareButton.tsx
@@ -1,0 +1,72 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { LinkIcon, VIcon } from '../icons';
+import { Tooltip } from '../tooltip/Tooltip';
+import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
+import { ReferralCampaignKey } from '../../lib/referral';
+import { LogEvent, Origin, TargetType } from '../../lib/log';
+import type { PublicProfile } from '../../lib/user';
+import type { ShareProvider } from '../../lib/share';
+
+export interface ProfileShareButtonProps {
+  user: PublicProfile;
+  isSameUser?: boolean;
+  buttonSize?: ButtonSize;
+  buttonVariant?: ButtonVariant;
+  className?: string;
+}
+
+/**
+ * Copy-link control for a profile. One click copies the (shortened, referral-
+ * tagged) profile URL and confirms twice over — the glyph flips to a green
+ * check for a beat and a toast names what was copied. No share menu: picking a
+ * network is a second decision, and the link on the clipboard covers every
+ * destination. Mobile still gets the native share sheet where the platform
+ * offers one.
+ */
+export function ProfileShareButton({
+  user,
+  isSameUser,
+  buttonSize = ButtonSize.Small,
+  buttonVariant = ButtonVariant.Subtle,
+  className,
+}: ProfileShareButtonProps): ReactElement {
+  const text = isSameUser
+    ? 'Check out my profile on daily.dev'
+    : `Check out ${user.name}'s profile on daily.dev`;
+  const label = isSameUser
+    ? 'Copy link to your profile'
+    : `Copy link to @${user.username}'s profile`;
+
+  const [copying, shareOrCopy] = useShareOrCopyLink({
+    link: user.permalink,
+    text,
+    cid: ReferralCampaignKey.ShareProfile,
+    copyMessage: isSameUser
+      ? '✅ Copied link to your profile'
+      : `✅ Copied link to @${user.username}'s profile`,
+    logObject: (provider: ShareProvider) => ({
+      event_name: LogEvent.ShareProfile,
+      target_id: user.id,
+      target_type: TargetType.ProfilePage,
+      extra: JSON.stringify({ provider, origin: Origin.Profile }),
+    }),
+  });
+
+  return (
+    <Tooltip content={label}>
+      <Button
+        type="button"
+        variant={buttonVariant}
+        size={buttonSize}
+        icon={
+          copying ? <VIcon className="text-status-success" /> : <LinkIcon />
+        }
+        aria-label={label}
+        className={className}
+        onClick={() => shareOrCopy()}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/shared/src/components/share/ShareActions.spec.tsx
+++ b/packages/shared/src/components/share/ShareActions.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { ShareActions } from './ShareActions';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { ShareProvider } from '../../lib/share';
+import { useViewSize } from '../../hooks/useViewSize';
+
+jest.mock('../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const useViewSizeMock = useViewSize as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+const onShare = jest.fn();
+const link = 'https://daily.dev/posts/abc';
+const text = 'Check this out';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useViewSizeMock.mockReturnValue(true); // default: laptop
+  Object.assign(navigator, {
+    clipboard: { writeText },
+  });
+});
+
+const renderComponent = (
+  props: Partial<Parameters<typeof ShareActions>[0]> = {},
+): RenderResult => {
+  const client = new QueryClient();
+  return render(
+    <TestBootProvider client={client}>
+      <ShareActions link={link} text={text} onShare={onShare} {...props} />
+    </TestBootProvider>,
+  );
+};
+
+describe('ShareActions inline variant', () => {
+  it('renders copy link plus a compact set of social networks', () => {
+    renderComponent({ variant: 'inline' });
+
+    expect(screen.getByText('Copy link')).toBeInTheDocument();
+    expect(screen.getByText('X')).toBeInTheDocument();
+    expect(screen.getByText('WhatsApp')).toBeInTheDocument();
+  });
+
+  it('copies the link and reports the CopyLink provider', async () => {
+    renderComponent({ variant: 'inline' });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(link));
+    expect(onShare).toHaveBeenCalledWith(ShareProvider.CopyLink);
+  });
+});
+
+describe('ShareActions icon variant on mobile', () => {
+  beforeEach(() => useViewSizeMock.mockReturnValue(false));
+
+  it('copies on a single tap when native share is unavailable', async () => {
+    renderComponent();
+
+    const trigger = screen.getByLabelText('Copy link');
+    await act(async () => {
+      fireEvent.click(trigger);
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(link));
+    expect(onShare).toHaveBeenCalledWith(ShareProvider.CopyLink);
+  });
+});

--- a/packages/shared/src/components/share/ShareActions.tsx
+++ b/packages/shared/src/components/share/ShareActions.tsx
@@ -1,0 +1,161 @@
+import type { ReactElement } from 'react';
+import React, { useRef, useState } from 'react';
+import classNames from 'classnames';
+import { Popover, PopoverTrigger } from '@radix-ui/react-popover';
+import { PopoverContent } from '../popover/Popover';
+import { SocialShareList } from '../widgets/SocialShareList';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { CopyIcon } from '../icons';
+import { Tooltip } from '../tooltip/Tooltip';
+import { Typography, TypographyType } from '../typography/Typography';
+import { useViewSize, ViewSize } from '../../hooks/useViewSize';
+import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
+import { shouldUseNativeShare } from '../../lib/func';
+import { ShareProvider } from '../../lib/share';
+import type { ReferralCampaignKey } from '../../lib/referral';
+
+export type ShareActionsVariant = 'icon' | 'inline';
+
+export interface ShareActionsProps {
+  link: string;
+  /** Share text / description used for native share + pre-filled network text. */
+  text: string;
+  cid?: ReferralCampaignKey;
+  variant?: ShareActionsVariant;
+  /** Desktop only: reveal the popover on hover as well as click. */
+  openOnHover?: boolean;
+  buttonVariant?: ButtonVariant;
+  buttonSize?: ButtonSize;
+  /** Tooltip + accessible label for the icon-only trigger. */
+  label?: string;
+  emailTitle?: string;
+  emailSummary?: string;
+  className?: string;
+  /** Called for any share/copy so the caller can log with its own origin. */
+  onShare?: (provider: ShareProvider) => void;
+}
+
+const HOVER_CLOSE_DELAY = 120;
+
+export function ShareActions({
+  link,
+  text,
+  cid,
+  variant = 'icon',
+  openOnHover = false,
+  buttonVariant = ButtonVariant.Tertiary,
+  buttonSize = ButtonSize.Small,
+  label = 'Copy link',
+  emailTitle,
+  emailSummary,
+  className,
+  onShare,
+}: ShareActionsProps): ReactElement {
+  const isLaptop = useViewSize(ViewSize.Laptop);
+  const [open, setOpen] = useState(false);
+  const [copying, shareOrCopy] = useShareOrCopyLink({ link, text, cid });
+  const closeTimeout = useRef<ReturnType<typeof setTimeout>>();
+
+  const list = (
+    <SocialShareList
+      link={link}
+      description={text}
+      emailTitle={emailTitle}
+      emailSummary={emailSummary}
+      isCopying={copying}
+      onCopy={() => {
+        onShare?.(ShareProvider.CopyLink);
+        shareOrCopy();
+      }}
+      onNativeShare={() => {
+        onShare?.(ShareProvider.Native);
+        shareOrCopy();
+      }}
+      onClickSocial={(provider) => onShare?.(provider)}
+    />
+  );
+
+  if (variant === 'inline') {
+    return (
+      <div className={classNames('flex flex-wrap gap-2', className)}>
+        {list}
+      </div>
+    );
+  }
+
+  // Mobile: a single tap goes straight to the native share sheet (or copy when
+  // native share is unavailable) — no popover, per sharing UX guidance.
+  if (!isLaptop) {
+    return (
+      <Tooltip content={label}>
+        <Button
+          type="button"
+          variant={buttonVariant}
+          size={buttonSize}
+          icon={<CopyIcon secondary={copying} />}
+          aria-label={label}
+          className={className}
+          onClick={() => {
+            onShare?.(
+              shouldUseNativeShare()
+                ? ShareProvider.Native
+                : ShareProvider.CopyLink,
+            );
+            shareOrCopy();
+          }}
+        />
+      </Tooltip>
+    );
+  }
+
+  const cancelClose = () => {
+    if (closeTimeout.current) {
+      clearTimeout(closeTimeout.current);
+    }
+  };
+  const hoverProps = openOnHover
+    ? {
+        onMouseEnter: () => {
+          cancelClose();
+          setOpen(true);
+        },
+        onMouseLeave: () => {
+          closeTimeout.current = setTimeout(
+            () => setOpen(false),
+            HOVER_CLOSE_DELAY,
+          );
+        },
+      }
+    : undefined;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip content={label} visible={!open}>
+        <PopoverTrigger asChild>
+          <Button
+            type="button"
+            variant={buttonVariant}
+            size={buttonSize}
+            icon={<CopyIcon secondary={copying} />}
+            aria-label={label}
+            pressed={open}
+            className={className}
+            {...hoverProps}
+          />
+        </PopoverTrigger>
+      </Tooltip>
+      <PopoverContent
+        side="top"
+        align="center"
+        avoidCollisions
+        className="flex w-80 flex-wrap justify-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-popover p-4 shadow-2 data-[side=bottom]:mt-1 data-[side=top]:mb-1"
+        {...hoverProps}
+      >
+        <Typography type={TypographyType.Callout} bold className="w-full">
+          Share
+        </Typography>
+        {list}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/shared/src/hooks/useShareCopyIcon.ts
+++ b/packages/shared/src/hooks/useShareCopyIcon.ts
@@ -1,0 +1,14 @@
+import { featureShareCopyIcon } from '../lib/featureManagement';
+import { useConditionalFeature } from './useConditionalFeature';
+
+// Resolves whether copy-link actions should render the new `CopyIcon` instead
+// of the legacy `LinkIcon`. Gated so the core-icon swap ramps behind
+// `share_copy_icon` (control = false = existing `LinkIcon`, no metric impact).
+export const useShareCopyIcon = (shouldEvaluate = true): boolean => {
+  const { value } = useConditionalFeature({
+    feature: featureShareCopyIcon,
+    shouldEvaluate,
+  });
+
+  return value;
+};

--- a/packages/shared/src/hooks/useShareOrCopyLink.ts
+++ b/packages/shared/src/hooks/useShareOrCopyLink.ts
@@ -13,12 +13,15 @@ export interface UseShareOrCopyLinkProps {
   logObject?: (provider: ShareProvider) => LogEvent;
   shortenUrl?: boolean;
   cid?: ReferralCampaignKey;
+  /** Toast copy for the copy path; defaults to the generic "Copied link". */
+  copyMessage?: string;
 }
 export function useShareOrCopyLink({
   link,
   text,
   logObject,
   cid,
+  copyMessage,
 }: UseShareOrCopyLinkProps): ReturnType<typeof useCopyLink> {
   const { logEvent } = useLogContext();
   const [copying, copyLink] = useCopyLink();
@@ -45,7 +48,7 @@ export function useShareOrCopyLink({
       }
     } else {
       logShareEvent(ShareProvider.CopyLink);
-      copyLink({ link: shortLink });
+      copyLink({ link: shortLink, message: copyMessage });
     }
   };
 

--- a/packages/shared/src/hooks/useSharingVisibility.ts
+++ b/packages/shared/src/hooks/useSharingVisibility.ts
@@ -1,0 +1,22 @@
+import { featureSharingVisibility } from '../lib/featureManagement';
+import { useConditionalFeature } from './useConditionalFeature';
+
+interface UseSharingVisibility {
+  isEnabled: boolean;
+  isLoading: boolean;
+}
+
+// Master gate for the sharing-visibility initiative. Wraps the
+// `sharing_visibility` kill-switch so every surface can guard on it with one
+// call. Pass `shouldEvaluate` to avoid evaluating GrowthBook until the surface
+// would actually render (per repo convention).
+export const useSharingVisibility = (
+  shouldEvaluate = true,
+): UseSharingVisibility => {
+  const { value, isLoading } = useConditionalFeature({
+    feature: featureSharingVisibility,
+    shouldEvaluate,
+  });
+
+  return { isEnabled: shouldEvaluate && value, isLoading };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -293,3 +293,18 @@ export const featureNotificationsRedesign = new Feature(
 // `analytics.impressions` field. Control hides it entirely. Keep the default
 // `false` — GrowthBook ramps it.
 export const featureCardImpressions = new Feature('card_impressions', false);
+
+// Master kill-switch for the sharing-visibility initiative (copy-link/share
+// affordances added across many surfaces). Each surface also ships behind its
+// own per-topic flag; this one can disable the whole initiative at once. Keep
+// the default `false` — GrowthBook ramps it.
+export const featureSharingVisibility = new Feature(
+  'sharing_visibility',
+  false,
+);
+
+// Swaps the core copy-link glyph from `LinkIcon` to `CopyIcon` across share
+// surfaces (feed card, brief header, mobile share widget). This touches a core,
+// high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
+// Keep the default `false` (control = existing `LinkIcon`).
+export const featureShareCopyIcon = new Feature('share_copy_icon', false);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -101,6 +101,13 @@ export enum Origin {
   DailyPage = 'daily page',
   EngagementBanner = 'engagement banner',
   EngagementFeedStrip = 'engagement feed strip',
+  // sharing visibility initiative
+  ReadingStreak = 'reading streak',
+  HappeningNow = 'happening now',
+  Achievements = 'achievements',
+  GameCenter = 'game center',
+  DevCard = 'devcard',
+  CopyMyFeed = 'copy my feed',
 }
 
 export enum LogEvent {

--- a/packages/storybook/stories/components/ProfileShareButton.stories.tsx
+++ b/packages/storybook/stories/components/ProfileShareButton.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import ProfileHeader from '@dailydotdev/shared/src/components/profile/ProfileHeader';
+import { ProfileShareButton } from '@dailydotdev/shared/src/components/profile/ProfileShareButton';
+import {
+  profile,
+  userStats,
+  withShareProviders,
+} from '../share/shareStoryContext';
+
+const meta: Meta<typeof ProfileShareButton> = {
+  title: 'Components/Share/ProfileShareButton',
+  component: ProfileShareButton,
+  args: { user: profile },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Profile copy-link control. One click copies the shortened, referral-tagged profile URL, flips the glyph to a green check for a second and toasts what was copied — no network picker. Mobile still gets the native share sheet where the platform offers one. Ships unconditionally — no flag.',
+      },
+    },
+  },
+  decorators: [withShareProviders()],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ProfileShareButton>;
+
+// Public profile: the label names whose profile is being copied.
+export const OnPublicProfile: Story = {};
+
+// Owner profile: first-person label, same control.
+export const OwnProfile: Story = {
+  args: { isSameUser: true },
+};
+
+// Copied state: the glyph flips to a green check for a second. The clipboard is
+// stubbed because the Storybook iframe isn't allowed to write to the real one.
+export const Copied: Story = {
+  play: async ({ canvasElement }) => {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => undefined },
+    });
+
+    const button = within(canvasElement).getByLabelText(
+      "Copy link to @idoshamun's profile",
+    );
+    await userEvent.click(button);
+    await waitFor(() =>
+      expect(button.querySelector('.text-status-success')).toBeInTheDocument(),
+    );
+  },
+};
+
+type HeaderStory = StoryObj<typeof ProfileHeader>;
+
+const headerMeta = {
+  render: (args: React.ComponentProps<typeof ProfileHeader>) => (
+    <ProfileHeader {...args} />
+  ),
+};
+
+// The control in place on a public profile header — it takes over the slot the
+// (inapplicable) edit button used to reserve.
+export const InPublicHeader: HeaderStory = {
+  ...headerMeta,
+  args: { user: profile, userStats, isSameUser: false },
+};
+
+// The control in place on the owner's header, alongside "Edit profile".
+export const InOwnHeader: HeaderStory = {
+  ...headerMeta,
+  args: { user: profile, userStats, isSameUser: true },
+};

--- a/packages/storybook/stories/components/ShareActions.stories.tsx
+++ b/packages/storybook/stories/components/ShareActions.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ShareActions } from '@dailydotdev/shared/src/components/share/ShareActions';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import { fn } from 'storybook/test';
+
+const meta: Meta<typeof ShareActions> = {
+  title: 'Components/Share/ShareActions',
+  component: ShareActions,
+  args: {
+    link: 'https://daily.dev/posts/how-to-ship-fast',
+    text: 'Check out this post on daily.dev',
+    onShare: fn(),
+  },
+  argTypes: {
+    variant: {
+      control: 'inline-radio',
+      options: ['icon', 'inline'],
+      description:
+        'icon = copy-icon trigger with a popover (desktop) / native share (mobile); inline = the social row rendered directly',
+    },
+    openOnHover: {
+      control: 'boolean',
+      description: 'Desktop only: reveal the popover on hover as well as click',
+    },
+    label: { control: 'text' },
+    link: { control: 'text' },
+    text: { control: 'text' },
+  },
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+      });
+      // Mock the short-URL resolution so copy/social actions don't hit network.
+      queryClient.setQueryData(['shortUrl'], 'https://dly.to/abc123');
+
+      const LogContext = getLogContextStatic();
+
+      const mockUser = {
+        id: '1',
+        name: 'Test User',
+        username: 'testuser',
+        email: 'test@example.com',
+        image:
+          'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+        providers: ['google'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        permalink: 'https://daily.dev/testuser',
+      } as unknown as LoggedUser;
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider
+            value={{
+              user: mockUser,
+              shouldShowLogin: false,
+              isLoggedIn: true,
+              isAuthReady: true,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              tokenRefreshed: true,
+              getRedirectUri: fn(),
+              loadingUser: false,
+              loadedUserFromCache: true,
+              refetchBoot: fn(),
+              squads: [],
+              isAndroidApp: false,
+            }}
+          >
+            <LogContext.Provider
+              value={{
+                logEvent: fn(),
+                logEventStart: fn(),
+                logEventEnd: fn(),
+                sendBeacon: () => false,
+              }}
+            >
+              <div className="flex min-h-40 items-center justify-center">
+                <Story />
+              </div>
+            </LogContext.Provider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ShareActions>;
+
+// Icon trigger — click to open the share popover on desktop; a single tap opens
+// the native share sheet on mobile.
+export const Icon: Story = {
+  args: { variant: 'icon' },
+};
+
+// Popover also opens on hover (desktop) for the feed-card share-out pattern.
+export const IconOpenOnHover: Story = {
+  args: { variant: 'icon', openOnHover: true },
+};
+
+// The full social row, for headers / share strips / drawers.
+export const Inline: Story = {
+  args: { variant: 'inline' },
+};

--- a/packages/storybook/stories/share/Overview.stories.tsx
+++ b/packages/storybook/stories/share/Overview.stories.tsx
@@ -1,0 +1,464 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { ProfileShareButton } from '@dailydotdev/shared/src/components/profile/ProfileShareButton';
+import ProfileHeader from '@dailydotdev/shared/src/components/profile/ProfileHeader';
+import { Header as ProfileMobileHeader } from '@dailydotdev/shared/src/components/profile/Header';
+import CustomFeedOptionsMenu from '@dailydotdev/shared/src/components/CustomFeedOptionsMenu';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { LinkIcon, VIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  ShareStoryProviders,
+  profile,
+  userStats,
+  withShareProviders,
+} from './shareStoryContext';
+import {
+  Code,
+  DeviceFrame,
+  Grid,
+  Muted,
+  Page,
+  PageHeader,
+  Section,
+  Specimen,
+  Table,
+} from './reviewLayout';
+
+/**
+ * Review page for the profile sharing work in PR #6354: every surface it
+ * touches, every state, on one scrollable page. The behaviour ships
+ * unconditionally — there is no flag to toggle, so what renders below is what
+ * every user gets. Scoped to this PR: the surfaces PR 1 (#6343) owns are not
+ * documented here.
+ */
+
+const shareProps = {
+  text: `Check out ${profile.name}'s profile on daily.dev`,
+  link: profile.permalink,
+  cid: undefined,
+};
+
+const menuProps = {
+  onAdd: fn(),
+  onUndo: fn(),
+  onCreateNewFeed: fn(),
+  shareProps,
+};
+
+const HeaderCard = ({ children }: { children: ReactNode }): ReactElement => (
+  <div className="w-full overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-background-subtle">
+    {children}
+  </div>
+);
+
+const Review = (): ReactElement => (
+  <Page>
+    <PageHeader
+      eyebrow="Profile sharing · States & variants"
+      title="Every share control, every state, on one page"
+    >
+      Sharing a profile used to mean finding “Share” inside a <Code>⋯</Code>{' '}
+      menu — and on your own profile, on desktop, there was no way to do it at
+      all. This puts a real copy-link control on the profile header instead.
+      Everything below is the live component, shipping to everyone: no flag, no
+      variant arm.
+    </PageHeader>
+
+    <Section n="01" title="What ships, where">
+      <Table
+        columns={['Surface', 'Before', 'Now']}
+        rows={[
+          [
+            'Profile header — own profile',
+            'Edit profile button only; no way to share your own profile on desktop',
+            'Copy-link button next to Edit profile — one click copies',
+          ],
+          [
+            'Profile header — public profile',
+            'An invisible Edit placeholder holding the row height',
+            'Copy-link button fills that slot',
+          ],
+          [
+            'Pinned mobile profile bar',
+            'Share buried in the ⋯ menu',
+            'Copy-link icon in the bar, while pinned',
+          ],
+          [
+            'Profile ⋯ menus (bar + actions card)',
+            '“Share” menu entry',
+            'Entry removed — promoted to the visible control',
+          ],
+          [
+            'Feed card · brief header · mobile share widget',
+            <>
+              <LinkIcon key="a" /> LinkIcon
+            </>,
+            'Untouched by this PR — they belong to PR 1 (#6343)',
+          ],
+        ]}
+      />
+      <Muted>
+        The copy-link glyph is deliberately the one already used across the
+        product, so the new control reads as the same action developers know
+        from feed cards rather than a new one.
+      </Muted>
+    </Section>
+
+    <Section n="02" title="What one click does" badge="ProfileShareButton">
+      <Muted>
+        One click copies the profile link — shortened through{' '}
+        <Code>dly.to</Code> with the <Code>ShareProfile</Code> campaign — and
+        confirms twice: the glyph flips to a green check for a beat, and a toast
+        names exactly what landed on the clipboard. No network picker: choosing
+        a destination is a second decision, and the link covers all of them. On
+        mobile, where the platform offers a native share sheet, a tap still
+        opens that instead. The control does not use PR 1's ShareActions popover
+        — see the open questions.
+      </Muted>
+      <Grid cols={2}>
+        <Specimen
+          label="Click it"
+          note="Copies, flips to the green check for a second, and fires the toast."
+        >
+          <ProfileShareButton user={profile} />
+        </Specimen>
+        <Specimen
+          label="Copied — the confirmed state"
+          note="VIcon in text-status-success, the same green check used across the product."
+        >
+          <Button
+            variant={ButtonVariant.Subtle}
+            size={ButtonSize.Small}
+            icon={<VIcon className="text-status-success" />}
+            aria-label="Copied"
+          />
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="03" title="Variant and size" badge="props">
+      <Muted>
+        The control takes <Code>buttonVariant</Code> and <Code>buttonSize</Code>
+        so each surface matches the control group around it. These are the two
+        combinations in use.
+      </Muted>
+      <Grid cols={2}>
+        <Specimen
+          label="Subtle · Small — default"
+          note="Profile header: same variant and size as the Edit button beside it and the ⋯ menu below it."
+        >
+          <ProfileShareButton user={profile} />
+        </Specimen>
+        <Specimen
+          label="Float · Small"
+          note="Pinned mobile bar: Float, to match the award / options icons around it."
+        >
+          <ProfileShareButton
+            user={profile}
+            buttonVariant={ButtonVariant.Float}
+          />
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="04" title="Responsive behaviour" badge="useViewSize(Laptop)">
+      <Muted>
+        Below laptop there is no popover at all: one tap calls{' '}
+        <Code>navigator.share</Code>, or copies when native share is
+        unavailable. The frame below is the real story rendered at 390px, so
+        this is the actual mobile branch and not a mock-up.
+      </Muted>
+      <div style={{ display: 'flex', gap: 28, flexWrap: 'wrap' }}>
+        <div>
+          <div
+            style={{
+              fontSize: 11.5,
+              fontWeight: 800,
+              textTransform: 'uppercase',
+              letterSpacing: 0.7,
+              color: 'var(--theme-text-tertiary)',
+              marginBottom: 8,
+            }}
+          >
+            390px — mobile
+          </div>
+          <DeviceFrame
+            storyId="components-share-overview--mobile-profile-header"
+            height={560}
+          />
+        </div>
+        <div style={{ flex: 1, minWidth: 320 }}>
+          <Specimen
+            label="Laptop and up — desktop"
+            note="Same component, popover branch."
+            align="start"
+          >
+            <HeaderCard>
+              <ProfileHeader
+                user={profile}
+                userStats={userStats}
+                isSameUser={false}
+              />
+            </HeaderCard>
+          </Specimen>
+        </div>
+      </div>
+    </Section>
+
+    <Section n="05" title="Profile header" badge="ProfileHeader">
+      <Muted>
+        On a public profile the control takes the slot an <Code>invisible</Code>{' '}
+        Edit button used to reserve purely to hold the row height, so the header
+        is no taller than before. On your own profile it sits beside Edit, both
+        Subtle and Small, bottom-aligned to the avatar.
+      </Muted>
+      <Grid cols={2}>
+        <Specimen label="Public profile" align="start">
+          <HeaderCard>
+            <ProfileHeader
+              user={profile}
+              userStats={userStats}
+              isSameUser={false}
+            />
+          </HeaderCard>
+        </Specimen>
+        <Specimen label="Own profile" align="start">
+          <HeaderCard>
+            <ProfileHeader user={profile} userStats={userStats} isSameUser />
+          </HeaderCard>
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="06" title="Pinned mobile bar" badge="profile/Header · sticky">
+      <Muted>
+        The bar only shows the control while it is pinned. Unpinned, the profile
+        card right below owns it, and two identical copy buttons on one screen
+        read as a mistake. This is a mobile surface, so each frame below is the
+        real story at 390px — at desktop width it would show controls (Edit
+        profile) that a phone never gets.
+      </Muted>
+      <Grid cols={3}>
+        <Specimen
+          label="Pinned"
+          note="Utility icon sits after the Follow group with ml-1, so the two intents never read as one control group."
+          padded={false}
+        >
+          <DeviceFrame
+            storyId="components-share-overview--mobile-pinned-bar"
+            height={72}
+            width={340}
+          />
+        </Specimen>
+        <Specimen
+          label="Unpinned"
+          note="No share control: the profile card right below is showing its own."
+          padded={false}
+        >
+          <DeviceFrame
+            storyId="components-share-overview--mobile-unpinned-bar"
+            height={72}
+            width={340}
+          />
+        </Specimen>
+        <Specimen
+          label="Pinned — own profile"
+          note="Same control, first-person label."
+          padded={false}
+        >
+          <DeviceFrame
+            storyId="components-share-overview--mobile-pinned-bar-own"
+            height={72}
+            width={340}
+          />
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="07" title="The ⋯ menu" badge="hideShare">
+      <Muted>
+        Click each trigger. Profile menus pass the new <Code>hideShare</Code>{' '}
+        prop because the header now carries a visible control; every other
+        caller keeps the entry, so no other surface changes.
+      </Muted>
+      <Grid cols={2}>
+        <Specimen
+          label="hideShare: false — every other caller"
+          note="Share · Add to custom feed · Block · Report"
+        >
+          <CustomFeedOptionsMenu {...menuProps} />
+        </Specimen>
+        <Specimen
+          label="hideShare: true — the two profile menus"
+          note="Add to custom feed · Block · Report. Share moved up to the header."
+        >
+          <CustomFeedOptionsMenu {...menuProps} hideShare />
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="08" title="The copy-link glyph">
+      <Muted>
+        The same <Code>LinkIcon</Code> the feed card action bar, the brief
+        header and the mobile share widget already use — those surfaces are
+        untouched. Its filled (<Code>secondary</Code>) state is the post-copy
+        confirmation.
+      </Muted>
+      <Grid cols={2}>
+        <Specimen label="Idle" note="Subtle Small, as it renders in the header">
+          <Button
+            variant={ButtonVariant.Subtle}
+            size={ButtonSize.Small}
+            icon={<LinkIcon />}
+            aria-label="Copy link"
+          />
+        </Specimen>
+        <Specimen
+          label="Copied — for one second"
+          note="Green check, then back to the link glyph."
+        >
+          <Button
+            variant={ButtonVariant.Subtle}
+            size={ButtonSize.Small}
+            icon={<VIcon className="text-status-success" />}
+            aria-label="Copied"
+          />
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="09" title="Copy and accessible labels">
+      <Muted>
+        Both label variants are asserted in <Code>ProfileShareButton.spec</Code>
+        . The share text is what lands in the tweet / WhatsApp message / email
+        subject.
+      </Muted>
+      <Table
+        columns={['Context', 'aria-label + tooltip', 'Toast / share text']}
+        rows={[
+          [
+            'Public profile',
+            <Code key="l1">Copy link to @idoshamun&apos;s profile</Code>,
+            '✅ Copied link to @idoshamun’s profile',
+          ],
+          [
+            'Own profile',
+            <Code key="l2">Copy link to your profile</Code>,
+            '✅ Copied link to your profile',
+          ],
+          [
+            'Native share sheet (mobile)',
+            '—',
+            'Check out …’s profile on daily.dev + the shortened link',
+          ],
+        ]}
+      />
+      <Grid cols={2}>
+        <Specimen label="Public label" note="Hover the button to see it.">
+          <ProfileShareButton user={profile} />
+        </Specimen>
+        <Specimen label="Own label" note="Hover the button to see it.">
+          <ProfileShareButton user={profile} isSameUser />
+        </Specimen>
+      </Grid>
+    </Section>
+
+    <Section n="10" title="Open questions for this review">
+      <Table
+        columns={['#', 'Question', 'Where to look']}
+        rows={[
+          [
+            '1',
+            'Is “pinned only” right for the mobile bar, or should the icon always be there and accept two copy buttons on one screen?',
+            'Section 06',
+          ],
+          [
+            '2',
+            'Removing “Share” from the profile ⋯ menus moves cheese for anyone who learned it there. Keep both?',
+            'Section 07',
+          ],
+          [
+            '2b',
+            "Copy-only on desktop means no one-click path to X / LinkedIn from a profile. Acceptable, or should PR 1's ShareActions popover come back as a secondary affordance?",
+            'Section 02',
+          ],
+          [
+            '3',
+            'Toast + share-sheet wording — “Check out …’s profile on daily.dev” is inherited from the old menu item. Worth a copy pass?',
+            'Section 09',
+          ],
+          [
+            '4',
+            'Ships to everyone with no flag, so there is no ramp and no kill-switch short of a revert.',
+            'PR description',
+          ],
+          [
+            '5',
+            'The per-profile OG unfurl image is deliberately deferred — it needs a screenshot-service route on the backend.',
+            'PR description',
+          ],
+        ]}
+      />
+    </Section>
+  </Page>
+);
+
+const meta: Meta = {
+  title: 'Components/Share/Overview',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Profile sharing review page: every surface and state the share control touches.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const StatesAndVariants: Story = {
+  render: () => (
+    <ShareStoryProviders>
+      <Review />
+    </ShareStoryProviders>
+  ),
+};
+
+/**
+ * Rendered at 390px inside section 03. Also useful on its own with the
+ * Storybook viewport toolbar.
+ */
+export const MobileProfileHeader: Story = {
+  render: () => (
+    <ProfileHeader user={profile} userStats={userStats} isSameUser={false} />
+  ),
+  decorators: [withShareProviders('w-full')],
+};
+
+/** The three pinned-bar states, each embedded at 390px in section 05. */
+export const MobilePinnedBar: Story = {
+  render: () => (
+    <ProfileMobileHeader user={profile} sticky isSameUser={false} />
+  ),
+  decorators: [withShareProviders('w-full')],
+};
+
+export const MobileUnpinnedBar: Story = {
+  render: () => <ProfileMobileHeader user={profile} isSameUser={false} />,
+  decorators: [withShareProviders('w-full')],
+};
+
+export const MobilePinnedBarOwn: Story = {
+  render: () => <ProfileMobileHeader user={profile} sticky isSameUser />,
+  decorators: [withShareProviders('w-full')],
+};

--- a/packages/storybook/stories/share/reviewLayout.tsx
+++ b/packages/storybook/stories/share/reviewLayout.tsx
@@ -1,0 +1,350 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+
+/**
+ * Presentational scaffolding for the sharing-visibility review page. Uses the
+ * daily.dev theme CSS variables so it follows Storybook's light/dark toggle,
+ * and stays provider-free so it can wrap live components without adding
+ * context of its own.
+ */
+
+const SANS =
+  '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+
+export const Page = ({ children }: { children: ReactNode }): ReactElement => (
+  <div
+    style={{
+      fontFamily: SANS,
+      color: 'var(--theme-text-primary)',
+      background: 'var(--theme-background-default)',
+      padding: '32px 40px 96px',
+      maxWidth: 1180,
+      margin: '0 auto',
+    }}
+  >
+    {children}
+  </div>
+);
+
+export const PageHeader = ({
+  eyebrow,
+  title,
+  children,
+}: {
+  eyebrow: string;
+  title: string;
+  children?: ReactNode;
+}): ReactElement => (
+  <header style={{ marginBottom: 36, maxWidth: 860 }}>
+    <div
+      style={{
+        fontSize: 13,
+        fontWeight: 700,
+        letterSpacing: 1,
+        textTransform: 'uppercase',
+        color: 'var(--theme-accent-cabbage-default)',
+        marginBottom: 8,
+      }}
+    >
+      {eyebrow}
+    </div>
+    <h1 style={{ fontSize: 32, fontWeight: 800, margin: 0, lineHeight: 1.15 }}>
+      {title}
+    </h1>
+    {children && (
+      <div
+        style={{
+          marginTop: 14,
+          fontSize: 16,
+          lineHeight: 1.55,
+          color: 'var(--theme-text-secondary)',
+          textWrap: 'pretty',
+        }}
+      >
+        {children}
+      </div>
+    )}
+  </header>
+);
+
+export const Section = ({
+  n,
+  title,
+  badge,
+  children,
+}: {
+  n: string;
+  title: string;
+  badge?: string;
+  children: ReactNode;
+}): ReactElement => (
+  <section style={{ marginTop: 56 }}>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'baseline',
+        gap: 12,
+        marginBottom: 8,
+        paddingBottom: 10,
+        borderBottom: '1px solid var(--theme-divider-tertiary)',
+      }}
+    >
+      <span
+        style={{
+          fontSize: 13,
+          fontWeight: 800,
+          color: 'var(--theme-text-tertiary)',
+        }}
+      >
+        {n}
+      </span>
+      <h2 style={{ fontSize: 22, fontWeight: 800, margin: 0 }}>{title}</h2>
+      {badge && <Code>{badge}</Code>}
+    </div>
+    {children}
+  </section>
+);
+
+export const Muted = ({
+  children,
+  style,
+}: {
+  children: ReactNode;
+  style?: React.CSSProperties;
+}): ReactElement => (
+  <p
+    style={{
+      fontSize: 15,
+      lineHeight: 1.55,
+      color: 'var(--theme-text-secondary)',
+      margin: '0 0 16px',
+      maxWidth: 820,
+      textWrap: 'pretty',
+      ...style,
+    }}
+  >
+    {children}
+  </p>
+);
+
+export const Code = ({ children }: { children: ReactNode }): ReactElement => (
+  <code
+    style={{
+      fontSize: 12,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+      color: 'var(--theme-text-tertiary)',
+      background: 'var(--theme-surface-float)',
+      padding: '2px 7px',
+      borderRadius: 6,
+      whiteSpace: 'nowrap',
+    }}
+  >
+    {children}
+  </code>
+);
+
+type Tone = 'neutral' | 'on' | 'off';
+
+const toneColor: Record<Tone, string> = {
+  neutral: 'var(--theme-text-tertiary)',
+  on: 'var(--theme-accent-avocado-default)',
+  off: 'var(--theme-text-quaternary)',
+};
+
+/**
+ * A single labelled specimen: caption on top, the live component on a surface
+ * below. `tone` colours the caption rule so flag-on / flag-off columns read at
+ * a glance.
+ */
+export const Specimen = ({
+  label,
+  note,
+  tone = 'neutral',
+  align = 'center',
+  padded = true,
+  children,
+}: {
+  label: string;
+  note?: ReactNode;
+  tone?: Tone;
+  align?: 'center' | 'start';
+  padded?: boolean;
+  children: ReactNode;
+}): ReactElement => (
+  <div style={{ minWidth: 0 }}>
+    <div
+      style={{
+        fontSize: 11.5,
+        fontWeight: 800,
+        textTransform: 'uppercase',
+        letterSpacing: 0.7,
+        color: toneColor[tone],
+        marginBottom: 8,
+        paddingBottom: 6,
+        borderBottom: `2px solid ${toneColor[tone]}`,
+      }}
+    >
+      {label}
+    </div>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: align === 'center' ? 'center' : 'flex-start',
+        minHeight: 76,
+        padding: padded ? 20 : 0,
+        borderRadius: 12,
+        border: '1px solid var(--theme-divider-tertiary)',
+        background: 'var(--theme-surface-float)',
+        overflow: 'hidden',
+      }}
+    >
+      {children}
+    </div>
+    {note && (
+      <div
+        style={{
+          fontSize: 13,
+          lineHeight: 1.5,
+          color: 'var(--theme-text-tertiary)',
+          marginTop: 8,
+          textWrap: 'pretty',
+        }}
+      >
+        {note}
+      </div>
+    )}
+  </div>
+);
+
+export const Grid = ({
+  cols = 2,
+  gap = 24,
+  children,
+}: {
+  cols?: number;
+  gap?: number;
+  children: ReactNode;
+}): ReactElement => (
+  <div
+    style={{
+      display: 'grid',
+      gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+      gap,
+      alignItems: 'start',
+      marginBottom: 8,
+    }}
+  >
+    {children}
+  </div>
+);
+
+const cell: React.CSSProperties = {
+  padding: '9px 12px',
+  fontSize: 13,
+  textAlign: 'left',
+  verticalAlign: 'top',
+  borderBottom: '1px solid var(--theme-divider-tertiary)',
+  color: 'var(--theme-text-secondary)',
+};
+
+export const Table = ({
+  columns,
+  rows,
+}: {
+  columns: string[];
+  rows: ReactNode[][];
+}): ReactElement => (
+  <div style={{ overflowX: 'auto', marginBottom: 16 }}>
+    <table
+      style={{
+        width: '100%',
+        minWidth: 640,
+        borderCollapse: 'collapse',
+        background: 'var(--theme-surface-float)',
+        borderRadius: 10,
+        overflow: 'hidden',
+      }}
+    >
+      <thead>
+        <tr>
+          {columns.map((c) => (
+            <th
+              key={c}
+              style={{
+                ...cell,
+                fontWeight: 700,
+                color: 'var(--theme-text-primary)',
+                borderBottom: '2px solid var(--theme-divider-secondary)',
+              }}
+            >
+              {c}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, ri) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <tr key={`row-${ri}`}>
+            {r.map((c, ci) => (
+              <td key={columns[ci]} style={cell}>
+                {c}
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+/**
+ * Renders another story in a narrow iframe so the genuinely viewport-driven
+ * branches (`useViewSize(ViewSize.Laptop)`) can be reviewed at mobile width on
+ * the same page — no faking, it is the real component at 390px.
+ */
+export const DeviceFrame = ({
+  storyId,
+  width = 390,
+  height = 220,
+}: {
+  storyId: string;
+  width?: number;
+  height?: number;
+}): ReactElement => {
+  // The embedded story is a separate document, so Storybook's theme toggle
+  // doesn't reach it — mirror the root theme class into its globals instead.
+  const [theme, setTheme] = React.useState('light');
+
+  React.useEffect(() => {
+    const root = document.documentElement;
+    const sync = () =>
+      setTheme(root.classList.contains('dark') ? 'dark' : 'light');
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div
+      style={{
+        width,
+        height,
+        flexShrink: 0,
+        borderRadius: 16,
+        border: '1px solid var(--theme-divider-secondary)',
+        overflow: 'hidden',
+        background: 'var(--theme-background-default)',
+      }}
+    >
+      <iframe
+        title={storyId}
+        src={`/iframe.html?viewMode=story&id=${storyId}&globals=theme:${theme}`}
+        style={{ width: '100%', height: '100%', border: 0 }}
+      />
+    </div>
+  );
+};

--- a/packages/storybook/stories/share/shareStoryContext.tsx
+++ b/packages/storybook/stories/share/shareStoryContext.tsx
@@ -1,0 +1,151 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fn } from 'storybook/test';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import { GrowthBookProvider } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
+import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import { getShortLinkProps } from '@dailydotdev/shared/src/hooks/utils/useGetShortUrl';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
+import type {
+  LoggedUser,
+  PublicProfile,
+} from '@dailydotdev/shared/src/lib/user';
+
+/**
+ * Shared scaffolding for every sharing story (ShareActions, ProfileShareButton
+ * and the Overview review page) so the mock user, the seeded short link and the
+ * toast surface are defined once.
+ */
+
+export const mockUser = {
+  id: 'u1',
+  name: 'Ido Shamun',
+  username: 'idoshamun',
+  email: 'ido@daily.dev',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2020-01-01T00:00:00.000Z',
+  permalink: 'https://app.daily.dev/idoshamun',
+} as unknown as LoggedUser;
+
+export const profile = {
+  ...mockUser,
+  bio: 'Co-founder of daily.dev. Building the homepage millions of developers open every morning.',
+  cover:
+    'https://media.daily.dev/image/upload/f_auto,q_auto/v1/placeholders/cover',
+  reputation: 4210,
+  isPlus: true,
+} as unknown as PublicProfile;
+
+export const userStats = {
+  upvotes: 1240,
+  numFollowers: 8300,
+  numFollowing: 210,
+};
+
+export const SHORT_LINK = 'https://dly.to/abc123';
+
+const createQueryClient = (): QueryClient => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+
+  // Seed the short-URL resolution so copy/social actions never hit network.
+  const { queryKey } = getShortLinkProps(
+    profile.permalink,
+    ReferralCampaignKey.ShareProfile,
+    mockUser,
+  );
+  queryClient.setQueryData(queryKey, SHORT_LINK);
+  queryClient.setQueryData(['shortUrl'], SHORT_LINK);
+
+  return queryClient;
+};
+
+const authValue = {
+  user: mockUser,
+  isLoggedIn: true,
+  isAuthReady: true,
+  tokenRefreshed: true,
+  shouldShowLogin: false,
+  showLogin: fn(),
+  closeLogin: fn(),
+  logout: fn(),
+  updateUser: fn(),
+  getRedirectUri: fn(),
+  loadingUser: false,
+  loadedUserFromCache: true,
+  refetchBoot: fn(),
+  squads: [],
+  isAndroidApp: false,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+// Only what the profile surfaces actually read; the real provider is a boot
+// round-trip we don't want in a story.
+const settingsValue = {
+  themeMode: 'dark',
+  loadedSettings: true,
+  insaneMode: false,
+  spaciness: 'eco',
+  openNewTab: true,
+  showTopSites: true,
+  sidebarExpanded: true,
+  sortingEnabled: false,
+  optOutReadingStreak: false,
+  flags: {},
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any;
+
+const logValue = {
+  logEvent: fn(),
+  logEventStart: fn(),
+  logEventEnd: fn(),
+  sendBeacon: () => false,
+};
+
+export function ShareStoryProviders({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement {
+  const [queryClient] = React.useState(createQueryClient);
+  const LogContext = getLogContextStatic();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider value={authValue}>
+        <SettingsContext.Provider value={settingsValue}>
+          <GrowthBookProvider
+            app={BootApp.Webapp}
+            user={mockUser}
+            deviceId="storybook"
+          >
+            <LogContext.Provider value={logValue}>
+              {children}
+              {/* Real toast surface, so copy actions in the stories confirm
+                  exactly the way they do in the product. */}
+              <Toast autoDismissNotifications />
+            </LogContext.Provider>
+          </GrowthBookProvider>
+        </SettingsContext.Provider>
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+}
+
+/** Decorator for single-component stories: all providers plus a width cap. */
+export const withShareProviders =
+  (className = 'mx-auto w-full max-w-[40rem]') =>
+  (Story: React.ComponentType): ReactElement =>
+    (
+      <ShareStoryProviders>
+        <div className={className}>
+          <Story />
+        </div>
+      </ShareStoryProviders>
+    );


### PR DESCRIPTION
Foundation for the sharing-visibility initiative — a reusable share affordance + flags. Behind flags; `share_copy_icon` default off means no user-visible change vs main.

Part of the multi-PR sharing-visibility initiative (Storybook-first, one PR per surface). Full plan tracked separately.

**Highlights**
- `ShareActions` primitive (icon/inline; desktop popover, mobile native share) + Storybook story
- `feature_sharing_visibility` master kill-switch + `useSharingVisibility` gate
- core copy-icon swap (LinkIcon→CopyIcon) gated behind `share_copy_icon` (default off) via `useShareCopyIcon`
- new share-surface `Origin` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-website-sharing-visibilit.preview.app.daily.dev