### PR TITLE
feat(share): leaderboard share affordances + share-my-rank card

### DIFF
--- a/packages/shared/src/components/cards/Leaderboard/CurrentUserPositionRow.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/CurrentUserPositionRow.tsx
@@ -1,17 +1,9 @@
 import type { ReactElement } from 'react';
 import React from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { useAuthContext } from '../../../contexts/AuthContext';
-import { gqlClient } from '../../../graphql/common';
-import type {
-  LeaderboardPosition,
-  LeaderboardType,
-} from '../../../graphql/leaderboard';
-import {
-  isLeaderboardPositionSupported,
-  LEADERBOARD_POSITION_QUERY,
-} from '../../../graphql/leaderboard';
-import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import type { LeaderboardType } from '../../../graphql/leaderboard';
+import { isLeaderboardPositionSupported } from '../../../graphql/leaderboard';
+import { useLeaderboardPosition } from '../../../hooks/leaderboard/useLeaderboardPosition';
 import { largeNumberFormat } from '../../../lib';
 import { UserHighlight } from '../../widgets/PostUsersHighlights';
 
@@ -31,27 +23,16 @@ export function CurrentUserPositionRow({
     !visibleUserIds.has(user.id) &&
     isLeaderboardPositionSupported(type);
 
-  const { data } = useQuery({
-    queryKey: generateQueryKey(RequestKey.LeaderboardPosition, user, type),
-    queryFn: async () => {
-      const res = await gqlClient.request<{
-        leaderboardPosition: LeaderboardPosition | null;
-      }>(LEADERBOARD_POSITION_QUERY, { type });
+  const { position } = useLeaderboardPosition({ type, enabled });
 
-      return res.leaderboardPosition;
-    },
-    enabled,
-    staleTime: StaleTime.Default,
-  });
-
-  if (!enabled || !data) {
+  if (!enabled || !position) {
     return null;
   }
 
   const rankLabel =
-    data.rank === null
-      ? `${largeNumberFormat(data.cappedAt)}+`
-      : `#${data.rank.toLocaleString()}`;
+    position.rank === null
+      ? `${largeNumberFormat(position.cappedAt)}+`
+      : `#${position.rank.toLocaleString()}`;
 
   return (
     <li className="mt-1.5 flex w-full flex-row items-center rounded-8 border-t border-border-subtlest-tertiary px-2 pt-3">

--- a/packages/shared/src/components/cards/Leaderboard/LeaderboardListContainer.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/LeaderboardListContainer.tsx
@@ -1,10 +1,36 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import type { LeaderboardListContainerProps } from './common';
 import { LeaderboardCard } from './common';
 import Link from '../../utilities/Link';
 import { ArrowIcon } from '../../icons';
 import { IconSize } from '../../Icon';
+
+interface TitleHeadingProps {
+  title: string;
+  titleHref?: string;
+  className?: string;
+}
+
+const TitleHeading = ({
+  title,
+  titleHref,
+  className,
+}: TitleHeadingProps): ReactElement => (
+  <h3 className={classNames('font-bold typo-title3', className)}>
+    {titleHref ? (
+      <Link href={titleHref} passHref prefetch={false}>
+        <a className="flex w-fit items-center gap-1 hover:underline">
+          {title}
+          <ArrowIcon className="rotate-90" size={IconSize.XSmall} />
+        </a>
+      </Link>
+    ) : (
+      <>{title}</>
+    )}
+  </h3>
+);
 
 export function LeaderboardListContainer({
   children,
@@ -13,25 +39,20 @@ export function LeaderboardListContainer({
   titleHref,
   footer,
   header,
+  titleAction,
 }: LeaderboardListContainerProps): ReactElement {
+  const defaultHeader = titleAction ? (
+    <div className="mb-2 flex items-center justify-between gap-2">
+      <TitleHeading title={title} titleHref={titleHref} />
+      {titleAction}
+    </div>
+  ) : (
+    <TitleHeading title={title} titleHref={titleHref} className="mb-2" />
+  );
+
   return (
     <LeaderboardCard className={className}>
-      {header ?? (
-        <h3 className="mb-2 font-bold typo-title3">
-          {titleHref ? (
-            <Link href={titleHref} passHref prefetch={false}>
-              <a className="flex w-fit items-center gap-1 hover:underline">
-                {title}
-                {titleHref && (
-                  <ArrowIcon className="rotate-90" size={IconSize.XSmall} />
-                )}
-              </a>
-            </Link>
-          ) : (
-            <>{title}</>
-          )}
-        </h3>
-      )}
+      {header ?? defaultHeader}
       <ol className="flex flex-col gap-1.5 typo-body">{children}</ol>
       {footer && <div className="mt-auto">{footer}</div>}
     </LeaderboardCard>

--- a/packages/shared/src/components/cards/Leaderboard/LeaderboardRankShare.spec.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/LeaderboardRankShare.spec.tsx
@@ -1,0 +1,183 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { LeaderboardRankShare } from './LeaderboardRankShare';
+import type { LeaderboardPosition } from '../../../graphql/leaderboard';
+import { LeaderboardType } from '../../../graphql/leaderboard';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import loggedUser from '../../../../__tests__/fixture/loggedUser';
+import { useLeaderboardShareEnabled } from '../../../hooks/leaderboard/useLeaderboardShareEnabled';
+import { useLeaderboardPosition } from '../../../hooks/leaderboard/useLeaderboardPosition';
+import { useViewSize } from '../../../hooks/useViewSize';
+import { getShortLinkProps } from '../../../hooks/utils/useGetShortUrl';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import { TOAST_NOTIF_KEY } from '../../../hooks/useToastNotification';
+import type { ToastNotification } from '../../../hooks/useToastNotification';
+
+// `NEXT_PUBLIC_WEBAPP_URL` is '/' under jest, but the referral tracker builds a
+// `new URL(...)` and needs the absolute origin production actually ships.
+jest.mock('../../../lib/constants', () => ({
+  ...jest.requireActual('../../../lib/constants'),
+  webappUrl: 'https://app.daily.dev/',
+}));
+
+jest.mock('../../../hooks/leaderboard/useLeaderboardShareEnabled', () => ({
+  useLeaderboardShareEnabled: jest.fn(),
+}));
+
+jest.mock('../../../hooks/leaderboard/useLeaderboardPosition', () => ({
+  useLeaderboardPosition: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const shareEnabledMock = useLeaderboardShareEnabled as jest.Mock;
+const positionMock = useLeaderboardPosition as jest.Mock;
+const viewSizeMock = useViewSize as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const link = 'https://app.daily.dev/users/longestStreak';
+const shortLink = 'https://dly.to/rank12';
+
+const mockPosition = (
+  position: LeaderboardPosition | null,
+  isPending = false,
+) => positionMock.mockReturnValue({ position, isPending });
+
+let client: QueryClient;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  shareEnabledMock.mockReturnValue(true);
+  viewSizeMock.mockReturnValue(true); // laptop
+  mockPosition({ rank: 12, score: 340, cappedAt: 5000 });
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // Pre-seed the short-URL cache so the copy path never hits the network.
+  const { queryKey } = getShortLinkProps(
+    link,
+    ReferralCampaignKey.Generic,
+    loggedUser,
+  );
+  client.setQueryData(queryKey, shortLink);
+});
+
+afterEach(() => {
+  delete (navigator as unknown as { share?: unknown }).share;
+  globalThis.localStorage.removeItem('mobile');
+});
+
+const renderComponent = (type = LeaderboardType.LongestStreak): RenderResult =>
+  render(
+    <TestBootProvider client={client} auth={{ user: loggedUser }}>
+      <LeaderboardRankShare type={type} />
+    </TestBootProvider>,
+  );
+
+describe('LeaderboardRankShare', () => {
+  it('renders the rank headline and the pre-filled share text', () => {
+    renderComponent();
+
+    expect(screen.getByText('#12')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "I'm #12 on the daily.dev longest streak leaderboard. Still climbing.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('uses the top-tier copy for a top three rank', () => {
+    mockPosition({ rank: 2, score: 900, cappedAt: 5000 });
+    renderComponent();
+
+    expect(
+      screen.getByText(
+        "Somehow I'm #2 on the daily.dev longest streak leaderboard. Come take the spot.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing while the position is still loading', () => {
+    mockPosition(null, true);
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the viewer sits past the ranked cap', () => {
+    mockPosition({ rank: null, score: 3, cappedAt: 5000 });
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByText(/#undefined|#null/)).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when the API returns no position at all', () => {
+    mockPosition(null);
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a leaderboard without position support', () => {
+    const { container } = renderComponent(LeaderboardType.MostUpvoted);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the flag is off', () => {
+    shareEnabledMock.mockReturnValue(false);
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('copies the tracked link and shows a toast on desktop', async () => {
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Share your rank'));
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(shortLink));
+    await waitFor(() =>
+      expect(
+        (client.getQueryData(TOAST_NOTIF_KEY) as ToastNotification)?.message,
+      ).toEqual('✅ Copied link to clipboard'),
+    );
+  });
+
+  it('opens the native share sheet with the rank text on mobile', async () => {
+    viewSizeMock.mockReturnValue(false);
+    globalThis.localStorage.setItem('mobile', 'true');
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share });
+
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Share your rank'));
+    });
+
+    await waitFor(() => expect(share).toHaveBeenCalled());
+    expect(share.mock.calls[0][0].text).toContain(
+      "I'm #12 on the daily.dev longest streak leaderboard",
+    );
+    expect(share.mock.calls[0][0].text).toContain(shortLink);
+  });
+});

--- a/packages/shared/src/components/cards/Leaderboard/LeaderboardRankShare.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/LeaderboardRankShare.tsx
@@ -77,7 +77,7 @@ export function LeaderboardRankCard({
         label="Share your rank"
         onShare={(provider) =>
           logEvent({
-            event_name: LogEvent.ShareLeaderboardRank,
+            event_name: LogEvent.ShareLeaderboard,
             target_id: type,
             extra: JSON.stringify({
               provider,

--- a/packages/shared/src/components/cards/Leaderboard/LeaderboardRankShare.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/LeaderboardRankShare.tsx
@@ -1,0 +1,128 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { ShareActions } from '../../share/ShareActions';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { TopRankBadge } from './TopRankBadge';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useLogContext } from '../../../contexts/LogContext';
+import type { LeaderboardType } from '../../../graphql/leaderboard';
+import {
+  isLeaderboardPositionSupported,
+  leaderboardTypeToTitle,
+} from '../../../graphql/leaderboard';
+import { useLeaderboardPosition } from '../../../hooks/leaderboard/useLeaderboardPosition';
+import { useLeaderboardShareEnabled } from '../../../hooks/leaderboard/useLeaderboardShareEnabled';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import {
+  getLeaderboardRankShareText,
+  getLeaderboardUrl,
+} from '../../../lib/leaderboardShare';
+import { LogEvent, Origin } from '../../../lib/log';
+
+interface LeaderboardRankCardProps {
+  type: LeaderboardType;
+  rank: number;
+  className?: string;
+}
+
+// Presentation only — takes a resolved rank so Storybook can render every
+// state. Product surfaces should use `LeaderboardRankShare`, which owns the
+// flag gate and the "no honest rank to share" cases.
+export function LeaderboardRankCard({
+  type,
+  rank,
+  className,
+}: LeaderboardRankCardProps): ReactElement {
+  const { logEvent } = useLogContext();
+  const board = leaderboardTypeToTitle[type].toLowerCase();
+  const text = getLeaderboardRankShareText(type, rank);
+
+  return (
+    <section
+      className={classNames(
+        'mb-6 flex items-center gap-3 rounded-12 border border-border-subtlest-tertiary bg-surface-float p-4',
+        className,
+      )}
+      aria-label="Your leaderboard rank"
+    >
+      <TopRankBadge rankIndex={rank - 1} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <Typography type={TypographyType.Callout} bold>
+          You&apos;re <span className="tabular-nums">#{rank}</span> on the{' '}
+          {board} leaderboard
+        </Typography>
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+          className="truncate"
+        >
+          {text}
+        </Typography>
+      </div>
+      <ShareActions
+        link={getLeaderboardUrl(type)}
+        text={text}
+        cid={ReferralCampaignKey.Generic}
+        emailTitle={`My daily.dev ${board} rank`}
+        emailSummary={text}
+        buttonVariant={ButtonVariant.Primary}
+        buttonSize={ButtonSize.Medium}
+        className="shrink-0"
+        label="Share your rank"
+        onShare={(provider) =>
+          logEvent({
+            event_name: LogEvent.ShareLeaderboardRank,
+            target_id: type,
+            extra: JSON.stringify({
+              provider,
+              rank,
+              origin: Origin.Leaderboard,
+            }),
+          })
+        }
+      />
+    </section>
+  );
+}
+
+interface LeaderboardRankShareProps {
+  type: LeaderboardType;
+  className?: string;
+}
+
+export function LeaderboardRankShare({
+  type,
+  className,
+}: LeaderboardRankShareProps): ReactElement | null {
+  const isEnabled = useLeaderboardShareEnabled();
+  const { user, isAuthReady } = useAuthContext();
+  const isSupported = isLeaderboardPositionSupported(type);
+  const { position, isPending } = useLeaderboardPosition({
+    type,
+    enabled: isEnabled && isAuthReady && !!user && isSupported,
+  });
+
+  if (!isEnabled || !user || !isSupported || isPending) {
+    return null;
+  }
+
+  // `rank` is null once the viewer sits past `cappedAt` — there is no honest
+  // number to put in the share text, so no rank-share affordance either.
+  if (!position || position.rank === null) {
+    return null;
+  }
+
+  return (
+    <LeaderboardRankCard
+      type={type}
+      rank={position.rank}
+      className={className}
+    />
+  );
+}

--- a/packages/shared/src/components/cards/Leaderboard/LeaderboardShareButton.spec.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/LeaderboardShareButton.spec.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { LeaderboardShareButton } from './LeaderboardShareButton';
+import { LeaderboardListContainer } from './LeaderboardListContainer';
+import { LeaderboardType } from '../../../graphql/leaderboard';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import loggedUser from '../../../../__tests__/fixture/loggedUser';
+import { useLeaderboardShareEnabled } from '../../../hooks/leaderboard/useLeaderboardShareEnabled';
+import { useViewSize } from '../../../hooks/useViewSize';
+import { getShortLinkProps } from '../../../hooks/utils/useGetShortUrl';
+import { ReferralCampaignKey } from '../../../lib/referral';
+
+// `NEXT_PUBLIC_WEBAPP_URL` is '/' under jest, but the referral tracker builds a
+// `new URL(...)` and needs the absolute origin production actually ships.
+jest.mock('../../../lib/constants', () => ({
+  ...jest.requireActual('../../../lib/constants'),
+  webappUrl: 'https://app.daily.dev/',
+}));
+
+jest.mock('../../../hooks/leaderboard/useLeaderboardShareEnabled', () => ({
+  useLeaderboardShareEnabled: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const shareEnabledMock = useLeaderboardShareEnabled as jest.Mock;
+const viewSizeMock = useViewSize as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const link = 'https://app.daily.dev/users/longestStreak';
+const shortLink = 'https://dly.to/board';
+
+let client: QueryClient;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  shareEnabledMock.mockReturnValue(true);
+  viewSizeMock.mockReturnValue(true); // laptop
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const { queryKey } = getShortLinkProps(
+    link,
+    ReferralCampaignKey.Generic,
+    loggedUser,
+  );
+  client.setQueryData(queryKey, shortLink);
+});
+
+const renderButton = (): RenderResult =>
+  render(
+    <TestBootProvider client={client} auth={{ user: loggedUser }}>
+      <LeaderboardShareButton type={LeaderboardType.LongestStreak} />
+    </TestBootProvider>,
+  );
+
+describe('LeaderboardShareButton', () => {
+  it('renders a labelled trigger naming the leaderboard', () => {
+    renderButton();
+
+    expect(
+      screen.getByLabelText('Share the longest streak leaderboard'),
+    ).toBeInTheDocument();
+  });
+
+  it('copies the leaderboard permalink', async () => {
+    renderButton();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByLabelText('Share the longest streak leaderboard'),
+      );
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Copy link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(shortLink));
+  });
+
+  it('renders nothing when the flag is off', () => {
+    shareEnabledMock.mockReturnValue(false);
+    const { container } = renderButton();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+const renderContainer = (titleAction?: React.ReactNode): RenderResult =>
+  render(
+    <TestBootProvider client={client} auth={{ user: loggedUser }}>
+      <LeaderboardListContainer
+        title="Longest streak"
+        titleHref="/users/longestStreak"
+        titleAction={titleAction}
+      >
+        <li>row</li>
+      </LeaderboardListContainer>
+    </TestBootProvider>,
+  );
+
+describe('LeaderboardListContainer title action', () => {
+  it('keeps the plain heading markup when no title action is passed', () => {
+    renderContainer();
+
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading).toHaveClass('mb-2');
+    // No wrapper is inserted: the heading still sits directly above the list.
+    expect(heading.nextElementSibling?.tagName).toBe('OL');
+  });
+
+  it('lays the heading and the action out in one row when passed', () => {
+    renderContainer(
+      <LeaderboardShareButton type={LeaderboardType.LongestStreak} />,
+    );
+
+    const heading = screen.getByRole('heading', { level: 3 });
+    expect(heading).not.toHaveClass('mb-2');
+    expect(heading.parentElement).toHaveClass('justify-between');
+    expect(
+      screen.getByLabelText('Share the longest streak leaderboard'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/cards/Leaderboard/LeaderboardShareButton.tsx
+++ b/packages/shared/src/components/cards/Leaderboard/LeaderboardShareButton.tsx
@@ -1,0 +1,64 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { ButtonSize } from '../../buttons/Button';
+import { ShareActions } from '../../share/ShareActions';
+import { useLogContext } from '../../../contexts/LogContext';
+import type { LeaderboardType } from '../../../graphql/leaderboard';
+import { leaderboardTypeToTitle } from '../../../graphql/leaderboard';
+import { useLeaderboardShareEnabled } from '../../../hooks/leaderboard/useLeaderboardShareEnabled';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import {
+  getLeaderboardShareText,
+  getLeaderboardUrl,
+} from '../../../lib/leaderboardShare';
+import { LogEvent, Origin } from '../../../lib/log';
+
+interface LeaderboardShareControlProps {
+  type: LeaderboardType;
+  buttonSize?: ButtonSize;
+  className?: string;
+}
+
+// Presentation only — renders unconditionally so Storybook can show it without
+// a GrowthBook instance. Product surfaces should use `LeaderboardShareButton`.
+export function LeaderboardShareControl({
+  type,
+  buttonSize,
+  className,
+}: LeaderboardShareControlProps): ReactElement {
+  const { logEvent } = useLogContext();
+  const title = leaderboardTypeToTitle[type];
+  const text = getLeaderboardShareText(type);
+
+  return (
+    <ShareActions
+      link={getLeaderboardUrl(type)}
+      text={text}
+      cid={ReferralCampaignKey.Generic}
+      emailTitle={title}
+      emailSummary={text}
+      buttonSize={buttonSize}
+      className={className}
+      label={`Share the ${title.toLowerCase()} leaderboard`}
+      onShare={(provider) =>
+        logEvent({
+          event_name: LogEvent.ShareLeaderboard,
+          target_id: type,
+          extra: JSON.stringify({ provider, origin: Origin.Leaderboard }),
+        })
+      }
+    />
+  );
+}
+
+export function LeaderboardShareButton(
+  props: LeaderboardShareControlProps,
+): ReactElement | null {
+  const isEnabled = useLeaderboardShareEnabled();
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return <LeaderboardShareControl {...props} />;
+}

--- a/packages/shared/src/components/cards/Leaderboard/common.ts
+++ b/packages/shared/src/components/cards/Leaderboard/common.ts
@@ -8,6 +8,8 @@ export interface LeaderboardListContainerProps {
   className?: string;
   footer?: ReactNode;
   header?: ReactNode;
+  /** Trailing control rendered next to the card title (e.g. a share button). */
+  titleAction?: ReactNode;
 }
 
 export const LeaderboardCard = classed(

--- a/packages/shared/src/hooks/leaderboard/useLeaderboardPosition.ts
+++ b/packages/shared/src/hooks/leaderboard/useLeaderboardPosition.ts
@@ -1,0 +1,45 @@
+import { useQuery } from '@tanstack/react-query';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { gqlClient } from '../../graphql/common';
+import type {
+  LeaderboardPosition,
+  LeaderboardType,
+} from '../../graphql/leaderboard';
+import { LEADERBOARD_POSITION_QUERY } from '../../graphql/leaderboard';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
+
+interface UseLeaderboardPositionProps {
+  type: LeaderboardType;
+  enabled: boolean;
+}
+
+interface UseLeaderboardPosition {
+  position: LeaderboardPosition | null;
+  isPending: boolean;
+}
+
+// The API resolves the position for the *viewer*, so there is no user argument.
+// `position` is null both while disabled and when the backend has no row for
+// the viewer; callers must treat a null `position.rank` (viewer sits past
+// `cappedAt`) as "no rank" rather than rendering a number.
+export const useLeaderboardPosition = ({
+  type,
+  enabled,
+}: UseLeaderboardPositionProps): UseLeaderboardPosition => {
+  const { user } = useAuthContext();
+
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.LeaderboardPosition, user, type),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        leaderboardPosition: LeaderboardPosition | null;
+      }>(LEADERBOARD_POSITION_QUERY, { type });
+
+      return res.leaderboardPosition;
+    },
+    enabled,
+    staleTime: StaleTime.Default,
+  });
+
+  return { position: data ?? null, isPending: enabled && isPending };
+};

--- a/packages/shared/src/hooks/leaderboard/useLeaderboardShareEnabled.spec.tsx
+++ b/packages/shared/src/hooks/leaderboard/useLeaderboardShareEnabled.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { useLeaderboardShareEnabled } from './useLeaderboardShareEnabled';
+import { useConditionalFeature } from '../useConditionalFeature';
+import type { Feature } from '../../lib/featureManagement';
+import {
+  featureSharingVisibility,
+  featureShareLeaderboard,
+} from '../../lib/featureManagement';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+
+jest.mock('../useConditionalFeature', () => ({
+  useConditionalFeature: jest.fn(),
+}));
+
+const conditionalFeatureMock = useConditionalFeature as jest.Mock;
+const evaluated: string[] = [];
+
+const mockFlags = (flags: Record<string, boolean>) =>
+  conditionalFeatureMock.mockImplementation(
+    ({
+      feature,
+      shouldEvaluate,
+    }: {
+      feature: Feature<boolean>;
+      shouldEvaluate?: boolean;
+    }) => {
+      if (shouldEvaluate !== false) {
+        evaluated.push(feature.id);
+      }
+
+      return {
+        value:
+          shouldEvaluate === false ? feature.defaultValue : flags[feature.id],
+        isLoading: false,
+      };
+    },
+  );
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <TestBootProvider client={new QueryClient()}>{children}</TestBootProvider>
+);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  evaluated.length = 0;
+});
+
+describe('useLeaderboardShareEnabled', () => {
+  it('is off while the sharing-visibility kill switch is off', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: false,
+      [featureShareLeaderboard.id]: true,
+    });
+
+    const { result } = renderHook(() => useLeaderboardShareEnabled(), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(false);
+    // The per-topic flag must not be evaluated for control users.
+    expect(evaluated).not.toContain(featureShareLeaderboard.id);
+  });
+
+  it('is off when the per-topic flag is off', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: true,
+      [featureShareLeaderboard.id]: false,
+    });
+
+    const { result } = renderHook(() => useLeaderboardShareEnabled(), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is on only when both flags are on', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: true,
+      [featureShareLeaderboard.id]: true,
+    });
+
+    const { result } = renderHook(() => useLeaderboardShareEnabled(), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('never evaluates anything when the caller opts out', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: true,
+      [featureShareLeaderboard.id]: true,
+    });
+
+    const { result } = renderHook(() => useLeaderboardShareEnabled(false), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(false);
+    expect(evaluated).toHaveLength(0);
+  });
+});

--- a/packages/shared/src/hooks/leaderboard/useLeaderboardShareEnabled.ts
+++ b/packages/shared/src/hooks/leaderboard/useLeaderboardShareEnabled.ts
@@ -1,0 +1,17 @@
+import { featureShareLeaderboard } from '../../lib/featureManagement';
+import { useConditionalFeature } from '../useConditionalFeature';
+import { useSharingVisibility } from '../useSharingVisibility';
+
+// Gate for every leaderboard share affordance (directory cards, leaderboard
+// page header, personal rank card). The per-topic flag is only evaluated once
+// the sharing-visibility master switch is on, so control users never get
+// bucketed into the experiment.
+export const useLeaderboardShareEnabled = (shouldEvaluate = true): boolean => {
+  const { isEnabled: isSharingEnabled } = useSharingVisibility(shouldEvaluate);
+  const { value } = useConditionalFeature({
+    feature: featureShareLeaderboard,
+    shouldEvaluate: isSharingEnabled,
+  });
+
+  return isSharingEnabled && value;
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,9 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Adds share affordances to the leaderboard surfaces: a per-leaderboard share
+// on the directory cards, a page-level share on a leaderboard page, and the
+// personal "share my rank" card. Gated together with the sharing-visibility
+// master switch. Keep the default `false` — GrowthBook ramps it.
+export const featureShareLeaderboard = new Feature('share_leaderboard', false);

--- a/packages/shared/src/lib/leaderboardShare.ts
+++ b/packages/shared/src/lib/leaderboardShare.ts
@@ -1,0 +1,32 @@
+import type { LeaderboardType } from '../graphql/leaderboard';
+import { leaderboardTypeToTitle } from '../graphql/leaderboard';
+import { webappUrl } from './constants';
+
+// A leaderboard's public permalink — the same URL the directory card links to,
+// so a shared rank always lands on the board the rank was earned on.
+export const getLeaderboardUrl = (type: LeaderboardType): string =>
+  `${webappUrl}users/${type}`;
+
+export const getLeaderboardShareText = (type: LeaderboardType): string => {
+  const title = leaderboardTypeToTitle[type].toLowerCase();
+
+  return `Top developers by ${title} on daily.dev`;
+};
+
+const TOP_TIER_RANK = 3;
+
+// Pre-filled text for "share my rank". Deliberately understated — a share sheet
+// full of superlatives reads like a template, not like a developer.
+export const getLeaderboardRankShareText = (
+  type: LeaderboardType,
+  rank: number,
+): string => {
+  const title = leaderboardTypeToTitle[type].toLowerCase();
+  const board = `the daily.dev ${title} leaderboard`;
+
+  if (rank <= TOP_TIER_RANK) {
+    return `Somehow I'm #${rank} on ${board}. Come take the spot.`;
+  }
+
+  return `I'm #${rank} on ${board}. Still climbing.`;
+};

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -531,6 +531,9 @@ export enum LogEvent {
   SubmitGivebackCauseSuggestionError = 'submit giveback cause suggestion error',
   // Daily homepage
   DailyFeedback = 'daily feedback',
+  // Sharing visibility — leaderboards
+  ShareLeaderboard = 'share leaderboard',
+  ShareLeaderboardRank = 'share leaderboard rank',
 }
 
 export enum TargetType {

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -531,9 +531,8 @@ export enum LogEvent {
   SubmitGivebackCauseSuggestionError = 'submit giveback cause suggestion error',
   // Daily homepage
   DailyFeedback = 'daily feedback',
-  // Sharing visibility — leaderboards
+  // Sharing visibility — leaderboard (rank shares carry `rank` in extra)
   ShareLeaderboard = 'share leaderboard',
-  ShareLeaderboardRank = 'share leaderboard rank',
 }
 
 export enum TargetType {

--- a/packages/storybook/stories/components/LeaderboardShare.stories.tsx
+++ b/packages/storybook/stories/components/LeaderboardShare.stories.tsx
@@ -1,0 +1,202 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  LeaderboardRankCard,
+  LeaderboardRankShare,
+} from '@dailydotdev/shared/src/components/cards/Leaderboard/LeaderboardRankShare';
+import { LeaderboardShareControl } from '@dailydotdev/shared/src/components/cards/Leaderboard/LeaderboardShareButton';
+import { UserTopList } from '@dailydotdev/shared/src/components/cards/Leaderboard/UserTopList';
+import { FeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { LeaderboardType } from '@dailydotdev/shared/src/graphql/leaderboard';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import { fn } from 'storybook/test';
+
+const mockUser = {
+  id: '1',
+  name: 'Ada Lovelace',
+  username: 'ada',
+  email: 'ada@example.com',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/ada',
+  reputation: 420,
+} as unknown as LoggedUser;
+
+/**
+ * The repo-wide GrowthBook storybook mock returns `value || 'control'`, so a
+ * `false` default reads back as the truthy string 'control' and every flag
+ * looks ON. These stories therefore never assert a flag: the ON states render
+ * the presentational components directly, and the control state holds
+ * `FeaturesReadyContext` as not-ready, which is the one reliable way to force
+ * `useConditionalFeature` back to the default here. Jest owns the real
+ * flag-off guarantee (`useLeaderboardShareEnabled.spec.tsx`).
+ */
+const withProviders =
+  ({ featuresReady = true }: { featuresReady?: boolean } = {}) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const LogContext = getLogContextStatic();
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={
+            {
+              user: mockUser,
+              isLoggedIn: true,
+              isAuthReady: true,
+              shouldShowLogin: false,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              tokenRefreshed: true,
+              getRedirectUri: fn(),
+              refetchBoot: fn(),
+              squads: [],
+            } as never
+          }
+        >
+          <FeaturesReadyContext.Provider
+            value={{
+              ready: featuresReady,
+              getFeatureValue: (feature) => feature.defaultValue as never,
+            }}
+          >
+            <LogContext.Provider
+              value={{
+                logEvent: fn(),
+                logEventStart: fn(),
+                logEventEnd: fn(),
+                sendBeacon: () => false,
+              }}
+            >
+              <div className="mx-auto w-full max-w-screen-tablet p-4">
+                <Story />
+              </div>
+            </LogContext.Provider>
+          </FeaturesReadyContext.Provider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+
+const Note = ({ children }: { children: React.ReactNode }) => (
+  <p className="text-text-tertiary typo-footnote">{children}</p>
+);
+
+const meta: Meta<typeof LeaderboardRankCard> = {
+  title: 'Components/Share/LeaderboardShare',
+  component: LeaderboardRankCard,
+  args: { type: LeaderboardType.LongestStreak, rank: 12 },
+  argTypes: {
+    type: {
+      control: 'select',
+      options: Object.values(LeaderboardType),
+    },
+    rank: { control: { type: 'number', min: 1 } },
+  },
+  decorators: [withProviders()],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LeaderboardRankCard>;
+
+// The headline affordance: the viewer's own rank, with the exact text that
+// will be shared spelled out underneath it.
+export const OwnRank: Story = {};
+
+// Top three earns the medal badge and the cheekier line.
+export const OwnRankTopThree: Story = {
+  args: { rank: 2 },
+};
+
+// Four figures — the rank stays legible thanks to tabular numerals.
+export const OwnRankDeep: Story = {
+  args: { rank: 1487 },
+};
+
+export const RankShareByLeaderboard: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <LeaderboardRankCard
+        {...args}
+        type={LeaderboardType.LongestStreak}
+        rank={3}
+      />
+      <LeaderboardRankCard
+        {...args}
+        type={LeaderboardType.HighestReputation}
+        rank={58}
+      />
+      <LeaderboardRankCard
+        {...args}
+        type={LeaderboardType.MostReadingDays}
+        rank={204}
+      />
+    </div>
+  ),
+};
+
+// Unranked / still loading / control all resolve to the same thing: nothing.
+// `LeaderboardRankShare` is the gated component, so with features held
+// not-ready it renders the control variant.
+export const NoRankOrFlagOff: Story = {
+  render: () => (
+    <div className="flex flex-col gap-2">
+      <LeaderboardRankShare type={LeaderboardType.LongestStreak} />
+      <Note>
+        Unranked (rank past the cap), still loading, or flag off — the rank card
+        renders nothing and the page keeps its current layout.
+      </Note>
+    </div>
+  ),
+  decorators: [withProviders({ featuresReady: false })],
+};
+
+const leaderboardItems = [
+  { score: 96, user: { ...mockUser, id: '1', username: 'ada' } },
+  { score: 74, user: { ...mockUser, id: '2', username: 'grace' } },
+  { score: 51, user: { ...mockUser, id: '3', username: 'linus' } },
+];
+
+// Directory surface: each leaderboard card on /users gets its own share
+// control next to the card title.
+export const DirectoryCard: StoryObj = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <UserTopList
+        containerProps={{
+          title: 'Longest streak',
+          titleHref: `/users/${LeaderboardType.LongestStreak}`,
+          titleAction: (
+            <LeaderboardShareControl type={LeaderboardType.LongestStreak} />
+          ),
+        }}
+        items={leaderboardItems}
+        isLoading={false}
+        concatScore={false}
+      />
+      <UserTopList
+        containerProps={{
+          title: 'Longest streak',
+          titleHref: `/users/${LeaderboardType.LongestStreak}`,
+        }}
+        items={leaderboardItems}
+        isLoading={false}
+        concatScore={false}
+      />
+      <Note>
+        Top: sharing on. Bottom: control — no title action is passed, so the
+        heading keeps its original markup.
+      </Note>
+    </div>
+  ),
+};

--- a/packages/webapp/pages/users.tsx
+++ b/packages/webapp/pages/users.tsx
@@ -24,6 +24,8 @@ import { CompanyTopList } from '@dailydotdev/shared/src/components/cards/Leaderb
 import type { PopularHotTakes } from '@dailydotdev/shared/src/components/cards/Leaderboard/PopularHotTakesList';
 import { PopularHotTakesList } from '@dailydotdev/shared/src/components/cards/Leaderboard/PopularHotTakesList';
 import { PublicPageSignupBanner } from '@dailydotdev/shared/src/components/auth/PublicPageSignupBanner';
+import { LeaderboardShareButton } from '@dailydotdev/shared/src/components/cards/Leaderboard/LeaderboardShareButton';
+import { useLeaderboardShareEnabled } from '@dailydotdev/shared/src/hooks/leaderboard/useLeaderboardShareEnabled';
 import { getLayout as getFooterNavBarLayout } from '../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../components/layouts/MainLayout';
 import { defaultOpenGraph } from '../next-seo';
@@ -85,6 +87,11 @@ const LeaderboardPage = ({
   const { isFallback: isLoading } = useRouter();
   const { isV2 } = useLayoutVariant();
   const isV2Laptop = isV2;
+  const isShareEnabled = useLeaderboardShareEnabled();
+  // Only hand the card a title action when sharing is on, so the control
+  // variant keeps the plain `<h3>` heading instead of an empty flex wrapper.
+  const shareAction = (type: LeaderboardType) =>
+    isShareEnabled ? <LeaderboardShareButton type={type} /> : undefined;
 
   if (isLoading) {
     return <></>;
@@ -107,6 +114,7 @@ const LeaderboardPage = ({
               containerProps={{
                 title: 'Highest level',
                 titleHref: `/users/${LeaderboardType.HighestLevel}`,
+                titleAction: shareAction(LeaderboardType.HighestLevel),
               }}
               items={highestLevel}
               isLoading={isLoading}
@@ -117,6 +125,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Highest reputation',
               titleHref: `/users/${LeaderboardType.HighestReputation}`,
+              titleAction: shareAction(LeaderboardType.HighestReputation),
             }}
             items={highestReputation}
             isLoading={isLoading}
@@ -126,6 +135,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Longest streak',
               titleHref: `/users/${LeaderboardType.LongestStreak}`,
+              titleAction: shareAction(LeaderboardType.LongestStreak),
             }}
             items={longestStreak}
             isLoading={isLoading}
@@ -136,6 +146,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Highest post views',
               titleHref: `/users/${LeaderboardType.HighestPostViews}`,
+              titleAction: shareAction(LeaderboardType.HighestPostViews),
             }}
             items={highestPostViews}
             isLoading={isLoading}
@@ -144,6 +155,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Most upvoted',
               titleHref: `/users/${LeaderboardType.MostUpvoted}`,
+              titleAction: shareAction(LeaderboardType.MostUpvoted),
             }}
             items={mostUpvoted}
             isLoading={isLoading}
@@ -152,6 +164,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Most referrals',
               titleHref: `/users/${LeaderboardType.MostReferrals}`,
+              titleAction: shareAction(LeaderboardType.MostReferrals),
             }}
             items={mostReferrals}
             isLoading={isLoading}
@@ -160,6 +173,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Most reading days',
               titleHref: `/users/${LeaderboardType.MostReadingDays}`,
+              titleAction: shareAction(LeaderboardType.MostReadingDays),
             }}
             items={mostReadingDays}
             isLoading={isLoading}
@@ -169,6 +183,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Most achievement points',
               titleHref: `/users/${LeaderboardType.MostAchievementPoints}`,
+              titleAction: shareAction(LeaderboardType.MostAchievementPoints),
             }}
             items={mostAchievementPoints}
             isLoading={isLoading}
@@ -177,6 +192,7 @@ const LeaderboardPage = ({
             containerProps={{
               title: 'Most verified employees',
               titleHref: `/users/${LeaderboardType.MostVerifiedUsers}`,
+              titleAction: shareAction(LeaderboardType.MostVerifiedUsers),
             }}
             items={mostVerifiedUsers}
             isLoading={isLoading}

--- a/packages/webapp/pages/users/[id].tsx
+++ b/packages/webapp/pages/users/[id].tsx
@@ -31,6 +31,9 @@ import {
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import { LeaderboardShareButton } from '@dailydotdev/shared/src/components/cards/Leaderboard/LeaderboardShareButton';
+import { LeaderboardRankShare } from '@dailydotdev/shared/src/components/cards/Leaderboard/LeaderboardRankShare';
+import { useLeaderboardShareEnabled } from '@dailydotdev/shared/src/hooks/leaderboard/useLeaderboardShareEnabled';
 import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
 import { getLayout } from '../../components/layouts/MainLayout';
 import { defaultOpenGraph } from '../../next-seo';
@@ -72,6 +75,12 @@ const LeaderboardDetailPage = ({
   const isCompany = isCompanyLeaderboard(leaderboardType);
   const isLevelLeaderboard = leaderboardType === LeaderboardType.HighestLevel;
   const concatScore = leaderboardType !== LeaderboardType.LongestStreak;
+  const isShareEnabled = useLeaderboardShareEnabled();
+  // Rendered as `undefined` when sharing is off so the header/breadcrumb row
+  // keeps its control-variant DOM instead of an empty actions wrapper.
+  const shareButton = isShareEnabled ? (
+    <LeaderboardShareButton type={leaderboardType} />
+  ) : undefined;
 
   if (isLoading || !title) {
     return <></>;
@@ -97,7 +106,9 @@ const LeaderboardDetailPage = ({
               </strong>
             </span>
           }
-        />
+        >
+          {shareButton}
+        </PageHeader>
       )}
       <PageWrapperLayout>
         {!isV2Laptop && (
@@ -110,9 +121,11 @@ const LeaderboardDetailPage = ({
               <span className="px-1">/</span>
               {title}
             </BreadCrumbs>
+            {shareButton}
           </div>
         )}
         <div className="mx-auto w-full max-w-screen-laptop">
+          {!isCompany && <LeaderboardRankShare type={leaderboardType} />}
           {isCompany ? (
             <CompanyTopList
               containerProps={{ title }}


### PR DESCRIPTION
Part of the **sharing visibility** initiative. Stacked on PR 1 (#6343) — base is `claude/website-sharing-visibility-be6b32`, **not** `main`.

## What changed

### 1. Share your own rank (the headline)
A rank card above the list on a leaderboard page (`/users/[type]`), for signed-in viewers who actually have a rank:

> **You're #12 on the longest streak leaderboard**
> _I'm #12 on the daily.dev longest streak leaderboard. Still climbing._

- The pre-filled share text is rendered under the headline, so what you'll post is what you see.
- Top-3 gets the existing `TopRankBadge` medal and a different line ("Somehow I'm #2 on the daily.dev longest streak leaderboard. Come take the spot.").
- Rank uses `tabular-nums`; the share control is an `aria-label`'d, keyboard-operable `ShareActions` trigger (mobile → native share sheet, desktop → share popover).

### 2. Directory share (`/users`)
Each leaderboard card gets its own share control next to the card title, sharing that board's permalink. Delivered through a new optional `titleAction` slot on `LeaderboardListContainer`.

### 3. Page-level share (`/users/[type]`)
In the v2 `PageHeader` actions slot and in the legacy breadcrumb row.

**Composition check:** the detail page deliberately does *not* pass `titleAction`, so the page-level share and the card share never double-render. The directory page has no page-level share for the same reason.

## How rank is sourced

The **existing** `leaderboardPosition(type)` query (`packages/shared/src/graphql/leaderboard.ts`) → `{ rank: number | null, score, cappedAt }`. No new field, no invented name.

- It is **viewer-scoped** — there is no `userId` argument; the API resolves the position of the authenticated caller.
- It is only supported for `highestReputation`, `longestStreak`, `mostReadingDays` (`isLeaderboardPositionSupported`). Other boards render no rank card.
- `rank` is `null` when the viewer sits past `cappedAt`. That renders **nothing** — there is no honest number, so no share affordance. Same for loading, no data, signed-out, and unsupported boards. There is no code path that can produce "I'm #undefined".

`useLeaderboardPosition` extracts the query `CurrentUserPositionRow` already ran inline; both now share one cache entry (identical query key).

## OG image — deferred, with a backend dependency

**Not shipped.** Building it now would be half-building it:

1. **No per-user rank on the API.** `leaderboardPosition` takes no `userId`, so an ISR image-generator page (the `screenshot_wrapper` pattern in `pages/image-generator/`) cannot resolve *someone else's* rank at build time. Deriving it from the top-100 board query would silently break for anyone outside the top 100. **Backend dependency: a public `leaderboardPosition(type, userId)` (or equivalent) field.**
2. **Nothing would consume the image.** A leaderboard page is statically generated with one shared `og:image`; it cannot vary per viewer. A per-rank image needs a per-rank shareable URL, which does not exist yet.
3. **The screenshot service must learn the new route** — a separate backend change regardless.

Shipping the rank-share affordance now; the image is a clean follow-up once (1) lands.

## Flag

`share_leaderboard`, default `false`, appended at the end of `featureManagement.ts`.

Gated via `useLeaderboardShareEnabled()`: `useSharingVisibility()` (the initiative kill-switch) is evaluated first, and the per-topic flag is only evaluated with `shouldEvaluate: isSharingEnabled` — control users are never bucketed into the experiment.

**Flag-off is pixel-identical to the PR 1 branch.** Both pages compute the flag and pass the slot as `undefined` when off, so no empty wrapper is introduced: the card heading keeps its original `<h3 class="mb-2 …">` directly above the `<ol>`, and `PageHeader` renders no actions container. Asserted in tests.

New log events (end of the `LogEvent` enum): `share leaderboard`, `share leaderboard rank`. Reuses the existing `Origin.Leaderboard`.

## Storybook

`Components/Share/LeaderboardShare` — own rank, top-3, deep rank (4 figures), all three supported boards, the renders-nothing state, and the directory card on/off side by side.

⚠️ Note in the story file: the repo-wide `packages/storybook/mock/gb.ts` does `return value || 'control'`, so a `false` default flag reads back as the truthy string `'control'` and **every flag looks ON in Storybook**. These stories therefore never assert a flag — ON states render the presentational components (`LeaderboardRankCard`, `LeaderboardShareControl`) directly, and the control state holds `FeaturesReadyContext` as not-ready. Jest owns the real flag-off guarantee.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — pass
- `pnpm --filter shared lint` — pass
- `pnpm --filter webapp lint` — pass
- `NODE_ENV=test pnpm --filter shared test` — 297 suites / 2003 tests pass
- `NODE_ENV=test pnpm --filter webapp test` — 44 suites / 297 tests pass
- `tsc --noEmit` on `packages/storybook` reports no errors in the new story (package has pre-existing errors elsewhere; `pnpm --filter storybook lint` cannot run)

Tests cover: copy → clipboard + toast; mobile tap → `navigator.share` carrying the rank text and tracked link; loading / `rank: null` / no data / unsupported board / signed-out all render nothing; flag-off renders nothing and leaves the container DOM untouched; and the flag chaining (per-topic flag not evaluated while the kill-switch is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-leaderboard.preview.app.daily.dev