### PR TITLE
feat(share): post page & modal sharing treatments behind share_post_page

### DIFF
--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -20,6 +20,8 @@ import { useGetShortUrl } from '../hooks';
 import { ReferralCampaignKey } from '../lib';
 import { ProfileImageSize } from './ProfilePicture';
 import { useAuthContext } from '../contexts/AuthContext';
+import { useSharePostPage } from '../hooks/useSharePostPage';
+import { ShareModuleHeader } from './post/share/ShareModuleHeader';
 
 interface ShareBarProps {
   post: Post;
@@ -41,6 +43,7 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const { openModal } = useLazyModal();
   const { logOpts } = useContext(ActiveFeedContext);
   const { squads } = useAuthContext();
+  const isSharePostPageEnabled = useSharePostPage();
 
   const shareableSquadsCount = useMemo(
     () => getShareableSquads(squads).length,
@@ -91,13 +94,23 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
 
   return (
     <WidgetContainer className="hidden flex-col !border-0 p-3 laptop:flex">
-      <h4 className="mb-4 font-bold text-text-primary typo-callout">
-        Would you recommend this post?
-      </h4>
+      {isSharePostPageEnabled ? (
+        <ShareModuleHeader className="mb-4" />
+      ) : (
+        <h4 className="mb-4 font-bold text-text-primary typo-callout">
+          Would you recommend this post?
+        </h4>
+      )}
       <div className="grid grid-cols-4 gap-2 gap-y-4">
         <SocialShareButton
           size={ButtonSize.Medium}
-          variant={ButtonVariant.Tertiary}
+          // Copy link is the action that actually travels, so promote it above
+          // the network tiles once the redesigned module is on.
+          variant={
+            isSharePostPageEnabled
+              ? ButtonVariant.Primary
+              : ButtonVariant.Tertiary
+          }
           onClick={logAndCopyLink}
           pressed={copying}
           icon={

--- a/packages/shared/src/components/ShareMobile.tsx
+++ b/packages/shared/src/components/ShareMobile.tsx
@@ -18,6 +18,8 @@ import type { Post } from '../graphql/posts';
 import { useLogContext } from '../contexts/LogContext';
 import { useSharePost } from '../hooks/useSharePost';
 import type { UsePostContent } from '../hooks/usePostContent';
+import { useSharePostPage } from '../hooks/useSharePostPage';
+import { ShareModuleHeader } from './post/share/ShareModuleHeader';
 
 export interface ShareMobileProps {
   post: Post;
@@ -37,6 +39,7 @@ export function ShareMobile({
   const { logEvent } = useLogContext();
   const { logOpts } = useContext(ActiveFeedContext);
   const showCopyIcon = useShareCopyIcon();
+  const isSharePostPageEnabled = useSharePostPage();
 
   const onShare = () => {
     logEvent(
@@ -46,6 +49,35 @@ export function ShareMobile({
     );
     openSharePost({ post });
   };
+
+  // Redesigned module: a reason to share up top, then two full-width buttons
+  // with a clear primary — instead of two same-weight coloured text links.
+  if (isSharePostPageEnabled) {
+    return (
+      <WidgetContainer className="flex flex-col items-start gap-2 p-3 laptop:hidden">
+        <ShareModuleHeader className="mb-1" />
+        <Button
+          className="w-full"
+          size={ButtonSize.Small}
+          onClick={onCopyPostLink}
+          pressed={copying}
+          icon={showCopyIcon ? <CopyIcon secondary={copying} /> : <LinkIcon />}
+          variant={ButtonVariant.Primary}
+        >
+          {copying ? 'Copied!' : 'Copy link'}
+        </Button>
+        <Button
+          className="w-full"
+          size={ButtonSize.Small}
+          onClick={onShare}
+          icon={<ShareIcon />}
+          variant={ButtonVariant.Secondary}
+        >
+          Share with your friends
+        </Button>
+      </WidgetContainer>
+    );
+  }
 
   return (
     <WidgetContainer className="flex flex-col items-start gap-2 p-3 laptop:hidden">

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -27,6 +27,8 @@ import { useSmartTitle } from '../../hooks/post/useSmartTitle';
 import { PostTagList } from './tags/PostTagList';
 import PostSourceInfo from './PostSourceInfo';
 import { useReaderInstallPromptGate } from '../../hooks/useReaderInstallPromptGate';
+import { useSharePostPage } from '../../hooks/useSharePostPage';
+import { CopySummaryButton } from './share/CopySummaryButton';
 
 type PostContentRawProps = Omit<PostContentProps, 'post'> & { post: Post };
 
@@ -103,6 +105,7 @@ export function PostContentRaw({
     onReadArticle();
   };
   const showCodeSnippets = useFeature(feature.showCodeSnippets);
+  const isSharePostPageEnabled = useSharePostPage(!!post.summary);
   const { title } = useSmartTitle(post);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const isVideoType = isVideoPost(post);
@@ -199,6 +202,13 @@ export function PostContentRaw({
             >
               {post.summary}
             </p>
+            {isSharePostPageEnabled && (
+              <CopySummaryButton
+                className="mt-3"
+                post={post}
+                summary={post.summary}
+              />
+            )}
           </div>
         )}
         <PostTagList post={post} />

--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -32,6 +32,8 @@ import { usePlusSubscription } from '../../hooks/usePlusSubscription';
 import SocialBar from '../cards/socials/SocialBar';
 import { PostContentReminder } from './common/PostContentReminder';
 import { useSettingsContext } from '../../contexts/SettingsContext';
+import { useSharePostPage } from '../../hooks/useSharePostPage';
+import { ShareWithTeamStrip } from './share/ShareWithTeamStrip';
 
 const AuthorOnboarding = dynamic(
   () => import(/* webpackChunkName: "authorOnboarding" */ './AuthorOnboarding'),
@@ -77,6 +79,7 @@ function PostEngagements({
     false,
   );
   const [linkClicked, setLinkClicked] = useState(false);
+  const isSharePostPageEnabled = useSharePostPage();
 
   const handleLinkClick = () => {
     setLinkClicked(true);
@@ -126,6 +129,9 @@ function PostEngagements({
       />
       <PostContentReminder post={post} />
       <PostContentShare post={post} />
+      {isSharePostPageEnabled && (
+        <ShareWithTeamStrip className="mt-6" post={post} />
+      )}
       {linkClicked && <SocialBar post={post} className="mt-6" />}
       <span className="mt-3 flex flex-row items-center">
         <Typography type={TypographyType.Callout}>Sort:</Typography>

--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -10,6 +10,7 @@ import { AuthTriggers } from '../../lib/auth';
 import type { NewCommentRef } from './NewComment';
 import { NewComment } from './NewComment';
 import { PostActions } from './PostActions';
+import { usePostActions } from '../../hooks/post/usePostActions';
 import { PostComments } from './PostComments';
 import { PostUpvotesCommentsCount } from './PostUpvotesCommentsCount';
 import type { Comment } from '../../graphql/comments';
@@ -80,6 +81,7 @@ function PostEngagements({
   );
   const [linkClicked, setLinkClicked] = useState(false);
   const isSharePostPageEnabled = useSharePostPage();
+  const { interaction } = usePostActions({ post });
 
   const handleLinkClick = () => {
     setLinkClicked(true);
@@ -129,7 +131,10 @@ function PostEngagements({
       />
       <PostContentReminder post={post} />
       <PostContentShare post={post} />
-      {isSharePostPageEnabled && (
+      {/* PostContentShare owns the engagement column right after an upvote, so
+       * the team strip stands down until that module is dismissed — otherwise
+       * two full-width share modules stack back-to-back. */}
+      {isSharePostPageEnabled && interaction !== 'upvote' && (
         <ShareWithTeamStrip className="mt-6" post={post} />
       )}
       {linkClicked && <SocialBar post={post} className="mt-6" />}

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -51,6 +51,9 @@ import { PostMenuOptions } from '../PostMenuOptions';
 import { FocusCardActionBar } from './FocusCardActionBar';
 import { PostDiscussionPanel } from './PostDiscussionPanel';
 import { CollectionSources } from './CollectionSources';
+import { useSharePostPage } from '../../../hooks/useSharePostPage';
+import { CopySummaryButton } from '../share/CopySummaryButton';
+import { ShareWithTeamStrip } from '../share/ShareWithTeamStrip';
 
 const PostCodeSnippets = dynamic(() =>
   import(/* webpackChunkName: "postCodeSnippets" */ '../PostCodeSnippets').then(
@@ -250,6 +253,7 @@ export const PostFocusCard = ({
   const { isReaderEnabled } = useReaderModalEligibility();
   const isReaderVariant = isReaderEnabled && post.type === PostType.Article;
   const showCodeSnippets = useFeature(feature.showCodeSnippets);
+  const isSharePostPageEnabled = useSharePostPage();
   const focusCommentRef = useRef<() => void>(() => {});
   const discussionRef = useRef<HTMLDivElement>(null);
   // The video is a small floating preview on tablet/desktop and expands to the
@@ -323,6 +327,36 @@ export const PostFocusCard = ({
         {getReadPostButtonText(post)}
       </Button>
     ) : null;
+
+  // Freeform/welcome posts render `contentHtml` instead and never carry a
+  // summary, so the copy action is absent there by construction.
+  const renderSummary = (): ReactElement | null => {
+    if (!article.summary) {
+      return null;
+    }
+
+    const summary = isVideoType ? (
+      <VideoSummary summary={article.summary} />
+    ) : (
+      <p
+        className="select-text break-words text-text-secondary typo-markdown"
+        data-testid="tldr-container"
+      >
+        {article.summary}
+      </p>
+    );
+
+    if (!isSharePostPageEnabled) {
+      return summary;
+    }
+
+    return (
+      <div className="flex flex-col items-start gap-3">
+        {summary}
+        <CopySummaryButton post={post} summary={article.summary} />
+      </div>
+    );
+  };
 
   return (
     <article
@@ -524,17 +558,7 @@ export const PostFocusCard = ({
               <ContentEmbeds embeds={article.contentEmbeds} variant="post" />
             </>
           ) : (
-            article.summary &&
-            (isVideoType ? (
-              <VideoSummary summary={article.summary} />
-            ) : (
-              <p
-                className="select-text break-words text-text-secondary typo-markdown"
-                data-testid="tldr-container"
-              >
-                {article.summary}
-              </p>
-            ))
+            renderSummary()
           )}
 
           <PostTagList post={article} />
@@ -569,6 +593,8 @@ export const PostFocusCard = ({
             // read as too large here).
             className="-mt-2"
           />
+
+          {isSharePostPageEnabled && <ShareWithTeamStrip post={post} />}
 
           <div ref={discussionRef} className="scroll-mt-16">
             <PostDiscussionPanel

--- a/packages/shared/src/components/post/share/CopySummaryButton.tsx
+++ b/packages/shared/src/components/post/share/CopySummaryButton.tsx
@@ -1,0 +1,79 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { Post } from '../../../graphql/posts';
+import { Button } from '../../buttons/Button';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { Tooltip } from '../../tooltip/Tooltip';
+import { CopyIcon } from '../../icons';
+import { useCopyText } from '../../../hooks/useCopy';
+import { useGetShortUrl } from '../../../hooks';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import { useLogContext } from '../../../contexts/LogContext';
+import { postLogEvent } from '../../../lib/feed';
+import { LogEvent, Origin } from '../../../lib/log';
+import { ShareProvider } from '../../../lib/share';
+
+interface CopySummaryButtonProps {
+  post: Post;
+  /**
+   * The TL;DR text. Freeform/welcome posts have no summary, so the button is
+   * correctly absent there — pass whatever the surface rendered.
+   */
+  summary?: string;
+  className?: string;
+}
+
+/**
+ * Secondary action at the end of the TL;DR block: copies the summary plus a
+ * short link back to the post, so pasting into a chat keeps the attribution.
+ * Deliberately a quiet tertiary button — "Read post" stays the primary CTA.
+ */
+export const CopySummaryButton = ({
+  post,
+  summary,
+  className,
+}: CopySummaryButtonProps): ReactElement | null => {
+  const [copying, copyText] = useCopyText();
+  const { getShortUrl } = useGetShortUrl();
+  const { logEvent } = useLogContext();
+
+  if (!summary) {
+    return null;
+  }
+
+  const onCopySummary = async () => {
+    const shortLink = await getShortUrl(
+      post.commentsPermalink,
+      ReferralCampaignKey.SharePost,
+    );
+    await copyText({
+      textToCopy: `${summary}\n\n${shortLink}`,
+      message: '✅ Copied summary to clipboard',
+    });
+    logEvent(
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: {
+          provider: ShareProvider.CopyLink,
+          origin: Origin.PostSummary,
+        },
+      }),
+    );
+  };
+
+  return (
+    <Tooltip content="Copies the TL;DR and a link back to the post">
+      <Button
+        aria-label="Copy summary"
+        className={className}
+        icon={<CopyIcon secondary={copying} />}
+        onClick={onCopySummary}
+        pressed={copying}
+        size={ButtonSize.Small}
+        type="button"
+        variant={ButtonVariant.Tertiary}
+      >
+        {copying ? 'Copied!' : 'Copy summary'}
+      </Button>
+    </Tooltip>
+  );
+};

--- a/packages/shared/src/components/post/share/PostPageShare.spec.tsx
+++ b/packages/shared/src/components/post/share/PostPageShare.spec.tsx
@@ -1,0 +1,165 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import nock from 'nock';
+import { CopySummaryButton } from './CopySummaryButton';
+import { ShareWithTeamStrip } from './ShareWithTeamStrip';
+import { ShareMobile } from '../../ShareMobile';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import defaultPost from '../../../../__tests__/fixture/post';
+import type { Post } from '../../../graphql/posts';
+import { PostType } from '../../../graphql/posts';
+import { TOAST_NOTIF_KEY } from '../../../hooks/useToastNotification';
+import { useViewSize } from '../../../hooks/useViewSize';
+import { useSharePostPage } from '../../../hooks/useSharePostPage';
+import { Origin } from '../../../lib/log';
+
+jest.mock('../../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+jest.mock('../../../hooks/useSharePostPage', () => ({
+  __esModule: true,
+  useSharePostPage: jest.fn(),
+}));
+
+const useViewSizeMock = useViewSize as jest.Mock;
+const useSharePostPageMock = useSharePostPage as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+const nativeShare = jest.fn().mockResolvedValue(undefined);
+
+const summary =
+  'React Compiler memoizes components automatically, so most useMemo calls become dead weight.';
+
+const articlePost: Post = { ...defaultPost, summary };
+// Freeform posts are authored inside daily.dev and never carry a TL;DR.
+const freeformPost: Post = {
+  ...defaultPost,
+  type: PostType.Freeform,
+  summary: undefined,
+};
+
+let client: QueryClient;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  nock.cleanAll();
+  client = new QueryClient();
+  useViewSizeMock.mockReturnValue(true); // default: laptop
+  useSharePostPageMock.mockReturnValue(true);
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+const renderComponent = (ui: React.ReactElement): RenderResult =>
+  render(<TestBootProvider client={client}>{ui}</TestBootProvider>);
+
+const getToast = () =>
+  client.getQueryData<{ message: string }>(TOAST_NOTIF_KEY);
+
+describe('CopySummaryButton', () => {
+  it('copies the summary plus the post link and shows a toast', async () => {
+    const logEvent = jest.fn();
+    render(
+      <TestBootProvider client={client} log={{ logEvent }}>
+        <CopySummaryButton post={articlePost} summary={summary} />
+      </TestBootProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy summary'));
+    });
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        `${summary}\n\n${articlePost.commentsPermalink}`,
+      ),
+    );
+    expect(getToast()?.message).toEqual('✅ Copied summary to clipboard');
+    await waitFor(() =>
+      expect(logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extra: expect.stringContaining(Origin.PostSummary),
+        }),
+      ),
+    );
+  });
+
+  it('renders nothing for a freeform post, which has no summary', () => {
+    renderComponent(
+      <CopySummaryButton post={freeformPost} summary={freeformPost.summary} />,
+    );
+
+    expect(screen.queryByLabelText('Copy summary')).not.toBeInTheDocument();
+  });
+});
+
+describe('ShareWithTeamStrip', () => {
+  it('copies the post link so it can be pasted into Slack', async () => {
+    renderComponent(<ShareWithTeamStrip post={articlePost} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Send to Slack'));
+    });
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(articlePost.commentsPermalink),
+    );
+    expect(getToast()?.message).toEqual(
+      '✅ Link copied — paste it in any Slack channel',
+    );
+  });
+
+  it('uses the native share sheet on mobile', async () => {
+    useViewSizeMock.mockReturnValue(false);
+    Object.assign(navigator, { share: nativeShare, maxTouchPoints: 5 });
+    renderComponent(<ShareWithTeamStrip post={articlePost} />);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('More sharing options'));
+    });
+
+    await waitFor(() => expect(nativeShare).toHaveBeenCalled());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (navigator as any).share;
+  });
+});
+
+describe('post page share flag', () => {
+  const renderShareMobile = () =>
+    renderComponent(
+      <ShareMobile
+        post={articlePost}
+        link={articlePost.commentsPermalink}
+        origin={Origin.ArticlePage}
+        onCopyPostLink={jest.fn()}
+      />,
+    );
+
+  it('keeps the existing share widget when the flag is off', () => {
+    useSharePostPageMock.mockReturnValue(false);
+    renderShareMobile();
+
+    expect(
+      screen.queryByText('Know someone who should read this?'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Copy link')).toBeInTheDocument();
+    expect(screen.getByText('Share with your friends')).toBeInTheDocument();
+  });
+
+  it('adds the encouraging heading when the flag is on', () => {
+    renderShareMobile();
+
+    expect(
+      screen.getByText('Know someone who should read this?'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Copy link')).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/share/ShareModuleHeader.tsx
+++ b/packages/shared/src/components/post/share/ShareModuleHeader.tsx
@@ -1,0 +1,31 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../typography/Typography';
+
+/**
+ * Shared heading for the redesigned recommend module, so the desktop
+ * (`ShareBar`) and mobile (`ShareMobile`) widgets read as the same module.
+ * Reframes the old yes/no question ("Would you recommend this post?") as a
+ * reason to act.
+ */
+export const ShareModuleHeader = ({
+  className,
+}: {
+  className?: string;
+}): ReactElement => (
+  <div className={classNames('flex flex-col gap-0.5', className)}>
+    <Typography bold tag={TypographyTag.H4} type={TypographyType.Callout}>
+      Know someone who should read this?
+    </Typography>
+    <Typography color={TypographyColor.Tertiary} type={TypographyType.Footnote}>
+      One link is all it takes — it is how most posts on daily.dev reach their
+      next reader.
+    </Typography>
+  </div>
+);

--- a/packages/shared/src/components/post/share/ShareWithTeamStrip.tsx
+++ b/packages/shared/src/components/post/share/ShareWithTeamStrip.tsx
@@ -1,0 +1,105 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import { Button } from '../../buttons/Button';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { SlackIcon } from '../../icons';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { ShareActions } from '../../share/ShareActions';
+import { useCopyPostLink } from '../../../hooks/useCopyPostLink';
+import { useGetShortUrl } from '../../../hooks';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import { useLogContext } from '../../../contexts/LogContext';
+import { postLogEvent } from '../../../lib/feed';
+import { LogEvent, Origin } from '../../../lib/log';
+import { ShareProvider } from '../../../lib/share';
+
+interface ShareWithTeamStripProps {
+  post: Post;
+  className?: string;
+}
+
+/**
+ * Quiet band offering the single most common "share at work" move.
+ *
+ * Slack publishes no web share-intent URL (unlike X/WhatsApp/LinkedIn), so
+ * "Send to Slack" copies the post link: Slack unfurls a pasted daily.dev link
+ * into a rich card from the post's OG tags. A first-class Slack app posting via
+ * `chat.postMessage`/`chat.unfurl` is a backend dependency, not something the
+ * client can do on its own.
+ */
+export const ShareWithTeamStrip = ({
+  post,
+  className,
+}: ShareWithTeamStripProps): ReactElement => {
+  const [copying, copyLink] = useCopyPostLink();
+  const { getShortUrl } = useGetShortUrl();
+  const { logEvent } = useLogContext();
+
+  const logShare = (provider: ShareProvider) =>
+    logEvent(
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: { provider, origin: Origin.PostTeamShare },
+      }),
+    );
+
+  const onSendToSlack = async () => {
+    const shortLink = await getShortUrl(
+      post.commentsPermalink,
+      ReferralCampaignKey.SharePost,
+    );
+    copyLink({
+      link: shortLink,
+      message: '✅ Link copied — paste it in any Slack channel',
+    });
+    logShare(ShareProvider.CopyLink);
+  };
+
+  return (
+    <div
+      className={classNames(
+        'flex flex-col gap-3 rounded-14 border border-border-subtlest-tertiary bg-surface-float px-4 py-3 tablet:flex-row tablet:items-center',
+        className,
+      )}
+      data-testid="share-with-team-strip"
+    >
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Typography bold type={TypographyType.Callout}>
+          Share this with your team
+        </Typography>
+        <Typography
+          color={TypographyColor.Tertiary}
+          type={TypographyType.Footnote}
+        >
+          Drop the link in a channel — it unfurls with the title and summary.
+        </Typography>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Button
+          icon={<SlackIcon />}
+          onClick={onSendToSlack}
+          pressed={copying}
+          size={ButtonSize.Small}
+          type="button"
+          variant={ButtonVariant.Secondary}
+        >
+          {copying ? 'Copied!' : 'Send to Slack'}
+        </Button>
+        <ShareActions
+          cid={ReferralCampaignKey.SharePost}
+          emailSummary={post.summary}
+          emailTitle={post.title}
+          label="More sharing options"
+          link={post.commentsPermalink}
+          onShare={logShare}
+          text={post.title ?? post.sharedPost?.title ?? ''}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/hooks/useSharePostPage.ts
+++ b/packages/shared/src/hooks/useSharePostPage.ts
@@ -1,0 +1,18 @@
+import { featureSharePostPage } from '../lib/featureManagement';
+import { useConditionalFeature } from './useConditionalFeature';
+import { useSharingVisibility } from './useSharingVisibility';
+
+// Per-topic gate for the post page/modal sharing treatments (TL;DR copy, the
+// team share strip, the redesigned recommend module). Stacked on top of the
+// `sharing_visibility` master kill-switch so the topic flag is only evaluated
+// once the initiative itself is on.
+export const useSharePostPage = (shouldEvaluate = true): boolean => {
+  const { isEnabled: isInitiativeEnabled } =
+    useSharingVisibility(shouldEvaluate);
+  const { value } = useConditionalFeature({
+    feature: featureSharePostPage,
+    shouldEvaluate: shouldEvaluate && isInitiativeEnabled,
+  });
+
+  return shouldEvaluate && isInitiativeEnabled && value;
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,9 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Post page/modal sharing treatments: the TL;DR "Copy summary" action, the
+// "share this with your team" strip and the redesigned recommend module. Gated
+// on top of `sharing_visibility` so it can ramp on its own. Keep the default
+// `false` — control is the current post page.
+export const featureSharePostPage = new Feature('share_post_page', false);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -108,6 +108,8 @@ export enum Origin {
   GameCenter = 'game center',
   DevCard = 'devcard',
   CopyMyFeed = 'copy my feed',
+  PostSummary = 'post summary',
+  PostTeamShare = 'post team share',
 }
 
 export enum LogEvent {

--- a/packages/storybook/stories/components/share/PostPageShare.stories.tsx
+++ b/packages/storybook/stories/components/share/PostPageShare.stories.tsx
@@ -1,0 +1,175 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fn } from 'storybook/test';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import { SourceType } from '@dailydotdev/shared/src/graphql/sources';
+import { CopySummaryButton } from '@dailydotdev/shared/src/components/post/share/CopySummaryButton';
+import { ShareWithTeamStrip } from '@dailydotdev/shared/src/components/post/share/ShareWithTeamStrip';
+import { ShareModuleHeader } from '@dailydotdev/shared/src/components/post/share/ShareModuleHeader';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { OpenLinkIcon } from '@dailydotdev/shared/src/components/icons';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+
+const summary =
+  'React Compiler memoizes components automatically, so most useMemo and useCallback calls become dead weight. The article walks through what the compiler can and cannot infer, and where you still need to reach for manual memoization.';
+
+const post = {
+  id: 'p1',
+  title: 'You can delete most of your useMemo calls',
+  permalink: 'https://daily.dev/r/p1',
+  commentsPermalink: 'https://app.daily.dev/posts/p1',
+  createdAt: '2026-05-01T00:00:00.000Z',
+  numUpvotes: 128,
+  numComments: 24,
+  summary,
+  type: PostType.Article,
+  source: {
+    id: 'react',
+    handle: 'reactjs',
+    name: 'React',
+    permalink: 'https://app.daily.dev/sources/reactjs',
+    image: 'https://media.daily.dev/image/upload/t_logo,f_auto/v1/logos/react',
+    type: SourceType.Machine,
+  },
+} as unknown as Post;
+
+// Freeform posts are authored inside daily.dev and never carry a generated
+// TL;DR, so the copy-summary action has nothing to copy.
+const freeformPost = {
+  ...post,
+  id: 'p2',
+  type: PostType.Freeform,
+  summary: undefined,
+} as unknown as Post;
+
+const mockUser = {
+  id: '1',
+  name: 'Test User',
+  username: 'testuser',
+  email: 'test@example.com',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/testuser',
+} as unknown as LoggedUser;
+
+const meta: Meta = {
+  title: 'Components/Share/PostPageShare',
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+      });
+      // Mock the short-URL resolution so copy/social actions don't hit network.
+      queryClient.setQueryData(['shortUrl'], 'https://dly.to/abc123');
+
+      const LogContext = getLogContextStatic();
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider
+            value={{
+              user: mockUser,
+              shouldShowLogin: false,
+              isLoggedIn: true,
+              isAuthReady: true,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              tokenRefreshed: true,
+              getRedirectUri: fn(),
+              loadingUser: false,
+              loadedUserFromCache: true,
+              refetchBoot: fn(),
+              squads: [],
+              isAndroidApp: false,
+            }}
+          >
+            <LogContext.Provider
+              value={{
+                logEvent: fn(),
+                logEventStart: fn(),
+                logEventEnd: fn(),
+                sendBeacon: () => false,
+              }}
+            >
+              <div className="mx-auto flex w-full max-w-[40rem] flex-col gap-4 p-4">
+                <Story />
+              </div>
+            </LogContext.Provider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// Wish-list #1 — the TL;DR block with its secondary copy action. "Read post"
+// stays the only filled button so the copy action never competes with it.
+export const CopySummary: Story = {
+  render: () => (
+    <>
+      <p className="select-text break-words text-text-secondary typo-markdown">
+        {summary}
+      </p>
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          icon={<OpenLinkIcon />}
+          size={ButtonSize.Small}
+          tag="a"
+          href={post.permalink}
+          variant={ButtonVariant.Primary}
+        >
+          Read post
+        </Button>
+        <CopySummaryButton post={post} summary={post.summary} />
+      </div>
+    </>
+  ),
+};
+
+// Freeform posts have no summary — the action renders nothing at all.
+export const CopySummaryOnFreeform: Story = {
+  render: () => (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button size={ButtonSize.Small} variant={ButtonVariant.Primary}>
+        Read post
+      </Button>
+      <CopySummaryButton post={freeformPost} summary={freeformPost.summary} />
+    </div>
+  ),
+};
+
+// Wish-list #6 — the quiet team strip. "Send to Slack" copies the link, since
+// Slack has no web share-intent URL; a pasted daily.dev link unfurls from OG.
+export const TeamStrip: Story = {
+  render: () => <ShareWithTeamStrip post={post} />,
+};
+
+// The strip collapses to a stacked layout below tablet.
+export const TeamStripNarrow: Story = {
+  render: () => (
+    <div className="w-[22rem]">
+      <ShareWithTeamStrip post={post} />
+    </div>
+  ),
+};
+
+// Wish-list #10 — the heading shared by the desktop and mobile recommend
+// modules, replacing the old "Would you recommend this post?" question.
+export const RecommendModuleHeader: Story = {
+  render: () => <ShareModuleHeader />,
+};


### PR DESCRIPTION
Stacks on **PR 1** (#6343, `claude/website-sharing-visibility-be6b32`) — review that first.

Covers sharing-visibility wish-list items **#1** (TL;DR copy), **#6** (team strip), **#8** (all post types) and **#10** (redesign the share widget).

## What changed

Both the classic path (`PostContent` → `BasePostContent` → `PostEngagements`) and the redesign path (`PostFocusCard`, swapped in by `usePostRedesign` on **both** the post page and the post modal) get the treatment, so post page + modal + every post type are covered by construction.

**#1 — "Copy summary"** (`post/share/CopySummaryButton.tsx`)
A quiet tertiary button at the end of the TL;DR block that copies the summary plus a short link back to the post, so a paste keeps its attribution. Deliberately **secondary** — "Read post" stays the only filled CTA. Wired into the classic `tldr-container` block in `PostContent.tsx` and into the summary block (text *and* video variants) in `PostFocusCard.tsx`. Freeform/welcome posts carry no summary, so the button is absent there by construction — asserted in a test.

**#6 — "Share this with your team"** (`post/share/ShareWithTeamStrip.tsx`)
A quiet band (not a modal) in a fixed slot in the engagements region: after `PostContentShare` in `PostEngagements.tsx`, and directly below `FocusCardActionBar` in `PostFocusCard.tsx`. Left side is the invitation; right side is "Send to Slack" plus the PR-1 `ShareActions` popover for everything else.

**#10 — redesigned recommend module** (`post/share/ShareModuleHeader.tsx`)
`ShareBar.tsx` (desktop) and `ShareMobile.tsx` (mobile) share one heading — "Know someone who should read this?" with a supporting line — replacing the old yes/no "Would you recommend this post?". Copy link is promoted to the primary action in both. PR 1's `share_copy_icon` behaviour in `ShareMobile` is preserved in both branches.

## Flag

`share_post_page` (`featureSharePostPage`, default `false`, appended at the end of `featureManagement.ts`).

Gated through `useSharePostPage()`, which stacks the topic flag on top of the `sharing_visibility` master kill-switch and uses `useConditionalFeature` with `shouldEvaluate`, so the topic flag is only evaluated once the initiative is on (and, for the TL;DR button, only when the post actually has a summary).

**Flag-off is DOM-identical to the PR 1 branch** — every new element is behind the gate, and the wrapper `div` added around the redesign summary only renders when the flag is on. `ShareMobile` uses an early return so the control branch is byte-identical.

## ⚠️ Open question — Slack (resolved, not guessed)

`ShareProvider` / `getShareLink` in `packages/shared/src/lib/share.ts` have **no Slack target**, and Slack publishes no public web share-intent URL (unlike X / WhatsApp / LinkedIn / Telegram / Reddit / Facebook). The repo's only Slack integration is `SlackIntegrationModal` / `UserIntegrationType.Slack`, which connects a **squad** to a channel — it cannot post an arbitrary post on the user's behalf.

**Decision:** "Send to Slack" copies the post link and toasts `✅ Link copied — paste it in any Slack channel`. Slack unfurls a pasted daily.dev link into a rich card from the post's OG tags, so the outcome is the intended one with no fake URL invented.

**Backend dependency:** a first-class Slack app posting via `chat.postMessage` / `chat.unfurl` (real channel picker, one-click send) needs a daily-api Slack OAuth scope + endpoint. Not something the client can do alone — worth a follow-up ticket if we want the real thing.

## Logging

`LogEvent.SharePost` + `ShareProvider` + a per-surface `Origin`. Reused the existing enum where it fit; appended two genuinely-missing values at the end: `Origin.PostSummary` and `Origin.PostTeamShare`. The redesigned recommend module keeps the existing `Origin.ShareBar`.

## Verification

| Check | Result |
| --- | --- |
| `node ./scripts/typecheck-strict-changed.js` | ✅ no errors from this change. 4 pre-existing strict errors surface in `PostEngagements.tsx` (lines `isSourcePublicSquad(post.source)`, the `TimeSortIcon` className, `ref={commentRef}`, `onSignUp`) — all untouched by this PR, confirmed present on the base branch. |
| `pnpm --filter @dailydotdev/shared lint` | ✅ clean |
| `NODE_ENV=test pnpm --filter shared test` | ✅ 295 suites / 1991 tests |
| `pnpm --filter webapp test` | ✅ 44 suites / 297 tests |
| Storybook `tsc --noEmit` | ✅ clean for the new story |

New tests in `packages/shared/src/components/post/share/PostPageShare.spec.tsx`:
- copy summary writes summary + link to the clipboard **and** shows a toast, and logs `Origin.PostSummary`
- the TL;DR button renders **nothing** on a freeform post
- "Send to Slack" copies the post link and toasts the paste hint
- the mobile path calls `navigator.share`
- **flag-off preserves the existing widget exactly**; flag-on adds the heading

The existing `ShareBar.spec.tsx` passes unchanged (it renders flag-off).

## Storybook

`packages/storybook/stories/components/share/PostPageShare.stories.tsx` — `CopySummary` (next to a real "Read post" primary, to show the hierarchy), `CopySummaryOnFreeform` (renders nothing), `TeamStrip`, `TeamStripNarrow` (stacked below tablet), `RecommendModuleHeader`.

## Deliberately left out

- No change to `post/focus/DiscussionShareRow.tsx` — it already ships the compact share row for the discussion panel and needed nothing for these items.
- No restructuring of the `ShareBar` squads grid (option counts, "Show more options" collapse) — out of scope for a copy/emphasis redesign and it would have churned `ShareBar.spec.tsx`.
- No native Slack integration (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-post-page-core.preview.app.daily.dev