### PR TITLE
feat(share): share controls on Happening Now (page, topic, highlight)

### DIFF
--- a/packages/shared/src/components/highlights/DigestCTA.tsx
+++ b/packages/shared/src/components/highlights/DigestCTA.tsx
@@ -12,6 +12,7 @@ import SourceActionsNotify from '../sources/SourceActions/SourceActionsNotify';
 import Link from '../utilities/Link';
 import { HighlightShareButton } from './HighlightShareButton';
 import { ButtonSize } from '../buttons/Button';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 const CTA_HEIGHT = 'h-10';
 
@@ -86,9 +87,10 @@ const DigestCTAContent = ({
         <HighlightShareButton
           link={shareLink}
           text={`Follow ${displayName} news on daily.dev`}
-          label={`Copy link to ${displayName}`}
+          label={`Share ${displayName}`}
           level="topic"
           targetId={source.id ?? displayName}
+          cid={ReferralCampaignKey.Generic}
           buttonSize={ButtonSize.XSmall}
           className="ml-auto shrink-0"
         />

--- a/packages/shared/src/components/highlights/DigestCTA.tsx
+++ b/packages/shared/src/components/highlights/DigestCTA.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useCallback } from 'react';
+import classNames from 'classnames';
 import type { ChannelDigestConfiguration } from '../../graphql/highlights';
 import type { Source } from '../../graphql/sources';
 import { SourceType } from '../../graphql/sources';
@@ -9,6 +10,8 @@ import { useSourceActionsFollow } from '../../hooks/source/useSourceActionsFollo
 import { useSourceActionsNotify } from '../../hooks/source/useSourceActionsNotify';
 import SourceActionsNotify from '../sources/SourceActions/SourceActionsNotify';
 import Link from '../utilities/Link';
+import { HighlightShareButton } from './HighlightShareButton';
+import { ButtonSize } from '../buttons/Button';
 
 const CTA_HEIGHT = 'h-10';
 
@@ -22,6 +25,12 @@ const DigestCTASkeleton = (): ReactElement => (
 interface DigestCTAProps {
   digest: ChannelDigestConfiguration;
   displayName: string;
+  /**
+   * Absolute link to this channel's Happening Now tab. Only set when
+   * `share_happening_now` is on, so the control is gated on the prop and the
+   * flag-off DOM is untouched.
+   */
+  shareLink?: string;
 }
 
 interface DigestCTAContentProps extends DigestCTAProps {
@@ -31,6 +40,7 @@ interface DigestCTAContentProps extends DigestCTAProps {
 const DigestCTAContent = ({
   digest,
   displayName,
+  shareLink,
   source,
 }: DigestCTAContentProps): ReactElement => {
   const { isAuthReady, isLoggedIn } = useAuthContext();
@@ -61,7 +71,9 @@ const DigestCTAContent = ({
     <div
       className={`flex items-center gap-2 px-4 py-2 text-text-tertiary typo-callout ${CTA_HEIGHT}`}
     >
-      <span>
+      {/* The share control eats horizontal room, so the copy only gets the
+      shrink + ellipsis treatment when it is actually rendered. */}
+      <span className={classNames(shareLink && 'min-w-0 flex-1 truncate')}>
         Get a {digest.frequency} digest of{' '}
         <Link href={source.permalink}>
           <a className="font-bold text-text-primary hover:underline">
@@ -70,7 +82,18 @@ const DigestCTAContent = ({
         </Link>{' '}
         news
       </span>
-      <span className="ml-auto shrink-0">
+      {shareLink && (
+        <HighlightShareButton
+          link={shareLink}
+          text={`Follow ${displayName} news on daily.dev`}
+          label={`Copy link to ${displayName}`}
+          level="topic"
+          targetId={source.id ?? displayName}
+          buttonSize={ButtonSize.XSmall}
+          className="ml-auto shrink-0"
+        />
+      )}
+      <span className={classNames('shrink-0', !shareLink && 'ml-auto')}>
         <SourceActionsNotify
           haveNotificationsOn={haveNotificationsOn}
           onClick={(event) => {
@@ -87,6 +110,7 @@ const DigestCTAContent = ({
 export const DigestCTA = ({
   digest,
   displayName,
+  shareLink,
 }: DigestCTAProps): ReactElement | null => {
   const source = digest.source
     ? {
@@ -104,6 +128,7 @@ export const DigestCTA = ({
     <DigestCTAContent
       digest={digest}
       displayName={displayName}
+      shareLink={shareLink}
       source={source}
     />
   );

--- a/packages/shared/src/components/highlights/HighlightItem.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightItem.spec.tsx
@@ -22,7 +22,7 @@ jest.mock('../../hooks/useViewSize', () => {
 const useViewSizeMock = useViewSize as jest.Mock;
 const scrollIntoView = jest.fn();
 const summary = 'A concise summary for the expanded highlight item.';
-const SHARE_LABEL = 'Copy link to this highlight';
+const SHARE_LABEL = 'Share this highlight';
 
 const highlight: PostHighlightFeed = {
   id: 'highlight-1',

--- a/packages/shared/src/components/highlights/HighlightItem.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightItem.spec.tsx
@@ -1,10 +1,28 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import type { PostHighlightFeed } from '../../graphql/highlights';
 import { HighlightItem } from './HighlightItem';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { useViewSize } from '../../hooks/useViewSize';
+import type { ToastNotification } from '../../hooks/useToastNotification';
+import { TOAST_NOTIF_KEY } from '../../hooks/useToastNotification';
 
+jest.mock('../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const useViewSizeMock = useViewSize as jest.Mock;
 const scrollIntoView = jest.fn();
 const summary = 'A concise summary for the expanded highlight item.';
+const SHARE_LABEL = 'Copy link to this highlight';
 
 const highlight: PostHighlightFeed = {
   id: 'highlight-1',
@@ -27,7 +45,8 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
-  scrollIntoView.mockClear();
+  jest.clearAllMocks();
+  useViewSizeMock.mockReturnValue(true); // default: laptop
 });
 
 describe('HighlightItem', () => {
@@ -44,5 +63,81 @@ describe('HighlightItem', () => {
       '/posts/post-1',
     );
     expect(scrollIntoView).toHaveBeenCalled();
+  });
+});
+
+let client: QueryClient;
+
+const renderWithShare = (showShare: boolean) => {
+  client = new QueryClient();
+  return render(
+    <TestBootProvider client={client}>
+      <HighlightItem
+        highlight={highlight}
+        defaultExpanded
+        showShare={showShare}
+      />
+    </TestBootProvider>,
+  );
+};
+
+describe('HighlightItem share control', () => {
+  it('should not render a share control when the flag is off', () => {
+    renderWithShare(false);
+
+    expect(
+      screen.getByRole('link', { name: /read more/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByLabelText(SHARE_LABEL)).not.toBeInTheDocument();
+  });
+
+  it('should render exactly one share control per highlight when enabled', () => {
+    renderWithShare(true);
+
+    expect(screen.getAllByLabelText(SHARE_LABEL)).toHaveLength(1);
+    expect(
+      screen.getByRole('link', { name: /read more/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('should copy the post link and show a toast on desktop', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderWithShare(true);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(SHARE_LABEL));
+    });
+    await act(async () => {
+      fireEvent.click(await screen.findByText('Copy link'));
+    });
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith('/posts/post-1'),
+    );
+    await waitFor(() =>
+      expect(
+        client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY)?.message,
+      ).toEqual('✅ Copied link to clipboard'),
+    );
+  });
+
+  it('should open the native share sheet on a single tap on mobile', async () => {
+    useViewSizeMock.mockReturnValue(false);
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share, maxTouchPoints: 2 });
+
+    renderWithShare(true);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText(SHARE_LABEL));
+    });
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        text: `${highlight.headline}\n/posts/post-1`,
+      }),
+    );
   });
 });

--- a/packages/shared/src/components/highlights/HighlightItem.tsx
+++ b/packages/shared/src/components/highlights/HighlightItem.tsx
@@ -6,17 +6,23 @@ import { stripHtmlTags } from '../../lib/strings';
 import { PostType } from '../../graphql/posts';
 import { ArrowIcon } from '../icons/Arrow';
 import { IconSize } from '../Icon';
+import { ButtonSize } from '../buttons/Button';
 import Link from '../utilities/Link';
 import { RelativeTime } from '../utilities/RelativeTime';
+import { HighlightShareButton } from './HighlightShareButton';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 interface HighlightItemProps {
   highlight: PostHighlightFeed;
   defaultExpanded?: boolean;
+  /** Gated by `share_happening_now`; resolved once by `HighlightsPage`. */
+  showShare?: boolean;
 }
 
 export const HighlightItem = ({
   highlight,
   defaultExpanded = false,
+  showShare = false,
 }: HighlightItemProps): ReactElement => {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const ref = useRef<HTMLElement>(null);
@@ -52,6 +58,14 @@ export const HighlightItem = ({
     return '';
   }, [highlight.post]);
 
+  const readMore = (
+    <Link href={highlight.post.commentsPermalink}>
+      <a className="flex items-center gap-1 font-bold text-text-link typo-footnote hover:underline">
+        Read more
+      </a>
+    </Link>
+  );
+
   return (
     <article ref={ref}>
       <button
@@ -81,11 +95,22 @@ export const HighlightItem = ({
       {expanded && tldr && (
         <div className="flex flex-col gap-3 px-4 pb-3">
           <p className="text-text-secondary typo-markdown">{tldr}</p>
-          <Link href={highlight.post.commentsPermalink}>
-            <a className="flex items-center gap-1 font-bold text-text-link typo-footnote hover:underline">
-              Read more
-            </a>
-          </Link>
+          {showShare ? (
+            <div className="flex items-center gap-2">
+              {readMore}
+              <HighlightShareButton
+                link={highlight.post.commentsPermalink}
+                text={highlight.headline}
+                label="Copy link to this highlight"
+                level="highlight"
+                targetId={highlight.id}
+                cid={ReferralCampaignKey.SharePost}
+                buttonSize={ButtonSize.XSmall}
+              />
+            </div>
+          ) : (
+            readMore
+          )}
         </div>
       )}
     </article>

--- a/packages/shared/src/components/highlights/HighlightItem.tsx
+++ b/packages/shared/src/components/highlights/HighlightItem.tsx
@@ -101,7 +101,7 @@ export const HighlightItem = ({
               <HighlightShareButton
                 link={highlight.post.commentsPermalink}
                 text={highlight.headline}
-                label="Copy link to this highlight"
+                label="Share this highlight"
                 level="highlight"
                 targetId={highlight.id}
                 cid={ReferralCampaignKey.SharePost}

--- a/packages/shared/src/components/highlights/HighlightShareButton.tsx
+++ b/packages/shared/src/components/highlights/HighlightShareButton.tsx
@@ -1,0 +1,68 @@
+import type { ReactElement } from 'react';
+import React, { useCallback } from 'react';
+import { ShareActions } from '../share/ShareActions';
+import type { ButtonSize } from '../buttons/Button';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, Origin } from '../../lib/log';
+import type { ReferralCampaignKey } from '../../lib/referral';
+import type { ShareProvider } from '../../lib/share';
+
+// Which of the three Happening Now nesting levels the control belongs to. Kept
+// on the log payload so the levels can be compared without three log events.
+export type HighlightShareLevel = 'page' | 'topic' | 'highlight';
+
+export interface HighlightShareButtonProps {
+  link: string;
+  text: string;
+  label: string;
+  level: HighlightShareLevel;
+  targetId: string;
+  cid?: ReferralCampaignKey;
+  buttonSize?: ButtonSize;
+  className?: string;
+}
+
+// Thin logging wrapper around the shared `ShareActions` primitive so all three
+// Happening Now levels emit an identically shaped event. `LogEvent.ShareLog` is
+// the generic share event: a highlight is not a full `Post` here (the feed query
+// only returns id + permalink), so emitting `SharePost` would produce events
+// missing every standard post property.
+export const HighlightShareButton = ({
+  link,
+  text,
+  label,
+  level,
+  targetId,
+  cid,
+  buttonSize,
+  className,
+}: HighlightShareButtonProps): ReactElement => {
+  const { logEvent } = useLogContext();
+
+  const onShare = useCallback(
+    (provider: ShareProvider) => {
+      logEvent({
+        event_name: LogEvent.ShareLog,
+        target_id: targetId,
+        extra: JSON.stringify({
+          origin: Origin.HappeningNow,
+          provider,
+          level,
+        }),
+      });
+    },
+    [logEvent, targetId, level],
+  );
+
+  return (
+    <ShareActions
+      link={link}
+      text={text}
+      label={label}
+      cid={cid}
+      buttonSize={buttonSize}
+      className={className}
+      onShare={onShare}
+    />
+  );
+};

--- a/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import nock from 'nock';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { HighlightsPage } from './HighlightsPage';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { mockGraphQL } from '../../../__tests__/helpers/graphql';
+import {
+  HIGHLIGHTS_PAGE_QUERY,
+  MAJOR_HEADLINES_MAX_FIRST,
+  POST_HIGHLIGHTS_FEED_QUERY,
+} from '../../graphql/highlights';
+import {
+  featureSharingVisibility,
+  featureShareHappeningNow,
+} from '../../lib/featureManagement';
+
+const PAGE_SHARE_LABEL = 'Share Happening Now';
+const TOPIC_SHARE_LABEL = 'Copy link to AI agents';
+const ITEM_SHARE_LABEL = 'Copy link to this highlight';
+
+const summary = 'A concise summary for the expanded highlight item.';
+
+const highlightNode = (id: string) => ({
+  id,
+  channel: 'agents',
+  headline: `Headline ${id}`,
+  highlightedAt: '2026-04-05T09:00:00.000Z',
+  significance: 'major',
+  post: {
+    id: `post-${id}`,
+    type: 'article',
+    commentsPermalink: `/posts/post-${id}`,
+    summary,
+  },
+});
+
+const channelConfiguration = {
+  channel: 'agents',
+  displayName: 'AI agents',
+  digest: {
+    frequency: 'daily',
+    source: {
+      id: 'source-1',
+      name: 'AI agents',
+      image: 'https://daily.dev/image.jpg',
+      handle: 'ai-agents',
+      permalink: 'https://daily.dev/sources/ai-agents',
+    },
+  },
+};
+
+const mockPageQuery = () =>
+  mockGraphQL({
+    request: {
+      query: HIGHLIGHTS_PAGE_QUERY,
+      variables: { first: MAJOR_HEADLINES_MAX_FIRST },
+    },
+    result: {
+      data: {
+        majorHeadlines: {
+          pageInfo: { endCursor: null, hasNextPage: false },
+          edges: [{ node: highlightNode('h1') }],
+        },
+        channelConfigurations: [channelConfiguration],
+      },
+    },
+  });
+
+const mockChannelQuery = () =>
+  mockGraphQL({
+    request: {
+      query: POST_HIGHLIGHTS_FEED_QUERY,
+      variables: { channel: 'agents' },
+    },
+    result: {
+      data: { postHighlights: [highlightNode('h1'), highlightNode('h2')] },
+    },
+  });
+
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: jest.fn(),
+  });
+});
+
+const getGrowthBook = (enabled: boolean): GrowthBook => {
+  const gb = new GrowthBook();
+  gb.setFeatures({
+    [featureSharingVisibility.id]: { defaultValue: enabled },
+    [featureShareHappeningNow.id]: { defaultValue: enabled },
+  });
+
+  return gb;
+};
+
+const renderChannelTab = (enabled: boolean): RenderResult => {
+  (useRouter as jest.Mock).mockReturnValue({
+    query: { channel: 'agents', highlight: 'h1' },
+    pathname: '/highlights/[channel]',
+    push: jest.fn(),
+    asPath: '/highlights/agents',
+  } as unknown as NextRouter);
+
+  mockPageQuery();
+  mockChannelQuery();
+
+  return render(
+    <TestBootProvider
+      client={new QueryClient()}
+      gb={getGrowthBook(enabled)}
+      auth={{ isLoggedIn: false, user: undefined }}
+    >
+      <HighlightsPage />
+    </TestBootProvider>,
+  );
+};
+
+describe('HighlightsPage sharing', () => {
+  it('should render no share controls when the flag is off', async () => {
+    renderChannelTab(false);
+
+    expect(await screen.findByText(summary)).toBeInTheDocument();
+    expect(screen.queryByLabelText(PAGE_SHARE_LABEL)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(TOPIC_SHARE_LABEL)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(ITEM_SHARE_LABEL)).not.toBeInTheDocument();
+  });
+
+  it('should render exactly one control per level when enabled', async () => {
+    renderChannelTab(true);
+
+    // Only the route-expanded highlight exposes an item-level control, so the
+    // three levels never stack up into a row of share buttons.
+    expect(await screen.findByText(summary)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getAllByLabelText(PAGE_SHARE_LABEL)).toHaveLength(1),
+    );
+    expect(screen.getAllByLabelText(TOPIC_SHARE_LABEL)).toHaveLength(1);
+    expect(screen.getAllByLabelText(ITEM_SHARE_LABEL)).toHaveLength(1);
+  });
+});

--- a/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.spec.tsx
@@ -20,8 +20,8 @@ import {
 } from '../../lib/featureManagement';
 
 const PAGE_SHARE_LABEL = 'Share Happening Now';
-const TOPIC_SHARE_LABEL = 'Copy link to AI agents';
-const ITEM_SHARE_LABEL = 'Copy link to this highlight';
+const TOPIC_SHARE_LABEL = 'Share AI agents';
+const ITEM_SHARE_LABEL = 'Share this highlight';
 
 const summary = 'A concise summary for the expanded highlight item.';
 

--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -14,6 +14,12 @@ import {
 import { Tab, TabContainer } from '../tabs/TabContainer';
 import { DigestCTA } from './DigestCTA';
 import { HighlightItem } from './HighlightItem';
+import { HighlightShareButton } from './HighlightShareButton';
+import { useSharingVisibility } from '../../hooks/useSharingVisibility';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureShareHappeningNow } from '../../lib/featureManagement';
+import { webappUrl } from '../../lib/constants';
+import { ButtonSize } from '../buttons/Button';
 
 const MAJOR_HEADLINES_LABEL = 'Headlines';
 const ALL_HIGHLIGHTS_LABEL = 'All';
@@ -48,12 +54,14 @@ interface HighlightFeedListProps {
   highlights: PostHighlightFeed[];
   loading: boolean;
   expandedId?: string;
+  showShare?: boolean;
 }
 
 const HighlightFeedList = ({
   highlights,
   loading,
   expandedId,
+  showShare,
 }: HighlightFeedListProps): ReactElement => {
   if (loading) {
     return (
@@ -80,6 +88,7 @@ const HighlightFeedList = ({
           key={highlight.id}
           highlight={highlight}
           defaultExpanded={highlight.id === expandedId}
+          showShare={showShare}
         />
       ))}
     </div>
@@ -90,24 +99,29 @@ const MajorHeadlinesTab = ({
   highlights,
   loading,
   expandedId,
+  showShare,
 }: {
   highlights: PostHighlightFeed[];
   loading: boolean;
   expandedId?: string;
+  showShare?: boolean;
 }): ReactElement => (
   <HighlightFeedList
     highlights={highlights}
     loading={loading}
     expandedId={expandedId}
+    showShare={showShare}
   />
 );
 
 const ChannelTab = ({
   channel,
   expandedId,
+  showShare,
 }: {
   channel: ChannelConfiguration;
   expandedId?: string;
+  showShare?: boolean;
 }): ReactElement => {
   const { data, isFetching } = useChannelHighlights(channel.channel);
   const highlights = data?.postHighlights ?? [];
@@ -116,12 +130,19 @@ const ChannelTab = ({
   return (
     <>
       {channel.digest && (
-        <DigestCTA digest={channel.digest} displayName={channel.displayName} />
+        <DigestCTA
+          digest={channel.digest}
+          displayName={channel.displayName}
+          shareLink={
+            showShare ? `${webappUrl}highlights/${channel.channel}` : undefined
+          }
+        />
       )}
       <HighlightFeedList
         highlights={highlights}
         loading={loading}
         expandedId={expandedId}
+        showShare={showShare}
       />
     </>
   );
@@ -130,9 +151,11 @@ const ChannelTab = ({
 const AllHighlightsTab = ({
   active,
   expandedId,
+  showShare,
 }: {
   active: boolean;
   expandedId?: string;
+  showShare?: boolean;
 }): ReactElement => {
   const { data, isFetching } = useQuery({
     ...postHighlightsFeedQueryOptions(),
@@ -148,6 +171,7 @@ const AllHighlightsTab = ({
       highlights={highlights}
       loading={isFetching && !data}
       expandedId={expandedId}
+      showShare={showShare}
     />
   );
 };
@@ -171,12 +195,41 @@ export const HighlightsPage = (): ReactElement => {
     ? ALL_HIGHLIGHTS_LABEL
     : channelLabel ?? MAJOR_HEADLINES_LABEL;
 
+  // One flag evaluation for the whole surface: the per-topic and per-item
+  // controls receive the resolved boolean as a prop so nothing re-evaluates
+  // GrowthBook once per highlight row.
+  const { isEnabled: isSharingVisible } = useSharingVisibility();
+  const { value: isShareHappeningNowEnabled } = useConditionalFeature({
+    feature: featureShareHappeningNow,
+    shouldEvaluate: isSharingVisible,
+  });
+  const showShare = isSharingVisible && isShareHappeningNowEnabled;
+
+  const activePath = (() => {
+    if (isAllTab) {
+      return ALL_HIGHLIGHTS_URL;
+    }
+
+    return channel ? `${HIGHLIGHTS_BASE_URL}/${channel}` : HIGHLIGHTS_BASE_URL;
+  })();
+
   return (
     <main className="mx-auto flex w-full max-w-2xl flex-col pb-8 laptop:min-h-page laptop:border-x laptop:border-border-subtlest-tertiary">
       <header className="flex items-center px-3 py-4 laptop:px-4">
         <h1 className="feed-highlights-title-gradient font-bold typo-large-title">
           Happening Now
         </h1>
+        {showShare && (
+          <HighlightShareButton
+            link={`${webappUrl}${activePath.slice(1)}`}
+            text="See what's happening now in tech on daily.dev"
+            label="Share Happening Now"
+            level="page"
+            targetId={activeTab}
+            buttonSize={ButtonSize.Small}
+            className="ml-auto shrink-0"
+          />
+        )}
       </header>
       <TabContainer
         controlledActive={activeTab}
@@ -200,10 +253,15 @@ export const HighlightsPage = (): ReactElement => {
               highlights={majorHeadlines}
               loading={majorLoading}
               expandedId={expandedId}
+              showShare={showShare}
             />
           </Tab>,
           <Tab key="all" label={ALL_HIGHLIGHTS_LABEL} url={ALL_HIGHLIGHTS_URL}>
-            <AllHighlightsTab active={isAllTab} expandedId={expandedId} />
+            <AllHighlightsTab
+              active={isAllTab}
+              expandedId={expandedId}
+              showShare={showShare}
+            />
           </Tab>,
           ...channels.map((ch) => (
             <Tab
@@ -211,7 +269,11 @@ export const HighlightsPage = (): ReactElement => {
               label={ch.displayName}
               url={`${HIGHLIGHTS_BASE_URL}/${ch.channel}`}
             >
-              <ChannelTab channel={ch} expandedId={expandedId} />
+              <ChannelTab
+                channel={ch}
+                expandedId={expandedId}
+                showShare={showShare}
+              />
             </Tab>
           )),
         ]}

--- a/packages/shared/src/components/highlights/HighlightsPage.tsx
+++ b/packages/shared/src/components/highlights/HighlightsPage.tsx
@@ -20,6 +20,7 @@ import { useConditionalFeature } from '../../hooks/useConditionalFeature';
 import { featureShareHappeningNow } from '../../lib/featureManagement';
 import { webappUrl } from '../../lib/constants';
 import { ButtonSize } from '../buttons/Button';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 const MAJOR_HEADLINES_LABEL = 'Headlines';
 const ALL_HIGHLIGHTS_LABEL = 'All';
@@ -226,6 +227,7 @@ export const HighlightsPage = (): ReactElement => {
             label="Share Happening Now"
             level="page"
             targetId={activeTab}
+            cid={ReferralCampaignKey.Generic}
             buttonSize={ButtonSize.Small}
             className="ml-auto shrink-0"
           />

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,12 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Adds share/copy affordances to the Happening Now surface at three levels: the
+// whole page (header), a channel's digest CTA, and an individual expanded
+// highlight. Also gated by the `sharing_visibility` master switch. Keep the
+// default `false` — GrowthBook ramps it.
+export const featureShareHappeningNow = new Feature(
+  'share_happening_now',
+  false,
+);

--- a/packages/storybook/stories/components/HappeningNowShare.stories.tsx
+++ b/packages/storybook/stories/components/HappeningNowShare.stories.tsx
@@ -1,0 +1,208 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { DigestCTA } from '@dailydotdev/shared/src/components/highlights/DigestCTA';
+import { HighlightItem } from '@dailydotdev/shared/src/components/highlights/HighlightItem';
+import { HighlightShareButton } from '@dailydotdev/shared/src/components/highlights/HighlightShareButton';
+import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
+import type { PostHighlightFeed } from '@dailydotdev/shared/src/graphql/highlights';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { fn } from 'storybook/test';
+
+const CHANNEL_LINK = 'https://app.daily.dev/highlights/agents';
+const PAGE_LINK = 'https://app.daily.dev/highlights';
+
+const digest = {
+  frequency: 'daily',
+  source: {
+    id: 'source-1',
+    name: 'AI agents',
+    image: 'https://daily.dev/image.jpg',
+    handle: 'ai-agents',
+    permalink: 'https://app.daily.dev/sources/ai-agents',
+  },
+};
+
+const highlight: PostHighlightFeed = {
+  id: 'highlight-1',
+  channel: 'agents',
+  headline: 'Agent frameworks converge on a single tool-calling spec',
+  highlightedAt: new Date().toISOString(),
+  significance: 'major',
+  post: {
+    id: 'post-1',
+    type: 'article',
+    commentsPermalink: 'https://app.daily.dev/posts/post-1',
+    summary:
+      'The three biggest agent frameworks now emit the same tool-calling payload, which means adapters written for one runtime drop straight into the others.',
+  },
+};
+
+// The Happening Now header is part of `HighlightsPage`, which needs the router
+// and the highlights queries. The header row is reproduced here only so the
+// page-level control can be reviewed next to the other two levels.
+const PageHeader = (): React.ReactElement => (
+  <header className="flex items-center px-3 py-4 laptop:px-4">
+    <h1 className="font-bold text-text-primary typo-large-title">
+      Happening Now
+    </h1>
+    <HighlightShareButton
+      link={PAGE_LINK}
+      text="See what's happening now in tech on daily.dev"
+      label="Share Happening Now"
+      level="page"
+      targetId="Headlines"
+      buttonSize={ButtonSize.Small}
+      className="ml-auto shrink-0"
+    />
+  </header>
+);
+
+interface SurfaceProps {
+  showShare: boolean;
+}
+
+const HappeningNowSurface = ({
+  showShare,
+}: SurfaceProps): React.ReactElement => (
+  <div className="flex w-full flex-col border-x border-border-subtlest-tertiary">
+    {showShare ? (
+      <PageHeader />
+    ) : (
+      <header className="flex items-center px-3 py-4 laptop:px-4">
+        <h1 className="font-bold text-text-primary typo-large-title">
+          Happening Now
+        </h1>
+      </header>
+    )}
+    <DigestCTA
+      digest={digest}
+      displayName="AI agents"
+      shareLink={showShare ? CHANNEL_LINK : undefined}
+    />
+    <HighlightItem
+      highlight={highlight}
+      defaultExpanded
+      showShare={showShare}
+    />
+    <HighlightItem
+      highlight={{ ...highlight, id: 'highlight-2', headline: 'Second story' }}
+      showShare={showShare}
+    />
+  </div>
+);
+
+const meta: Meta<typeof HappeningNowSurface> = {
+  title: 'Components/Share/HappeningNow',
+  component: HappeningNowSurface,
+  args: { showShare: true },
+  argTypes: {
+    showShare: {
+      control: 'boolean',
+      description:
+        'Resolved value of `share_happening_now` (AND the `sharing_visibility` master switch). `HighlightsPage` evaluates it once and threads it down, so these stories take the resolved boolean directly — no GrowthBook mock is involved and the off state is a real control.',
+    },
+  },
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+      });
+      const LogContext = getLogContextStatic();
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <AuthContext.Provider
+            value={
+              {
+                user: null,
+                shouldShowLogin: false,
+                isLoggedIn: false,
+                isAuthReady: true,
+                showLogin: fn(),
+                closeLogin: fn(),
+                logout: fn(),
+                updateUser: fn(),
+                tokenRefreshed: true,
+                getRedirectUri: fn(),
+                loadingUser: false,
+                loadedUserFromCache: true,
+                refetchBoot: fn(),
+                squads: [],
+                isAndroidApp: false,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+              } as any
+            }
+          >
+            <LogContext.Provider
+              value={{
+                logEvent: fn(),
+                logEventStart: fn(),
+                logEventEnd: fn(),
+                sendBeacon: () => false,
+              }}
+            >
+              <div className="mx-auto flex w-full max-w-2xl">
+                <Story />
+              </div>
+            </LogContext.Provider>
+          </AuthContext.Provider>
+        </QueryClientProvider>
+      );
+    },
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HappeningNowSurface>;
+
+// All three levels at once — page header, channel digest CTA, expanded
+// highlight. Only the expanded highlight exposes an item-level control, so the
+// levels never pile up into a row of share buttons.
+export const AllLevels: Story = {
+  args: { showShare: true },
+};
+
+// True control: the same surface with the resolved flag off. Nothing about the
+// existing markup changes.
+export const FlagOff: Story = {
+  args: { showShare: false },
+};
+
+// Level 1 — the whole Happening Now page.
+export const PageLevel: Story = {
+  render: () => <PageHeader />,
+};
+
+// Level 2 — a single channel/topic, next to the digest subscribe control.
+export const TopicLevel: Story = {
+  render: () => (
+    <DigestCTA
+      digest={digest}
+      displayName="AI agents"
+      shareLink={CHANNEL_LINK}
+    />
+  ),
+};
+
+// Level 3 — a single highlight, next to "Read more".
+export const ItemLevel: Story = {
+  render: () => (
+    <HighlightItem highlight={highlight} defaultExpanded showShare />
+  ),
+};
+
+// `ShareActions` switches to a one-tap native share sheet below the laptop
+// breakpoint (it reads the real viewport via `useViewSize`), so narrow the
+// preview pane to exercise it. The frame below only previews the layout at
+// mobile width.
+export const MobileWidth: Story = {
+  args: { showShare: true },
+  render: (args) => (
+    <div className="w-[375px] border border-border-subtlest-tertiary">
+      <HappeningNowSurface {...args} />
+    </div>
+  ),
+};


### PR DESCRIPTION
Part of the sharing-visibility initiative. Builds on **PR 1** (`claude/website-sharing-visibility-be6b32`) — base this branch on it, not `main`.

## What changed

Three levels of share/copy on the Happening Now surface, all reusing the PR 1 `ShareActions` primitive:

| Level | Where | Control |
|---|---|---|
| **Page** | `HighlightsPage.tsx` header, right of the "Happening Now" title | `ShareActions` icon trigger, `aria-label="Share Happening Now"`. Link tracks the active tab (`/highlights`, `/highlights/all`, `/highlights/<channel>`). |
| **Topic** | `DigestCTA.tsx`, left of the digest notify button | Copy control, `aria-label="Copy link to <displayName>"`, links to that channel's tab. |
| **Highlight** | `HighlightItem.tsx`, next to "Read more" in the expanded body | Copy control, `aria-label="Copy link to this highlight"`, links to `post.commentsPermalink`. |

`commentsPermalink` was verified against the typed model: it is a required `string` on `PostHighlightFeed['post']` and is selected by `POST_HIGHLIGHT_FEED_FRAGMENT`. It's already used directly as a share href elsewhere (`ShareBar`).

New `HighlightShareButton.tsx` is a thin logging wrapper around `ShareActions` so all three levels emit an identically shaped event with `Origin.HappeningNow` (added by PR 1 — not duplicated) plus a `level` discriminator. It uses the generic `LogEvent.ShareLog`: a highlight is not a full `Post` here (the feed query returns only id + permalink), so `SharePost` would emit events missing every standard post property. **`lib/log.ts` is untouched.**

## Avoiding triple-rendering

The composition is:

```
HighlightsPage
├─ header  ......................... page-level control (1×, always)
└─ TabContainer  (shouldMountInactive = false → only the ACTIVE tab mounts)
   ├─ MajorHeadlinesTab → HighlightFeedList → HighlightItem[]
   ├─ AllHighlightsTab  → HighlightFeedList → HighlightItem[]
   └─ ChannelTab
      ├─ DigestCTA (only when channel.digest)  ... topic-level control (1×)
      └─ HighlightFeedList → HighlightItem[]
```

- `TabContainer` defaults to `shouldMountInactive: false` and `HighlightsPage` doesn't override it, so **only one tab subtree mounts** — never N `DigestCTA`s.
- `DigestCTA` is rendered from exactly one place (`ChannelTab`) and is not composed by `HighlightItem` or `HighlightFeedList`. Both `HighlightItem` and `DigestCTA` have no render sites outside `components/highlights/`.
- The item-level control only renders inside the **expanded** body, and only one highlight is expanded by default (the `?highlight=` route param), so the three levels do not stack into a row of share buttons. A test asserts exactly one control per level on a channel tab.

## Flag

`share_happening_now`, default `false`, appended at the very end of `featureManagement.ts`. Evaluated **once** in `HighlightsPage` via `useConditionalFeature` with `shouldEvaluate: useSharingVisibility().isEnabled`, then threaded down as a resolved `showShare` / `shareLink` prop — GrowthBook is not re-evaluated per highlight row, and `HighlightItem` stays provider-light.

Flag-off is byte-identical to the PR 1 branch: every new node is gated on the new prop, the `Read more` link and the digest notify `<span>` keep their original markup/classes, and the digest copy only gets `min-w-0 flex-1 truncate` when the share control is actually rendered.

## Storybook

`packages/storybook/stories/components/HappeningNowShare.stories.tsx` — `AllLevels`, `FlagOff`, `PageLevel`, `TopicLevel`, `ItemLevel`, `MobileWidth`. Because the components take a **resolved boolean prop** rather than reading the flag themselves, the known-broken `mock/gb.ts` (`value || 'control'` makes falsy flags read as truthy) is not in the path — the `FlagOff` story is a real control.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — pass
- `pnpm --filter shared lint` — pass (webapp untouched)
- `NODE_ENV=test pnpm --filter shared test` — 295 suites / 1991 tests pass
- `NODE_ENV=test pnpm --filter webapp test` — 44 suites / 297 tests pass

New tests assert: copy writes to the clipboard and pushes the `✅ Copied link to clipboard` toast; a single tap calls `navigator.share` on mobile; exactly one control renders per level with no duplication; and flag-off renders none of the three while keeping "Read more" intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-happening-now.preview.app.daily.dev