### PR TITLE
feat(markdown): render video files as <video> in posts

### DIFF
--- a/packages/shared/src/components/RenderMarkdown.tsx
+++ b/packages/shared/src/components/RenderMarkdown.tsx
@@ -16,6 +16,7 @@ import {
 } from './buttons/Button';
 import { ArrowIcon, CopyIcon } from './icons';
 import { useCopyText } from '../hooks/useCopy';
+import { getVideoMimeType, isVideoUrl } from '../lib/video';
 import {
   Typography,
   TypographyColor,
@@ -163,6 +164,18 @@ const RenderMarkdown = ({
       components={{
         ol({ children }) {
           return <ol>{children}</ol>;
+        },
+        img({ node, src, alt, ...props }) {
+          if (src && isVideoUrl(src)) {
+            const type = getVideoMimeType(src);
+            return (
+              // eslint-disable-next-line jsx-a11y/media-has-caption
+              <video controls preload="metadata" aria-label={alt}>
+                <source src={src} type={type} />
+              </video>
+            );
+          }
+          return <img src={src} alt={alt} {...props} />;
         },
         code({
           node,

--- a/packages/shared/src/components/fields/RichTextEditor/videoExtension.ts
+++ b/packages/shared/src/components/fields/RichTextEditor/videoExtension.ts
@@ -1,0 +1,40 @@
+import { Node, mergeAttributes } from '@tiptap/core';
+
+/**
+ * Minimal TipTap node so markdown videos (`![](file.mp4)`) survive editing.
+ * Without it, TipTap's schema strips unknown `<video>` tags and a post that
+ * embeds a video would lose it on save. Alt text round-trips via `aria-label`
+ * to match how the markdown converter serializes it back.
+ */
+export const Video = Node.create({
+  name: 'video',
+  group: 'block',
+  atom: true,
+  draggable: true,
+
+  addAttributes() {
+    return {
+      src: { default: null },
+      alt: {
+        default: null,
+        parseHTML: (element) => element.getAttribute('aria-label'),
+        renderHTML: (attributes) =>
+          attributes.alt ? { 'aria-label': attributes.alt } : {},
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: 'video' }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      'video',
+      mergeAttributes(HTMLAttributes, {
+        controls: 'true',
+        preload: 'metadata',
+      }),
+    ];
+  },
+});

--- a/packages/shared/src/components/fields/RichTextInput.spec.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.spec.tsx
@@ -15,6 +15,8 @@ jest.mock('next/dynamic', () => () => () => null);
 
 jest.mock('@tiptap/core', () => ({
   Extension: { create: jest.fn((config) => config) },
+  Node: { create: jest.fn((config) => config) },
+  mergeAttributes: jest.fn((...attrs) => Object.assign({}, ...attrs)),
   markInputRule: jest.fn(),
   nodeInputRule: jest.fn(),
 }));

--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -51,6 +51,7 @@ import { MarkdownCommand } from '../../hooks/input/useMarkdownInput';
 import type { RichTextToolbarRef } from './RichTextEditor/RichTextToolbar';
 import { RichTextToolbar } from './RichTextEditor/RichTextToolbar';
 import { MarkdownInputRules } from './RichTextEditor/markdownInputRules';
+import { Video } from './RichTextEditor/videoExtension';
 import { useMentionAutocomplete } from './RichTextEditor/useMentionAutocomplete';
 import { useEmojiAutocomplete } from './RichTextEditor/useEmojiAutocomplete';
 import { useImageUpload } from './RichTextEditor/useImageUpload';
@@ -348,6 +349,7 @@ function RichTextInput(
         placeholder: textareaProps.placeholder || 'Share your thoughts',
       }),
       Image,
+      Video,
       MarkdownInputRules,
       ...(maxLength ? [CharacterCount.configure({ limit: maxLength })] : []),
       LinkShortcut,

--- a/packages/shared/src/components/markdown.module.css
+++ b/packages/shared/src/components/markdown.module.css
@@ -90,6 +90,9 @@
       @apply outline-none ring-2 ring-accent-cabbage-default ring-offset-2 ring-offset-background-default;
     }
   }
+  & :where(video) {
+    @apply rounded-16 max-h-img-mobile tablet:max-h-img-desktop w-full;
+  }
   & > :where(:first-child) {
     @apply mt-0;
   }

--- a/packages/shared/src/lib/markdownConversion.spec.ts
+++ b/packages/shared/src/lib/markdownConversion.spec.ts
@@ -172,4 +172,31 @@ describe('markdownConversion', () => {
 
     expect(markdown).toBe('__EMPTY_PARAGRAPH__\n\nnext');
   });
+
+  it('should render video markdown as a video element', () => {
+    const html = markdownToHtmlBasic(
+      '![Bar chart race](https://daily-now-res.cloudinary.com/video/upload/v1/race.webm)',
+    );
+
+    expect(html).toBe(
+      '<video src="https://daily-now-res.cloudinary.com/video/upload/v1/race.webm" controls preload="metadata" aria-label="Bar chart race"><source src="https://daily-now-res.cloudinary.com/video/upload/v1/race.webm" type="video/webm" /></video>',
+    );
+  });
+
+  it('should keep video in markdown round-trip', () => {
+    const initialMarkdown =
+      '![Bar chart race](https://daily-now-res.cloudinary.com/video/upload/v1/race.webm)';
+    const html = markdownToHtmlBasic(initialMarkdown);
+    const markdown = htmlToMarkdownBasic(html);
+
+    expect(markdown).toBe(initialMarkdown);
+  });
+
+  it('should keep serializing videos rendered without a source child', () => {
+    const markdown = htmlToMarkdownBasic(
+      '<video src="https://daily.dev/clip.mp4" controls aria-label="Clip"></video>',
+    );
+
+    expect(markdown).toBe('![Clip](https://daily.dev/clip.mp4)');
+  });
 });

--- a/packages/shared/src/lib/markdownConversion.ts
+++ b/packages/shared/src/lib/markdownConversion.ts
@@ -1,3 +1,5 @@
+import { getVideoMimeType, isVideoUrl } from './video';
+
 const escapeHtml = (value: string): string =>
   value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 
@@ -23,8 +25,17 @@ const inlineMarkdownToHtml = (value: string): string => {
 
   result = result.replace(
     /!\[([^\]]*)\]\(([^)]+)\)/g,
-    (_, alt: string, url: string) =>
-      `<img src="${escapeAttribute(url)}" alt="${alt}" />`,
+    (_, alt: string, url: string) => {
+      const src = escapeAttribute(url);
+      if (isVideoUrl(url)) {
+        const type = getVideoMimeType(url);
+        const source = `<source src="${src}"${
+          type ? ` type="${type}"` : ''
+        } />`;
+        return `<video src="${src}" controls preload="metadata" aria-label="${alt}">${source}</video>`;
+      }
+      return `<img src="${src}" alt="${alt}" />`;
+    },
   );
 
   result = result.replace(
@@ -241,6 +252,12 @@ function serializeInline(node: Node): string {
       const alt = node.getAttribute('alt') || '';
       return `![${alt}](${src})`;
     }
+    case 'video': {
+      const source = node.querySelector('source');
+      const src = node.getAttribute('src') || source?.getAttribute('src') || '';
+      const alt = node.getAttribute('aria-label') || '';
+      return `![${alt}](${src})`;
+    }
     case 'p':
       return serializeChildren(node).trim();
     case 'li':
@@ -323,6 +340,7 @@ export const htmlToMarkdownBasic = (html: string): string => {
         case 'ol':
           return serializeList(node, true);
         case 'img':
+        case 'video':
           return serializeInline(node).trim();
         default:
           return serializeChildren(node).trim();

--- a/packages/shared/src/lib/video.ts
+++ b/packages/shared/src/lib/video.ts
@@ -1,0 +1,26 @@
+const videoMimeTypes: Record<string, string> = {
+  mp4: 'video/mp4',
+  webm: 'video/webm',
+  ogg: 'video/ogg',
+  ogv: 'video/ogg',
+  mov: 'video/quicktime',
+  m4v: 'video/x-m4v',
+};
+
+const getExtension = (url: string): string => {
+  // Drop query/hash before reading the extension so cloudinary transform
+  // params (e.g. `?_a=...`) don't hide it.
+  const path = url.split(/[?#]/, 1)[0];
+  const lastDot = path.lastIndexOf('.');
+  return lastDot === -1 ? '' : path.slice(lastDot + 1).toLowerCase();
+};
+
+/**
+ * Detects whether a markdown media URL points to a video file, so `![](url)`
+ * can render as a `<video>` instead of an `<img>`.
+ */
+export const isVideoUrl = (url: string): boolean =>
+  !!url && getExtension(url) in videoMimeTypes;
+
+export const getVideoMimeType = (url: string): string | undefined =>
+  videoMimeTypes[getExtension(url)];


### PR DESCRIPTION
## What

Markdown media written with image syntax (`![alt](file.webm)`) now renders as a `<video controls preload="metadata">` element when the URL points to a video file (`mp4/webm/ogg/ogv/mov/m4v`), instead of a broken `<img>`.

Playback is **controls, no autoplay** — poster frame, user presses play.

## Why

There's no markdown syntax for video (CommonMark treats `![](x)` as an image), and none of markdown-it / react-markdown / TipTap render a video file out of the box. This adds the small, idiomatic override at each layer.

## Changes (apps)

- **`lib/video.ts`** (new) — shared `isVideoUrl` / `getVideoMimeType` helper.
- **`lib/markdownConversion.ts`** — composer MD→HTML emits `<video>`; HTML→MD serializes it back to `![alt](url)` (alt round-trips via `aria-label`), so editing a post never drops a video.
- **`RichTextEditor/videoExtension.ts`** (new) + registered in `RichTextInput.tsx` — a TipTap `Video` node so the editor preserves `<video>` on save.
- **`RenderMarkdown.tsx`** — react-markdown `img` override renders video URLs (AI/other markdown content).
- **`markdown.module.css`** — video sizing to match images (no zoom cursor).

## Reader note

The freeform post reader renders **server-generated** `contentHtml`, so the reader itself is fixed in the paired daily-api PR. Verified DOMPurify preserves `<video controls preload aria-label>` + `<source type>`, so once the API emits `<video>`, the reader displays it with no further change.

## Tests

- Converter unit tests: added video render + round-trip cases (24/24 pass).
- `RichTextInput` tests pass (updated its `@tiptap/core` mock to stub `Node`/`mergeAttributes`).
- Changed-file strict typecheck + lint clean.

https://claude.ai/code/session_01F2JaBFSf2xVyYd6yeHi9zJ

### Preview domain
https://feat-markdown-video-support.preview.app.daily.dev