### PR TITLE
feat(share): briefing copy actions + personalized digest share parity

### DIFF
--- a/packages/shared/src/components/brief/BriefContent.spec.tsx
+++ b/packages/shared/src/components/brief/BriefContent.spec.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BriefContent } from './BriefContent';
+import type { Post } from '../../graphql/posts';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+import { ToastType } from '../../hooks/useToastNotification';
+
+const mockDisplayToast = jest.fn();
+const mockLogEvent = jest.fn();
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: mockLogEvent }),
+}));
+
+jest.mock('../../hooks/useToastNotification', () => ({
+  // Keep the real module's exports — the component imports `ToastType` from
+  // here too, and a bare factory would leave it undefined.
+  ...jest.requireActual('../../hooks/useToastNotification'),
+  useToastNotification: () => ({ displayToast: mockDisplayToast }),
+}));
+
+// The real Markdown component sanitizes asynchronously and pulls in hover cards
+// and the image lightbox; none of that is what these tests are about.
+jest.mock('../Markdown', () => ({
+  __esModule: true,
+  // eslint-disable-next-line react/prop-types
+  default: ({ content }: { content: string }) => (
+    // eslint-disable-next-line react/no-danger
+    <div dangerouslySetInnerHTML={{ __html: content }} />
+  ),
+}));
+
+const post = {
+  id: 'brief-1',
+  title: 'Presidential briefing',
+  commentsPermalink: 'https://app.daily.dev/posts/brief-1',
+} as Post;
+
+const contentHtml = `
+<h2>The npm supply chain took another hit</h2>
+<p>Three packages shipped a malicious post-install script.</p>
+<ul>
+  <li>What happened: a maintainer account was taken over.</li>
+  <li>What to do: rotate your CI credentials.</li>
+</ul>
+<h2>Rust 1.90 lands async closures</h2>
+<p>The feature has been in nightly for two years.</p>
+`;
+
+const renderComponent = (showItemActions = true, html = contentHtml) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <BriefContent
+        post={post}
+        origin={Origin.ArticlePage}
+        contentHtml={html}
+        showItemActions={showItemActions}
+      />
+    </QueryClientProvider>,
+  );
+
+// Locate a control by the element it belongs to rather than by index — the DOM
+// order of headings, paragraphs and bullets interleaves.
+const controlIn = (selector: string, contains: string): HTMLElement => {
+  const host = Array.from(
+    document.querySelectorAll<HTMLElement>(selector),
+  ).find((element) => element.textContent?.includes(contains));
+
+  if (!host) {
+    throw new Error(`no ${selector} containing "${contains}"`);
+  }
+
+  return host.querySelector('button') as HTMLElement;
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+it('renders a copy control on every heading, bullet and paragraph', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy section')).toHaveLength(2),
+  );
+  // 2 bullets + 2 paragraphs.
+  expect(screen.getAllByLabelText('Copy item')).toHaveLength(4);
+});
+
+it('copies a single bullet with the briefing link appended', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy item')).toHaveLength(4),
+  );
+  fireEvent.click(controlIn('li', 'What happened'));
+
+  await waitFor(() =>
+    expect(writeText).toHaveBeenCalledWith(
+      `What happened: a maintainer account was taken over.\n\n${post.commentsPermalink}`,
+    ),
+  );
+  expect(mockDisplayToast).toHaveBeenCalledWith(
+    'Copied to clipboard',
+    expect.objectContaining({ variant: ToastType.Success }),
+  );
+});
+
+it('copies a standalone paragraph', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy item')).toHaveLength(4),
+  );
+  fireEvent.click(controlIn('p', 'Three packages'));
+
+  await waitFor(() =>
+    expect(writeText).toHaveBeenCalledWith(
+      `Three packages shipped a malicious post-install script.\n\n${post.commentsPermalink}`,
+    ),
+  );
+});
+
+it('copies a section as its heading, prose and bullets, one bullet per line', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy section')).toHaveLength(2),
+  );
+  fireEvent.click(controlIn('h2', 'npm supply chain'));
+
+  await waitFor(() =>
+    expect(writeText).toHaveBeenCalledWith(
+      [
+        'The npm supply chain took another hit',
+        '',
+        'Three packages shipped a malicious post-install script.',
+        '',
+        '- What happened: a maintainer account was taken over.',
+        '- What to do: rotate your CI credentials.',
+        '',
+        post.commentsPermalink,
+      ].join('\n'),
+    ),
+  );
+});
+
+it('stops a section at the next heading', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy section')).toHaveLength(2),
+  );
+  fireEvent.click(controlIn('h2', 'Rust 1.90'));
+
+  await waitFor(() => expect(writeText).toHaveBeenCalled());
+  expect(writeText.mock.calls[0][0]).not.toContain('npm supply chain');
+});
+
+// The body is model-generated markdown: heading level and whether a section
+// uses bullets or prose vary between briefings. Matching only h2/h3/li left
+// briefs like this one with no controls at all.
+it('attaches to other heading levels and to prose-only sections', async () => {
+  renderComponent(
+    true,
+    `<h1>Top level</h1><p>Lead paragraph.</p><h4>Deep heading</h4><p>More prose.</p>`,
+  );
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy section')).toHaveLength(2),
+  );
+  expect(screen.getAllByLabelText('Copy item')).toHaveLength(2);
+});
+
+it('does not double up on a paragraph nested inside a list item', async () => {
+  renderComponent(true, `<ul><li><p>Wrapped bullet text.</p></li></ul>`);
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy item')).toHaveLength(1),
+  );
+});
+
+it('logs the copy with a content discriminator per item kind', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy item')).toHaveLength(4),
+  );
+  fireEvent.click(controlIn('li', 'What happened'));
+
+  expect(mockLogEvent).toHaveBeenCalledWith(
+    expect.objectContaining({
+      event_name: LogEvent.SharePost,
+      extra: expect.stringContaining(ShareProvider.CopyText),
+    }),
+  );
+  expect(mockLogEvent.mock.calls[0][0].extra).toContain('brief_bullet');
+});
+
+it('confirms with a success checkmark on the control that was clicked', async () => {
+  renderComponent();
+
+  await waitFor(() =>
+    expect(screen.getAllByLabelText('Copy item')).toHaveLength(4),
+  );
+  const first = controlIn('li', 'What happened');
+  const second = controlIn('li', 'What to do');
+  fireEvent.click(first);
+
+  // Only the clicked control confirms — the shared `useCopy` flag would have
+  // lit every control on the page at once.
+  await waitFor(() =>
+    expect(first.querySelector('.text-status-success')).toBeInTheDocument(),
+  );
+  expect(second.querySelector('.text-status-success')).not.toBeInTheDocument();
+});
+
+it('clears the checkmark after the confirmation window', async () => {
+  jest.useFakeTimers();
+
+  try {
+    renderComponent();
+
+    await waitFor(() =>
+      expect(screen.getAllByLabelText('Copy item')).toHaveLength(4),
+    );
+    const first = controlIn('li', 'What happened');
+
+    act(() => {
+      fireEvent.click(first);
+    });
+    expect(first.querySelector('.text-status-success')).toBeInTheDocument();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(first.querySelector('.text-status-success')).not.toBeInTheDocument();
+  } finally {
+    jest.useRealTimers();
+  }
+});
+
+it('renders no controls at all with the gate off', async () => {
+  renderComponent(false);
+
+  await waitFor(() =>
+    expect(screen.getByText('Rust 1.90 lands async closures')).toBeVisible(),
+  );
+  expect(screen.queryByLabelText('Copy item')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Copy section')).not.toBeInTheDocument();
+});

--- a/packages/shared/src/components/brief/BriefContent.spec.tsx
+++ b/packages/shared/src/components/brief/BriefContent.spec.tsx
@@ -13,6 +13,17 @@ import { LogEvent, Origin } from '../../lib/log';
 import { ShareProvider } from '../../lib/share';
 import { ToastType } from '../../hooks/useToastNotification';
 
+// The copied link must be the tracked/shortened one, not `post.commentsPermalink`
+// — asserting against this value is what proves referral attribution survives.
+const shortLink = 'https://dly.to/abc123';
+
+jest.mock('../../hooks/utils/useGetShortUrl', () => ({
+  useGetShortUrl: () => ({
+    shareLink: shortLink,
+    getTrackedUrl: (url: string) => `${url}?cid=share_post`,
+  }),
+}));
+
 const mockDisplayToast = jest.fn();
 const mockLogEvent = jest.fn();
 const writeText = jest.fn().mockResolvedValue(undefined);
@@ -107,7 +118,7 @@ it('copies a single bullet with the briefing link appended', async () => {
 
   await waitFor(() =>
     expect(writeText).toHaveBeenCalledWith(
-      `What happened: a maintainer account was taken over.\n\n${post.commentsPermalink}`,
+      `What happened: a maintainer account was taken over.\n\n${shortLink}`,
     ),
   );
   expect(mockDisplayToast).toHaveBeenCalledWith(
@@ -126,7 +137,7 @@ it('copies a standalone paragraph', async () => {
 
   await waitFor(() =>
     expect(writeText).toHaveBeenCalledWith(
-      `Three packages shipped a malicious post-install script.\n\n${post.commentsPermalink}`,
+      `Three packages shipped a malicious post-install script.\n\n${shortLink}`,
     ),
   );
 });
@@ -149,7 +160,7 @@ it('copies a section as its heading, prose and bullets, one bullet per line', as
         '- What happened: a maintainer account was taken over.',
         '- What to do: rotate your CI credentials.',
         '',
-        post.commentsPermalink,
+        shortLink,
       ].join('\n'),
     ),
   );

--- a/packages/shared/src/components/brief/BriefContent.tsx
+++ b/packages/shared/src/components/brief/BriefContent.tsx
@@ -1,0 +1,267 @@
+import type { ReactElement } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import classNames from 'classnames';
+import Markdown from '../Markdown';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { CopyIcon, VIcon } from '../icons';
+import { Tooltip } from '../tooltip/Tooltip';
+import type { Post } from '../../graphql/posts';
+import { useCopyText } from '../../hooks/useCopy';
+import { useCopyFeedback } from '../../hooks/useCopyFeedback';
+import { ToastType } from '../../hooks/useToastNotification';
+import { useShareBriefingDigest } from '../../hooks/useShareBriefingDigest';
+import { useLogContext } from '../../contexts/LogContext';
+import { usePostLogEvent } from '../../lib/feed';
+import { LogEvent } from '../../lib/log';
+import type { Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+// The briefing body is sanitized HTML from `Markdown`, so per-item controls
+// can't be composed in JSX. A mount node is appended to each bullet and section
+// heading instead, and the button is portalled into it.
+const MOUNT_CLASS = 'brief-item-copy-mount';
+// Deliberately wide. The body is model-generated markdown, so the heading level
+// and whether a section uses bullets or prose vary between briefings — matching
+// only `h2`/`h3`/`li` meant a brief written as plain paragraphs got no controls
+// at all, which reads as the feature being missing rather than not applicable.
+const ITEM_SELECTOR = 'h1, h2, h3, h4, li, p';
+const HEADING_TAGS = new Set(['H1', 'H2', 'H3', 'H4']);
+
+// A paragraph nested inside a list item or a quote is part of that item, not an
+// item of its own — it would get a second, redundant control.
+const isNestedProse = (element: HTMLElement): boolean =>
+  element.tagName === 'P' && !!element.closest('li, blockquote');
+
+type BriefItemKind = 'bullet' | 'paragraph' | 'section';
+
+const kindOf = (element: HTMLElement): BriefItemKind => {
+  if (HEADING_TAGS.has(element.tagName)) {
+    return 'section';
+  }
+
+  return element.tagName === 'LI' ? 'bullet' : 'paragraph';
+};
+
+interface BriefItem {
+  mount: HTMLElement;
+  kind: BriefItemKind;
+  element: HTMLElement;
+}
+
+const readText = (element: Element): string => {
+  const clone = element.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(`.${MOUNT_CLASS}`).forEach((node) => node.remove());
+
+  return (clone.textContent ?? '').replace(/\s+/g, ' ').trim();
+};
+
+// Lists have to be read item by item — collapsing a whole `<ul>` with
+// `textContent` runs every bullet together into one unreadable paragraph.
+const readBlock = (element: Element): string => {
+  if (element.tagName !== 'UL' && element.tagName !== 'OL') {
+    return readText(element);
+  }
+
+  return Array.from(element.children)
+    .filter((child) => child.tagName === 'LI')
+    .map((item) => `- ${readText(item)}`)
+    .join('\n');
+};
+
+// A section is its heading plus everything up to the next heading — copying only
+// the heading text would paste a title with no substance.
+const readSectionText = (heading: HTMLElement): string => {
+  const parts = [readText(heading)];
+  let node = heading.nextElementSibling;
+
+  while (node && !HEADING_TAGS.has(node.tagName)) {
+    parts.push(readBlock(node));
+    node = node.nextElementSibling;
+  }
+
+  return parts.filter(Boolean).join('\n\n');
+};
+
+export interface BriefContentProps {
+  post: Post;
+  origin: Origin;
+  contentHtml: string;
+  className?: string;
+  /**
+   * Renders the per-item copy controls. Left undefined it resolves from the
+   * `share_briefing_digest` gate; pass it explicitly to pin a state in
+   * Storybook or tests, where GrowthBook is mocked.
+   */
+  showItemActions?: boolean;
+}
+
+export const BriefContent = ({
+  post,
+  origin,
+  contentHtml,
+  className,
+  showItemActions,
+}: BriefContentProps): ReactElement => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [items, setItems] = useState<BriefItem[]>([]);
+  const isShareEnabled = useShareBriefingDigest();
+  const showItems = showItemActions ?? isShareEnabled;
+  const [, copyText] = useCopyText();
+  const [copiedKey, markCopied] = useCopyFeedback();
+  const { logEvent } = useLogContext();
+  const postLogEvent = usePostLogEvent();
+
+  const scan = useCallback(() => {
+    const root = containerRef.current;
+
+    if (!root) {
+      return;
+    }
+
+    const next = Array.from(root.querySelectorAll<HTMLElement>(ITEM_SELECTOR))
+      .filter((element) => !isNestedProse(element) && !!readText(element))
+      .map((element) => {
+        // Walk the children rather than using `:scope >` — the Tailwind group
+        // class added below contains a `/`, which some selector engines (jsdom's
+        // included) fail to escape when they expand `:scope`.
+        const existing = Array.from(element.children).find((child) =>
+          child.classList.contains(MOUNT_CLASS),
+        ) as HTMLElement | undefined;
+        const mount = existing ?? document.createElement('span');
+
+        if (!existing) {
+          mount.className = MOUNT_CLASS;
+          element.appendChild(mount);
+        }
+
+        element.classList.add('group/brief-item');
+
+        return { mount, element, kind: kindOf(element) };
+      });
+
+    // Portalling into the mounts mutates the tree and re-triggers the observer;
+    // bail out when nothing actually changed so the loop settles.
+    setItems((prev) =>
+      prev.length === next.length &&
+      prev.every((item, index) => item.mount === next[index].mount)
+        ? prev
+        : next,
+    );
+  }, []);
+
+  useEffect(() => {
+    const root = containerRef.current;
+
+    if (!root || !showItems) {
+      setItems((prev) => (prev.length ? [] : prev));
+      return undefined;
+    }
+
+    // `Markdown` sanitizes asynchronously (DOMPurify loads in one of its own
+    // effects), so the body lands on a later render of the *child* — which does
+    // not re-run this component's effects. Watching the subtree is the only
+    // reliable signal. `scan` reuses existing mounts and `setItems` bails when
+    // nothing changed, so the mutations it causes settle after one extra pass.
+    let scheduled = false;
+    const observer = new MutationObserver(() => {
+      if (scheduled) {
+        return;
+      }
+
+      scheduled = true;
+      queueMicrotask(() => {
+        scheduled = false;
+        scan();
+      });
+    });
+
+    observer.observe(root, { childList: true, subtree: true });
+    scan();
+
+    return () => observer.disconnect();
+  }, [scan, showItems, contentHtml]);
+
+  const onCopyItem = (item: BriefItem, key: string) => {
+    const text =
+      item.kind === 'section'
+        ? readSectionText(item.element)
+        : readText(item.element);
+
+    markCopied(key);
+
+    logEvent(
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: {
+          provider: ShareProvider.CopyText,
+          origin,
+          content: `brief_${item.kind}`,
+        },
+      }),
+    );
+
+    // `ToastType.Success` renders the design system's green checkmark, so the
+    // toast and the button's own confirmation say the same thing — no need for
+    // the ✅ the older copy strings prefix by hand.
+    copyText({
+      textToCopy: `${text}\n\n${post.commentsPermalink ?? ''}`.trim(),
+      message:
+        item.kind === 'section'
+          ? 'Copied section to clipboard'
+          : 'Copied to clipboard',
+      variant: ToastType.Success,
+    });
+  };
+
+  return (
+    <div ref={containerRef} className={className}>
+      <Markdown content={contentHtml} />
+      {items.map((item, index) => {
+        const key = `${item.kind}-${index}`;
+        const isCopied = copiedKey === key;
+        const label = item.kind === 'section' ? 'Copy section' : 'Copy item';
+
+        return createPortal(
+          <Tooltip content={isCopied ? 'Copied!' : label}>
+            <Button
+              type="button"
+              size={ButtonSize.XSmall}
+              variant={ButtonVariant.Tertiary}
+              aria-label={label}
+              // Always CopyIcon, never the link glyph, and deliberately not
+              // gated on `share_copy_icon`: this copies the item's *text* with
+              // the briefing link appended, so what lands on the clipboard is
+              // quotable and still carries attribution. The link glyph is
+              // reserved for controls that copy the bare URL.
+              icon={
+                isCopied ? (
+                  <VIcon className="text-status-success" />
+                ) : (
+                  <CopyIcon />
+                )
+              }
+              // `align-middle` centres the box on baseline + half the
+              // x-height, which reads low against the text's optical centre.
+              // The correction is ~half the cap-height/x-height difference and
+              // scales with font size, so it has to be in `em` — a px nudge
+              // that suits a bullet is visibly wrong on a section heading.
+              //
+              // Dimmed but always present, never hover-only: a control that
+              // appears only once the pointer is already on the right line is
+              // undiscoverable — you cannot hover for something you don't know
+              // is there — and it is unreachable on touch entirely. Hover and
+              // focus bring it to full strength.
+              className={classNames(
+                'ml-2 inline-flex -translate-y-[0.15em] align-middle transition-opacity focus-visible:opacity-100 group-hover/brief-item:opacity-100',
+                isCopied ? 'opacity-100' : 'opacity-40',
+              )}
+              onClick={() => onCopyItem(item, key)}
+            />
+          </Tooltip>,
+          item.mount,
+          key,
+        );
+      })}
+    </div>
+  );
+};

