### PR TITLE
feat(share): end-of-conversation share band

### DIFF
--- a/packages/shared/src/components/post/EndOfConversationShare.spec.tsx
+++ b/packages/shared/src/components/post/EndOfConversationShare.spec.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import {
+  activeDiscussionCommentThreshold,
+  EndOfConversationShare,
+} from './EndOfConversationShare';
+import type { Post } from '../../graphql/posts';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { useViewSize } from '../../hooks/useViewSize';
+import { useToastNotification } from '../../hooks/useToastNotification';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+jest.mock('../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+jest.mock('../../hooks/useToastNotification', () => {
+  const actual = jest.requireActual('../../hooks/useToastNotification');
+  return { __esModule: true, ...actual, useToastNotification: jest.fn() };
+});
+
+const useViewSizeMock = useViewSize as jest.Mock;
+const useToastNotificationMock = useToastNotification as jest.Mock;
+const displayToast = jest.fn();
+const writeText = jest.fn().mockResolvedValue(undefined);
+const logEvent = jest.fn();
+
+const permalink = 'https://app.daily.dev/posts/abc';
+
+const createPost = (numComments: number): Post =>
+  ({
+    id: 'abc',
+    title: 'Why your CI is slow',
+    permalink: 'https://daily.dev/posts/abc',
+    commentsPermalink: permalink,
+    numComments,
+  } as Post);
+
+const enabledFlags = {
+  sharing_visibility: { defaultValue: true },
+  share_end_of_conversation: { defaultValue: true },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useViewSizeMock.mockReturnValue(true); // default: laptop
+  useToastNotificationMock.mockReturnValue({
+    displayToast,
+    dismissToast: jest.fn(),
+  });
+  Object.assign(navigator, { clipboard: { writeText }, maxTouchPoints: 0 });
+  delete (navigator as unknown as { share?: unknown }).share;
+});
+
+const renderComponent = (
+  numComments: number,
+  features: Record<string, { defaultValue: boolean }> = enabledFlags,
+): RenderResult =>
+  render(
+    <TestBootProvider
+      client={new QueryClient()}
+      gb={new GrowthBook({ features })}
+      log={{ logEvent }}
+    >
+      <EndOfConversationShare post={createPost(numComments)} />
+    </TestBootProvider>,
+  );
+
+const band = () => screen.queryByText('Enjoyed this discussion?');
+
+describe('EndOfConversationShare threshold', () => {
+  it(`stays hidden at exactly ${activeDiscussionCommentThreshold} comments`, () => {
+    renderComponent(activeDiscussionCommentThreshold);
+
+    expect(band()).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Share this discussion'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('stays hidden with no comments at all', () => {
+    renderComponent(0);
+
+    expect(band()).not.toBeInTheDocument();
+  });
+
+  it(`renders one comment past the threshold`, () => {
+    renderComponent(activeDiscussionCommentThreshold + 1);
+
+    expect(band()).toBeInTheDocument();
+    expect(screen.getByText('Enjoyed this discussion?')).toBeInTheDocument();
+  });
+});
+
+describe('EndOfConversationShare flags', () => {
+  it('stays hidden when the master kill-switch is off', () => {
+    renderComponent(12, {
+      sharing_visibility: { defaultValue: false },
+      share_end_of_conversation: { defaultValue: true },
+    });
+
+    expect(band()).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when its own experiment flag is off', () => {
+    renderComponent(12, {
+      sharing_visibility: { defaultValue: true },
+      share_end_of_conversation: { defaultValue: false },
+    });
+
+    expect(band()).not.toBeInTheDocument();
+  });
+
+  it('stays hidden with both flags at their defaults', () => {
+    renderComponent(12, {});
+
+    expect(band()).not.toBeInTheDocument();
+  });
+});
+
+describe('EndOfConversationShare sharing', () => {
+  it('copies the link and toasts on desktop', async () => {
+    renderComponent(12);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Share this discussion'));
+    });
+    await act(async () => {
+      fireEvent.click(await screen.findByText('Copy link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(permalink));
+    expect(displayToast).toHaveBeenCalledWith(
+      '✅ Copied link to clipboard',
+      expect.anything(),
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.SharePost,
+        extra: JSON.stringify({
+          provider: ShareProvider.CopyLink,
+          origin: Origin.EndOfConversation,
+        }),
+      }),
+    );
+  });
+
+  it('opens the native share sheet on a single tap on mobile', async () => {
+    useViewSizeMock.mockReturnValue(false);
+    const share = jest.fn().mockResolvedValue(undefined);
+    // `shouldUseNativeShare` also requires a touch device.
+    Object.assign(navigator, { share, maxTouchPoints: 2 });
+
+    renderComponent(12);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Share this discussion'));
+    });
+
+    await waitFor(() => expect(share).toHaveBeenCalled());
+    expect(writeText).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.SharePost,
+        extra: JSON.stringify({
+          provider: ShareProvider.Native,
+          origin: Origin.EndOfConversation,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/shared/src/components/post/EndOfConversationShare.tsx
+++ b/packages/shared/src/components/post/EndOfConversationShare.tsx
@@ -1,0 +1,114 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../graphql/posts';
+import { ShareActions } from '../share/ShareActions';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../typography/Typography';
+import { ButtonSize, ButtonVariant } from '../buttons/common';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { useSharingVisibility } from '../../hooks/useSharingVisibility';
+import { featureShareEndOfConversation } from '../../lib/featureManagement';
+import { useLogContext } from '../../contexts/LogContext';
+import { postLogEvent } from '../../lib/feed';
+import { LogEvent, Origin } from '../../lib/log';
+import { ReferralCampaignKey } from '../../lib/referral';
+import type { ShareProvider } from '../../lib/share';
+
+/**
+ * A share prompt only earns its place at the end of a thread that has real
+ * back-and-forth — prompting on a quiet post trains people to ignore it. The
+ * band stays hidden until the post has MORE than this many comments, read from
+ * the typed `Post.numComments` field (total comments, replies included).
+ */
+export const activeDiscussionCommentThreshold = 3;
+
+export const hasActiveDiscussion = (post: Post): boolean =>
+  (post.numComments ?? 0) > activeDiscussionCommentThreshold;
+
+export interface EndOfConversationShareProps {
+  post: Post;
+  className?: string;
+}
+
+/**
+ * The band itself, including the activity threshold but without the feature
+ * gates, so Storybook can render both sides of the threshold without a
+ * GrowthBook instance.
+ */
+export const EndOfConversationShareBand = ({
+  post,
+  className,
+}: EndOfConversationShareProps): ReactElement | null => {
+  const { logEvent } = useLogContext();
+
+  if (!hasActiveDiscussion(post)) {
+    return null;
+  }
+
+  const onShare = (provider: ShareProvider): void =>
+    logEvent(
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: { provider, origin: Origin.EndOfConversation },
+      }),
+    );
+
+  return (
+    <aside
+      // Labelled by its own visible copy, so no aria-label here — a second
+      // "Share this discussion" label would shadow the share button's.
+      className={classNames(
+        'flex flex-col items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 text-center tablet:flex-row tablet:justify-between tablet:text-left',
+        className,
+      )}
+    >
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <Typography bold type={TypographyType.Callout}>
+          Enjoyed this discussion?
+        </Typography>
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          Send it to someone who&apos;d have opinions.
+        </Typography>
+      </div>
+      <ShareActions
+        link={post.commentsPermalink}
+        text={post.title ?? post.sharedPost?.title ?? ''}
+        cid={ReferralCampaignKey.SharePost}
+        buttonVariant={ButtonVariant.Primary}
+        buttonSize={ButtonSize.Medium}
+        label="Share this discussion"
+        className="shrink-0"
+        onShare={onShare}
+      />
+    </aside>
+  );
+};
+
+/**
+ * Encouraging share band rendered below the comment list of an active
+ * discussion. Gated by the initiative kill-switch plus its own experiment flag,
+ * and only evaluated once the post is past the activity threshold.
+ */
+export const EndOfConversationShare = ({
+  post,
+  className,
+}: EndOfConversationShareProps): ReactElement | null => {
+  const isActive = hasActiveDiscussion(post);
+  const { isEnabled: isInitiativeEnabled } = useSharingVisibility(isActive);
+  const { value: isBandEnabled } = useConditionalFeature({
+    feature: featureShareEndOfConversation,
+    shouldEvaluate: isActive && isInitiativeEnabled,
+  });
+
+  if (!isInitiativeEnabled || !isBandEnabled) {
+    return null;
+  }
+
+  return <EndOfConversationShareBand post={post} className={className} />;
+};

--- a/packages/shared/src/components/post/PostComments.spec.tsx
+++ b/packages/shared/src/components/post/PostComments.spec.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import { PostComments } from './PostComments';
+import type { Post } from '../../graphql/posts';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { Origin } from '../../lib/log';
+
+const mockRequestMethod = jest.fn();
+
+jest.mock('../comments/MainComment', () => ({
+  __esModule: true,
+  default: ({ comment }: { comment: { id: string } }) => (
+    <article data-testid="main-comment">{comment.id}</article>
+  ),
+}));
+
+jest.mock('../../hooks/useRequestProtocol', () => ({
+  useRequestProtocol: () => ({ requestMethod: mockRequestMethod() }),
+}));
+
+const buildComments = (count: number) => ({
+  postComments: {
+    pageInfo: { hasNextPage: false, endCursor: null },
+    edges: Array.from({ length: count }, (_, index) => ({
+      node: { id: `c${index}` },
+    })),
+  },
+});
+
+const createPost = (numComments: number): Post =>
+  ({
+    id: 'abc',
+    title: 'Why your CI is slow',
+    permalink: 'https://daily.dev/posts/abc',
+    commentsPermalink: 'https://app.daily.dev/posts/abc',
+    numComments,
+  } as Post);
+
+const enabledFlags = {
+  sharing_visibility: { defaultValue: true },
+  share_end_of_conversation: { defaultValue: true },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const renderComponent = (
+  numComments: number,
+  features: Record<string, { defaultValue: boolean }> = {},
+): RenderResult => {
+  mockRequestMethod.mockReturnValue(() =>
+    Promise.resolve(buildComments(numComments)),
+  );
+
+  return render(
+    <TestBootProvider
+      client={new QueryClient()}
+      gb={new GrowthBook({ features })}
+    >
+      <PostComments
+        post={createPost(numComments)}
+        origin={Origin.ArticlePage}
+      />
+    </TestBootProvider>,
+  );
+};
+
+describe('PostComments end-of-conversation share band', () => {
+  it('appends the band after the last comment on an active discussion', async () => {
+    renderComponent(6, enabledFlags);
+
+    const comments = await screen.findAllByTestId('main-comment');
+    await waitFor(() => expect(comments).toHaveLength(6));
+
+    expect(screen.getByText('Enjoyed this discussion?')).toBeInTheDocument();
+    expect(comments[5].nextElementSibling).toBe(
+      screen.getByRole('complementary'),
+    );
+  });
+
+  it('leaves the comment list untouched when the flags are off', async () => {
+    renderComponent(6);
+
+    const comments = await screen.findAllByTestId('main-comment');
+    await waitFor(() => expect(comments).toHaveLength(6));
+
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(comments[5].nextElementSibling).toBeNull();
+  });
+
+  it('keeps the band hidden on a quiet discussion even with the flags on', async () => {
+    renderComponent(2, enabledFlags);
+
+    const comments = await screen.findAllByTestId('main-comment');
+    await waitFor(() => expect(comments).toHaveLength(2));
+
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -24,6 +24,7 @@ import { useCommentContentPreferenceMutationSubscription } from './useCommentCon
 import { generateCommentsQueryKey } from '../../lib/query';
 import { CharmEmptyState } from '../charm/CharmEmptyState';
 import { cloudinaryCharmNoComments } from '../../lib/image';
+import { EndOfConversationShare } from './EndOfConversationShare';
 
 const threadCommentOrigins = new Set<Origin>([
   Origin.ArticleModal,
@@ -52,6 +53,12 @@ interface PostCommentsProps {
    * extra gap above the first item.
    */
   removeTopSpacing?: boolean;
+  /**
+   * Skips the end-of-conversation share band. Set by parents that place the
+   * band themselves so it lands at the true end of their surface (the redesign
+   * discussion panel renders it after its meta bar).
+   */
+  hideEndOfConversationShare?: boolean;
 }
 
 const noopShare = (): void => {};
@@ -70,6 +77,7 @@ export function PostComments({
   className = {},
   onCommented,
   removeTopSpacing = false,
+  hideEndOfConversationShare = false,
 }: PostCommentsProps): ReactElement {
   const { id } = post;
   const container = useRef<HTMLDivElement | null>(null);
@@ -165,6 +173,14 @@ export function PostComments({
           lazy={!commentHash && index >= lazyCommentThreshold}
         />
       ))}
+      {!hideEndOfConversationShare && (
+        <EndOfConversationShare
+          post={post}
+          // Cancels the list's mobile full-bleed negative margin so the band
+          // keeps its rounded edges inside the page gutter.
+          className={isModalThread ? undefined : 'mx-4 mobileL:mx-0'}
+        />
+      )}
     </div>
   );
 }

--- a/packages/shared/src/components/post/focus/PostDiscussionPanel.tsx
+++ b/packages/shared/src/components/post/focus/PostDiscussionPanel.tsx
@@ -24,6 +24,7 @@ import { ClickableText } from '../../buttons/ClickableText';
 import { IconSize } from '../../Icon';
 import { TimeSortIcon } from '../../icons/Sort/Time';
 import { SortCommentsBy } from '../../../graphql/comments';
+import { EndOfConversationShare } from '../EndOfConversationShare';
 import { DiscussionMetaBar } from './DiscussionMetaBar';
 import { DiscussionShareRow } from './DiscussionShareRow';
 
@@ -201,6 +202,7 @@ export const PostDiscussionPanel = ({
           onClickUpvote={(id, count) => onShowUpvoted(id, count, 'comment')}
           modalParentSelector={resolveModalParent}
           removeTopSpacing
+          hideEndOfConversationShare
         />
       </div>
       {showMetaBar && (
@@ -208,6 +210,7 @@ export const PostDiscussionPanel = ({
           <DiscussionMetaBar post={post} />
         </div>
       )}
+      <EndOfConversationShare post={post} />
     </section>
   );
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,12 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Renders an encouraging share band below the comment list once a post has an
+// active discussion (more than 3 comments). Part of the sharing-visibility
+// initiative, so it also sits behind the `sharing_visibility` kill-switch.
+// Keep the default `false` — GrowthBook ramps it.
+export const featureShareEndOfConversation = new Feature(
+  'share_end_of_conversation',
+  false,
+);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -108,6 +108,7 @@ export enum Origin {
   GameCenter = 'game center',
   DevCard = 'devcard',
   CopyMyFeed = 'copy my feed',
+  EndOfConversation = 'end of conversation',
 }
 
 export enum LogEvent {

--- a/packages/storybook/stories/components/EndOfConversationShare.stories.tsx
+++ b/packages/storybook/stories/components/EndOfConversationShare.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  activeDiscussionCommentThreshold,
+  EndOfConversationShareBand,
+} from '@dailydotdev/shared/src/components/post/EndOfConversationShare';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import { fn } from 'storybook/test';
+
+const basePost = {
+  id: 'p1',
+  title: 'Why your CI is slow and what actually fixes it',
+  permalink: 'https://daily.dev/posts/p1',
+  commentsPermalink: 'https://app.daily.dev/posts/p1',
+  numComments: 12,
+} as unknown as Post;
+
+const withPost = (numComments: number): Post =>
+  ({ ...basePost, numComments } as Post);
+
+const meta: Meta<typeof EndOfConversationShareBand> = {
+  title: 'Components/Share/EndOfConversationShare',
+  component: EndOfConversationShareBand,
+  args: { post: basePost },
+  parameters: {
+    docs: {
+      description: {
+        component: `Share band rendered below the comment list. It only appears once a post
+has an active discussion — more than ${activeDiscussionCommentThreshold} comments, read from
+\`Post.numComments\`. In the app it is additionally gated by the \`sharing_visibility\`
+kill-switch and the \`share_end_of_conversation\` experiment flag.`,
+      },
+    },
+  },
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+      });
+      // Mock the short-URL resolution so copy/social actions don't hit network.
+      queryClient.setQueryData(['shortUrl'], 'https://dly.to/abc123');
+
+      const LogContext = getLogContextStatic();
+
+      const mockUser = {
+        id: '1',
+        name: 'Test User',
+        username: 'testuser',
+        email: 'test@example.com',
+        image:
+          'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+        providers: ['google'],
+        createdAt: '2024-01-01T00:00:00.000Z',
+        permalink: 'https://daily.dev/testuser',
+      } as unknown as LoggedUser;
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider
+            value={{
+              user: mockUser,
+              shouldShowLogin: false,
+              isLoggedIn: true,
+              isAuthReady: true,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              tokenRefreshed: true,
+              getRedirectUri: fn(),
+              loadingUser: false,
+              loadedUserFromCache: true,
+              refetchBoot: fn(),
+              squads: [],
+              isAndroidApp: false,
+            }}
+          >
+            <LogContext.Provider
+              value={{
+                logEvent: fn(),
+                logEventStart: fn(),
+                logEventEnd: fn(),
+                sendBeacon: () => false,
+              }}
+            >
+              <div className="flex min-h-40 w-full max-w-2xl flex-col justify-center">
+                <Story />
+              </div>
+            </LogContext.Provider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EndOfConversationShareBand>;
+
+// Active discussion: the band renders below the comment list.
+export const ActiveDiscussion: Story = {
+  args: { post: withPost(12) },
+};
+
+// Exactly at the threshold — still hidden, the band needs MORE than 3 comments.
+export const AtThreshold: Story = {
+  args: { post: withPost(activeDiscussionCommentThreshold) },
+};
+
+// One comment past the threshold: the first state where the band shows.
+export const JustAboveThreshold: Story = {
+  args: { post: withPost(activeDiscussionCommentThreshold + 1) },
+};
+
+// Quiet post: nothing renders, so we never prompt on an empty discussion.
+export const NoComments: Story = {
+  args: { post: withPost(0) },
+};
+
+// Narrow the Storybook viewport to see the mobile layout: the band stacks and
+// a single tap on the share button opens the native share sheet (falling back
+// to copy when the device has no share target).
+export const Mobile: Story = {
+  args: { post: withPost(12) },
+  decorators: [
+    (Story) => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+};


### PR DESCRIPTION
Stacks on **PR 1** (`claude/website-sharing-visibility-be6b32`, #6343) — review that one first.

## What changed

Adds the **end-of-conversation share band**: an encouraging prompt rendered below the comment list once a post has a real discussion.

- **New** `packages/shared/src/components/post/EndOfConversationShare.tsx`
  - `EndOfConversationShareBand` — the band itself + the activity threshold, no feature gates (so Storybook can render both sides of the threshold without a GrowthBook instance).
  - `EndOfConversationShare` — the gated wrapper actually used by the app.
  - Reuses the Phase-0 `ShareActions` primitive: mobile taps straight into the native share sheet (copy fallback), desktop opens the share popover. No bespoke share control.
  - Copy: **"Enjoyed this discussion?" / "Send it to someone who'd have opinions."**
- **Classic path** — `PostComments.tsx` renders the band as the last child of the comment list. A new `hideEndOfConversationShare` prop lets a parent place the band itself.
- **Redesign path** — `PostDiscussionPanel.tsx` (used by `PostFocusCard` on both the post page and the post modal) sets `hideEndOfConversationShare` and renders the band at the true end of the panel, after the meta bar. This avoids a double band, since the panel composes `PostComments`.

## Threshold

**More than 3 comments** (`activeDiscussionCommentThreshold = 3`, checked with `>`).

Read from **`Post.numComments`** — verified against the typed GraphQL model in `packages/shared/src/graphql/posts.ts` (`numComments?: number`, total comments incl. replies), not from prose. At exactly 3, or with 0, nothing renders — we never show an empty or low-activity share prompt.

## Flag

`share_end_of_conversation` — `featureShareEndOfConversation`, appended at the end of `featureManagement.ts`, **default `false`**.

Gated on that flag **and** the master `useSharingVisibility()` kill-switch. Both use `useConditionalFeature` with `shouldEvaluate` tied to the comment threshold, so GrowthBook is only evaluated when the band could actually render.

**Flag-off is pixel-identical to PR 1** — the component returns `null`, adding no DOM. Asserted by a test.

## Logging

`LogEvent.SharePost` with `{ provider, origin }` via `postLogEvent`. New `Origin.EndOfConversation = 'end of conversation'` appended to the existing enum (no existing value covered this surface).

## Storybook

`packages/storybook/stories/components/EndOfConversationShare.stories.tsx` — `ActiveDiscussion`, `AtThreshold` (hidden), `JustAboveThreshold`, `NoComments` (hidden), `Mobile`. Same QueryClient + LogContext + mocked `['shortUrl']` decorator as `ShareActions.stories.tsx`. Verified visually in light and dark themes.

## Verification

| Check | Result |
| --- | --- |
| `node ./scripts/typecheck-strict-changed.js` | pass |
| `pnpm --filter shared lint` | pass (0 errors) |
| `NODE_ENV=test pnpm --filter shared test` | 296 suites / 1996 tests pass |
| `NODE_ENV=test pnpm --filter webapp test` | 44 suites / 297 tests pass |
| Storybook render (light + dark) | pass |

New tests (11):
- `EndOfConversationShare.spec.tsx` — hidden at exactly 3 and at 0; shown at 4; hidden with the master switch off; hidden with its own flag off; hidden at both defaults; desktop copy writes to the clipboard, toasts `✅ Copied link to clipboard` and logs `SharePost`/`copy link`/`end of conversation`; mobile single tap calls `navigator.share` and logs the `native` provider.
- `PostComments.spec.tsx` — band appended after the last comment on an active discussion; **flag-off leaves the comment list DOM untouched** (last child is still the last comment, no `complementary` landmark); hidden on a quiet discussion even with the flags on.

`pnpm --filter storybook lint` was not run — that script's `eslint` binary is missing in this repo state (pre-existing, unrelated to this PR).

## Deliberately left out

- Did not touch `EngagementRail` (reader modal) — out of scope; it consumes `PostComments`, so it inherits the band when the flags are on.
- No text label on the share trigger: `ShareActions` is icon-only by design, so the band uses the icon variant with an `aria-label` + tooltip ("Share this discussion") rather than forking the primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-end-of-conversation.preview.app.daily.dev