### PR TITLE
feat(share): surface a copy-link control on tag and source pages

### DIFF
--- a/packages/shared/src/components/CustomFeedOptionsMenu.tsx
+++ b/packages/shared/src/components/CustomFeedOptionsMenu.tsx
@@ -28,6 +28,8 @@ type CustomFeedOptionsMenuProps = {
   buttonVariant?: ButtonVariant;
   shareProps: UseShareOrCopyLinkProps;
   additionalOptions?: MenuItemProps[];
+  /** Drop the in-menu share entry when the surface renders a visible one. */
+  hideShare?: boolean;
 };
 
 const CustomFeedOptionsMenu = ({
@@ -38,13 +40,14 @@ const CustomFeedOptionsMenu = ({
   onCreateNewFeed,
   additionalOptions = [],
   buttonVariant = ButtonVariant.Float,
+  hideShare = false,
 }: CustomFeedOptionsMenuProps): ReactElement => {
   const { openModal } = useLazyModal();
   const [, onShareOrCopyLink] = useShareOrCopyLink(shareProps);
   const { feeds } = useFeeds();
 
   const handleOpenModal = () => {
-    if (feeds?.edges?.length > 0) {
+    if (feeds?.edges?.length) {
       return openModal({
         type: LazyModal.AddToCustomFeed,
         props: {
@@ -59,11 +62,15 @@ const CustomFeedOptionsMenu = ({
   };
 
   const options: MenuItemProps[] = [
-    {
-      icon: <MenuIcon Icon={ShareIcon} />,
-      label: 'Share',
-      action: () => onShareOrCopyLink(),
-    },
+    ...(hideShare
+      ? []
+      : [
+          {
+            icon: <MenuIcon Icon={ShareIcon} />,
+            label: 'Share',
+            action: () => onShareOrCopyLink(),
+          },
+        ]),
     {
       icon: <MenuIcon Icon={HashtagIcon} />,
       label: 'Add to custom feed',

--- a/packages/shared/src/components/share/EntityShareAction.spec.tsx
+++ b/packages/shared/src/components/share/EntityShareAction.spec.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import type { EntityShareActionProps } from './EntityShareAction';
+import { EntityShareAction } from './EntityShareAction';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+import { ReferralCampaignKey } from '../../lib/referral';
+import type { ToastNotification } from '../../hooks/useToastNotification';
+import { TOAST_NOTIF_KEY } from '../../hooks/useToastNotification';
+import { useViewSize } from '../../hooks/useViewSize';
+
+jest.mock('../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const useViewSizeMock = useViewSize as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+const logEvent = jest.fn();
+const link = 'https://daily.dev/tags/webdev';
+const text = 'Check out the webdev tag on daily.dev';
+
+let client: QueryClient;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  client = new QueryClient();
+  useViewSizeMock.mockReturnValue(true); // default: laptop
+  Object.assign(navigator, { clipboard: { writeText }, maxTouchPoints: 0 });
+});
+
+const renderComponent = (
+  display?: EntityShareActionProps['display'],
+): RenderResult =>
+  render(
+    <TestBootProvider client={client} log={{ logEvent }}>
+      <EntityShareAction
+        link={link}
+        text={text}
+        cid={ReferralCampaignKey.ShareTag}
+        event={LogEvent.ShareTag}
+        targetId="webdev"
+        origin={Origin.TagPage}
+        display={display}
+      />
+    </TestBootProvider>,
+  );
+
+const getToast = () =>
+  client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY) ?? null;
+
+/** The copy entry inside the share list, not the trigger that opens it. */
+const findListCopyEntry = () => screen.findByTestId('social-share-Copy link');
+
+describe('EntityShareAction', () => {
+  it('renders the split copy control by default', () => {
+    renderComponent();
+
+    expect(screen.getByLabelText('Copy link')).toBeInTheDocument();
+    expect(screen.getByLabelText('More share options')).toBeInTheDocument();
+  });
+
+  it('renders an unlabelled share trigger in the icon display', () => {
+    renderComponent('icon');
+
+    expect(screen.getByLabelText('Share')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+  });
+
+  it('copies the link straight from the label and shows the copied toast', async () => {
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(link));
+    await waitFor(() =>
+      expect(getToast()?.message).toEqual('✅ Copied link to clipboard'),
+    );
+    // The label copies on its own — the list only opens from the chevron.
+    expect(screen.queryByTestId('social-share-X')).not.toBeInTheDocument();
+  });
+
+  it('logs the entity share event with the provider and origin', async () => {
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy link'));
+    });
+
+    await waitFor(() =>
+      expect(logEvent).toHaveBeenCalledWith({
+        event_name: LogEvent.ShareTag,
+        target_id: 'webdev',
+        extra: JSON.stringify({
+          provider: ShareProvider.CopyLink,
+          origin: Origin.TagPage,
+        }),
+      }),
+    );
+  });
+
+  it('opens the share list from the chevron', async () => {
+    renderComponent();
+
+    // Radix's trigger opens on pointerdown/keydown, not click.
+    fireEvent.keyDown(screen.getByLabelText('More share options'), {
+      key: 'Enter',
+    });
+
+    expect(await screen.findByTestId('social-share-X')).toBeInTheDocument();
+    expect(await findListCopyEntry()).toBeInTheDocument();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('copies the link from the list entry too', async () => {
+    renderComponent();
+
+    fireEvent.keyDown(screen.getByLabelText('More share options'), {
+      key: 'Enter',
+    });
+    await act(async () => {
+      fireEvent.click(await findListCopyEntry());
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(link));
+  });
+
+  it('opens the native share sheet on a single tap on mobile', async () => {
+    useViewSizeMock.mockReturnValue(false);
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share, maxTouchPoints: 2 });
+
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy link'));
+    });
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({ text: `${text}\n${link}` }),
+    );
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/components/share/EntityShareAction.tsx
+++ b/packages/shared/src/components/share/EntityShareAction.tsx
@@ -1,0 +1,82 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { ShareActionsVariant } from './ShareActions';
+import { ShareActions } from './ShareActions';
+import { ButtonSize, ButtonVariant } from '../buttons/Button';
+import { Divider } from '../utilities/Divider';
+import { useLogContext } from '../../contexts/LogContext';
+import type { LogEvent, Origin } from '../../lib/log';
+import type { ReferralCampaignKey } from '../../lib/referral';
+import type { ShareProvider } from '../../lib/share';
+
+export interface EntityShareActionProps {
+  link: string;
+  text: string;
+  cid: ReferralCampaignKey;
+  /** Entity-specific share event, e.g. `LogEvent.ShareTag`. */
+  event: LogEvent;
+  targetId: string;
+  origin: Origin;
+  /**
+   * `split` (default) is the same labelled copy control the end-of-conversation
+   * band ships: the label copies, the chevron drops the share list. `icon` is
+   * the original icon-only trigger.
+   */
+  display?: Extract<ShareActionsVariant, 'icon' | 'split'>;
+}
+
+/**
+ * Share control for an entity header (tag / source), promoting share out of the
+ * "…" options menu. It reads as "Copy link" with a chevron: the primary intent
+ * is named and one click away, and the chevron says there is more than one way
+ * to share.
+ *
+ * Rendered as a fragment so the host action row's own gap does the spacing. The
+ * icon-only display keeps a leading vertical rule, which is what separates an
+ * unlabelled ghost icon from the filled Follow/Following button; the labelled
+ * control carries that separation in its own label and needs no rule.
+ */
+export function EntityShareAction({
+  link,
+  text,
+  cid,
+  event,
+  targetId,
+  origin,
+  display = 'split',
+}: EntityShareActionProps): ReactElement {
+  const { logEvent } = useLogContext();
+
+  const onShare = (provider: ShareProvider) =>
+    logEvent({
+      event_name: event,
+      target_id: targetId,
+      extra: JSON.stringify({ provider, origin }),
+    });
+
+  const isIcon = display === 'icon';
+
+  return (
+    <>
+      {isIcon && (
+        // `self-center` because host rows don't all set `items-center`.
+        <Divider vertical className="self-center" />
+      )}
+      <ShareActions
+        link={link}
+        text={text}
+        cid={cid}
+        variant={display}
+        label={isIcon ? 'Share' : 'Copy link'}
+        triggerText={isIcon ? undefined : 'Copy link'}
+        emailTitle={text}
+        emailSummary={text}
+        // Float matches the bell and the "…" button, so every secondary control
+        // in the host row reads as the same button.
+        buttonVariant={isIcon ? ButtonVariant.Tertiary : ButtonVariant.Float}
+        buttonSize={ButtonSize.Small}
+        onShare={onShare}
+      />
+    </>
+  );
+}

--- a/packages/shared/src/components/share/ShareActions.spec.tsx
+++ b/packages/shared/src/components/share/ShareActions.spec.tsx
@@ -10,7 +10,10 @@ import {
 import { QueryClient } from '@tanstack/react-query';
 import { ShareActions } from './ShareActions';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import defaultUser from '../../../__tests__/fixture/loggedUser';
+import { getShortLinkProps } from '../../hooks/utils/useGetShortUrl';
 import { ShareProvider } from '../../lib/share';
+import { ReferralCampaignKey } from '../../lib/referral';
 import { useViewSize } from '../../hooks/useViewSize';
 
 jest.mock('../../hooks/useViewSize', () => {
@@ -31,6 +34,8 @@ beforeEach(() => {
     clipboard: { writeText },
   });
 });
+
+const SHORT_LINK = 'https://dly.to/tagged';
 
 const renderComponent = (
   props: Partial<Parameters<typeof ShareActions>[0]> = {},
@@ -61,6 +66,46 @@ describe('ShareActions inline variant', () => {
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(link));
     expect(onShare).toHaveBeenCalledWith(ShareProvider.CopyLink);
+  });
+});
+
+describe('ShareActions social targets', () => {
+  it('tags the shared link with the campaign, like the copy path', async () => {
+    const open = jest.fn();
+    Object.assign(window, { open });
+
+    // `getShortUrl` keys its cache off the *tagged* url, so seeding that key
+    // and seeing the value come back proves the cid reached the social path.
+    // Without it the lookup misses and nothing resolves.
+    const client = new QueryClient();
+    const { queryKey } = getShortLinkProps(
+      link,
+      ReferralCampaignKey.ShareTag,
+      defaultUser,
+    );
+    client.setQueryData(queryKey, SHORT_LINK);
+
+    render(
+      <TestBootProvider
+        client={client}
+        auth={{ user: defaultUser, isAuthReady: true }}
+      >
+        <ShareActions
+          link={link}
+          text={text}
+          onShare={onShare}
+          variant="inline"
+          cid={ReferralCampaignKey.ShareTag}
+        />
+      </TestBootProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('social-share-X'));
+    });
+
+    await waitFor(() => expect(open).toHaveBeenCalled());
+    expect(open.mock.calls[0][0]).toContain(encodeURIComponent(SHORT_LINK));
   });
 });
 

--- a/packages/shared/src/components/share/ShareActions.tsx
+++ b/packages/shared/src/components/share/ShareActions.tsx
@@ -87,6 +87,9 @@ export function ShareActions({
     <SocialShareList
       link={link}
       description={text}
+      // The copy path tags the link through `useShareOrCopyLink`; the social
+      // targets need the same campaign or their traffic lands unattributed.
+      cid={cid}
       emailTitle={emailTitle}
       emailSummary={emailSummary}
       isCopying={copying}

--- a/packages/shared/src/components/sources/SourceActions/SourceActions.spec.tsx
+++ b/packages/shared/src/components/sources/SourceActions/SourceActions.spec.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { SourceActions } from './index';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import type { Source } from '../../../graphql/sources';
+import { SourceType } from '../../../graphql/sources';
+import { useSourceActions } from '../../../hooks';
+import { useContentPreference } from '../../../hooks/contentPreference/useContentPreference';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+jest.mock('../../../hooks/source/useSourceActions', () => ({
+  __esModule: true,
+  useSourceActions: jest.fn(),
+  default: jest.fn(),
+}));
+
+jest.mock('../../../hooks/contentPreference/useContentPreference', () => ({
+  useContentPreference: jest.fn(),
+}));
+
+const useSourceActionsMock = useSourceActions as jest.Mock;
+const useContentPreferenceMock = useContentPreference as jest.Mock;
+
+const source: Source = {
+  id: 'tds',
+  name: 'Towards Data Science',
+  handle: 'tds',
+  permalink: 'https://app.daily.dev/sources/tds',
+  image: 'https://media.daily.dev/tds',
+  type: SourceType.Machine,
+  public: true,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useSourceActionsMock.mockReturnValue({
+    isBlocked: false,
+    toggleBlock: jest.fn(),
+    isFollowing: false,
+    toggleFollow: jest.fn(),
+    haveNotificationsOn: false,
+    toggleNotify: jest.fn(),
+  });
+  useContentPreferenceMock.mockReturnValue({
+    follow: jest.fn(),
+    unfollow: jest.fn(),
+  });
+});
+
+const renderComponent = ({
+  showShare = true,
+  isFollowing = false,
+  isBlocked = false,
+} = {}): RenderResult => {
+  useSourceActionsMock.mockReturnValue({
+    isBlocked,
+    toggleBlock: jest.fn(),
+    isFollowing,
+    toggleFollow: jest.fn(),
+    haveNotificationsOn: false,
+    toggleNotify: jest.fn(),
+  });
+
+  return render(
+    <TestBootProvider client={new QueryClient()}>
+      <SourceActions source={source} {...(showShare && { showShare: true })} />
+    </TestBootProvider>,
+  );
+};
+
+// Radix's trigger opens on pointerdown/keydown, not click; keyboard also covers
+// the a11y requirement for the menu.
+const openOptionsMenu = () =>
+  fireEvent.keyDown(screen.getByLabelText('Options'), { key: 'Enter' });
+
+describe('SourceActions header treatment', () => {
+  it('surfaces the copy control next to Follow', async () => {
+    renderComponent();
+
+    expect(await screen.findByLabelText('Copy link')).toBeInTheDocument();
+    expect(screen.getAllByText('Follow').length).toBeGreaterThan(0);
+  });
+
+  it('keeps the control next to Following, alongside the bell', async () => {
+    renderComponent({ isFollowing: true });
+
+    expect(await screen.findByLabelText('Copy link')).toBeInTheDocument();
+    expect(screen.getAllByText('Following').length).toBeGreaterThan(0);
+    expect(screen.getByLabelText('Enable notifications')).toBeInTheDocument();
+  });
+
+  it('drops the in-menu share entry and moves Block into the menu', async () => {
+    renderComponent();
+
+    expect(screen.queryByTestId('blockButton')).not.toBeInTheDocument();
+
+    openOptionsMenu();
+
+    expect(await screen.findByText('Add to custom feed')).toBeInTheDocument();
+    expect(screen.getByText('Block')).toBeInTheDocument();
+    expect(screen.queryByText('Share')).not.toBeInTheDocument();
+  });
+
+  it('keeps Unblock in the row while blocked, and out of the menu', async () => {
+    renderComponent({ isBlocked: true });
+
+    expect(await screen.findByLabelText('Unblock')).toBeInTheDocument();
+
+    openOptionsMenu();
+
+    expect(await screen.findByText('Add to custom feed')).toBeInTheDocument();
+    expect(screen.queryByText('Block')).not.toBeInTheDocument();
+  });
+
+  it('leaves embedded consumers on the original row', async () => {
+    renderComponent({ showShare: false });
+
+    expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+    expect(screen.getByTestId('blockButton')).toBeInTheDocument();
+
+    openOptionsMenu();
+
+    expect(await screen.findByText('Share')).toBeInTheDocument();
+    expect(screen.getByText('Add to custom feed')).toBeInTheDocument();
+    // Block stays the row button it has always been, not a menu entry.
+    expect(screen.getAllByText('Block')).toHaveLength(1);
+  });
+});

--- a/packages/shared/src/components/sources/SourceActions/SourceActionsNotify.tsx
+++ b/packages/shared/src/components/sources/SourceActions/SourceActionsNotify.tsx
@@ -9,16 +9,24 @@ interface SourceActionsNotifyProps {
   haveNotificationsOn: boolean;
   onClick: (e: React.MouseEvent) => void;
   disabled?: boolean;
+  /** Overrides the state-derived variant when the host row wants one treatment
+   * across every secondary control. */
+  variant?: ButtonVariant;
 }
 
 const SourceActionsNotify = (props: SourceActionsNotifyProps): ReactElement => {
-  const { haveNotificationsOn, onClick, disabled } = props;
+  const {
+    haveNotificationsOn,
+    onClick,
+    disabled,
+    variant: variantProp,
+  } = props;
 
   const icon = haveNotificationsOn ? <BellSubscribedIcon /> : <BellAddIcon />;
   const label = `${haveNotificationsOn ? 'Disable' : 'Enable'} notifications`;
-  const variant = haveNotificationsOn
-    ? ButtonVariant.Subtle
-    : ButtonVariant.Secondary;
+  const variant =
+    variantProp ??
+    (haveNotificationsOn ? ButtonVariant.Subtle : ButtonVariant.Secondary);
 
   return (
     <Tooltip content={label}>

--- a/packages/shared/src/components/sources/SourceActions/index.tsx
+++ b/packages/shared/src/components/sources/SourceActions/index.tsx
@@ -8,9 +8,12 @@ import SourceActionsNotify from './SourceActionsNotify';
 import SourceActionsBlock from './SourceActionsBlock';
 import SourceActionsFollow from './SourceActionsFollow';
 import CustomFeedOptionsMenu from '../../CustomFeedOptionsMenu';
-import { LogEvent } from '../../../lib/log';
+import { LogEvent, Origin } from '../../../lib/log';
 import { useContentPreference } from '../../../hooks/contentPreference/useContentPreference';
 import { ContentPreferenceType } from '../../../graphql/contentPreference';
+import { EntityShareAction } from '../../share/EntityShareAction';
+import { MenuIcon } from '../../MenuIcon';
+import { BlockIcon } from '../../icons';
 
 interface SourceActionsButton {
   className?: string;
@@ -25,6 +28,12 @@ export interface SourceActionsProps {
   hideFollow?: boolean;
   notifyProps?: SourceActionsButton;
   hideNotify?: boolean;
+  /**
+   * Opt in to the header treatment: the visible share control, Block moved into
+   * the "…" menu and the bell restyled to match. Off by default so embedded
+   * consumers, e.g. the post page highlights widget, keep their existing row.
+   */
+  showShare?: boolean;
 }
 
 export const SourceActions = ({
@@ -35,6 +44,7 @@ export const SourceActions = ({
   hideNotify = false,
   source,
   notifyProps,
+  showShare = false,
 }: SourceActionsProps): ReactElement => {
   const {
     isBlocked,
@@ -49,6 +59,46 @@ export const SourceActions = ({
   const { follow, unfollow } = useContentPreference();
   const router = useRouter();
 
+  // `Source['id']` is optional on the model; the handle is the stable fallback
+  // every consumer of this row can rely on.
+  const sourceId = source.id ?? source.handle;
+
+  const shareProps = {
+    text: `Check out ${source.handle} on daily.dev`,
+    link: source.permalink,
+    cid: ReferralCampaignKey.ShareSource,
+  };
+
+  const canBlock = !hideBlock && !isFollowing;
+  // With the share control in the row, Block moves into the "…" menu so the row
+  // is one Follow button plus identical secondary controls. Blocked is the
+  // exception: Unblock is the only way back, so it stays visible — in the
+  // Follow slot, which is empty while blocked.
+  const showBlockInRow = showShare ? canBlock && isBlocked : canBlock;
+  const blockOptions =
+    showShare && canBlock && !isBlocked
+      ? [
+          {
+            icon: <MenuIcon Icon={BlockIcon} />,
+            label: 'Block',
+            action: toggleBlock,
+          },
+        ]
+      : [];
+
+  // Sits before the block button in the original row and after the share
+  // control in the header row, so it is defined once and placed twice.
+  const notifyButton = !hideNotify && isFollowing && (
+    <SourceActionsNotify
+      haveNotificationsOn={haveNotificationsOn}
+      onClick={toggleNotify}
+      // Float so the bell, the share control and the "…" button read as one
+      // treatment; the state still comes through in the icon.
+      {...(showShare && { variant: ButtonVariant.Float })}
+      {...notifyProps}
+    />
+  );
+
   return (
     <div className="inline-flex flex-row gap-2">
       {!hideFollow && !isBlocked && (
@@ -60,21 +110,26 @@ export const SourceActions = ({
           {...followProps}
         />
       )}
-      {!hideNotify && isFollowing && (
-        <SourceActionsNotify
-          haveNotificationsOn={haveNotificationsOn}
-          onClick={toggleNotify}
-          {...notifyProps}
-        />
-      )}
-      {!hideBlock && !isFollowing && (
+      {!showShare && notifyButton}
+      {showBlockInRow && (
         <SourceActionsBlock
           isBlocked={isBlocked}
           onClick={toggleBlock}
           {...blockProps}
         />
       )}
+      {showShare && (
+        <EntityShareAction
+          {...shareProps}
+          event={LogEvent.ShareSource}
+          targetId={sourceId}
+          origin={Origin.SourcePage}
+        />
+      )}
+      {showShare && notifyButton}
       <CustomFeedOptionsMenu
+        hideShare={showShare}
+        additionalOptions={blockOptions}
         onCreateNewFeed={() =>
           router.push(
             `/feeds/new?entityId=${source.id}&entityType=${ContentPreferenceType.Source}`,
@@ -82,7 +137,7 @@ export const SourceActions = ({
         }
         onAdd={(feedId) =>
           follow({
-            id: source.id,
+            id: sourceId,
             entity: ContentPreferenceType.Source,
             entityName: source.handle,
             feedId,
@@ -90,16 +145,14 @@ export const SourceActions = ({
         }
         onUndo={(feedId) =>
           unfollow({
-            id: source.id,
+            id: sourceId,
             entity: ContentPreferenceType.Source,
             entityName: source.handle,
             feedId,
           })
         }
         shareProps={{
-          text: `Check out ${source.handle} on daily.dev`,
-          link: source.permalink,
-          cid: ReferralCampaignKey.ShareSource,
+          ...shareProps,
           logObject: () => ({
             event_name: LogEvent.ShareSource,
             target_id: source.id,

--- a/packages/shared/src/components/tags/TagTopicPage.tsx
+++ b/packages/shared/src/components/tags/TagTopicPage.tsx
@@ -67,6 +67,8 @@ import {
   TypographyTag,
   TypographyType,
 } from '../typography/Typography';
+import { EntityShareAction } from '../share/EntityShareAction';
+import { MenuIcon } from '../MenuIcon';
 
 const SUPPORTED_TYPES = [
   PostType.Article,
@@ -307,21 +309,40 @@ export const TagTopicPage = ({
     },
   };
 
-  const blockButtonProps: ButtonProps<'button'> = {
-    size: ButtonSize.Small,
-    icon: tagStatus === 'blocked' ? <XIcon /> : <BlockIcon />,
-    onClick: async (): Promise<void> => {
-      if (!user) {
-        showLogin({ trigger: AuthTriggers.Filter });
-        return;
-      }
-      if (tagStatus === 'blocked') {
-        await onUnblockTags({ tags: [tag] });
-      } else {
-        await onBlockTags({ tags: [tag] });
-      }
-    },
+  // Shared by the row's Unblock button and the "…" menu's Block entry.
+  const onToggleBlock = async (): Promise<void> => {
+    if (!user) {
+      showLogin({ trigger: AuthTriggers.Filter });
+      return;
+    }
+    if (tagStatus === 'blocked') {
+      await onUnblockTags({ tags: [tag] });
+    } else {
+      await onBlockTags({ tags: [tag] });
+    }
   };
+
+  // Shared by the visible share control and the "…" menu entry so both always
+  // hand out the same link — `location.href` is the tag page itself.
+  const tagShareProps = {
+    text: `Check out the ${tag} tag on daily.dev`,
+    link: globalThis?.location?.href,
+    cid: ReferralCampaignKey.ShareTag,
+  };
+
+  // Block moves into the "…" menu so the row is one Follow button plus
+  // identical secondary controls. Blocked is the exception: Unblock is the only
+  // way back, so it stays visible — in the Follow slot, which is empty then.
+  const blockOptions =
+    tagStatus === 'unfollowed'
+      ? [
+          {
+            icon: <MenuIcon Icon={BlockIcon} />,
+            label: 'Block',
+            action: onToggleBlock,
+          },
+        ]
+      : [];
 
   const statParts: ReactNode[] = [];
   if (typeof followers === 'number') {
@@ -398,16 +419,26 @@ export const TagTopicPage = ({
                   {tagStatus === 'followed' ? 'Following' : 'Follow'}
                 </Button>
               )}
-              {tagStatus !== 'followed' && (
+              {tagStatus === 'blocked' && (
                 <Button
                   variant={ButtonVariant.Float}
-                  {...blockButtonProps}
-                  aria-label={tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+                  size={ButtonSize.Small}
+                  icon={<XIcon />}
+                  onClick={onToggleBlock}
+                  aria-label="Unblock"
                 >
-                  {tagStatus === 'blocked' ? 'Unblock' : 'Block'}
+                  Unblock
                 </Button>
               )}
+              <EntityShareAction
+                {...tagShareProps}
+                event={LogEvent.ShareTag}
+                targetId={tag}
+                origin={Origin.TagPage}
+              />
               <CustomFeedOptionsMenu
+                hideShare
+                additionalOptions={blockOptions}
                 onCreateNewFeed={() =>
                   push(
                     `${webappUrl}feeds/new?entityId=${tag}&entityType=${ContentPreferenceType.Keyword}`,
@@ -430,9 +461,7 @@ export const TagTopicPage = ({
                   })
                 }
                 shareProps={{
-                  text: `Check out the ${tag} tag on daily.dev`,
-                  link: globalThis?.location?.href,
-                  cid: ReferralCampaignKey.ShareTag,
+                  ...tagShareProps,
                   logObject: () => ({
                     event_name: LogEvent.ShareTag,
                     target_id: tag,

--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -16,6 +16,7 @@ import {
 import { IconSize } from '../Icon';
 import { ButtonColor, ButtonVariant } from '../buttons/Button';
 import { useGetShortUrl } from '../../hooks';
+import type { ReferralCampaignKey } from '../../lib/referral';
 
 interface SocialShareListProps {
   link: string;
@@ -27,6 +28,11 @@ interface SocialShareListProps {
   onNativeShare(): void;
   onClickSocial(provider: ShareProvider): void;
   shortenUrl?: boolean;
+  /**
+   * Attribution campaign for the shared link. Callers that hand in an already
+   * tagged `link` (e.g. the post share modal) can leave this out.
+   */
+  cid?: ReferralCampaignKey;
 }
 
 export function SocialShareList({
@@ -39,6 +45,7 @@ export function SocialShareList({
   onNativeShare,
   onClickSocial,
   shortenUrl = true,
+  cid,
 }: SocialShareListProps): ReactElement {
   const { getShortUrl } = useGetShortUrl();
 
@@ -46,7 +53,7 @@ export function SocialShareList({
     onClickSocial(provider);
 
     const isEmailShare = provider === ShareProvider.Email;
-    const shortLink = shortenUrl ? await getShortUrl(link) : link;
+    const shortLink = shortenUrl ? await getShortUrl(link, cid) : link;
     const shareLink = getShareLink({
       provider,
       link: shortLink,

--- a/packages/shared/src/lib/share.spec.ts
+++ b/packages/shared/src/lib/share.spec.ts
@@ -11,7 +11,9 @@ describe('getShareLink tests', () => {
       link,
       text,
     });
-    expect(result).toEqual(`https://wa.me/?text=${encodeURIComponent(link)}`);
+    expect(result).toEqual(
+      `https://wa.me/?text=${encodeURIComponent(`${text}\n${link}`)}`,
+    );
   });
 
   it('should return Twitter share link', () => {
@@ -46,7 +48,9 @@ describe('getShareLink tests', () => {
       text,
     });
     expect(result).toEqual(
-      `https://reddit.com/submit?url=${encodeURIComponent(link)}&title=${text}`,
+      `https://reddit.com/submit?url=${encodeURIComponent(
+        link,
+      )}&title=${encodeURIComponent(text)}`,
     );
   });
 
@@ -69,7 +73,9 @@ describe('getShareLink tests', () => {
       text,
     });
     expect(result).toEqual(
-      `https://t.me/share/url?url=${encodeURIComponent(link)}&text=${text}`,
+      `https://t.me/share/url?url=${encodeURIComponent(
+        link,
+      )}&text=${encodeURIComponent(text)}`,
     );
   });
 
@@ -98,6 +104,44 @@ describe('getShareLink tests', () => {
       `mailto:?subject=${encodeURIComponent(text)}&body=${encodeURIComponent(
         `${summary}\n\n${link}`,
       )}`,
+    );
+  });
+
+  // Post titles routinely carry `&`, `#` and `?`, which silently truncate or
+  // corrupt the shared text when interpolated raw.
+  const unsafeText = 'Rust & Go: what #1 teams ask? 100% real';
+
+  it('should encode Reddit titles containing URL characters', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Reddit,
+      link,
+      text: unsafeText,
+    });
+    expect(result).toEqual(
+      `https://reddit.com/submit?url=${encodeURIComponent(
+        link,
+      )}&title=${encodeURIComponent(unsafeText)}`,
+    );
+    expect(new URL(result).searchParams.get('title')).toEqual(unsafeText);
+  });
+
+  it('should encode Telegram text containing URL characters', () => {
+    const result = getShareLink({
+      provider: ShareProvider.Telegram,
+      link,
+      text: unsafeText,
+    });
+    expect(new URL(result).searchParams.get('text')).toEqual(unsafeText);
+  });
+
+  it('should carry the text into the WhatsApp message', () => {
+    const result = getShareLink({
+      provider: ShareProvider.WhatsApp,
+      link,
+      text: unsafeText,
+    });
+    expect(new URL(result).searchParams.get('text')).toEqual(
+      `${unsafeText}\n${link}`,
     );
   });
 });

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -12,8 +12,8 @@ export enum ShareProvider {
   Email = 'email',
 }
 
-export const getWhatsappShareLink = (link: string): string =>
-  `https://wa.me/?text=${encodeURIComponent(link)}`;
+export const getWhatsappShareLink = (link: string, text?: string): string =>
+  `https://wa.me/?text=${encodeURIComponent(text ? `${text}\n${link}` : link)}`;
 export const getTwitterShareLink = (link: string, text: string): string =>
   `http://twitter.com/share?url=${encodeURIComponent(
     link,
@@ -23,13 +23,17 @@ export const getFacebookShareLink = (link: string): string =>
     link,
   )}`;
 export const getRedditShareLink = (link: string, text: string): string =>
-  `https://reddit.com/submit?url=${encodeURIComponent(link)}&title=${text}`;
+  `https://reddit.com/submit?url=${encodeURIComponent(
+    link,
+  )}&title=${encodeURIComponent(text)}`;
 export const getLinkedInShareLink = (link: string): string =>
   `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(
     link,
   )}`;
 export const getTelegramShareLink = (link: string, text: string): string =>
-  `https://t.me/share/url?url=${encodeURIComponent(link)}&text=${text}`;
+  `https://t.me/share/url?url=${encodeURIComponent(
+    link,
+  )}&text=${encodeURIComponent(text)}`;
 export const getEmailShareLink = (
   link: string,
   subject: string,
@@ -57,7 +61,7 @@ export const getShareLink = ({
 }: GetShareLinkParams): string => {
   switch (provider) {
     case ShareProvider.WhatsApp:
-      return getWhatsappShareLink(link);
+      return getWhatsappShareLink(link, text);
     case ShareProvider.Twitter:
       return getTwitterShareLink(link, text);
     case ShareProvider.Facebook:

--- a/packages/storybook/stories/components/EntityShareAction.stories.tsx
+++ b/packages/storybook/stories/components/EntityShareAction.stories.tsx
@@ -1,0 +1,705 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fn } from 'storybook/test';
+import { EntityShareAction } from '@dailydotdev/shared/src/components/share/EntityShareAction';
+import { ShareActions } from '@dailydotdev/shared/src/components/share/ShareActions';
+import CustomFeedOptionsMenu from '@dailydotdev/shared/src/components/CustomFeedOptionsMenu';
+import { MenuIcon } from '@dailydotdev/shared/src/components/MenuIcon';
+import SourceActionsFollow from '@dailydotdev/shared/src/components/sources/SourceActions/SourceActionsFollow';
+import SourceActionsNotify from '@dailydotdev/shared/src/components/sources/SourceActions/SourceActionsNotify';
+import SourceActionsBlock from '@dailydotdev/shared/src/components/sources/SourceActions/SourceActionsBlock';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  BellAddIcon,
+  BellSubscribedIcon,
+  BlockIcon,
+  MiniCloseIcon as XIcon,
+  PlusIcon,
+} from '@dailydotdev/shared/src/components/icons';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { GrowthBookProvider } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import { LogEvent, Origin } from '@dailydotdev/shared/src/lib/log';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
+import { getShortLinkProps } from '@dailydotdev/shared/src/hooks/utils/useGetShortUrl';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+
+const mockUser = {
+  id: '1',
+  name: 'Test User',
+  username: 'testuser',
+  email: 'test@example.com',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/testuser',
+} as unknown as LoggedUser;
+
+const SHORT_LINK = 'https://dly.to/abc123';
+
+type Entity = 'tag' | 'source';
+
+/**
+ * Tag page: `default` shows Follow + Block, `following` drops Block, `blocked`
+ * drops Follow. The source page follows the same three-way split.
+ */
+type EntityState = 'default' | 'following' | 'blocked';
+
+const entityConfig: Record<
+  Entity,
+  {
+    link: string;
+    text: string;
+    cid: ReferralCampaignKey;
+    event: LogEvent;
+    targetId: string;
+    origin: Origin;
+  }
+> = {
+  tag: {
+    link: 'https://app.daily.dev/tags/webdev',
+    text: 'Check out the webdev tag on daily.dev',
+    cid: ReferralCampaignKey.ShareTag,
+    event: LogEvent.ShareTag,
+    targetId: 'webdev',
+    origin: Origin.TagPage,
+  },
+  source: {
+    link: 'https://app.daily.dev/sources/tds',
+    text: 'Check out tds on daily.dev',
+    cid: ReferralCampaignKey.ShareSource,
+    event: LogEvent.ShareSource,
+    targetId: 'tds',
+    origin: Origin.SourcePage,
+  },
+};
+
+/**
+ * `current` is the row as it was before this change: a Block button in the row
+ * and an icon-only share behind a vertical rule. Kept for comparison only.
+ * `proposed` is what both pages ship now — Block in the "…" menu, a labelled
+ * "Copy link" with a chevron, and the bell styled like the "…" button.
+ */
+type Layout = 'current' | 'proposed';
+
+const menuProps = (
+  entity: Entity,
+  { layout, state }: { layout: Layout; state: EntityState },
+) => ({
+  onAdd: fn(),
+  onUndo: fn(),
+  onCreateNewFeed: fn(),
+  shareProps: {
+    text: entityConfig[entity].text,
+    link: entityConfig[entity].link,
+    cid: entityConfig[entity].cid,
+  },
+  // Block leaves the row and becomes a menu entry in the proposed layout —
+  // except while blocked, where Unblock stays in the row as the visible way out
+  // of a state the user did not necessarily mean to be in. Burying the only
+  // escape behind "…" is what makes a blocked entity feel stuck.
+  additionalOptions:
+    layout === 'proposed' && state !== 'blocked'
+      ? [
+          {
+            icon: <MenuIcon Icon={BlockIcon} />,
+            label: 'Block',
+            action: fn(),
+          },
+        ]
+      : [],
+});
+
+// Every secondary control in the row is the same button: Float, size Small,
+// icon-only. The bell is the only one that also carries a state.
+const RowIconButton = ({
+  icon,
+  label,
+}: {
+  icon: ReactElement;
+  label: string;
+}): ReactElement => (
+  <Button
+    type="button"
+    size={ButtonSize.Small}
+    variant={ButtonVariant.Float}
+    icon={icon}
+    aria-label={label}
+    title={label}
+    onClick={fn()}
+  />
+);
+
+interface RowProps {
+  state: EntityState;
+  layout?: Layout;
+}
+
+// Mirrors the `/tags/[tag]` header action row (`TagTopicPage`): same icons,
+// same variants, same `gap-3`, same show/hide rules.
+const TagActionRow = ({
+  state,
+  layout = 'proposed',
+}: RowProps): ReactElement => {
+  const isCurrent = layout === 'current';
+
+  return (
+    <div className="inline-flex flex-row items-center gap-3">
+      {state !== 'blocked' && (
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Primary}
+          icon={state === 'following' ? <XIcon /> : <PlusIcon />}
+          aria-label={state === 'following' ? 'Unfollow' : 'Follow'}
+        >
+          {state === 'following' ? 'Following' : 'Follow'}
+        </Button>
+      )}
+      {/* Blocked keeps Unblock in the row in both layouts — it is the only way
+          back, so it never goes behind the "…" menu. */}
+      {(state === 'blocked' || (isCurrent && state !== 'following')) && (
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Float}
+          icon={state === 'blocked' ? <XIcon /> : <BlockIcon />}
+          aria-label={state === 'blocked' ? 'Unblock' : 'Block'}
+        >
+          {state === 'blocked' ? 'Unblock' : 'Block'}
+        </Button>
+      )}
+      <EntityShareAction
+        {...entityConfig.tag}
+        display={isCurrent ? 'icon' : 'split'}
+      />
+      <CustomFeedOptionsMenu
+        hideShare
+        {...menuProps('tag', { layout, state })}
+      />
+    </div>
+  );
+};
+
+interface SourceActionRowProps extends RowProps {
+  /** Only reachable while following: the bell toggles subscribed / not. */
+  notificationsOn?: boolean;
+  /** `/sources/[source]` passes `showShare`; embedded consumers don't. */
+  showShare?: boolean;
+}
+
+// Mirrors `SourceActions` (rendered inside `PageInfoHeader` on the source page):
+// same child components, same `gap-2`, same show/hide rules.
+const SourceActionRow = ({
+  state,
+  notificationsOn = false,
+  showShare = true,
+  layout = 'proposed',
+}: SourceActionRowProps): ReactElement => {
+  const isCurrent = layout === 'current';
+
+  return (
+    <div className="inline-flex flex-row items-center gap-2">
+      {state !== 'blocked' && (
+        <SourceActionsFollow
+          isFetching={false}
+          isSubscribed={state === 'following'}
+          onClick={fn()}
+          variant={ButtonVariant.Primary}
+        />
+      )}
+      {isCurrent && state === 'following' && (
+        <SourceActionsNotify
+          haveNotificationsOn={notificationsOn}
+          onClick={fn()}
+        />
+      )}
+      {/* Blocked keeps Unblock in the row in both layouts — it is the only way
+          back, so it never goes behind the "…" menu. In the proposed layout it
+          takes the Follow slot, which is empty while blocked. */}
+      {(state === 'blocked' || (isCurrent && state !== 'following')) && (
+        <SourceActionsBlock isBlocked={state === 'blocked'} onClick={fn()} />
+      )}
+      {showShare && (
+        <EntityShareAction
+          {...entityConfig.source}
+          display={isCurrent ? 'icon' : 'split'}
+        />
+      )}
+      {!isCurrent && state === 'following' && (
+        <RowIconButton
+          icon={notificationsOn ? <BellSubscribedIcon /> : <BellAddIcon />}
+          label={
+            notificationsOn ? 'Disable notifications' : 'Enable notifications'
+          }
+        />
+      )}
+      <CustomFeedOptionsMenu
+        hideShare={showShare}
+        {...menuProps('source', { layout, state })}
+      />
+    </div>
+  );
+};
+
+const Section = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: ReactNode;
+}): ReactElement => (
+  <section className="flex w-full flex-col gap-3">
+    <div className="flex flex-col gap-1 border-b border-border-subtlest-tertiary pb-2">
+      <Typography type={TypographyType.Title3} bold>
+        {title}
+      </Typography>
+      <Typography
+        type={TypographyType.Footnote}
+        color={TypographyColor.Tertiary}
+      >
+        {description}
+      </Typography>
+    </div>
+    <div className="flex flex-row flex-wrap gap-4">{children}</div>
+  </section>
+);
+
+const Case = ({
+  label,
+  note,
+  wide = false,
+  children,
+}: {
+  label: string;
+  note?: string;
+  /** Cases whose content is wider than a single action row. */
+  wide?: boolean;
+  children: ReactNode;
+}): ReactElement => (
+  <div
+    className={classNames(
+      'flex flex-col gap-2 rounded-12 border border-border-subtlest-tertiary p-4',
+      wide ? 'w-[34rem]' : 'w-80',
+    )}
+  >
+    <Typography type={TypographyType.Footnote} bold>
+      {label}
+    </Typography>
+    <div className="flex min-h-12 w-full flex-row flex-wrap items-center gap-y-2">
+      {children}
+    </div>
+    {note && (
+      <Typography
+        type={TypographyType.Caption1}
+        color={TypographyColor.Tertiary}
+      >
+        {note}
+      </Typography>
+    )}
+  </div>
+);
+
+const INTERACTION_CHECKS = [
+  'Click the “Copy link” label — it copies straight away and the copy glyph cross-fades into a green check for a second.',
+  'Click the chevron — the DS dropdown opens with the social tiles and the chevron rotates to point back at it.',
+  'Hover the two halves — one seam, not two borders meeting, and the whole control keeps a standard button’s height and radius.',
+  'Hover the three secondary controls (copy link, bell, “…”) — same Float surface, same size, same hover.',
+  'Open the “…” menu — Block lives there, under “Add to custom feed” (additionalOptions append; say the word if it should sit first).',
+  'Block a tag or source — Unblock comes back out into the row and leaves the menu, so the way back is never buried.',
+  'Switch the toolbar viewport to a mobile size — the chevron and the dropdown drop; a single tap opens the native share sheet.',
+  'Toggle the toolbar theme — the row and the dropdown have to hold contrast in dark mode.',
+];
+
+// Every state the promoted share control can be seen in, on one page.
+const Overview = (): ReactElement => (
+  <div className="flex w-full max-w-[76rem] flex-col gap-10">
+    <Section
+      title="Before / after"
+      description="What shipped: Block moved into the “…” menu, the icon-only share became a labelled “Copy link” whose chevron opens the full share list, and the bell took the same Float treatment as “…” — so every secondary control is one button."
+    >
+      <Case
+        wide
+        label="Before"
+        note="Follow · Block · | · share icon · … — three different button treatments in one row"
+      >
+        <SourceActionRow state="following" notificationsOn layout="current" />
+      </Case>
+      <Case
+        wide
+        label="After — live on both pages"
+        note="Follow · Copy link ▾ · bell · … — one named action, then identical icon buttons"
+      >
+        <SourceActionRow state="following" notificationsOn />
+      </Case>
+    </Section>
+
+    <Section
+      title="Tag page — /tags/[tag]"
+      description="TagTopicPage header row (gap-3). Block moves into the “…” menu, so the row holds one Follow button plus identical secondary controls — except while blocked, where Unblock takes the empty Follow slot."
+    >
+      <Case
+        label="Default — not followed"
+        note="Follow · Copy link ▾ · … — Block is inside the menu"
+      >
+        <TagActionRow state="default" />
+      </Case>
+      <Case label="Following" note="Identical row; Block stays in the menu">
+        <TagActionRow state="following" />
+      </Case>
+      <Case
+        label="Blocked"
+        note="Follow is dropped by the real row, so Unblock takes its slot — and leaves the menu"
+      >
+        <TagActionRow state="blocked" />
+      </Case>
+    </Section>
+
+    <Section
+      title="Source page — /sources/[source]"
+      description="SourceActions inside PageInfoHeader (gap-2). The bell only exists while following and now matches the “…” button exactly."
+    >
+      <Case label="Default — not followed" note="Follow · Copy link ▾ · …">
+        <SourceActionRow state="default" />
+      </Case>
+      <Case label="Following · notifications off">
+        <SourceActionRow state="following" />
+      </Case>
+      <Case
+        label="Following · notifications on"
+        note="Densest row: Following · Copy link ▾ · bell · …"
+      >
+        <SourceActionRow state="following" notificationsOn />
+      </Case>
+      <Case
+        label="Blocked"
+        note="Unblock takes the empty Follow slot and leaves the menu"
+      >
+        <SourceActionRow state="blocked" />
+      </Case>
+    </Section>
+
+    <Section
+      title="Who gets it"
+      description="No feature flag — the header treatment ships to everyone. The only switch left is the `showShare` prop, which SourceActions consumers use to opt in; embedded consumers keep the row they have today."
+    >
+      <Case
+        label="Source page header — showShare"
+        note="Copy link in the row, Block inside the “…” menu"
+      >
+        <SourceActionRow state="default" />
+      </Case>
+      <Case
+        label="Embedded consumer — post page"
+        note="No showShare: Block stays a row button and Share stays in the menu"
+      >
+        <SourceActionRow state="default" showShare={false} />
+      </Case>
+      <Case
+        label="Tag page header"
+        note="Always on — the tag page has no opt-out prop"
+      >
+        <TagActionRow state="default" />
+      </Case>
+    </Section>
+
+    <Section
+      title="The copy control"
+      description="The exact SplitShareButton from the end-of-conversation band (PR #6369): the label copies and cross-fades to a green check, the chevron opens the DS dropdown with the social tiles and rotates to point back at it. See Components/Share/SplitShareButton for its own variant/size matrix and the geometry check."
+    >
+      <Case
+        label="split — what the rows use"
+        note="Left half copies; right half drops the list. Float, size Small."
+      >
+        <EntityShareAction {...entityConfig.tag} display="split" />
+      </Case>
+      <Case
+        label="icon — the alternative display"
+        note="Unlabelled, so it needs the vertical rule to stay distinct from Follow, and it opens a Popover rather than the dropdown"
+      >
+        <div className="inline-flex flex-row items-center gap-3">
+          <EntityShareAction {...entityConfig.tag} display="icon" />
+        </div>
+      </Case>
+      <Case
+        wide
+        label="What the chevron opens"
+        note="The same social tiles, rendered inline: copy link first, then the networks"
+      >
+        <ShareActions
+          variant="inline"
+          link={entityConfig.tag.link}
+          text={entityConfig.tag.text}
+          cid={entityConfig.tag.cid}
+          onShare={fn()}
+        />
+      </Case>
+      <Case
+        wide
+        label="Next to Follow — Tertiary vs Float vs Subtle"
+        note="Each variant draws the seam differently: Float/Subtle reuse the DS border, Tertiary draws an inset rule"
+      >
+        <div className="flex flex-row items-center gap-3">
+          <Button
+            type="button"
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Primary}
+            icon={<PlusIcon />}
+          >
+            Follow
+          </Button>
+          {[
+            ButtonVariant.Tertiary,
+            ButtonVariant.Float,
+            ButtonVariant.Subtle,
+          ].map((variant) => (
+            <ShareActions
+              key={variant}
+              variant="split"
+              link={entityConfig.tag.link}
+              text={entityConfig.tag.text}
+              buttonVariant={variant}
+              label="Copy link"
+              triggerText="Copy link"
+              onShare={fn()}
+            />
+          ))}
+        </div>
+      </Case>
+    </Section>
+
+    <Section
+      title="Interactions to check by hand"
+      description="Driven by real interaction, so they can't be rendered statically above."
+    >
+      <ul className="flex list-disc flex-col gap-1 pl-5">
+        {INTERACTION_CHECKS.map((item) => (
+          <li key={item}>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Secondary}
+            >
+              {item}
+            </Typography>
+          </li>
+        ))}
+      </ul>
+    </Section>
+  </div>
+);
+
+interface PlaygroundProps {
+  entity: Entity;
+  state: EntityState;
+  notificationsOn: boolean;
+  layout: Layout;
+}
+
+const Playground = ({
+  entity,
+  state,
+  notificationsOn,
+  layout,
+}: PlaygroundProps): ReactElement =>
+  entity === 'tag' ? (
+    <TagActionRow state={state} layout={layout} />
+  ) : (
+    <SourceActionRow
+      state={state}
+      notificationsOn={notificationsOn}
+      layout={layout}
+    />
+  );
+
+const withProviders = (Story: React.ComponentType): ReactElement => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+  });
+
+  // Seed the resolved short URL for both campaigns so nothing hits network.
+  [ReferralCampaignKey.ShareTag, ReferralCampaignKey.ShareSource].forEach(
+    (cid) => {
+      Object.values(entityConfig).forEach((config) => {
+        const { queryKey } = getShortLinkProps(config.link, cid, mockUser);
+        queryClient.setQueryData(queryKey, SHORT_LINK);
+      });
+    },
+  );
+
+  const LogContext = getLogContextStatic();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContext.Provider
+        value={
+          {
+            user: mockUser,
+            isLoggedIn: true,
+            isAuthReady: true,
+            tokenRefreshed: true,
+            shouldShowLogin: false,
+            showLogin: fn(),
+            closeLogin: fn(),
+            logout: fn(),
+            updateUser: fn(),
+            getRedirectUri: fn(),
+            loadingUser: false,
+            loadedUserFromCache: true,
+            refetchBoot: fn(),
+            squads: [],
+            isAndroidApp: false,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+        }
+      >
+        <GrowthBookProvider
+          app={BootApp.Webapp}
+          user={mockUser}
+          deviceId="storybook"
+        >
+          <LogContext.Provider
+            value={{
+              logEvent: fn(),
+              logEventStart: fn(),
+              logEventEnd: fn(),
+              sendBeacon: () => false,
+            }}
+          >
+            <div className="flex min-h-40 flex-col items-center justify-center p-4">
+              <Story />
+            </div>
+          </LogContext.Provider>
+        </GrowthBookProvider>
+      </AuthContext.Provider>
+    </QueryClientProvider>
+  );
+};
+
+const meta: Meta<typeof Playground> = {
+  title: 'Components/Share/EntityShareAction',
+  component: Playground,
+  decorators: [withProviders],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Promotes share out of the tag/source "…" options menu into the header action row as a labelled "Copy link" button whose chevron opens the full share list (the SplitShareButton from PR #6369). Block moves into the "…" menu — except while blocked, where Unblock stays in the row. Ships to everyone: no feature flag.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Playground>;
+
+/** Every surface, state and flag combination on one page. Start here. */
+export const AllStates: StoryObj = {
+  render: () => <Overview />,
+  parameters: { controls: { disable: true } },
+};
+
+/** Drive a single row from the controls panel. */
+export const InteractivePlayground: Story = {
+  args: {
+    entity: 'tag',
+    state: 'default',
+    notificationsOn: false,
+    layout: 'proposed',
+  },
+  argTypes: {
+    entity: { control: 'inline-radio', options: ['tag', 'source'] },
+    state: {
+      control: 'inline-radio',
+      options: ['default', 'following', 'blocked'],
+    },
+    layout: {
+      control: 'inline-radio',
+      options: ['proposed', 'current'],
+      description:
+        'proposed = Copy link ▾ with Block in the menu; current = what the PR ships',
+    },
+    notificationsOn: {
+      control: 'boolean',
+      description: 'Source page only, and only while following',
+    },
+  },
+};
+
+export const TagDefault: StoryObj = {
+  render: () => <TagActionRow state="default" />,
+};
+
+export const TagFollowing: StoryObj = {
+  render: () => <TagActionRow state="following" />,
+};
+
+export const TagBlocked: StoryObj = {
+  render: () => <TagActionRow state="blocked" />,
+};
+
+export const SourceDefault: StoryObj = {
+  render: () => <SourceActionRow state="default" />,
+};
+
+export const SourceFollowing: StoryObj = {
+  render: () => <SourceActionRow state="following" />,
+};
+
+/** Densest row: Following + Copy link ▾ + bell + "…". */
+export const SourceFollowingWithNotifications: StoryObj = {
+  render: () => <SourceActionRow state="following" notificationsOn />,
+};
+
+/** The row as the PR ships it today, for side-by-side comparison. */
+export const CurrentLayout: StoryObj = {
+  render: () => (
+    <SourceActionRow state="following" notificationsOn layout="current" />
+  ),
+};
+
+export const SourceBlocked: StoryObj = {
+  render: () => <SourceActionRow state="blocked" />,
+};
+
+/**
+ * `SourceActions` is also rendered on the post page without `showShare`, so it
+ * keeps the row it has today: Block as a button, Share inside the "…" menu.
+ */
+export const EmbeddedConsumerOptedOut: StoryObj = {
+  render: () => <SourceActionRow state="default" showShare={false} />,
+};
+
+/** Mobile: a single tap opens the native share sheet instead of the popover. */
+export const TagMobile: StoryObj = {
+  render: () => <TagActionRow state="following" />,
+  globals: { viewport: { value: 'mobile1' } },
+};
+
+/** The popover's contents, rendered inline. */
+export const SharePopoverContents: StoryObj = {
+  render: () => (
+    <ShareActions
+      variant="inline"
+      link={entityConfig.tag.link}
+      text={entityConfig.tag.text}
+      cid={entityConfig.tag.cid}
+      onShare={fn()}
+    />
+  ),
+};

--- a/packages/webapp/__tests__/SourcePage.tsx
+++ b/packages/webapp/__tests__/SourcePage.tsx
@@ -8,7 +8,13 @@ import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
 import type { RenderResult } from '@testing-library/react';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import type { NextRouter } from 'next/router';
@@ -213,14 +219,40 @@ it('should show notify button if following', async () => {
   expect(notifyButton).toBeInTheDocument();
 });
 
-it('should show block button', async () => {
+// The feed cards carry their own options menus, so the header's is found via
+// the action row. Radix's trigger opens on pointerdown/keydown, not click.
+const findActionRow = async (): Promise<HTMLElement> => {
+  const anchor = await screen.findByLabelText(
+    /^(Toggle follow status|Unblock)/,
+  );
+  const row = anchor.parentElement;
+  if (!row) {
+    throw new Error('the action row button is not mounted in a row');
+  }
+  return row;
+};
+
+const openOptionsMenu = async () => {
+  const row = await findActionRow();
+  fireEvent.keyDown(within(row).getByLabelText('Options'), { key: 'Enter' });
+};
+
+/** Block left the row for the header's "…" menu. */
+const clickBlockOption = async () => {
+  await openOptionsMenu();
+  fireEvent.click(await screen.findByText('Block'));
+};
+
+it('should keep block in the options menu', async () => {
   renderComponent([
     createFeedMock(),
     createSourcesSettingsMock({ excludeSources: [] }),
   ]);
   await waitForNock();
-  const button = await screen.findByTestId('blockButton');
-  expect(button).toBeInTheDocument();
+  expect(screen.queryByTestId('blockButton')).not.toBeInTheDocument();
+
+  await openOptionsMenu();
+  expect(await screen.findByText('Block')).toBeInTheDocument();
 });
 
 it('should show login popup when logged-out on add to feed click', async () => {
@@ -239,8 +271,7 @@ it('should show login popup when logged-out on add to feed click', async () => {
     null,
   );
   await waitForNock();
-  const button = await screen.findByTestId('blockButton');
-  button.click();
+  await clickBlockOption();
   expect(showLogin).toBeCalledTimes(1);
 });
 
@@ -264,10 +295,15 @@ it('should activate notify from source', async () => {
     },
   });
   const button = await screen.findByTestId('blockButton');
-  const initialText = button.textContent;
+  expect(button).toHaveTextContent('Unblock');
   button.click();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
-  expect(initialText).not.toBe(button.textContent);
+  // Unblocking sends Block back into the "…" menu and clears the row.
+  await waitFor(() =>
+    expect(screen.queryByTestId('blockButton')).not.toBeInTheDocument(),
+  );
+  await openOptionsMenu();
+  expect(await screen.findByText('Block')).toBeInTheDocument();
 });
 
 it('should block source', async () => {
@@ -292,9 +328,8 @@ it('should block source', async () => {
       return { data: { feedSettings: { id: defaultUser.id } } };
     },
   });
-  const button = await screen.findByTestId('blockButton');
-  const initialText = button.textContent;
-  button.click();
+  await clickBlockOption();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
-  expect(initialText).not.toBe(button.textContent);
+  // Blocking brings Unblock out into the row.
+  expect(await screen.findByTestId('blockButton')).toHaveTextContent('Unblock');
 });

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -5,7 +5,13 @@ import nock from 'nock';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import React from 'react';
 import type { RenderResult } from '@testing-library/react';
-import { render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type {
   LoggedUser,
@@ -250,13 +256,48 @@ it('should request tag feed', async () => {
   });
 });
 
-it('should show follow and block buttons', async () => {
+// The feed cards carry their own options menus and copy-link buttons, so the
+// header's controls are found via the action row they share with Follow.
+const findActionRow = async (): Promise<HTMLElement> => {
+  const button = await screen.findByLabelText(/^(Follow|Unfollow|Unblock)$/);
+  const row = button.parentElement;
+  if (!row) {
+    throw new Error('the action row button is not mounted in a row');
+  }
+  return row;
+};
+
+// Radix's trigger opens on pointerdown/keydown, not click.
+const openOptionsMenu = async () => {
+  const row = await findActionRow();
+  fireEvent.keyDown(within(row).getByLabelText('Options'), { key: 'Enter' });
+};
+
+/** Block left the row for the header's "…" menu. */
+const clickBlockOption = async () => {
+  await openOptionsMenu();
+  fireEvent.click(await screen.findByText('Block'));
+};
+
+it('should show the follow button, with block in the options menu', async () => {
   renderComponent();
   await waitForNock();
   const followButton = await screen.findByLabelText('Follow');
   expect(followButton).toBeInTheDocument();
-  const blockButton = await screen.findByLabelText('Block');
-  expect(blockButton).toBeInTheDocument();
+  expect(screen.queryByLabelText('Block')).not.toBeInTheDocument();
+
+  await openOptionsMenu();
+  expect(await screen.findByText('Block')).toBeInTheDocument();
+});
+
+it('should show the copy-link control in the header', async () => {
+  renderComponent();
+  await waitForNock();
+  // Scoped to the action row — the feed cards carry copy-link buttons too.
+  // jsdom reports no laptop match, so this is the mobile path: the labelled
+  // trigger without the chevron, tapping straight through to native share.
+  const row = await findActionRow();
+  expect(within(row).getByLabelText('Copy link')).toBeInTheDocument();
 });
 
 it('should show only unfollow button', async () => {
@@ -289,8 +330,9 @@ it('should show follow and block buttons when logged-out', async () => {
   await waitForNock();
   const followButton = await screen.findByLabelText('Follow');
   expect(followButton).toBeInTheDocument();
-  const blockButton = await screen.findByLabelText('Block');
-  expect(blockButton).toBeInTheDocument();
+
+  await openOptionsMenu();
+  expect(await screen.findByText('Block')).toBeInTheDocument();
 });
 
 it('should show login popup when logged-out on follow click', async () => {
@@ -340,8 +382,7 @@ it('should show login popup when logged-out on block click', async () => {
     null,
   );
   await waitForNock();
-  const blockButton = await screen.findByLabelText('Block');
-  blockButton.click();
+  await clickBlockOption();
   expect(showLogin).toBeCalledTimes(1);
 });
 
@@ -392,8 +433,7 @@ it('should block tag', async () => {
       return { data: { feedSettings: { id: defaultUser.id } } };
     },
   });
-  const button = await screen.findByLabelText('Block');
-  button.click();
+  await clickBlockOption();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
 
   await waitFor(async () => {
@@ -458,10 +498,12 @@ it('should unblock tag', async () => {
   const button = await screen.findByLabelText('Unblock');
   button.click();
   await waitFor(() => expect(mutationCalled).toBeTruthy());
+  // Unblocking puts Follow back in the row and Block back in the "…" menu.
   await waitFor(async () => {
-    const followButton = await screen.findByLabelText('Block');
-    expect(followButton).toBeInTheDocument();
+    expect(await screen.findByLabelText('Follow')).toBeInTheDocument();
   });
+  await openOptionsMenu();
+  expect(await screen.findByText('Block')).toBeInTheDocument();
 });
 
 it('should load title and description for tag', async () => {

--- a/packages/webapp/__tests__/TagSourceSeo.spec.ts
+++ b/packages/webapp/__tests__/TagSourceSeo.spec.ts
@@ -1,0 +1,115 @@
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { KEYWORD_QUERY } from '@dailydotdev/shared/src/graphql/keywords';
+import {
+  SOURCE_QUERY,
+  SourceType,
+} from '@dailydotdev/shared/src/graphql/sources';
+import { getStaticProps as getTagStaticProps } from '../pages/tags/[tag]';
+import { getStaticProps as getSourceStaticProps } from '../pages/sources/[source]';
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => {
+  const actual = jest.requireActual('@dailydotdev/shared/src/graphql/common');
+
+  return { ...actual, gqlClient: { request: jest.fn() } };
+});
+
+const request = gqlClient.request as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// Share links are only worth promoting if the unfurl names the entity, so lock
+// the per-entity title/description that `next-seo` turns into og:title and
+// og:description (it falls back to `description` when `openGraph.description`
+// is unset). og:url/canonical come from `_app`'s DefaultSeo, per route.
+describe('tag page SEO', () => {
+  it('describes the specific tag', async () => {
+    request.mockImplementation((query) => {
+      if (query === KEYWORD_QUERY) {
+        return Promise.resolve({
+          keyword: {
+            value: 'webdev',
+            flags: {
+              title: 'Web Development',
+              description: 'Everything about building for the web.',
+            },
+          },
+        });
+      }
+
+      return Promise.reject(new Error('not mocked'));
+    });
+
+    const result = await getTagStaticProps({ params: { tag: 'webdev' } });
+
+    expect('props' in result && result.props.seo).toMatchObject({
+      title: 'Web Development posts | daily.dev',
+      description: 'Everything about building for the web.',
+      openGraph: { title: 'Web Development posts | daily.dev' },
+    });
+  });
+
+  it('falls back to a generated description when the tag has none', async () => {
+    request.mockImplementation((query) => {
+      if (query === KEYWORD_QUERY) {
+        return Promise.resolve({ keyword: { value: 'webdev', flags: {} } });
+      }
+
+      return Promise.reject(new Error('not mocked'));
+    });
+
+    const result = await getTagStaticProps({ params: { tag: 'webdev' } });
+
+    expect('props' in result && result.props.seo?.description).toEqual(
+      'Find all the recent posts, videos, updates and discussions about webdev',
+    );
+  });
+});
+
+describe('source page SEO', () => {
+  const source = {
+    id: 'tds',
+    name: 'Towards Data Science',
+    handle: 'tds',
+    permalink: 'https://app.daily.dev/sources/tds',
+    image: 'https://media.daily.dev/tds',
+    type: SourceType.Machine,
+    public: true,
+    description: 'Sharing concepts, ideas and codes.',
+  };
+
+  it('describes the specific source', async () => {
+    request.mockImplementation((query) => {
+      if (query === SOURCE_QUERY) {
+        return Promise.resolve({ source });
+      }
+
+      return Promise.reject(new Error('not mocked'));
+    });
+
+    const result = await getSourceStaticProps({ params: { source: 'tds' } });
+
+    expect('props' in result && result.props.seo).toMatchObject({
+      title: 'Towards Data Science posts | daily.dev',
+      description: 'Sharing concepts, ideas and codes.',
+      openGraph: { title: 'Towards Data Science posts | daily.dev' },
+    });
+  });
+
+  it('keeps the generic description when the source has none', async () => {
+    request.mockImplementation((query) => {
+      if (query === SOURCE_QUERY) {
+        return Promise.resolve({ source: { ...source, description: null } });
+      }
+
+      return Promise.reject(new Error('not mocked'));
+    });
+
+    const result = await getSourceStaticProps({ params: { source: 'tds' } });
+
+    expect('props' in result && result.props.seo?.description).toContain(
+      'daily.dev is the easiest way',
+    );
+  });
+});

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -291,7 +291,7 @@ const SourcePage = ({
             <h1 className="ml-2 w-fit typo-title2">{source.name}</h1>
           </div>
           <div className="flex flex-row gap-3">
-            <SourceActions source={source} />
+            <SourceActions source={source} showShare />
           </div>
           {source?.description && (
             <p className="typo-body">{source?.description}</p>


### PR DESCRIPTION
Part of the **sharing visibility** initiative. Now stacked on #6369 (`claude/share-split-copy-button`) — **not** `main` — because both PRs share the copy-link control. Review #6343 → #6349 → #6369 → this one, or read this diff alone: it only touches the two entity headers.

## What changed

Share moves out of the buried `CustomFeedOptionsMenu` "…" menu into the header action row on both entity pages, as **#6369's `SplitShareButton`**: the left half copies the link (the glyph cross-fades to a green check), the chevron drops the standard social list.

- **Tags** — `TagTopicPage` header (the real tag surface; `PageInfoHeader` named in the brief is a `classed` div used only by the source page).
- **Sources** — `SourceActions`, rendered inside `PageInfoHeader` on `/sources/[source]`.

### The row

| State | Row | "…" menu |
| --- | --- | --- |
| Not followed | `Follow` · `Copy link ⌄` · `⋮` | Add to custom feed · **Block** |
| Following | `Following` · `Copy link ⌄` · `bell` · `⋮` | Add to custom feed |
| Blocked | **`Unblock`** · `Copy link ⌄` · `⋮` | Add to custom feed |

**Block leaves the row for the menu**, so the row is one filled Follow button plus secondary controls that all look and behave the same. **Blocked is the deliberate exception:** Unblock is the only way back out of a state a user may not have meant to enter, so it stays visible — in the Follow slot, which is empty while blocked — and leaves the menu, so it never appears twice.

The notification bell takes `ButtonVariant.Float`, matching the copy control and the "…" button. Its state still reads from the icon.

## No feature flag

This ships to everyone. `share_tags_sources` and `useShareTagsSources` are gone — nothing else read them. `sharing_visibility` stays in the codebase; it still gates the initiative's other surfaces, but these two rows no longer consult it.

**That means no runtime off-switch for these rows: turning them off after merge takes a revert.** Flagged deliberately, per the product call to show it to everyone.

## Structure

- `components/share/EntityShareAction.tsx` — wraps #6369's `ShareActions` with the entity's link/text/cid and the per-surface log event. `display` defaults to `split`; `icon` keeps the original icon-only trigger (behind a vertical rule) for any surface that wants it.
- `CustomFeedOptionsMenu` gains `hideShare`, so the in-menu Share entry is dropped exactly where the visible control renders — never both. Default `false`, so every other consumer is unchanged.
- `SourceActionsNotify` gains an optional `variant` override; without it the state-derived variant is unchanged.
- `SourceActions` gains `showShare`. Only `/sources/[source]` passes it, so `PostUsersHighlights` on the post page keeps its existing row: Block as a button, Share inside the menu.
- Both surfaces derive one `shareProps` object feeding the visible control **and** the existing `CustomFeedOptionsMenu` `shareProps`, so both hand out the same link.

## The individual social share links

The copy path tags its link with the referral campaign through `useShareOrCopyLink`, but the social targets went out untagged — `SocialShareList` called `getShortUrl(link)` with no `cid`. The post share modal was unaffected because it pre-tags the link before handing it down, so this only hit `ShareActions` consumers, i.e. the control this PR surfaces. `SocialShareList` now takes an optional `cid` and `ShareActions` passes its own, so a share to X carries the same `userid`/`cid` a copied link does.

Two link builders also interpolated their text raw, so any `&`, `#`, `?` or `%` in a title silently truncated or corrupted the shared text — and post titles carry those constantly:

| Builder | Before | After |
| --- | --- | --- |
| `getRedditShareLink` | `&title=${text}` | `encodeURIComponent(text)` |
| `getTelegramShareLink` | `&text=${text}` | `encodeURIComponent(text)` |
| `getWhatsappShareLink` | bare URL, text dropped | `text\nlink`, matching the other targets |

Facebook and LinkedIn are left alone: both ignore the text/quote params they used to accept.

Note that `getShortUrl` returns the raw link for logged-out visitors, so their shares stay unattributed on every path, copy included. That is existing behaviour, unchanged here.

## Logging

`ShareProvider` + per-surface `Origin` on the existing entity events — `LogEvent.ShareTag` / `LogEvent.ShareSource` with `extra: {provider, origin}`.

> Deliberate deviation from the brief's `LogEvent.SharePost`: that event is post-shaped (always emitted via `postLogEvent`, carrying `post_*` fields and `target_type: 'post'`). Reusing the entity events keeps the promoted control measurable against the same event the "…" menu already fires, so the promotion is a clean before/after. Happy to switch if analytics prefers one event name.

## OG meta status, per route

Checked against `next-seo`'s actual `buildTags` behaviour rather than assuming.

| Route | og:title | og:description | og:url / canonical | og:image |
|---|---|---|---|---|
| `/tags/[tag]` | ✅ per-tag | ✅ per-tag (`flags.description`, else a generated sentence) | ✅ per-route, from `_app`'s `DefaultSeo` | ⚠️ generic daily.dev card |
| `/sources/[source]` | ✅ per-source | ✅ `source.description`, else the site default | ✅ per-route, same mechanism | ⚠️ generic daily.dev card |

A shared tag/source link **already** unfurls naming the specific entity — no code change needed. `__tests__/TagSourceSeo.spec.ts` locks that behaviour (including the nullable fallbacks) so it can't silently regress now that these links are promoted.

**Explicitly not faked:** per-entity `og:image`. There is no OG-image renderer for tags or sources — `og.daily.dev` only serves `/api/posts/:id`. Needs a backend/OG-service change, out of scope here.

## Storybook

`Components/Share/EntityShareAction` — one **All States** page mapping every surface, state and opt-in combination, a before/after comparison against the old row, the three copy-control displays, and an interactive playground. Plus per-state stories for isolated review.

## Verification

- `NODE_ENV=test pnpm --filter shared test` — 298 suites / 2009 tests ✅
- `NODE_ENV=test pnpm --filter webapp test` — 45 suites / 302 tests ✅ (cross-package check per AGENTS.md; `SourcePage.tsx` and `TagPage.tsx` reworked to reach Block through the menu)
- `pnpm --filter shared lint` ✅ · `pnpm --filter webapp lint` ✅
- `node ./scripts/typecheck-strict-changed.js` ✅ — clean. The 3 pre-existing violations in the files this PR touches are fixed rather than skip-listed: `feeds?.edges?.length > 0` → `feeds?.edges?.length`, and `source.id` hoisted to a `sourceId` fallback (`source.id ?? source.handle`) for the follow/unfollow entity id, since `Source['id']` is optional on the model.
- `build` not run, per instructions.

On the share links specifically: a regression test builds Reddit/Telegram/WhatsApp links from `Rust & Go: what #1 teams ask? 100% real` and reads the params back through `URL`, and the attribution test seeds the query cache under the *tagged* url's key so it only passes if the `cid` actually reaches the social path.

Tests assert: the label copies straight to the clipboard with the "✅ Copied link to clipboard" toast; the chevron opens the list without copying; mobile single tap → `navigator.share`; the entity log event carries provider + origin; the in-menu Share entry disappears only where the visible control shows; Block moves to the menu and Unblock returns to the row; and the embedded consumer keeps its original row.

## Open questions

1. Log event name — entity events (`ShareTag`/`ShareSource`) vs the brief's `SharePost`. See above.
2. Tag share link is `globalThis?.location?.href`, inherited verbatim from the existing menu wiring so both controls agree. It carries whatever query string the visitor arrived with. A canonical `${webappUrl}tags/${tag}` would be cleaner for a promoted control — easy follow-up.
3. Block sits under "Add to custom feed" in the menu (`additionalOptions` appends). Say the word if it should sit first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-tags-sources.preview.app.daily.dev