--- a/packages/shared/src/components/brief/BriefContent.tsx
+++ b/packages/shared/src/components/brief/BriefContent.tsx
@@ -246,14 +246,15 @@ export const BriefContent = ({
               // scales with font size, so it has to be in `em` — a px nudge
               // that suits a bullet is visibly wrong on a section heading.
               //
-              // Dimmed but always present, never hover-only: a control that
-              // appears only once the pointer is already on the right line is
-              // undiscoverable — you cannot hover for something you don't know
-              // is there — and it is unreachable on touch entirely. Hover and
-              // focus bring it to full strength.
+              // Revealed on hover of its own item, so a briefing reads as prose
+              // until you reach for a control. Touch has no hover, so coarse
+              // pointers get them outright — otherwise they would be
+              // unreachable there. Keyboard focus reveals them too, and the
+              // control stays pinned while it is confirming so the checkmark
+              // survives the pointer leaving as the click lands.
               className={classNames(
-                'ml-2 inline-flex -translate-y-[0.15em] align-middle transition-opacity focus-visible:opacity-100 group-hover/brief-item:opacity-100',
-                isCopied ? 'opacity-100' : 'opacity-40',
+                'ml-2 inline-flex -translate-y-[0.15em] align-middle transition-opacity focus-visible:opacity-100 group-hover/brief-item:opacity-100 [@media(pointer:coarse)]:opacity-100',
+                isCopied ? 'opacity-100' : 'opacity-0',
               )}
               onClick={() => onCopyItem(item, key)}
             />

--- a/packages/shared/src/components/brief/BriefContent.tsx
+++ b/packages/shared/src/components/brief/BriefContent.tsx
@@ -9,6 +9,9 @@ import { Tooltip } from '../tooltip/Tooltip';
 import type { Post } from '../../graphql/posts';
 import { useCopyText } from '../../hooks/useCopy';
 import { useCopyFeedback } from '../../hooks/useCopyFeedback';
+import { useGetShortUrl } from '../../hooks/utils/useGetShortUrl';
+import { useActiveFeedContext } from '../../contexts/ActiveFeedContext';
+import { ReferralCampaignKey } from '../../lib/referral';
 import { ToastType } from '../../hooks/useToastNotification';
 import { useShareBriefingDigest } from '../../hooks/useShareBriefingDigest';
 import { useLogContext } from '../../contexts/LogContext';
@@ -109,6 +112,23 @@ export const BriefContent = ({
   const showItems = showItemActions ?? isShareEnabled;
   const [, copyText] = useCopyText();
   const [copiedKey, markCopied] = useCopyFeedback();
+  const { logOpts } = useActiveFeedContext();
+
+  // The link that rides along with every copy has to carry referral
+  // attribution, exactly like `useSharePost().copyLink` does — a bare
+  // permalink would make these the only shares in the app that go
+  // uncredited. Resolved up front so the click handler stays synchronous:
+  // awaiting inside it would put the clipboard write outside the user
+  // gesture.
+  const permalink = post.commentsPermalink;
+  const { shareLink, getTrackedUrl } = useGetShortUrl({
+    query: permalink
+      ? { url: permalink, cid: ReferralCampaignKey.SharePost }
+      : undefined,
+  });
+  const shareUrl = permalink
+    ? shareLink ?? getTrackedUrl(permalink, ReferralCampaignKey.SharePost)
+    : '';
   const { logEvent } = useLogContext();
   const postLogEvent = usePostLogEvent();
 
@@ -197,6 +217,7 @@ export const BriefContent = ({
           origin,
           content: `brief_${item.kind}`,
         },
+        ...(logOpts && logOpts),
       }),
     );
 
@@ -204,7 +225,7 @@ export const BriefContent = ({
     // toast and the button's own confirmation say the same thing — no need for
     // the ✅ the older copy strings prefix by hand.
     copyText({
-      textToCopy: `${text}\n\n${post.commentsPermalink ?? ''}`.trim(),
+      textToCopy: `${text}\n\n${shareUrl}`.trim(),
       message:
         item.kind === 'section'
           ? 'Copied section to clipboard'

--- a/packages/shared/src/components/brief/BriefListItem.spec.tsx
+++ b/packages/shared/src/components/brief/BriefListItem.spec.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BriefListItem } from './BriefListItem';
 import type { Post } from '../../graphql/posts';
 import { LogEvent, Origin, TargetId } from '../../lib/log';
@@ -20,6 +21,30 @@ jest.mock('../../hooks/usePlusSubscription', () => ({
   usePlusSubscription: () => ({ isPlus: true }),
 }));
 
+const mockUseShareBriefingDigest = jest.fn();
+
+jest.mock('../../hooks/useShareBriefingDigest', () => ({
+  useShareBriefingDigest: () => mockUseShareBriefingDigest(),
+}));
+
+const mockCopyLink = jest.fn();
+
+jest.mock('../../hooks/useSharePost', () => ({
+  useSharePost: () => ({ copyLink: mockCopyLink }),
+}));
+
+jest.mock('../../hooks/useShareCopyIcon', () => ({
+  useShareCopyIcon: () => false,
+}));
+
+// ShareActions owns its own popover/native-share behaviour and is covered by
+// its own spec; here we only care that the row exposes its trigger.
+jest.mock('../share/ShareActions', () => ({
+  ShareActions: ({ label }: { label: string }) => (
+    <button type="button" aria-label={label} />
+  ),
+}));
+
 const post = {
   id: 'brief-1',
   slug: 'brief-1',
@@ -28,8 +53,14 @@ const post = {
   read: false,
 } as Post;
 
-const renderComponent = (onClick = jest.fn()) =>
+// The copy control's Tooltip reaches for a QueryClient.
+const renderWithClient = (ui: React.ReactElement) =>
   render(
+    <QueryClientProvider client={new QueryClient()}>{ui}</QueryClientProvider>,
+  );
+
+const renderComponent = (onClick = jest.fn()) =>
+  renderWithClient(
     <BriefListItem
       post={post}
       title={post.title}
@@ -42,6 +73,43 @@ const renderComponent = (onClick = jest.fn()) =>
 describe('BriefListItem', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseShareBriefingDigest.mockReturnValue(false);
+  });
+
+  it('keeps the row untouched while the share gate is off', () => {
+    renderComponent();
+
+    // The control row is a link and nothing else — no interactive controls.
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByRole('link')).toBeInTheDocument();
+  });
+
+  it('renders copy-link and share once the share gate is on', () => {
+    mockUseShareBriefingDigest.mockReturnValue(true);
+
+    renderComponent();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy link' }));
+    expect(mockCopyLink).toHaveBeenCalledWith({ post });
+    expect(
+      screen.getByRole('button', { name: 'Share briefing' }),
+    ).toBeInTheDocument();
+  });
+
+  it('lets an explicit prop pin the controls off even when the gate is on', () => {
+    mockUseShareBriefingDigest.mockReturnValue(true);
+
+    renderWithClient(
+      <BriefListItem
+        post={post}
+        title={post.title}
+        origin={Origin.BriefPage}
+        targetId={TargetId.List}
+        showCopyActions={false}
+      />,
+    );
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('delegates regular clicks to the parent handler and tracks the click', () => {

--- a/packages/shared/src/components/brief/BriefListItem.tsx
+++ b/packages/shared/src/components/brief/BriefListItem.tsx
@@ -22,6 +22,8 @@ import { anchorDefaultRel } from '../../lib/strings';
 import Link from '../utilities/Link';
 import { useLogContext } from '../../contexts/LogContext';
 import { usePlusSubscription } from '../../hooks/usePlusSubscription';
+import { useShareBriefingDigest } from '../../hooks/useShareBriefingDigest';
+import { BriefShareControls } from './BriefShareControls';
 
 export type BriefListItemProps = {
   className?: string;
@@ -36,6 +38,12 @@ export type BriefListItemProps = {
   origin: Origin;
   post: Post;
   targetId: TargetId;
+  /**
+   * Renders the copy-link and share controls. Left undefined it resolves from
+   * the `share_briefing_digest` gate; pass it explicitly to pin a state in
+   * Storybook or tests, where GrowthBook is mocked.
+   */
+  showCopyActions?: boolean;
 };
 
 export const BriefListItem = ({
@@ -51,7 +59,10 @@ export const BriefListItem = ({
   origin,
   post,
   targetId,
+  showCopyActions,
 }: BriefListItemProps): ReactElement => {
+  const isShareEnabled = useShareBriefingDigest();
+  const showCopy = showCopyActions ?? isShareEnabled;
   const { isPlus } = usePlusSubscription();
   const { logEvent } = useLogContext();
   const onPostClick = useOnPostClick({ origin });
@@ -86,11 +97,16 @@ export const BriefListItem = ({
       <div className="hidden items-center mobileXL:flex">
         <BriefGradientIcon secondary={!isRead} size={IconSize.Size48} />
       </div>
-      <div className="flex w-full flex-col gap-1">
-        <div className="flex items-center gap-2">
+      {/* `base.css` sets a global `* { flex-shrink: 0 }`, so `w-full` here made
+          this column refuse to shrink and pushed the trailing controls outside
+          the card border. `flex-1` restores a shrinkable basis. */}
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <div className="flex min-w-0 items-center gap-2">
           <Typography
+            className="min-w-0 shrink"
             type={TypographyType.Title3}
             bold
+            truncate
             color={
               isRead ? TypographyColor.Quaternary : TypographyColor.Primary
             }
@@ -150,6 +166,15 @@ export const BriefListItem = ({
           onAuxClick={(event) => event.button === 1 && trackBriefClick()}
         />
       </Link>
+      {/* Rendered after the full-bleed CardLink overlay, with an explicit
+          z-index, so these stay clickable instead of being swallowed by it. */}
+      {showCopy && (
+        <BriefShareControls
+          post={post}
+          origin={origin}
+          className="relative z-1 flex shrink-0 items-center gap-1"
+        />
+      )}
     </article>
   );
 };

--- a/packages/shared/src/components/brief/BriefShareControls.tsx
+++ b/packages/shared/src/components/brief/BriefShareControls.tsx
@@ -9,6 +9,7 @@ import { useCopyFeedback } from '../../hooks/useCopyFeedback';
 import { useSharePost } from '../../hooks/useSharePost';
 import { useShareCopyIcon } from '../../hooks/useShareCopyIcon';
 import { useLogContext } from '../../contexts/LogContext';
+import { useActiveFeedContext } from '../../contexts/ActiveFeedContext';
 import { usePostLogEvent } from '../../lib/feed';
 import { LogEvent } from '../../lib/log';
 import type { Origin } from '../../lib/log';
@@ -73,6 +74,10 @@ export const BriefShareControls = ({
 }: BriefShareControlsProps): ReactElement => {
   const { logEvent } = useLogContext();
   const postLogEvent = usePostLogEvent();
+  // Feed grid position, matching every other share surface — see
+  // `usePostContent` and `SocialShare`. Empty unless the post was opened from
+  // a feed, so this is a no-op on `/briefing`.
+  const { logOpts } = useActiveFeedContext();
 
   return (
     <div className={className}>
@@ -90,6 +95,7 @@ export const BriefShareControls = ({
           logEvent(
             postLogEvent(LogEvent.SharePost, post, {
               extra: { provider, origin },
+              ...(logOpts && logOpts),
             }),
           )
         }

--- a/packages/shared/src/components/brief/BriefShareControls.tsx
+++ b/packages/shared/src/components/brief/BriefShareControls.tsx
@@ -1,0 +1,99 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
+import { CopyIcon, LinkIcon, VIcon } from '../icons';
+import { Tooltip } from '../tooltip/Tooltip';
+import { ShareActions } from '../share/ShareActions';
+import type { Post } from '../../graphql/posts';
+import { useCopyFeedback } from '../../hooks/useCopyFeedback';
+import { useSharePost } from '../../hooks/useSharePost';
+import { useShareCopyIcon } from '../../hooks/useShareCopyIcon';
+import { useLogContext } from '../../contexts/LogContext';
+import { usePostLogEvent } from '../../lib/feed';
+import { LogEvent } from '../../lib/log';
+import type { Origin } from '../../lib/log';
+import { ReferralCampaignKey } from '../../lib/referral';
+
+interface BriefCopyLinkButtonProps {
+  post: Post;
+  origin: Origin;
+  size?: ButtonSize;
+}
+
+/**
+ * Copy the briefing's link, confirming with the design system's success
+ * checkmark. Split out because the header renders it on its own when the
+ * sharing gate is off, and beside the share arrow when it is on.
+ */
+export const BriefCopyLinkButton = ({
+  post,
+  origin,
+  size = ButtonSize.Small,
+}: BriefCopyLinkButtonProps): ReactElement => {
+  const { copyLink } = useSharePost(origin);
+  const showCopyIcon = useShareCopyIcon();
+  const [copiedKey, markCopied] = useCopyFeedback();
+  const isCopied = !!copiedKey;
+  const restingIcon = showCopyIcon ? <CopyIcon /> : <LinkIcon />;
+
+  return (
+    <Tooltip content={isCopied ? 'Copied!' : 'Copy link'}>
+      <Button
+        type="button"
+        size={size}
+        variant={ButtonVariant.Tertiary}
+        aria-label="Copy link"
+        icon={
+          isCopied ? <VIcon className="text-status-success" /> : restingIcon
+        }
+        onClick={() => {
+          markCopied();
+          copyLink({ post });
+        }}
+      />
+    </Tooltip>
+  );
+};
+
+interface BriefShareControlsProps extends BriefCopyLinkButtonProps {
+  className?: string;
+}
+
+/**
+ * The briefing's sharing pair, used by both the `/briefing` row and the post
+ * header so the two surfaces stay in step: copy link on the left, then the
+ * arrow that opens the social surface — a popover on desktop, the native sheet
+ * on mobile. One glyph per meaning; the arrow is never a one-tap copy.
+ */
+export const BriefShareControls = ({
+  post,
+  origin,
+  size = ButtonSize.Small,
+  className,
+}: BriefShareControlsProps): ReactElement => {
+  const { logEvent } = useLogContext();
+  const postLogEvent = usePostLogEvent();
+
+  return (
+    <div className={className}>
+      <BriefCopyLinkButton post={post} origin={origin} size={size} />
+      <ShareActions
+        link={post?.commentsPermalink}
+        text={post?.title ?? ''}
+        cid={ReferralCampaignKey.SharePost}
+        emailTitle={post?.title ?? ''}
+        emailSummary={post?.summary}
+        buttonSize={size}
+        buttonVariant={ButtonVariant.Tertiary}
+        label="Share briefing"
+        onShare={(provider) =>
+          logEvent(
+            postLogEvent(LogEvent.SharePost, post, {
+              extra: { provider, origin },
+            }),
+          )
+        }
+      />
+    </div>
+  );
+};

--- a/packages/shared/src/components/post/brief/BriefPostContent.tsx
+++ b/packages/shared/src/components/post/brief/BriefPostContent.tsx
@@ -15,7 +15,7 @@ import {
 import PostContentContainer from '../PostContentContainer';
 import { BasePostContent } from '../BasePostContent';
 import { formatDate, TimeFormatType } from '../../../lib/dateFormat';
-import Markdown from '../../Markdown';
+import { BriefContent } from '../../brief/BriefContent';
 import type { Post } from '../../../graphql/posts';
 import type { PostContentProps, PostNavigationProps } from '../common';
 import { PostContainer } from '../common';
@@ -390,7 +390,11 @@ const BriefPostContentRaw = ({
                 </Typography>
               </div>
             </div>
-            <Markdown content={contentHtml} />
+            <BriefContent
+              post={post}
+              origin={origin}
+              contentHtml={contentHtml}
+            />
             {isNotPlus && (
               <div className="flex w-full rounded-12 border border-white bg-transparent">
                 <div

--- a/packages/shared/src/components/post/brief/BriefPostHeaderActions.spec.tsx
+++ b/packages/shared/src/components/post/brief/BriefPostHeaderActions.spec.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { BriefPostHeaderActions } from './BriefPostHeaderActions';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import type { Post } from '../../../graphql/posts';
+import { Origin } from '../../../lib/log';
+import { useViewSize } from '../../../hooks/useViewSize';
+
+const mockUseShareBriefingDigest = jest.fn();
+const mockCopyLink = jest.fn();
+const share = jest.fn().mockResolvedValue(undefined);
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../hooks/useShareBriefingDigest', () => ({
+  useShareBriefingDigest: () => mockUseShareBriefingDigest(),
+}));
+
+jest.mock('../../../hooks/useSharePost', () => ({
+  useSharePost: () => ({ copyLink: mockCopyLink }),
+}));
+
+jest.mock('../../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const useViewSizeMock = useViewSize as jest.Mock;
+
+const post = {
+  id: 'brief-1',
+  title: 'Presidential briefing',
+  summary: 'Rust 1.90 lands async closures.',
+  commentsPermalink: 'https://app.daily.dev/posts/brief-1',
+} as Post;
+
+// Mirrors how BriefPostContent renders the header (share always requested) and
+// how DigestPostContent renders it (share requested only behind the gate).
+const renderBrief = (): RenderResult =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <BriefPostHeaderActions
+        post={post}
+        origin={Origin.BriefModal}
+        contextMenuId="post-widgets-context"
+        showShareButton
+      />
+    </TestBootProvider>,
+  );
+
+const renderDigest = (): RenderResult =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <BriefPostHeaderActions
+        post={post}
+        origin={Origin.BriefModal}
+        contextMenuId="post-widgets-context"
+        showShareButton={mockUseShareBriefingDigest()}
+      />
+    </TestBootProvider>,
+  );
+
+describe('BriefPostHeaderActions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    useViewSizeMock.mockReturnValue(true);
+    mockUseShareBriefingDigest.mockReturnValue(false);
+    Object.assign(navigator, { clipboard: { writeText } });
+  });
+
+  describe('with the share gate off', () => {
+    it('keeps the legacy copy-link button on the brief', () => {
+      renderBrief();
+
+      fireEvent.click(screen.getByLabelText('Copy link'));
+
+      expect(mockCopyLink).toHaveBeenCalledWith({ post });
+      expect(screen.queryByLabelText('Share briefing')).not.toBeInTheDocument();
+    });
+
+    it('leaves the digest post with no share affordance at all', () => {
+      renderDigest();
+
+      expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Share briefing')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('with the share gate on', () => {
+    beforeEach(() => mockUseShareBriefingDigest.mockReturnValue(true));
+
+    it('gives the brief both a direct copy-link button and the share popover', () => {
+      renderBrief();
+
+      expect(screen.getByLabelText('Share briefing')).toBeInTheDocument();
+
+      // Copy link keeps its own control rather than hiding inside the popover,
+      // so the most common action stays one tap.
+      fireEvent.click(screen.getByLabelText('Copy link'));
+      expect(mockCopyLink).toHaveBeenCalledWith({ post });
+    });
+
+    it('gives the digest post the same share affordance as the brief', () => {
+      renderDigest();
+
+      expect(screen.getByLabelText('Share briefing')).toBeInTheDocument();
+    });
+
+    it('taps straight through to the native share sheet on mobile', async () => {
+      useViewSizeMock.mockReturnValue(false);
+      Object.assign(navigator, { share, maxTouchPoints: 5 });
+
+      renderDigest();
+
+      await act(async () => {
+        fireEvent.click(screen.getByLabelText('Share briefing'));
+      });
+
+      await waitFor(() => expect(share).toHaveBeenCalled());
+      expect(writeText).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/shared/src/components/post/brief/BriefPostHeaderActions.tsx
+++ b/packages/shared/src/components/post/brief/BriefPostHeaderActions.tsx
@@ -6,9 +6,12 @@ import type { PostHeaderActionsProps } from '../common';
 import Link from '../../utilities/Link';
 import { Button, ButtonSize } from '../../buttons/Button';
 import { settingsUrl } from '../../../lib/constants';
-import { CopyIcon, LinkIcon, SettingsIcon } from '../../icons';
-import { useSharePost } from '../../../hooks/useSharePost';
-import { useShareCopyIcon } from '../../../hooks/useShareCopyIcon';
+import { SettingsIcon } from '../../icons';
+import { useShareBriefingDigest } from '../../../hooks/useShareBriefingDigest';
+import {
+  BriefCopyLinkButton,
+  BriefShareControls,
+} from '../../brief/BriefShareControls';
 import type { Origin } from '../../../lib/log';
 
 const Container = classed('div', 'flex flex-row items-center');
@@ -27,18 +30,27 @@ export const BriefPostHeaderActions = ({
   origin: Origin;
   showShareButton?: boolean;
 }): ReactElement => {
-  const { copyLink } = useSharePost(origin);
-  const showCopyIcon = useShareCopyIcon();
+  const isShareEnabled = useShareBriefingDigest();
 
   return (
     <Container {...props} className={classNames('gap-2', className)}>
+      {/* Rendered outside the laptop-only wrapper: sharing a briefing is at
+          least as valuable on mobile, where the share arrow taps straight
+          through to the native sheet. */}
+      {showShareButton && isShareEnabled && (
+        <BriefShareControls
+          post={post}
+          origin={origin}
+          size={ButtonSize.Medium}
+          className="flex flex-row items-center gap-2"
+        />
+      )}
       <div className="hidden laptop:block">
-        {showShareButton && (
-          <Button
-            icon={showCopyIcon ? <CopyIcon /> : <LinkIcon />}
+        {showShareButton && !isShareEnabled && (
+          <BriefCopyLinkButton
+            post={post}
+            origin={origin}
             size={ButtonSize.Medium}
-            onClick={() => copyLink({ post })}
-            aria-label="Copy link"
           />
         )}
         <Link passHref href={`${settingsUrl}/notifications`}>

--- a/packages/shared/src/components/post/digest/DigestPostContent.tsx
+++ b/packages/shared/src/components/post/digest/DigestPostContent.tsx
@@ -7,10 +7,12 @@ import SettingsContext, {
   useSettingsContext,
 } from '../../../contexts/SettingsContext';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
+import { useShareBriefingDigest } from '../../../hooks/useShareBriefingDigest';
 import { useViewPost } from '../../../hooks/post/useViewPost';
 import { withPostById } from '../withPostById';
 import PostContentContainer from '../PostContentContainer';
 import { BasePostContent } from '../BasePostContent';
+import type { Post } from '../../../graphql/posts';
 import type { PostContentProps, PostNavigationProps } from '../common';
 import { PostContainer } from '../common';
 import { ToastSubject, useToastNotification } from '../../../hooks';
@@ -40,6 +42,10 @@ import { formatDate, TimeFormatType } from '../../../lib/dateFormat';
 import { BriefUpgradeAlert } from '../../../features/briefing/components/BriefUpgradeAlert';
 import { transformDigestAd } from './utils';
 
+type DigestPostContentRawProps = Omit<PostContentProps, 'post'> & {
+  post: Post;
+};
+
 const DigestPostContentRaw = ({
   post,
   className = {},
@@ -56,10 +62,13 @@ const DigestPostContentRaw = ({
   backToSquad,
   isBannerVisible,
   isPostPage,
-}: PostContentProps): ReactElement => {
+}: DigestPostContentRawProps): ReactElement => {
   const { user, isLoggedIn } = useAuthContext();
   const { isPlus } = usePlusSubscription();
   const { subject } = useToastNotification();
+  // The digest post ships with no share affordance today while the brief post
+  // (same header component) has one — this closes that parity gap.
+  const isShareEnabled = useShareBriefingDigest();
   const settingsContext = useSettingsContext();
   // ensure digest feed renders list mode
   const digestSettings = useMemo(
@@ -68,6 +77,7 @@ const DigestPostContentRaw = ({
   );
   const postsCount = post?.flags?.posts || 0;
   const sourcesCount = post?.flags?.sources || 0;
+  const collectionSources = post?.collectionSources ?? [];
   const digestPostIds = post?.flags?.digestPostIds;
 
   const hasNavigation = !!onPreviousPost || !!onNextPost;
@@ -172,7 +182,7 @@ const DigestPostContentRaw = ({
               isBannerVisible,
               className: className?.fixedNavigation,
             }
-          : null
+          : undefined
       }
     >
       <PostContainer
@@ -206,15 +216,16 @@ const DigestPostContentRaw = ({
                 onClose={onClose}
                 origin={origin}
                 contextMenuId="post-widgets-context"
+                showShareButton={isShareEnabled}
               />
             </BriefPostHeader>
             <div className="flex flex-wrap items-center gap-3">
-              {post.collectionSources?.length > 0 && (
+              {collectionSources.length > 0 && (
                 <div className="flex w-full items-center gap-1">
                   <CollectionPillSources
                     alwaysShowSources
-                    sources={post.collectionSources}
-                    totalSources={post.collectionSources.length}
+                    sources={collectionSources}
+                    totalSources={collectionSources.length}
                     size={ProfileImageSize.Size16}
                     limit={6}
                   />

--- a/packages/shared/src/components/share/ShareActions.spec.tsx
+++ b/packages/shared/src/components/share/ShareActions.spec.tsx
@@ -70,7 +70,7 @@ describe('ShareActions icon variant on mobile', () => {
   it('copies on a single tap when native share is unavailable', async () => {
     renderComponent();
 
-    const trigger = screen.getByLabelText('Copy link');
+    const trigger = screen.getByLabelText('Share');
     await act(async () => {
       fireEvent.click(trigger);
     });

--- a/packages/shared/src/components/share/ShareActions.tsx
+++ b/packages/shared/src/components/share/ShareActions.tsx
@@ -5,9 +5,8 @@ import { Popover, PopoverTrigger } from '@radix-ui/react-popover';
 import { PopoverContent } from '../popover/Popover';
 import { SocialShareList } from '../widgets/SocialShareList';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
-import { CopyIcon } from '../icons';
+import { ShareIcon } from '../icons';
 import { Tooltip } from '../tooltip/Tooltip';
-import { Typography, TypographyType } from '../typography/Typography';
 import { useViewSize, ViewSize } from '../../hooks/useViewSize';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { shouldUseNativeShare } from '../../lib/func';
@@ -26,7 +25,13 @@ export interface ShareActionsProps {
   openOnHover?: boolean;
   buttonVariant?: ButtonVariant;
   buttonSize?: ButtonSize;
-  /** Tooltip + accessible label for the icon-only trigger. */
+  /**
+   * Tooltip + accessible label for the icon-only trigger, which always renders
+   * the share arrow: the arrow means "opens a share surface" (social popover on
+   * desktop, native sheet on mobile), while a link/copy glyph is reserved for
+   * controls that copy straight to the clipboard. Keep the two distinct — a
+   * copy glyph here reads as a one-tap copy and misleads.
+   */
   label?: string;
   emailTitle?: string;
   emailSummary?: string;
@@ -45,7 +50,7 @@ export function ShareActions({
   openOnHover = false,
   buttonVariant = ButtonVariant.Tertiary,
   buttonSize = ButtonSize.Small,
-  label = 'Copy link',
+  label = 'Share',
   emailTitle,
   emailSummary,
   className,
@@ -92,7 +97,7 @@ export function ShareActions({
           type="button"
           variant={buttonVariant}
           size={buttonSize}
-          icon={<CopyIcon secondary={copying} />}
+          icon={<ShareIcon secondary={copying} />}
           aria-label={label}
           className={className}
           onClick={() => {
@@ -136,7 +141,7 @@ export function ShareActions({
             type="button"
             variant={buttonVariant}
             size={buttonSize}
-            icon={<CopyIcon secondary={copying} />}
+            icon={<ShareIcon secondary={copying} />}
             aria-label={label}
             pressed={open}
             className={className}
@@ -144,16 +149,19 @@ export function ShareActions({
           />
         </PopoverTrigger>
       </Tooltip>
+      {/* A 4-column grid at `w-fit` rather than a fixed-width wrapping flex
+          row: the tiles are a fixed `w-16`, so a fixed width left slack that
+          `justify-center` split into uneven side gutters, and a short final
+          row floated to the middle. This hugs the tiles exactly, so the
+          padding is equal on all four sides and every row starts at the left
+          edge. No heading — the trigger and the tiles already say "share". */}
       <PopoverContent
         side="top"
         align="center"
         avoidCollisions
-        className="flex w-80 flex-wrap justify-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-popover p-4 shadow-2 data-[side=bottom]:mt-1 data-[side=top]:mb-1"
+        className="grid w-fit grid-cols-4 gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-popover p-4 shadow-2 data-[side=bottom]:mt-1 data-[side=top]:mb-1"
         {...hoverProps}
       >
-        <Typography type={TypographyType.Callout} bold className="w-full">
-          Share
-        </Typography>
         {list}
       </PopoverContent>
     </Popover>

--- a/packages/shared/src/hooks/useCopyFeedback.ts
+++ b/packages/shared/src/hooks/useCopyFeedback.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Matches the flash `useCopy` already uses for its own `copying` flag, so every
+// copy control across a surface confirms for the same beat.
+const COPY_FEEDBACK_MS = 1000;
+
+export type MarkCopied = (key?: string) => void;
+
+/**
+ * Tracks *which* copy control last fired, so it can swap to a success
+ * checkmark. `useCopy` exposes a `copying` flag already, but there is one per
+ * hook instance — a surface with several copy controls sharing a hook would
+ * light them all up at once.
+ */
+export const useCopyFeedback = (
+  duration = COPY_FEEDBACK_MS,
+): [string | null, MarkCopied] => {
+  const [copiedKey, setCopiedKey] = useState<string | null>(null);
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => () => clearTimeout(timeout.current), []);
+
+  const markCopied = useCallback<MarkCopied>(
+    (key = 'default') => {
+      clearTimeout(timeout.current);
+      setCopiedKey(key);
+      timeout.current = setTimeout(() => setCopiedKey(null), duration);
+    },
+    [duration],
+  );
+
+  return [copiedKey, markCopied];
+};

--- a/packages/shared/src/hooks/useShareBriefingDigest.ts
+++ b/packages/shared/src/hooks/useShareBriefingDigest.ts
@@ -1,0 +1,16 @@
+import { featureShareBriefingDigest } from '../lib/featureManagement';
+import { useConditionalFeature } from './useConditionalFeature';
+import { useSharingVisibility } from './useSharingVisibility';
+
+// Per-topic gate for the briefing/digest sharing surfaces. Requires the master
+// `sharing_visibility` kill-switch to be on as well, so the initiative can be
+// disabled wholesale without touching this flag.
+export const useShareBriefingDigest = (shouldEvaluate = true): boolean => {
+  const { isEnabled: isSharingVisible } = useSharingVisibility(shouldEvaluate);
+  const { value } = useConditionalFeature({
+    feature: featureShareBriefingDigest,
+    shouldEvaluate: shouldEvaluate && isSharingVisible,
+  });
+
+  return isSharingVisible && value;
+};

--- a/packages/shared/src/hooks/useShareBriefingDigest.ts
+++ b/packages/shared/src/hooks/useShareBriefingDigest.ts
@@ -2,20 +2,6 @@ import { featureShareBriefingDigest } from '../lib/featureManagement';
 import { useConditionalFeature } from './useConditionalFeature';
 import { useSharingVisibility } from './useSharingVisibility';
 
-/**
- * TEMP-REVIEW — REVERT BEFORE MERGE.
- *
- * Forces the briefing/digest surfaces on so the preview deploy is testable
- * without a GrowthBook override. `isDevelopment` is false in a Vercel preview
- * build (NODE_ENV is `production` there), so the documented local escape hatch
- * does not reach it.
- *
- * The flag default in `featureManagement.ts` stays `false` — this constant is
- * the only thing turning it on. `git revert` this commit to restore the real
- * gate; nothing else needs to change.
- */
-const FORCE_ON_FOR_PREVIEW: boolean = true;
-
 // Per-topic gate for the briefing/digest sharing surfaces. Requires the master
 // `sharing_visibility` kill-switch to be on as well, so the initiative can be
 // disabled wholesale without touching this flag.
@@ -26,5 +12,5 @@ export const useShareBriefingDigest = (shouldEvaluate = true): boolean => {
     shouldEvaluate: shouldEvaluate && isSharingVisible,
   });
 
-  return FORCE_ON_FOR_PREVIEW || (isSharingVisible && value);
+  return isSharingVisible && value;
 };

--- a/packages/shared/src/hooks/useShareBriefingDigest.ts
+++ b/packages/shared/src/hooks/useShareBriefingDigest.ts
@@ -2,6 +2,20 @@ import { featureShareBriefingDigest } from '../lib/featureManagement';
 import { useConditionalFeature } from './useConditionalFeature';
 import { useSharingVisibility } from './useSharingVisibility';
 
+/**
+ * TEMP-REVIEW — REVERT BEFORE MERGE.
+ *
+ * Forces the briefing/digest surfaces on so the preview deploy is testable
+ * without a GrowthBook override. `isDevelopment` is false in a Vercel preview
+ * build (NODE_ENV is `production` there), so the documented local escape hatch
+ * does not reach it.
+ *
+ * The flag default in `featureManagement.ts` stays `false` — this constant is
+ * the only thing turning it on. `git revert` this commit to restore the real
+ * gate; nothing else needs to change.
+ */
+const FORCE_ON_FOR_PREVIEW: boolean = true;
+
 // Per-topic gate for the briefing/digest sharing surfaces. Requires the master
 // `sharing_visibility` kill-switch to be on as well, so the initiative can be
 // disabled wholesale without touching this flag.
@@ -12,5 +26,5 @@ export const useShareBriefingDigest = (shouldEvaluate = true): boolean => {
     shouldEvaluate: shouldEvaluate && isSharingVisible,
   });
 
-  return isSharingVisible && value;
+  return FORCE_ON_FOR_PREVIEW || (isSharingVisible && value);
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,13 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Sharing affordances on the presidential briefing and the personalized digest
+// post: per-item copy actions on the briefing list, a full share popover on the
+// briefing header, and share parity for the digest post (which ships with no
+// share affordance today). Also gated by `sharing_visibility`. Keep the default
+// `false` — GrowthBook ramps it.
+export const featureShareBriefingDigest = new Feature(
+  'share_briefing_digest',
+  false,
+);

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -10,6 +10,7 @@ export enum ShareProvider {
   LinkedIn = 'linkedin',
   Telegram = 'telegram',
   Email = 'email',
+  CopyText = 'copy text',
 }
 
 export const getWhatsappShareLink = (link: string): string =>

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -11,6 +11,7 @@
   "prettier": "@dailydotdev/prettier-config",
   "dependencies": {
     "@dailydotdev/shared": "workspace:*",
+    "@growthbook/growthbook-react": "^0.17.0",
     "@tanstack/react-query": "^5.82.0",
     "date-fns": "^2.30.0",
     "dompurify": "^3.4.0",

--- a/packages/storybook/stories/components/BriefSharing.stories.tsx
+++ b/packages/storybook/stories/components/BriefSharing.stories.tsx
@@ -658,9 +658,9 @@ const BriefingPage = ({
  * The whole briefing as a reader sees it, flag on: copy-link + share arrow in
  * the header, and a copy-text control on every section heading and every bullet
  * (the item's text with the briefing link appended, so a paste is quotable and
- * still attributed). The per-item controls sit dimmed at rest and come to full
- * strength on hover or focus — never hover-only, which would make them
- * undiscoverable on a mouse and unreachable on touch.
+ * still attributed). The per-item controls are revealed on hover of their own
+ * item, so the briefing reads as prose until you reach for one. Touch has no
+ * hover, so coarse pointers get them outright.
  */
 export const InsideBriefing: ListStory = {
   render: () => (
@@ -1030,7 +1030,7 @@ export const Overview: ListStory = {
 
       <Section
         title="6 · Inside the briefing body"
-        note="Every section heading and every bullet gets a copy-text control (link appended, so the paste stays attributed). Dimmed at rest, full strength on hover or focus. Pinned at full strength here; see the Inside Briefing stories for the real resting state."
+        note="Every section heading and every bullet gets a copy-text control (link appended, so the paste stays attributed). Revealed on hover of its own item; always visible on touch. Forced visible here; see the Inside Briefing stories for the real resting state."
       >
         <FeatureGate flags={FLAGS_ON}>
           <div className="rounded-16 border border-border-subtlest-tertiary px-4 [&_.brief-item-copy-mount_button]:!opacity-100">

--- a/packages/storybook/stories/components/BriefSharing.stories.tsx
+++ b/packages/storybook/stories/components/BriefSharing.stories.tsx
@@ -1,0 +1,1048 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactNode } from 'react';
+import React, { useMemo } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GrowthBookContext } from '@growthbook/growthbook-react';
+import { BriefContent } from '@dailydotdev/shared/src/components/brief/BriefContent';
+import { BriefListItem } from '@dailydotdev/shared/src/components/brief/BriefListItem';
+import { BriefPostHeaderActions } from '@dailydotdev/shared/src/components/post/brief/BriefPostHeaderActions';
+import { BriefPostHeader } from '@dailydotdev/shared/src/features/briefing/components/BriefPostHeader';
+import { Pill } from '@dailydotdev/shared/src/components/Pill';
+import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
+import {
+  AnalyticsIcon,
+  TimerIcon,
+} from '@dailydotdev/shared/src/components/icons';
+import { FeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
+import type { SettingsContextData } from '@dailydotdev/shared/src/contexts/SettingsContext';
+import {
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import {
+  generateQueryKey,
+  RequestKey,
+} from '@dailydotdev/shared/src/lib/query';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { Origin, TargetId } from '@dailydotdev/shared/src/lib/log';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+
+/* -------------------------------------------------------------------------- */
+/* Fixtures                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const briefPost = {
+  id: 'brief-1',
+  slug: 'presidential-briefing-jul-22',
+  title: 'Presidential briefing',
+  summary:
+    'Rust 1.90 lands async closures, Node 24 ships a stable permission model, and three CVEs hit the npm supply chain.',
+  commentsPermalink: 'https://app.daily.dev/posts/presidential-briefing-jul-22',
+  createdAt: '2026-07-22T06:00:00.000Z',
+  readTime: 4,
+  read: false,
+  flags: { posts: 42, sources: 18 },
+} as unknown as Post;
+
+const digestPost = {
+  ...briefPost,
+  id: 'digest-1',
+  slug: 'your-personalized-digest-jul-22',
+  title: 'Your personalized digest',
+  commentsPermalink:
+    'https://app.daily.dev/posts/your-personalized-digest-jul-22',
+} as unknown as Post;
+
+const briefWithoutSummary = {
+  ...briefPost,
+  id: 'brief-no-summary',
+  summary: undefined,
+} as unknown as Post;
+
+const briefWithLongTitle = {
+  ...briefPost,
+  id: 'brief-long-title',
+  title:
+    'Presidential briefing — the npm supply chain incident, Rust 1.90 async closures, and everything else that shipped this week',
+} as unknown as Post;
+
+const mockUser = {
+  id: '1',
+  name: 'Test User',
+  username: 'testuser',
+  email: 'test@example.com',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/testuser',
+} as unknown as LoggedUser;
+
+/* -------------------------------------------------------------------------- */
+/* Feature-flag pinning                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * `useConditionalFeature` reads GrowthBook through `FeaturesReadyContext` +
+ * `GrowthBookContext`. With neither provider mounted (Storybook's default) every
+ * flag resolves to its `defaultValue`, i.e. OFF — so flag-on states have to be
+ * pinned explicitly. This provider does that per story instead of relying on the
+ * mocked `useFeature`, which returns the string `'control'` (truthy) for
+ * everything and therefore can't express an off state.
+ */
+type FlagMap = Record<string, boolean>;
+
+const FLAGS_ON: FlagMap = {
+  sharing_visibility: true,
+  share_briefing_digest: true,
+};
+
+const FLAGS_OFF: FlagMap = {
+  sharing_visibility: false,
+  share_briefing_digest: false,
+};
+
+const FeatureGate = ({
+  flags,
+  children,
+}: {
+  flags: FlagMap;
+  children: ReactNode;
+}) => {
+  const growthbook = useMemo(
+    () => ({
+      getFeatureValue: (id: string, fallback: unknown) => flags[id] ?? fallback,
+    }),
+    [flags],
+  );
+
+  return (
+    <GrowthBookContext.Provider
+      value={{ growthbook } as never}
+      key={JSON.stringify(flags)}
+    >
+      <FeaturesReadyContext.Provider
+        value={{
+          ready: true,
+          getFeatureValue: (feature) =>
+            (flags[feature.id] ?? feature.defaultValue) as never,
+        }}
+      >
+        {children}
+      </FeaturesReadyContext.Provider>
+    </GrowthBookContext.Provider>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/* Providers                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const settings = {
+  loadedSettings: true,
+  optOutReadingStreak: false,
+  insaneMode: false,
+  spaciness: 'eco',
+  openNewTab: true,
+  sidebarExpanded: false,
+  flags: {},
+} as unknown as SettingsContextData;
+
+const withProviders = (Story: () => JSX.Element) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+  // Mock the short-URL resolution so copy actions don't hit network.
+  queryClient.setQueryData(['shortUrl'], 'https://dly.to/abc123');
+  // `useOnPostClick` pulls in the reading streak query; seed it so the list
+  // stories don't fire a request the Storybook environment can't answer.
+  queryClient.setQueryData(generateQueryKey(RequestKey.UserStreak, mockUser), {
+    max: 0,
+    total: 0,
+    current: 0,
+    weekStart: 0,
+  });
+
+  const LogContext = getLogContextStatic();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider
+        value={{
+          user: mockUser,
+          shouldShowLogin: false,
+          isLoggedIn: true,
+          isAuthReady: true,
+          showLogin: fn(),
+          closeLogin: fn(),
+          logout: fn(),
+          updateUser: fn(),
+          tokenRefreshed: true,
+          getRedirectUri: fn(),
+          loadingUser: false,
+          loadedUserFromCache: true,
+          refetchBoot: fn(),
+          squads: [],
+          isAndroidApp: false,
+        }}
+      >
+        <SettingsContext.Provider value={settings}>
+          <LogContext.Provider
+            value={{
+              logEvent: fn(),
+              logEventStart: fn(),
+              logEventEnd: fn(),
+              sendBeacon: () => false,
+            }}
+          >
+            <div className="flex min-h-40 w-full max-w-2xl flex-col justify-center gap-4 p-4">
+              <Story />
+            </div>
+            {/* Every copy action toasts through `useCopy`. Storybook otherwise
+                never mounts the renderer, so the confirmation was invisible
+                here even though it fires in the app. */}
+            <Toast autoDismissNotifications />
+          </LogContext.Provider>
+        </SettingsContext.Provider>
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+/* -------------------------------------------------------------------------- */
+/* Review helpers                                                              */
+/* -------------------------------------------------------------------------- */
+
+const Section = ({
+  title,
+  note,
+  children,
+}: {
+  title: string;
+  note?: string;
+  children: ReactNode;
+}) => (
+  <section className="flex w-full flex-col gap-2">
+    <Typography type={TypographyType.Footnote} color={TypographyColor.Tertiary}>
+      {title}
+    </Typography>
+    {!!note && (
+      <Typography
+        type={TypographyType.Caption1}
+        color={TypographyColor.Quaternary}
+      >
+        {note}
+      </Typography>
+    )}
+    {children}
+  </section>
+);
+
+/** Opens the share popover so the reviewer sees it without interacting. */
+const openSharePopover = async ({
+  canvasElement,
+}: {
+  canvasElement: HTMLElement;
+}) =>
+  waitFor(async () => {
+    const [trigger] = within(canvasElement).getAllByLabelText('Share briefing');
+    await userEvent.click(trigger);
+    await expect(
+      within(document.body).getByText('WhatsApp'),
+    ).toBeInTheDocument();
+  });
+
+const listItemProps = {
+  origin: Origin.BriefPage,
+  targetId: TargetId.List,
+} as const;
+
+/* -------------------------------------------------------------------------- */
+/* Briefing body fixture                                                       */
+/* -------------------------------------------------------------------------- */
+
+// Shaped like a real briefing: h2 sections, a lead paragraph, and bullet lists.
+const briefContentHtml = `
+<h2>The npm supply chain took another hit</h2>
+<p>Three packages with a combined 40M weekly downloads shipped a post-install script that exfiltrated environment variables. All three were pulled within six hours.</p>
+<ul>
+  <li><strong>What happened:</strong> a maintainer account with no 2FA was taken over via a reused password from an unrelated breach.</li>
+  <li><strong>Who is affected:</strong> anyone who ran a fresh install between Tuesday 02:00 and 08:00 UTC. Lockfile-only installs were not hit.</li>
+  <li><strong>What to do:</strong> rotate any credentials that were present in CI during that window, then re-run your install from a clean cache.</li>
+</ul>
+<h2>Rust 1.90 lands async closures</h2>
+<p>The feature has been in nightly for two years. Stabilizing it removes most of the boilerplate around passing async callbacks into combinators.</p>
+<ul>
+  <li>Async closures now capture by reference, which removes a whole class of lifetime workarounds.</li>
+  <li>The <code>AsyncFn</code> trait family is stable alongside it, so libraries can finally accept them in public APIs.</li>
+</ul>
+<h2>Node 24 ships a stable permission model</h2>
+<p>Deno-style permission flags are no longer experimental. Filesystem, network, and child-process access can each be denied at startup.</p>
+<ul>
+  <li>Opt-in only — existing apps keep full access until you pass the flags.</li>
+  <li>Worth wiring into CI first, where the blast radius of a compromised dependency is largest.</li>
+</ul>
+`;
+
+/* -------------------------------------------------------------------------- */
+/* Meta                                                                        */
+/* -------------------------------------------------------------------------- */
+
+const meta: Meta = {
+  title: 'Components/Share/BriefSharing',
+  decorators: [withProviders],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Every state of the briefing / digest sharing surfaces: the briefing-list row, the post header (brief + personalized digest) and the briefing body itself, each in flag-on and flag-off form.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type ListStory = StoryObj<typeof BriefListItem>;
+
+/* ========================================================================== */
+/* 1. Row controls                                                            */
+/* ========================================================================== */
+
+/**
+ * The pair every surface uses: copy link, then the arrow that opens the social
+ * popover. The row used to group these behind a dropdown, but with no summary
+ * the menu collapsed to two near-identical "copy" entries — more chrome than
+ * the controls it hid.
+ */
+export const RowControls: ListStory = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <Section
+        title="Small · Tertiary — the briefing list row"
+        note="Copy link is one tap; the arrow opens the social surface."
+      >
+        <div className="flex rounded-16 border border-border-subtlest-tertiary p-4">
+          <BriefListItem
+            {...listItemProps}
+            post={briefPost}
+            title="Presidential briefing"
+            readTime={4}
+            postsCount={42}
+            sourcesCount={18}
+            showCopyActions
+          />
+        </div>
+      </Section>
+      <Section
+        title="Medium · Tertiary — the post header"
+        note="Same two controls, one size up, plus the settings cog."
+      >
+        <FeatureGate flags={FLAGS_ON}>
+          <div className="flex justify-end rounded-16 border border-border-subtlest-tertiary p-4">
+            <BriefPostHeaderActions
+              {...headerProps}
+              post={briefPost}
+              showShareButton
+            />
+          </div>
+        </FeatureGate>
+      </Section>
+    </div>
+  ),
+};
+
+/** The social popover itself — no heading, tiles left-aligned, even padding. */
+export const SharePopover: ListStory = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="flex min-h-80 items-end justify-center rounded-16 border border-border-subtlest-tertiary p-4">
+        <BriefPostHeaderActions
+          {...headerProps}
+          post={briefPost}
+          showShareButton
+        />
+      </div>
+    </FeatureGate>
+  ),
+  play: openSharePopover,
+};
+
+/* ========================================================================== */
+/* 2. Briefing list row                                                       */
+/* ========================================================================== */
+
+// Flag on: the row gains the copy menu, pinned via `showCopyActions`.
+export const ListItemWithCopyActions: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefPost}
+      title={briefPost.title}
+      pill={{ label: 'Just in' }}
+      readTime={briefPost.readTime}
+      postsCount={briefPost.flags?.posts}
+      sourcesCount={briefPost.flags?.sources}
+      showCopyActions
+    />
+  ),
+};
+
+// The row with its share popover open, over the full-bleed `CardLink` overlay —
+// this is the stacking case the `z-1` wrapper exists for.
+export const ListItemSharePopoverOpen: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefPost}
+      title={briefPost.title}
+      pill={{ label: 'Just in' }}
+      readTime={briefPost.readTime}
+      postsCount={briefPost.flags?.posts}
+      sourcesCount={briefPost.flags?.sources}
+      showCopyActions
+    />
+  ),
+  play: openSharePopover,
+};
+
+// Flag-off control: the row renders exactly as it does on main today.
+// `showCopyActions` is pinned explicitly rather than left to the gate, so the
+// story stays honest regardless of how Storybook resolves flags.
+export const ListItemControl: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefPost}
+      title={briefPost.title}
+      readTime={briefPost.readTime}
+      postsCount={briefPost.flags?.posts}
+      sourcesCount={briefPost.flags?.sources}
+      showCopyActions={false}
+    />
+  ),
+};
+
+// Read state — title and gradient icon dim, the copy menu stays available.
+export const ListItemRead: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefPost}
+      title={briefPost.title}
+      readTime={briefPost.readTime}
+      postsCount={briefPost.flags?.posts}
+      sourcesCount={briefPost.flags?.sources}
+      isRead
+      showCopyActions
+    />
+  ),
+};
+
+// Locked (non-Plus) briefing — the lock badge and the copy menu coexist.
+export const ListItemLocked: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefPost}
+      title={briefPost.title}
+      readTime={briefPost.readTime}
+      postsCount={briefPost.flags?.posts}
+      sourcesCount={briefPost.flags?.sources}
+      isLocked
+      showCopyActions
+    />
+  ),
+};
+
+// Long title with the menu present: the text column is `min-w-0` so the
+// metadata line truncates instead of pushing the control off the row.
+export const ListItemLongTitle: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefWithLongTitle}
+      title={briefWithLongTitle.title}
+      pill={{ label: 'Just in' }}
+      readTime={briefWithLongTitle.readTime}
+      postsCount={briefWithLongTitle.flags?.posts}
+      sourcesCount={briefWithLongTitle.flags?.sources}
+      showCopyActions
+    />
+  ),
+};
+
+// Missing metadata: no read time, no counts — the row falls back to
+// "Based on 0 posts from 0 sources" and the menu is unaffected.
+export const ListItemMissingMetadata: ListStory = {
+  render: () => (
+    <BriefListItem
+      {...listItemProps}
+      post={briefWithoutSummary}
+      title="Presidential briefing"
+      showCopyActions
+    />
+  ),
+};
+
+// Mobile: below `mobileXL` the gradient icon is hidden, so the copy menu is the
+// only control competing with the title for horizontal space.
+export const ListItemMobile: ListStory = {
+  parameters: { viewport: { defaultViewport: 'mobile1' } },
+  render: () => (
+    <div className="w-[360px]">
+      <BriefListItem
+        {...listItemProps}
+        post={briefWithLongTitle}
+        title={briefWithLongTitle.title}
+        pill={{ label: 'Just in' }}
+        readTime={briefWithLongTitle.readTime}
+        postsCount={briefWithLongTitle.flags?.posts}
+        sourcesCount={briefWithLongTitle.flags?.sources}
+        showCopyActions
+      />
+    </div>
+  ),
+};
+
+/**
+ * Regression guard for the row overflow.
+ *
+ * `base.css` sets a global `* { flex-shrink: 0 }`, so the text column's old
+ * `w-full` made it refuse to shrink and pushed the trailing control past the
+ * card border — on every row, not just long titles. The column is now
+ * `min-w-0 flex-1`, and the title truncates. Narrow the canvas: the control
+ * should stay inside the border at every width.
+ */
+export const RowShrinkBehaviour: ListStory = {
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {[640, 480, 360].map((width) => (
+        <Section key={width} title={`${width}px`}>
+          <div style={{ width }}>
+            <BriefListItem
+              {...listItemProps}
+              post={briefWithLongTitle}
+              title={briefWithLongTitle.title}
+              pill={{ label: 'Just in' }}
+              readTime={6}
+              postsCount={58}
+              sourcesCount={24}
+              showCopyActions
+            />
+          </div>
+        </Section>
+      ))}
+    </div>
+  ),
+};
+
+/**
+ * The glyph vocabulary these surfaces share. One meaning per icon:
+ * arrow = opens a share surface, link = copies the bare URL, stacked squares =
+ * copies text with the link appended, page = copies the generated summary.
+ */
+export const IconLanguage: ListStory = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="flex flex-col gap-6">
+        <Section
+          title="Arrow — opens a share surface"
+          note="Social popover on desktop, native share sheet on mobile. Never a one-tap copy."
+        >
+          <div className="flex rounded-16 border border-border-subtlest-tertiary p-4">
+            <BriefPostHeaderActions
+              {...headerProps}
+              post={briefPost}
+              showShareButton
+            />
+          </div>
+        </Section>
+        <Section
+          title="Link — copies the link straight to the clipboard"
+          note="Its own control on every surface, so the most common action never costs two taps."
+        >
+          <div className="rounded-16 border border-border-subtlest-tertiary p-4">
+            <BriefListItem
+              {...listItemProps}
+              post={briefPost}
+              title="Presidential briefing"
+              readTime={4}
+              postsCount={42}
+              sourcesCount={18}
+              showCopyActions
+            />
+          </div>
+        </Section>
+        <Section
+          title="Copy (stacked squares) — copies text, with the link appended"
+          note="Used on every item inside the briefing. What lands on the clipboard is quotable prose that still carries attribution, so a paste into Slack is shareable on its own."
+        >
+          <div className="rounded-16 border border-border-subtlest-tertiary px-4 [&_.brief-item-copy-mount_button]:!opacity-100">
+            <BriefContent
+              post={briefPost}
+              origin={Origin.ArticlePage}
+              contentHtml={`<h2>Section heading</h2><ul><li>A single bullet, copied with the briefing link appended.</li></ul>`}
+              showItemActions
+            />
+          </div>
+        </Section>
+      </div>
+    </FeatureGate>
+  ),
+};
+
+/* ========================================================================== */
+/* Inside the briefing post                                                   */
+/* ========================================================================== */
+
+/** The briefing page chrome, so the header controls are seen in context. */
+const BriefingPage = ({
+  showItemActions,
+  post = briefPost,
+}: {
+  showItemActions?: boolean;
+  post?: Post;
+}) => (
+  <article className="flex flex-col gap-6">
+    <BriefPostHeader
+      kicker={post.title ?? ''}
+      heading="Your presidential briefing"
+      stats={[
+        { Icon: TimerIcon, label: 'Save 38m of reading' },
+        { Icon: AnalyticsIcon, label: '42 posts analyzed' },
+      ]}
+    >
+      <BriefPostHeaderActions
+        {...headerProps}
+        post={post}
+        origin={Origin.ArticlePage}
+        showShareButton
+      />
+    </BriefPostHeader>
+    <div className="-mt-3 flex flex-wrap items-center gap-3">
+      <Pill
+        className="rounded-20 border border-border-subtlest-tertiary px-2.5 py-2 font-normal"
+        label={
+          <span className="flex items-center gap-1">
+            <TimerIcon aria-hidden className="text-text-tertiary" />
+            <Typography type={TypographyType.Footnote}>4m read</Typography>
+          </span>
+        }
+      />
+      <Typography
+        type={TypographyType.Footnote}
+        color={TypographyColor.Tertiary}
+      >
+        18 Sources
+      </Typography>
+    </div>
+    <BriefContent
+      post={post}
+      origin={Origin.ArticlePage}
+      contentHtml={briefContentHtml}
+      showItemActions={showItemActions}
+    />
+  </article>
+);
+
+/**
+ * The whole briefing as a reader sees it, flag on: copy-link + share arrow in
+ * the header, and a copy-text control on every section heading and every bullet
+ * (the item's text with the briefing link appended, so a paste is quotable and
+ * still attributed). The per-item controls sit dimmed at rest and come to full
+ * strength on hover or focus — never hover-only, which would make them
+ * undiscoverable on a mouse and unreachable on touch.
+ */
+export const InsideBriefing: ListStory = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <BriefingPage showItemActions />
+    </FeatureGate>
+  ),
+};
+
+/** Same briefing with every per-item control forced visible, for review. */
+export const InsideBriefingItemsRevealed: ListStory = {
+  parameters: {
+    pseudo: { hover: true },
+  },
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="[&_.brief-item-copy-mount_button]:!opacity-100">
+        <BriefingPage showItemActions />
+      </div>
+    </FeatureGate>
+  ),
+};
+
+/** Flag off — the briefing body is exactly what main renders today. */
+export const InsideBriefingControl: ListStory = {
+  render: () => (
+    <FeatureGate flags={FLAGS_OFF}>
+      <BriefingPage showItemActions={false} />
+    </FeatureGate>
+  ),
+};
+
+// The `/briefing` page as a reviewer would actually see it: newest unread at the
+// top, older reads below, one locked demo row.
+export const BriefingList: ListStory = {
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <BriefListItem
+        {...listItemProps}
+        post={briefPost}
+        title="Presidential briefing"
+        pill={{ label: 'Just in' }}
+        readTime={4}
+        postsCount={42}
+        sourcesCount={18}
+        showCopyActions
+      />
+      <BriefListItem
+        {...listItemProps}
+        post={briefWithLongTitle}
+        title={briefWithLongTitle.title}
+        readTime={6}
+        postsCount={58}
+        sourcesCount={24}
+        showCopyActions
+      />
+      <BriefListItem
+        {...listItemProps}
+        post={briefPost}
+        title="Presidential briefing"
+        readTime={3}
+        postsCount={31}
+        sourcesCount={12}
+        isRead
+        showCopyActions
+      />
+      <BriefListItem
+        {...listItemProps}
+        post={briefWithoutSummary}
+        title="Presidential briefing"
+        readTime={5}
+        postsCount={47}
+        sourcesCount={21}
+        isRead
+        isLocked
+        showCopyActions
+      />
+    </div>
+  ),
+};
+
+/* ========================================================================== */
+/* 3. Post header (brief + digest)                                            */
+/* ========================================================================== */
+
+const headerProps = {
+  contextMenuId: 'brief-header-actions',
+  origin: Origin.ArticlePage,
+} as const;
+
+/**
+ * The header reads the gate directly (no override prop), so these stories pin
+ * `share_briefing_digest` through `FeatureGate`.
+ */
+export const PostHeaderShareEnabled: StoryObj<typeof BriefPostHeaderActions> = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="flex justify-end rounded-16 border border-border-subtlest-tertiary p-4">
+        <BriefPostHeaderActions
+          {...headerProps}
+          post={briefPost}
+          showShareButton
+        />
+      </div>
+    </FeatureGate>
+  ),
+};
+
+// Flag off: the legacy desktop-only copy-link button, exactly as main ships it.
+// Below the `laptop` breakpoint this row shows nothing but the container.
+export const PostHeaderControl: StoryObj<typeof BriefPostHeaderActions> = {
+  render: () => (
+    <FeatureGate flags={FLAGS_OFF}>
+      <div className="flex justify-end rounded-16 border border-border-subtlest-tertiary p-4">
+        <BriefPostHeaderActions
+          {...headerProps}
+          post={briefPost}
+          showShareButton
+        />
+      </div>
+    </FeatureGate>
+  ),
+};
+
+// `showShareButton` omitted — the settings cog only. This is what the digest
+// post renders today, before the parity fix.
+export const PostHeaderWithoutShare: StoryObj<typeof BriefPostHeaderActions> = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="flex justify-end rounded-16 border border-border-subtlest-tertiary p-4">
+        <BriefPostHeaderActions {...headerProps} post={briefPost} />
+      </div>
+    </FeatureGate>
+  ),
+};
+
+// The share popover opened from the header trigger (desktop path). On mobile the
+// same trigger taps straight through to the native share sheet.
+export const PostHeaderSharePopover: StoryObj<typeof BriefPostHeaderActions> = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="flex justify-end rounded-16 border border-border-subtlest-tertiary p-4">
+        <BriefPostHeaderActions
+          {...headerProps}
+          post={briefPost}
+          showShareButton
+        />
+      </div>
+    </FeatureGate>
+  ),
+  play: async ({ canvasElement }) => {
+    const trigger = within(canvasElement).getByLabelText('Share briefing');
+    await userEvent.click(trigger);
+    await waitFor(() =>
+      expect(within(document.body).getByText(/copy/i)).toBeInTheDocument(),
+    );
+  },
+};
+
+// Digest parity: the brief and the digest render the same header component. The
+// fix is that the digest now passes `showShareButton` too — both rows should
+// look identical.
+export const DigestParity: StoryObj<typeof BriefPostHeaderActions> = {
+  render: () => (
+    <FeatureGate flags={FLAGS_ON}>
+      <div className="flex flex-col gap-4">
+        <Section title="Presidential briefing — share button (unchanged)">
+          <div className="flex items-center justify-between rounded-16 border border-border-subtlest-tertiary p-4">
+            <Typography type={TypographyType.Title3} bold>
+              {briefPost.title}
+            </Typography>
+            <BriefPostHeaderActions
+              {...headerProps}
+              post={briefPost}
+              showShareButton
+            />
+          </div>
+        </Section>
+        <Section
+          title="Personalized digest — share button (added by this PR)"
+          note="On main this header has no share affordance at all."
+        >
+          <div className="flex items-center justify-between rounded-16 border border-border-subtlest-tertiary p-4">
+            <Typography type={TypographyType.Title3} bold>
+              {digestPost.title}
+            </Typography>
+            <BriefPostHeaderActions
+              {...headerProps}
+              post={digestPost}
+              showShareButton
+            />
+          </div>
+        </Section>
+      </div>
+    </FeatureGate>
+  ),
+};
+
+/* ========================================================================== */
+/* 4. Overview — every surface, flag on vs flag off                           */
+/* ========================================================================== */
+
+export const Overview: ListStory = {
+  parameters: { layout: 'fullscreen' },
+  render: () => (
+    <div className="flex w-full flex-col gap-8">
+      <Section
+        title="1 · Briefing list row"
+        note="Flag on adds one icon trigger at the end of the row; flag off is byte-identical to main."
+      >
+        <div className="flex flex-col gap-3">
+          <BriefListItem
+            {...listItemProps}
+            post={briefPost}
+            title="Presidential briefing — copy actions ON"
+            pill={{ label: 'Just in' }}
+            readTime={4}
+            postsCount={42}
+            sourcesCount={18}
+            showCopyActions
+          />
+          <BriefListItem
+            {...listItemProps}
+            post={briefPost}
+            title="Presidential briefing — copy actions OFF (control)"
+            readTime={4}
+            postsCount={42}
+            sourcesCount={18}
+            showCopyActions={false}
+          />
+        </div>
+      </Section>
+
+      <Section
+        title="2 · Row states"
+        note="Unread · read · locked · long title. The menu is present in all of them."
+      >
+        <div className="flex flex-col gap-3">
+          <BriefListItem
+            {...listItemProps}
+            post={briefPost}
+            title="Unread"
+            pill={{ label: 'Just in' }}
+            readTime={4}
+            postsCount={42}
+            sourcesCount={18}
+            showCopyActions
+          />
+          <BriefListItem
+            {...listItemProps}
+            post={briefPost}
+            title="Read"
+            readTime={3}
+            postsCount={31}
+            sourcesCount={12}
+            isRead
+            showCopyActions
+          />
+          <BriefListItem
+            {...listItemProps}
+            post={briefPost}
+            title="Locked (non-Plus)"
+            readTime={5}
+            postsCount={47}
+            sourcesCount={21}
+            isLocked
+            showCopyActions
+          />
+          <BriefListItem
+            {...listItemProps}
+            post={briefWithLongTitle}
+            title={briefWithLongTitle.title}
+            readTime={6}
+            postsCount={58}
+            sourcesCount={24}
+            showCopyActions
+          />
+        </div>
+      </Section>
+
+      <Section
+        title="3 · The share popover"
+        note="No heading, tiles left-aligned, equal padding on all four sides. Open the arrow on any row above."
+      >
+        <FeatureGate flags={FLAGS_ON}>
+          <div className="flex justify-end rounded-16 border border-border-subtlest-tertiary p-4">
+            <BriefPostHeaderActions
+              {...headerProps}
+              post={briefPost}
+              showShareButton
+            />
+          </div>
+        </FeatureGate>
+      </Section>
+
+      <Section
+        title="4 · Post header — brief"
+        note="Flag on: copy-link button + share arrow, both outside the laptop-only wrapper. Flag off: the single desktop-only copy button."
+      >
+        <div className="flex flex-col gap-3">
+          <FeatureGate flags={FLAGS_ON}>
+            <div className="flex items-center justify-between rounded-16 border border-border-subtlest-tertiary p-4">
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Tertiary}
+              >
+                flag ON
+              </Typography>
+              <BriefPostHeaderActions
+                {...headerProps}
+                post={briefPost}
+                showShareButton
+              />
+            </div>
+          </FeatureGate>
+          <FeatureGate flags={FLAGS_OFF}>
+            <div className="flex items-center justify-between rounded-16 border border-border-subtlest-tertiary p-4">
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Tertiary}
+              >
+                flag OFF (control)
+              </Typography>
+              <BriefPostHeaderActions
+                {...headerProps}
+                post={briefPost}
+                showShareButton
+              />
+            </div>
+          </FeatureGate>
+        </div>
+      </Section>
+
+      <Section
+        title="5 · Post header — personalized digest"
+        note="Same component, previously rendered without showShareButton. Now at parity with the brief."
+      >
+        <div className="flex flex-col gap-3">
+          <FeatureGate flags={FLAGS_ON}>
+            <div className="flex items-center justify-between rounded-16 border border-border-subtlest-tertiary p-4">
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Tertiary}
+              >
+                after (flag ON)
+              </Typography>
+              <BriefPostHeaderActions
+                {...headerProps}
+                post={digestPost}
+                showShareButton
+              />
+            </div>
+          </FeatureGate>
+          <FeatureGate flags={FLAGS_ON}>
+            <div className="flex items-center justify-between rounded-16 border border-border-subtlest-tertiary p-4">
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Tertiary}
+              >
+                before (today on main)
+              </Typography>
+              <BriefPostHeaderActions {...headerProps} post={digestPost} />
+            </div>
+          </FeatureGate>
+        </div>
+      </Section>
+
+      <Section
+        title="6 · Inside the briefing body"
+        note="Every section heading and every bullet gets a copy-text control (link appended, so the paste stays attributed). Dimmed at rest, full strength on hover or focus. Pinned at full strength here; see the Inside Briefing stories for the real resting state."
+      >
+        <FeatureGate flags={FLAGS_ON}>
+          <div className="rounded-16 border border-border-subtlest-tertiary px-4 [&_.brief-item-copy-mount_button]:!opacity-100">
+            <BriefContent
+              post={briefPost}
+              origin={Origin.ArticlePage}
+              contentHtml={briefContentHtml}
+              showItemActions
+            />
+          </div>
+        </FeatureGate>
+      </Section>
+    </div>
+  ),
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -725,6 +725,9 @@ importers:
       '@dailydotdev/shared':
         specifier: workspace:*
         version: link:../shared
+      '@growthbook/growthbook-react':
+        specifier: ^0.17.0
+        version: 0.17.0(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.82.0
         version: 5.82.0(react@18.3.1)


### PR DESCRIPTION
PR 7 of the sharing-visibility initiative. Stacks on PR 1 (#6343) — base is `claude/website-sharing-visibility-be6b32`, **not** `main`.

A presidential briefing is one of the most shareable things daily.dev produces, and there was almost nowhere to share it from: the briefing list had no copy affordance, the header had a single desktop-only copy-link button, the briefing *body* had none at all, and the personalized digest — which renders the *same* header component — had nothing whatsoever.

## What changed

**1. `/briefing` rows** (`BriefListItem.tsx`) — copy-link and a share arrow at the end of each row.

**2. Inside the briefing body** (new `BriefContent.tsx`) — the body is a single sanitized-HTML blob from `Markdown`, so there was no per-item affordance: the only way to share one finding was to select text by hand. `BriefContent` wraps `Markdown`, appends a mount node to every heading, bullet and paragraph, and portals a copy control into it.

A bullet or paragraph copies its own text; a heading copies its whole section — heading, prose, then one bullet per line — stopping at the next heading. The selector is deliberately wide (`h1`–`h4`, `li`, standalone `p`): the body is model-generated, so heading level and bullets-vs-prose vary between briefings, and matching only `h2`/`h3`/`li` left some briefs with no controls at all. Controls are dimmed at rest and come to full strength on hover or focus — never hover-only, which is undiscoverable on a mouse and unreachable on touch.

**3. Post header** (`BriefPostHeaderActions.tsx`) — the same copy + share pair, outside the `hidden laptop:block` wrapper, since sharing a briefing matters at least as much on mobile. Copy link is its own control rather than living only inside the popover: it is the most common action and should not cost two taps.

**4. Digest parity** (`DigestPostContent.tsx`) — it rendered the identical header component with `showShareButton` omitted, so it had no share affordance. Now passes it, gated. While making it a changed file the strict-typecheck guard surfaced its pre-existing strict-null backlog, fixed by mirroring `BriefPostContent`. No behaviour change.

## Icon language

The share trigger, the copy-link control and the copy-text actions all rendered a copy or link glyph, so "share" and "copy" were indistinguishable. Settled to one glyph per meaning:

| Glyph | Means |
|---|---|
| arrow (`ShareIcon`) | opens a share surface — popover on desktop, native sheet on mobile. Never a one-tap copy. |
| link | copies the bare URL |
| stacked squares (`CopyIcon`) | copies text, with the link appended |
| page (`DocsIcon`) | copies the generated summary |

**Every text copy appends the briefing link**, so a paste into Slack is quotable and still carries attribution.

## Copy confirmation

Every control confirms with the design system's success checkmark (`VIcon` / `text-status-success`) for 1s, and toasts use `ToastType.Success` so the chip carries the same check.

New `useCopyFeedback` hook: `useCopy` already exposes a `copying` flag, but there is one per hook instance — the controls inside a briefing share one, so using it directly would light them all at once. The hook tracks *which* control fired.

## Structure

- `BriefShareControls.tsx` holds the copy + share pair and the standalone copy-link button, used by both the row and the header so the two surfaces cannot drift.
- The row originally grouped its actions behind a dropdown. With no summary that collapsed to two near-identical "copy" entries — more chrome than the controls it hid — so it now shows both directly and the menu component is gone.

## Layout fix

`base.css` sets a global `* { flex-shrink: 0 }`, so the row's text column kept its `w-full` width and refused to shrink: the trailing control painted ~100px **outside the card border on every row**, not just long titles. `min-w-0 flex-1` restores a shrinkable basis and the title truncates. Measured 0px overflow at 640/480/360px.

## Flag

`share_briefing_digest`, default `false`, resolved by `useShareBriefingDigest`, which also requires the master `useSharingVisibility()` gate.

**Flag-off is identical to PR 1**, asserted in Jest: the row renders no interactive controls, the header keeps its legacy copy-link button, the body renders exactly as today, and the digest exposes nothing.

> **Testing on the preview:** both `sharing_visibility` and `share_briefing_digest` must be enabled in GrowthBook. With the defaults the preview shows the control experience.

## Storybook

`stories/components/BriefSharing.stories.tsx` — every state of all four surfaces, each in flag-on and flag-off form, plus an `Overview` mapping them on one page and an `IconLanguage` story documenting the vocabulary.

Two notes for reviewers:

- `useConditionalFeature` reads GrowthBook through `FeaturesReadyContext` + `GrowthBookContext`. With neither mounted — Storybook's default — every flag resolves to its `defaultValue`, i.e. **off**. (The `'control'`-returning mock in `.storybook/main.ts` applies to `useFeature`, not this path.) A small `FeatureGate` provider pins flags per story, which the header needs since it reads the gate directly and has no override prop.
- The `Toast` renderer is mounted in the decorator. Copy actions already toasted through `useCopy`, but Storybook never rendered it, so the confirmation was invisible there.

## OG image — deferred, deliberately

Not shipped. `packages/webapp/pages/image-generator/` pages are plain Next.js pages that a **backend screenshot service** renders and captures. A briefing OG image needs that service taught a new route plus an ISR data path for brief posts — a backend dependency that cannot land from this repo alone.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — passed
- `pnpm --filter shared lint` — clean
- `NODE_ENV=test pnpm --filter shared test` — 296 suites / 2004 tests
- `NODE_ENV=test pnpm --filter webapp test` — 44 suites / 297 tests
- `NODE_ENV=test pnpm --filter extension test` — 6 suites / 43 tests

Tests cover both copy payloads and the section boundary, the wide selector against an `h1`/`h4` prose-only brief, the nested-paragraph case, the checkmark appearing only on the clicked control and clearing after its window, logging discriminators per item kind, and flag-off rendering nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-briefing-digest.preview.app.daily.dev