### PR TITLE
feat(share): celebrations, achievements & game center share (PR 13)

### DIFF
--- a/packages/shared/src/components/modals/AchievementCompletionModal.tsx
+++ b/packages/shared/src/components/modals/AchievementCompletionModal.tsx
@@ -10,7 +10,7 @@ import { useActions } from '../../hooks/useActions';
 import { useProfileAchievements } from '../../hooks/profile/useProfileAchievements';
 import { useTrackedAchievement } from '../../hooks/profile/useTrackedAchievement';
 import { ActionType } from '../../graphql/actions';
-import { LogEvent, TargetType } from '../../lib/log';
+import { LogEvent, Origin, TargetType } from '../../lib/log';
 import type { LazyModalCommonProps, ModalProps } from './common/Modal';
 import { Modal } from './common/Modal';
 import { ModalClose } from './common/ModalClose';
@@ -23,6 +23,8 @@ import {
 import { Checkbox } from '../fields/Checkbox';
 import { getTargetCount } from '../../graphql/user/achievements';
 import { sortLockedAchievements } from './achievement/sortAchievements';
+import { useShareCelebrations } from '../../hooks/useShareCelebrations';
+import { AchievementShareActions } from '../../features/profile/components/achievements/AchievementShareActions';
 
 const SPARKLE_DURATION_MS = 4500;
 
@@ -66,6 +68,7 @@ export const AchievementCompletionModal = ({
     }
   };
 
+  const isShareEnabled = useShareCelebrations();
   const [phase, setPhase] = useState<'celebrate' | 'pickNext'>('celebrate');
   const [isTracking, setIsTracking] = useState(false);
   const [showSparkles, setShowSparkles] = useState(true);
@@ -211,6 +214,17 @@ export const AchievementCompletionModal = ({
                   <div className="text-text-invert rounded-14 bg-accent-cabbage-default px-3 py-1 font-bold typo-subhead">
                     +{unlockedAchievement.achievement.points} points
                   </div>
+                  {isShareEnabled && (
+                    <AchievementShareActions
+                      achievement={unlockedAchievement.achievement}
+                      username={user?.username}
+                      name={user?.name}
+                      isOwner
+                      withLabels
+                      origin={Origin.Achievements}
+                      className="mt-1"
+                    />
+                  )}
                 </div>
 
                 <Button

--- a/packages/shared/src/components/modals/AchievementShowcaseModal.tsx
+++ b/packages/shared/src/components/modals/AchievementShowcaseModal.tsx
@@ -17,6 +17,9 @@ import type { PublicProfile } from '../../lib/user';
 import { useShowcaseAchievements } from '../../hooks/profile/useShowcaseAchievements';
 import { useProfileAchievements } from '../../hooks/profile/useProfileAchievements';
 import { useToastNotification } from '../../hooks/useToastNotification';
+import { useShareCelebrations } from '../../hooks/useShareCelebrations';
+import { AchievementShareActions } from '../../features/profile/components/achievements/AchievementShareActions';
+import { Origin } from '../../lib/log';
 
 const MAX_SHOWCASE = 5;
 
@@ -33,6 +36,7 @@ export const AchievementShowcaseModal = ({
     useShowcaseAchievements(user);
   const { achievements } = useProfileAchievements(user);
   const { displayToast } = useToastNotification();
+  const isShareEnabled = useShareCelebrations();
 
   const initialSelectedIds = useMemo(
     () => showcaseAchievements.map((sa) => sa.achievement.id),
@@ -123,12 +127,12 @@ export const AchievementShowcaseModal = ({
               const isDisabled =
                 !isSelected && selectedIds.length >= MAX_SHOWCASE;
 
-              return (
+              const row = (
                 <button
-                  key={userAchievement.achievement.id}
                   type="button"
                   className={classNames(
                     'flex items-center gap-3 rounded-12 border p-3 transition-colors',
+                    isShareEnabled && 'min-w-0 flex-1',
                     isSelected
                       ? 'border-accent-cabbage-default bg-surface-float'
                       : 'border-border-subtlest-tertiary bg-surface-float',
@@ -182,6 +186,32 @@ export const AchievementShowcaseModal = ({
                     </div>
                   </div>
                 </button>
+              );
+
+              if (!isShareEnabled) {
+                return (
+                  <React.Fragment key={userAchievement.achievement.id}>
+                    {row}
+                  </React.Fragment>
+                );
+              }
+
+              // Rendered next to the toggle, never inside it — a button nested
+              // in a button is invalid and would swallow the row selection.
+              return (
+                <div
+                  key={userAchievement.achievement.id}
+                  className="flex items-center gap-2"
+                >
+                  {row}
+                  <AchievementShareActions
+                    achievement={userAchievement.achievement}
+                    username={user.username}
+                    name={user.name}
+                    isOwner
+                    origin={Origin.Achievements}
+                  />
+                </div>
               );
             })}
           </div>

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.spec.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.spec.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import NewStreakModal from './NewStreakModal';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import { useShareCelebrations } from '../../../hooks/useShareCelebrations';
+
+jest.mock('../../../hooks/useShareCelebrations', () => ({
+  __esModule: true,
+  useShareCelebrations: jest.fn(),
+}));
+
+jest.mock('../../../hooks', () => ({
+  ...jest.requireActual('../../../hooks'),
+  useActions: () => ({
+    completeAction: jest.fn(),
+    checkHasCompleted: () => false,
+    isActionsFetched: true,
+  }),
+}));
+
+const useShareCelebrationsMock = useShareCelebrations as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useShareCelebrationsMock.mockReturnValue(false);
+});
+
+const renderModal = () =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <NewStreakModal
+        isOpen
+        currentStreak={10}
+        maxStreak={20}
+        onRequestClose={jest.fn()}
+      />
+    </TestBootProvider>,
+  );
+
+describe('NewStreakModal — share celebration', () => {
+  it('renders the milestone with no share control when the flag is off', () => {
+    renderModal();
+
+    expect(screen.getByText('10 days streak')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Share streak')).not.toBeInTheDocument();
+    expect(screen.queryByText('Share your streak')).not.toBeInTheDocument();
+  });
+
+  it('renders exactly one share control when the flag is on', () => {
+    useShareCelebrationsMock.mockReturnValue(true);
+    renderModal();
+
+    expect(screen.getAllByLabelText('Share streak')).toHaveLength(1);
+    expect(screen.getByText('Share your streak')).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -12,12 +12,22 @@ import {
 } from '../../../lib/image';
 import type { StreakModalProps } from './common';
 import { useLogContext } from '../../../contexts/LogContext';
-import { LogEvent, TargetType } from '../../../lib/log';
+import { LogEvent, Origin, TargetType } from '../../../lib/log';
 import { generateQueryKey, RequestKey } from '../../../lib/query';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useActions } from '../../../hooks';
 import { ActionType } from '../../../graphql/actions';
 import StreakReminderSwitch from '../../streak/StreakReminderSwitch';
+import { ShareActions } from '../../share/ShareActions';
+import { ButtonVariant } from '../../buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
+import { useShareCelebrations } from '../../../hooks/useShareCelebrations';
+import { webappUrl } from '../../../lib/constants';
+import { ReferralCampaignKey } from '../../../lib/referral';
 
 const Paragraph = classed('p', 'text-center text-text-tertiary');
 
@@ -37,6 +47,7 @@ export default function NewStreakModal({
   const shouldShowSplash = currentStreak >= maxStreak;
   const daysPlural = currentStreak === 1 ? 'day' : 'days';
   const loggedImpression = useRef(false);
+  const isShareEnabled = useShareCelebrations();
 
   useEffect(() => {
     if (loggedImpression.current) {
@@ -120,9 +131,42 @@ export default function NewStreakModal({
             ? 'Epic win! You are in a league of your own'
             : `New milestone reached! You are unstoppable.`}
         </Paragraph>
+        {isShareEnabled && (
+          <div className="mt-6 flex items-center gap-2">
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              Share your streak
+            </Typography>
+            <ShareActions
+              link={webappUrl}
+              text={
+                shouldShowSplash
+                  ? `New personal record: ${currentStreak} ${daysPlural} of reading on daily.dev`
+                  : `${currentStreak} ${daysPlural} of reading on daily.dev and counting`
+              }
+              cid={ReferralCampaignKey.Generic}
+              label="Share streak"
+              emailTitle={`${currentStreak} ${daysPlural} reading streak`}
+              buttonVariant={ButtonVariant.Secondary}
+              onShare={(provider) =>
+                logEvent({
+                  event_name: LogEvent.ShareStreakMilestone,
+                  target_type: TargetType.StreaksMilestone,
+                  target_id: currentStreak?.toString(),
+                  extra: JSON.stringify({
+                    origin: Origin.ReadingStreak,
+                    provider,
+                  }),
+                })
+              }
+            />
+          </div>
+        )}
         <Checkbox
           name="show_streaks"
-          className="mt-10"
+          className={isShareEnabled ? 'mt-6' : 'mt-10'}
           checked={isStreakModalDisabled}
           onToggleCallback={handleOptOut}
         >

--- a/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
+++ b/packages/shared/src/components/modals/streaks/NewStreakModal.tsx
@@ -152,7 +152,7 @@ export default function NewStreakModal({
               buttonVariant={ButtonVariant.Secondary}
               onShare={(provider) =>
                 logEvent({
-                  event_name: LogEvent.ShareStreakMilestone,
+                  event_name: LogEvent.ShareLog,
                   target_type: TargetType.StreaksMilestone,
                   target_id: currentStreak?.toString(),
                   extra: JSON.stringify({

--- a/packages/shared/src/features/profile/components/achievements/AchievementCard.spec.tsx
+++ b/packages/shared/src/features/profile/components/achievements/AchievementCard.spec.tsx
@@ -1,9 +1,22 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryClient } from '@tanstack/react-query';
+import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
 import type { UserAchievement } from '../../../../graphql/user/achievements';
 import { AchievementType } from '../../../../graphql/user/achievements';
 import { AchievementCard } from './AchievementCard';
+import { useShareCelebrations } from '../../../../hooks/useShareCelebrations';
+
+jest.mock('../../../../hooks/useShareCelebrations', () => ({
+  __esModule: true,
+  useShareCelebrations: jest.fn(),
+}));
+
+const useShareCelebrationsMock = useShareCelebrations as jest.Mock;
+
+beforeEach(() => {
+  useShareCelebrationsMock.mockReturnValue(false);
+});
 
 const createLockedAchievement = (
   overrides: Partial<UserAchievement> = {},
@@ -34,7 +47,7 @@ const renderCard = (
   });
 
   return render(
-    <QueryClientProvider client={client}>
+    <TestBootProvider client={client}>
       <AchievementCard
         userAchievement={createLockedAchievement()}
         isOwner
@@ -42,7 +55,7 @@ const renderCard = (
         onUntrack={jest.fn()}
         {...props}
       />
-    </QueryClientProvider>,
+    </TestBootProvider>,
   );
 };
 
@@ -126,5 +139,52 @@ describe('AchievementCard — stop tracking', () => {
     expect(
       screen.queryByRole('button', { name: /^track$/i }),
     ).not.toBeInTheDocument();
+  });
+});
+
+describe('AchievementCard — share celebrations', () => {
+  const unlocked = createLockedAchievement({
+    unlockedAt: '2026-05-04T10:00:00.000Z',
+    progress: 1,
+  });
+  const shareUser = { username: 'ada', name: 'Ada Lovelace' };
+
+  it('renders no share or download control when the flag is off', () => {
+    renderCard({ userAchievement: unlocked, shareUser });
+
+    expect(
+      screen.queryByLabelText('Share this achievement'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Download badge')).not.toBeInTheDocument();
+    expect(screen.getByText(/^Unlocked/)).toBeInTheDocument();
+  });
+
+  it('renders exactly one share and one download control when the flag is on', () => {
+    useShareCelebrationsMock.mockReturnValue(true);
+    renderCard({ userAchievement: unlocked, shareUser });
+
+    expect(screen.getAllByLabelText('Share this achievement')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Download badge')).toHaveLength(1);
+    expect(screen.getByText(/^Unlocked/)).toBeInTheDocument();
+  });
+
+  it('renders no share control without a shareUser, even with the flag on', () => {
+    useShareCelebrationsMock.mockReturnValue(true);
+    renderCard({ userAchievement: unlocked });
+
+    expect(
+      screen.queryByLabelText('Share this achievement'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Download badge')).not.toBeInTheDocument();
+  });
+
+  it('renders no share control for a locked achievement', () => {
+    useShareCelebrationsMock.mockReturnValue(true);
+    renderCard({ shareUser });
+
+    expect(
+      screen.queryByLabelText('Share this achievement'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Download badge')).not.toBeInTheDocument();
   });
 });

--- a/packages/shared/src/features/profile/components/achievements/AchievementCard.tsx
+++ b/packages/shared/src/features/profile/components/achievements/AchievementCard.tsx
@@ -23,12 +23,15 @@ import { ProgressBar } from '../../../../components/fields/ProgressBar';
 import HoverCard from '../../../../components/cards/common/HoverCard';
 import { anchorDefaultRel } from '../../../../lib/strings';
 import { PinIcon } from '../../../../components/icons';
+import { useShareCelebrations } from '../../../../hooks/useShareCelebrations';
+import { Origin } from '../../../../lib/log';
 import {
   AchievementRarityTier,
   getAchievementRarityTier,
   rarityGlowClasses,
 } from './achievementRarity';
 import { RaritySparkles } from './RaritySparkles';
+import { AchievementShareActions } from './AchievementShareActions';
 
 interface AchievementCardProps {
   userAchievement: UserAchievement;
@@ -38,6 +41,12 @@ interface AchievementCardProps {
   onTrack?: (achievementId: string) => Promise<void>;
   onUntrack?: () => Promise<void>;
   isUntrackPending?: boolean;
+  /**
+   * Profile the card belongs to. Opt-in: only the achievements tab passes it,
+   * so the many other consumers (game center, widgets, tracker hover card) keep
+   * their current DOM.
+   */
+  shareUser?: { username?: string; name?: string };
 }
 
 export function AchievementCard({
@@ -48,6 +57,7 @@ export function AchievementCard({
   onTrack,
   onUntrack,
   isUntrackPending = false,
+  shareUser,
 }: AchievementCardProps): ReactElement {
   const { achievement, progress, unlockedAt } = userAchievement;
   const targetCount = getTargetCount(achievement);
@@ -62,6 +72,28 @@ export function AchievementCard({
     rarityTier === AchievementRarityTier.Emerald
       ? '<1%'
       : `${Math.round(achievement.rarity ?? 0)}%`;
+  const isShareEnabled = useShareCelebrations(!!shareUser && isUnlocked);
+  const showShare = isShareEnabled && !!shareUser && isUnlocked;
+  const unlockedMeta = unlockedAt ? (
+    <>
+      <Typography
+        type={TypographyType.Footnote}
+        color={TypographyColor.Quaternary}
+      >
+        Unlocked {formatDate({ value: unlockedAt, type: TimeFormatType.Post })}
+      </Typography>
+      {achievement.rarity != null && (
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Quaternary}
+          className="mt-1"
+        >
+          Earned by {rarityLabel} of users
+        </Typography>
+      )}
+    </>
+  ) : null;
+
   return (
     <div
       className={classNames(
@@ -189,24 +221,20 @@ export function AchievementCard({
         </div>
       )}
 
-      {isUnlocked && unlockedAt && (
-        <div className="mt-3 flex flex-col">
-          <Typography
-            type={TypographyType.Footnote}
-            color={TypographyColor.Quaternary}
-          >
-            Unlocked{' '}
-            {formatDate({ value: unlockedAt, type: TimeFormatType.Post })}
-          </Typography>
-          {achievement.rarity != null && (
-            <Typography
-              type={TypographyType.Caption1}
-              color={TypographyColor.Quaternary}
-              className="mt-1"
-            >
-              Earned by {rarityLabel} of users
-            </Typography>
-          )}
+      {isUnlocked && unlockedAt && !showShare && (
+        <div className="mt-3 flex flex-col">{unlockedMeta}</div>
+      )}
+
+      {isUnlocked && unlockedAt && showShare && (
+        <div className="mt-3 flex items-end justify-between gap-2">
+          <div className="flex min-w-0 flex-col">{unlockedMeta}</div>
+          <AchievementShareActions
+            achievement={achievement}
+            username={shareUser.username}
+            name={shareUser.name}
+            isOwner={isOwner}
+            origin={Origin.Achievements}
+          />
         </div>
       )}
     </div>

--- a/packages/shared/src/features/profile/components/achievements/AchievementShareActions.spec.tsx
+++ b/packages/shared/src/features/profile/components/achievements/AchievementShareActions.spec.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { AchievementShareActions } from './AchievementShareActions';
+import { AchievementType } from '../../../../graphql/user/achievements';
+import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
+import { Origin } from '../../../../lib/log';
+import { useViewSize } from '../../../../hooks/useViewSize';
+import { downloadUrl } from '../../../../lib/blob';
+import { shouldUseNativeShare } from '../../../../lib/func';
+
+jest.mock('../../../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+jest.mock('../../../../lib/func', () => {
+  const actual = jest.requireActual('../../../../lib/func');
+  return { __esModule: true, ...actual, shouldUseNativeShare: jest.fn() };
+});
+
+jest.mock('../../../../lib/blob', () => ({
+  __esModule: true,
+  downloadUrl: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockDisplayToast = jest.fn();
+jest.mock('../../../../hooks/useToastNotification', () => ({
+  ...jest.requireActual('../../../../hooks/useToastNotification'),
+  useToastNotification: () => ({ displayToast: mockDisplayToast }),
+}));
+
+const useViewSizeMock = useViewSize as jest.Mock;
+const downloadUrlMock = downloadUrl as jest.Mock;
+const shouldUseNativeShareMock = shouldUseNativeShare as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const achievement = {
+  id: 'ach-1',
+  name: 'Night owl',
+  description: 'Read 100 posts after midnight',
+  image: 'https://daily.dev/achievement.png',
+  type: AchievementType.Milestone,
+  criteria: { targetCount: 100 },
+  points: 250,
+  rarity: 3,
+  unit: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useViewSizeMock.mockReturnValue(true);
+  shouldUseNativeShareMock.mockReturnValue(false);
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+const renderActions = (
+  props: Partial<React.ComponentProps<typeof AchievementShareActions>> = {},
+): RenderResult =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <AchievementShareActions
+        achievement={achievement}
+        username="ada"
+        name="Ada Lovelace"
+        isOwner
+        origin={Origin.Achievements}
+        {...props}
+      />
+    </TestBootProvider>,
+  );
+
+describe('AchievementShareActions', () => {
+  it('renders exactly one download control and one share control', () => {
+    renderActions();
+
+    expect(screen.getAllByLabelText('Download badge')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Share this achievement')).toHaveLength(1);
+  });
+
+  it('downloads the achievement badge image', async () => {
+    renderActions();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Download badge'));
+    });
+
+    await waitFor(() =>
+      expect(downloadUrlMock).toHaveBeenCalledWith({
+        url: achievement.image,
+        filename: 'Night owl.png',
+      }),
+    );
+  });
+
+  it('copies the achievement link and toasts when native share is unavailable', async () => {
+    useViewSizeMock.mockReturnValue(false); // mobile
+    renderActions();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Share this achievement'));
+    });
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        expect.stringContaining('ada/achievements'),
+      ),
+    );
+    expect(mockDisplayToast).toHaveBeenCalledWith(
+      '✅ Copied link to clipboard',
+      expect.anything(),
+    );
+  });
+
+  it('uses the native share sheet on mobile when available', async () => {
+    useViewSizeMock.mockReturnValue(false);
+    shouldUseNativeShareMock.mockReturnValue(true);
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share });
+    renderActions();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Share this achievement'));
+    });
+
+    await waitFor(() => expect(share).toHaveBeenCalled());
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('omits the share control when the profile has no username', () => {
+    renderActions({ username: undefined });
+
+    expect(
+      screen.queryByLabelText('Share this achievement'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Download badge')).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/features/profile/components/achievements/AchievementShareActions.tsx
+++ b/packages/shared/src/features/profile/components/achievements/AchievementShareActions.tsx
@@ -1,0 +1,110 @@
+import type { ReactElement } from 'react';
+import React, { useCallback } from 'react';
+import classNames from 'classnames';
+import { useMutation } from '@tanstack/react-query';
+import type { Achievement } from '../../../../graphql/user/achievements';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../../components/buttons/Button';
+import { DownloadIcon } from '../../../../components/icons';
+import { Tooltip } from '../../../../components/tooltip/Tooltip';
+import { ShareActions } from '../../../../components/share/ShareActions';
+import { useLogContext } from '../../../../contexts/LogContext';
+import type { Origin } from '../../../../lib/log';
+import { LogEvent, TargetType } from '../../../../lib/log';
+import { downloadUrl } from '../../../../lib/blob';
+import { ReferralCampaignKey } from '../../../../lib/referral';
+import type { ShareProvider } from '../../../../lib/share';
+import {
+  getAchievementDownloadFilename,
+  getAchievementShareLink,
+  getAchievementShareText,
+} from './achievementShare';
+
+export interface AchievementShareActionsProps {
+  achievement: Achievement;
+  /** Profile the achievement belongs to — the share link points at it. */
+  username?: string;
+  name?: string;
+  isOwner?: boolean;
+  origin: Origin;
+  /** Peak-end moments (unlock modal) get a labelled button, lists get icons. */
+  withLabels?: boolean;
+  buttonSize?: ButtonSize;
+  className?: string;
+}
+
+export function AchievementShareActions({
+  achievement,
+  username,
+  name,
+  isOwner = false,
+  origin,
+  withLabels = false,
+  buttonSize = ButtonSize.Small,
+  className,
+}: AchievementShareActionsProps): ReactElement {
+  const { logEvent } = useLogContext();
+  const { mutateAsync: download, isPending: isDownloading } = useMutation({
+    mutationFn: downloadUrl,
+  });
+
+  const logShare = useCallback(
+    (event_name: LogEvent, provider?: ShareProvider) =>
+      logEvent({
+        event_name,
+        target_type: TargetType.AchievementCard,
+        target_id: achievement.id,
+        extra: JSON.stringify({ origin, ...(provider && { provider }) }),
+      }),
+    [achievement.id, logEvent, origin],
+  );
+
+  const onDownload = useCallback(async () => {
+    await download({
+      url: achievement.image,
+      filename: getAchievementDownloadFilename(achievement),
+    });
+    logShare(LogEvent.DownloadAchievement);
+  }, [achievement, download, logShare]);
+
+  const downloadLabel = 'Download badge';
+
+  return (
+    <div className={classNames('flex items-center gap-1', className)}>
+      <Tooltip content={downloadLabel}>
+        <Button
+          type="button"
+          variant={
+            withLabels ? ButtonVariant.Secondary : ButtonVariant.Tertiary
+          }
+          size={buttonSize}
+          icon={<DownloadIcon secondary={isDownloading} />}
+          aria-label={downloadLabel}
+          loading={isDownloading}
+          disabled={!achievement.image}
+          onClick={() => onDownload()}
+        >
+          {withLabels ? downloadLabel : undefined}
+        </Button>
+      </Tooltip>
+      {!!username && (
+        <ShareActions
+          link={getAchievementShareLink(username)}
+          text={getAchievementShareText(achievement, isOwner, name)}
+          cid={ReferralCampaignKey.ShareProfile}
+          label="Share this achievement"
+          emailTitle={achievement.name}
+          emailSummary={achievement.description}
+          buttonVariant={
+            withLabels ? ButtonVariant.Secondary : ButtonVariant.Tertiary
+          }
+          buttonSize={buttonSize}
+          onShare={(provider) => logShare(LogEvent.ShareAchievement, provider)}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/shared/src/features/profile/components/achievements/AchievementShareCard.tsx
+++ b/packages/shared/src/features/profile/components/achievements/AchievementShareCard.tsx
@@ -1,0 +1,120 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { UserAchievement } from '../../../../graphql/user/achievements';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../../../../components/typography/Typography';
+import LogoIcon from '../../../../svg/LogoIcon';
+import LogoText from '../../../../svg/LogoText';
+import { formatDate, TimeFormatType } from '../../../../lib/dateFormat';
+import {
+  AchievementRarityTier,
+  getAchievementRarityTier,
+  rarityGlowClasses,
+} from './achievementRarity';
+
+export interface AchievementShareCardUser {
+  name?: string | null;
+  username?: string | null;
+  image?: string | null;
+}
+
+export interface AchievementShareCardProps {
+  userAchievement: UserAchievement;
+  user: AchievementShareCardUser;
+}
+
+// Static, self-contained render of a single unlocked achievement. Used by the
+// `/image-generator/achievement/...` page that the backend screenshot service
+// turns into a PNG, so it must not depend on viewport, hover or client-only
+// data — everything it needs arrives as props.
+export function AchievementShareCard({
+  userAchievement,
+  user,
+}: AchievementShareCardProps): ReactElement {
+  const { achievement, unlockedAt } = userAchievement;
+  const rarityTier = getAchievementRarityTier(achievement.rarity);
+  const rarityLabel =
+    rarityTier === AchievementRarityTier.Emerald
+      ? '<1%'
+      : `${Math.round(achievement.rarity ?? 0)}%`;
+
+  return (
+    <div
+      className={classNames(
+        'flex w-[32rem] flex-col items-center gap-4 rounded-24 border bg-background-default px-10 py-9 text-center',
+        rarityTier
+          ? rarityGlowClasses[rarityTier]
+          : 'border-border-subtlest-tertiary',
+      )}
+    >
+      <img
+        src={achievement.image}
+        alt={achievement.name}
+        className="size-32 rounded-16 object-cover"
+      />
+      <div className="flex flex-col items-center gap-1">
+        <Typography
+          tag={TypographyTag.H1}
+          type={TypographyType.Title1}
+          color={TypographyColor.Primary}
+          bold
+        >
+          {achievement.name}
+        </Typography>
+        <Typography
+          type={TypographyType.Body}
+          color={TypographyColor.Tertiary}
+          className="max-w-96"
+        >
+          {achievement.description}
+        </Typography>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="rounded-14 bg-surface-float px-3 py-1 font-bold text-text-primary typo-subhead">
+          {achievement.points} points
+        </span>
+        {achievement.rarity != null && (
+          <span className="rounded-14 bg-surface-float px-3 py-1 font-bold text-text-primary typo-subhead">
+            Earned by {rarityLabel}
+          </span>
+        )}
+      </div>
+
+      <div className="flex w-full flex-col items-center gap-1 border-t border-border-subtlest-tertiary pt-4">
+        <div className="flex items-center gap-2">
+          {!!user.image && (
+            <img
+              src={user.image}
+              alt={user.name ?? user.username ?? ''}
+              className="size-8 rounded-full object-cover"
+            />
+          )}
+          <Typography type={TypographyType.Callout} bold>
+            {user.name ?? `@${user.username}`}
+          </Typography>
+        </div>
+        {!!unlockedAt && (
+          <Typography
+            tag={TypographyTag.Time}
+            type={TypographyType.Footnote}
+            color={TypographyColor.Quaternary}
+            dateTime={new Date(unlockedAt).toISOString()}
+          >
+            Unlocked{' '}
+            {formatDate({ value: unlockedAt, type: TimeFormatType.Post })}
+          </Typography>
+        )}
+        <div className="mt-2 flex">
+          <LogoIcon className={{ container: 'h-logo' }} />
+          <LogoText className={{ container: 'ml-1 h-logo' }} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/shared/src/features/profile/components/achievements/AchievementsList.tsx
+++ b/packages/shared/src/features/profile/components/achievements/AchievementsList.tsx
@@ -279,6 +279,7 @@ export function AchievementsList({
               onTrack={canTrackAchievements ? handleTrack : undefined}
               onUntrack={canTrackAchievements ? handleUntrack : undefined}
               isUntrackPending={isUntrackPending}
+              shareUser={user}
             />
           ))}
         </div>

--- a/packages/shared/src/features/profile/components/achievements/ProfileAchievements.spec.tsx
+++ b/packages/shared/src/features/profile/components/achievements/ProfileAchievements.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { ProfileAchievements } from './ProfileAchievements';
+import { AchievementType } from '../../../../graphql/user/achievements';
+import type { UserAchievement } from '../../../../graphql/user/achievements';
+import type { PublicProfile } from '../../../../lib/user';
+import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
+import { useShareCelebrations } from '../../../../hooks/useShareCelebrations';
+import { useProfileAchievements } from '../../../../hooks/profile/useProfileAchievements';
+
+jest.mock('../../../../hooks/useShareCelebrations', () => ({
+  __esModule: true,
+  useShareCelebrations: jest.fn(),
+}));
+
+jest.mock('../../../../hooks/profile/useProfileAchievements', () => ({
+  __esModule: true,
+  useProfileAchievements: jest.fn(),
+}));
+
+// The list is exercised by its own specs; stubbing it keeps this spec focused
+// on the page-level share control.
+jest.mock('./AchievementsList', () => ({
+  __esModule: true,
+  AchievementsList: () => <div data-testid="achievements-list" />,
+}));
+
+const useShareCelebrationsMock = useShareCelebrations as jest.Mock;
+const useProfileAchievementsMock = useProfileAchievements as jest.Mock;
+
+const userAchievement: UserAchievement = {
+  achievement: {
+    id: 'ach1',
+    name: 'First Post',
+    description: 'Publish your first post',
+    image: 'https://daily.dev/achievement.png',
+    type: AchievementType.Milestone,
+    criteria: { targetCount: 1 },
+    points: 10,
+    rarity: null,
+    unit: null,
+  },
+  progress: 1,
+  unlockedAt: '2026-05-04T10:00:00.000Z',
+  createdAt: null,
+  updatedAt: null,
+};
+
+const profile = {
+  id: 'u1',
+  name: 'Ada Lovelace',
+  username: 'ada',
+  createdAt: '2024-01-01T00:00:00.000Z',
+} as PublicProfile;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useShareCelebrationsMock.mockReturnValue(false);
+  useProfileAchievementsMock.mockReturnValue({
+    achievements: [userAchievement],
+    unlockedCount: 1,
+    totalCount: 1,
+    totalPoints: 10,
+    isPending: false,
+    isError: false,
+  });
+});
+
+const renderPage = () =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <ProfileAchievements user={profile} />
+    </TestBootProvider>,
+  );
+
+describe('ProfileAchievements — page share', () => {
+  it('renders no share control when the flag is off', () => {
+    renderPage();
+
+    expect(
+      screen.queryByLabelText('Share achievements'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders exactly one page-level share control when the flag is on', () => {
+    useShareCelebrationsMock.mockReturnValue(true);
+    renderPage();
+
+    expect(screen.getAllByLabelText('Share achievements')).toHaveLength(1);
+  });
+
+  it('renders no share control while achievements are loading', () => {
+    useShareCelebrationsMock.mockReturnValue(true);
+    useProfileAchievementsMock.mockReturnValue({
+      achievements: undefined,
+      unlockedCount: 0,
+      totalCount: 0,
+      totalPoints: 0,
+      isPending: true,
+      isError: false,
+    });
+    renderPage();
+
+    expect(
+      screen.queryByLabelText('Share achievements'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/features/profile/components/achievements/ProfileAchievements.tsx
+++ b/packages/shared/src/features/profile/components/achievements/ProfileAchievements.tsx
@@ -21,6 +21,12 @@ import { useConditionalFeature } from '../../../../hooks/useConditionalFeature';
 import { achievementTrackingWidgetFeature } from '../../../../lib/featureManagement';
 import { shouldShowAchievementTracker } from '../../../../lib/achievements';
 import { useLayoutVariant } from '../../../../hooks/layout/useLayoutVariant';
+import { useShareCelebrations } from '../../../../hooks/useShareCelebrations';
+import { ShareActions } from '../../../../components/share/ShareActions';
+import { useLogContext } from '../../../../contexts/LogContext';
+import { LogEvent, Origin } from '../../../../lib/log';
+import { ReferralCampaignKey } from '../../../../lib/referral';
+import { getAchievementShareLink } from './achievementShare';
 
 const AchievementTrackingWidget = dynamic(() =>
   import('../ProfileWidgets/AchievementTrackingWidget').then(
@@ -88,6 +94,13 @@ export function ProfileAchievements({
     !isAchievementTrackingWidgetLoading &&
     shouldRenderTrackingWidget;
   const { openModal } = useLazyModal();
+  const { logEvent } = useLogContext();
+  const hasAchievements =
+    !isPending && !isError && !!achievements?.length && !!user.username;
+  const isShareEnabled = useShareCelebrations(hasAchievements);
+  const shareLink = user.username
+    ? getAchievementShareLink(user.username)
+    : null;
 
   if (isPending) {
     return (
@@ -163,6 +176,29 @@ export function ProfileAchievements({
           >
             ({unlockedCount}/{totalCount})
           </Typography>
+          {isShareEnabled && !!shareLink && (
+            <ShareActions
+              link={shareLink}
+              text={
+                isOwner
+                  ? 'Check out the achievements I unlocked on daily.dev'
+                  : `Check out the achievements ${user.name} unlocked on daily.dev`
+              }
+              cid={ReferralCampaignKey.ShareProfile}
+              label="Share achievements"
+              emailTitle={`Achievements by ${user.name}`}
+              onShare={(provider) =>
+                logEvent({
+                  event_name: LogEvent.ShareAchievements,
+                  target_id: user.id,
+                  extra: JSON.stringify({
+                    origin: Origin.Achievements,
+                    provider,
+                  }),
+                })
+              }
+            />
+          )}
         </div>
         {loggedUser && !isOwner && (
           <Button

--- a/packages/shared/src/features/profile/components/achievements/ProfileAchievements.tsx
+++ b/packages/shared/src/features/profile/components/achievements/ProfileAchievements.tsx
@@ -24,7 +24,7 @@ import { useLayoutVariant } from '../../../../hooks/layout/useLayoutVariant';
 import { useShareCelebrations } from '../../../../hooks/useShareCelebrations';
 import { ShareActions } from '../../../../components/share/ShareActions';
 import { useLogContext } from '../../../../contexts/LogContext';
-import { LogEvent, Origin } from '../../../../lib/log';
+import { LogEvent, Origin, TargetType } from '../../../../lib/log';
 import { ReferralCampaignKey } from '../../../../lib/referral';
 import { getAchievementShareLink } from './achievementShare';
 
@@ -190,6 +190,9 @@ export function ProfileAchievements({
               onShare={(provider) =>
                 logEvent({
                   event_name: LogEvent.ShareAchievement,
+                  // Page-level share: target_type keeps target_id resolvable
+                  // against the card-level events, which use AchievementCard.
+                  target_type: TargetType.ProfilePage,
                   target_id: user.id,
                   extra: JSON.stringify({
                     origin: Origin.Achievements,

--- a/packages/shared/src/features/profile/components/achievements/ProfileAchievements.tsx
+++ b/packages/shared/src/features/profile/components/achievements/ProfileAchievements.tsx
@@ -189,7 +189,7 @@ export function ProfileAchievements({
               emailTitle={`Achievements by ${user.name}`}
               onShare={(provider) =>
                 logEvent({
-                  event_name: LogEvent.ShareAchievements,
+                  event_name: LogEvent.ShareAchievement,
                   target_id: user.id,
                   extra: JSON.stringify({
                     origin: Origin.Achievements,

--- a/packages/shared/src/features/profile/components/achievements/achievementShare.ts
+++ b/packages/shared/src/features/profile/components/achievements/achievementShare.ts
@@ -1,0 +1,23 @@
+import type { Achievement } from '../../../../graphql/user/achievements';
+import { webappUrl } from '../../../../lib/constants';
+
+// Achievements are shown on the public profile achievements tab, so that page
+// is the shareable destination for a single achievement.
+export const getAchievementShareLink = (username: string): string =>
+  `${webappUrl}${username}/achievements`;
+
+export const getAchievementShareText = (
+  achievement: Pick<Achievement, 'name'>,
+  isOwner: boolean,
+  name?: string,
+): string =>
+  isOwner
+    ? `I just unlocked the "${achievement.name}" achievement on daily.dev`
+    : `${name ?? 'This developer'} unlocked the "${
+        achievement.name
+      }" achievement on daily.dev`;
+
+export const getAchievementDownloadFilename = (
+  achievement: Pick<Achievement, 'name'>,
+): string =>
+  `${achievement.name.replace(/[^\w\s-]/g, '').trim() || 'achievement'}.png`;

--- a/packages/shared/src/hooks/useShareCelebrations.spec.tsx
+++ b/packages/shared/src/hooks/useShareCelebrations.spec.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useShareCelebrations } from './useShareCelebrations';
+import loggedUser from '../../__tests__/fixture/loggedUser';
+import { AuthContextProvider } from '../contexts/AuthContext';
+import type { FeaturesReadyContextValue } from '../components/GrowthBookProvider';
+import {
+  FeaturesReadyContext,
+  GrowthBookProvider,
+} from '../components/GrowthBookProvider';
+import { BootApp } from '../lib/boot';
+
+const client = new QueryClient();
+
+const createWrapper = (features: Record<string, { defaultValue: boolean }>) => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <AuthContextProvider
+        user={loggedUser}
+        updateUser={jest.fn()}
+        tokenRefreshed
+        getRedirectUri={jest.fn()}
+        loadingUser={false}
+        loadedUserFromCache
+        squads={[]}
+      >
+        <FeaturesReadyContext.Provider
+          value={{ ready: true } as FeaturesReadyContextValue}
+        >
+          <GrowthBookProvider
+            app={BootApp.Test}
+            user={loggedUser}
+            deviceId="123"
+            experimentation={{ f: '{}', e: [], a: [], features }}
+          >
+            {children}
+          </GrowthBookProvider>
+        </FeaturesReadyContext.Provider>
+      </AuthContextProvider>
+    </QueryClientProvider>
+  );
+
+  return Wrapper;
+};
+
+describe('useShareCelebrations', () => {
+  beforeEach(() => client.clear());
+
+  it('is off when both flags are off', async () => {
+    const { result } = renderHook(() => useShareCelebrations(), {
+      wrapper: createWrapper({
+        sharing_visibility: { defaultValue: false },
+        share_celebrations: { defaultValue: false },
+      }),
+    });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('is off when only the per-topic flag is on', async () => {
+    const { result } = renderHook(() => useShareCelebrations(), {
+      wrapper: createWrapper({
+        sharing_visibility: { defaultValue: false },
+        share_celebrations: { defaultValue: true },
+      }),
+    });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('is off when only the master kill-switch is on', async () => {
+    const { result } = renderHook(() => useShareCelebrations(), {
+      wrapper: createWrapper({
+        sharing_visibility: { defaultValue: true },
+        share_celebrations: { defaultValue: false },
+      }),
+    });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+
+  it('is on only when both flags are on', async () => {
+    const { result } = renderHook(() => useShareCelebrations(), {
+      wrapper: createWrapper({
+        sharing_visibility: { defaultValue: true },
+        share_celebrations: { defaultValue: true },
+      }),
+    });
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('stays off when the surface opts out of evaluation', async () => {
+    const { result } = renderHook(() => useShareCelebrations(false), {
+      wrapper: createWrapper({
+        sharing_visibility: { defaultValue: true },
+        share_celebrations: { defaultValue: true },
+      }),
+    });
+
+    await waitFor(() => expect(result.current).toBe(false));
+  });
+});

--- a/packages/shared/src/hooks/useShareCelebrations.ts
+++ b/packages/shared/src/hooks/useShareCelebrations.ts
@@ -1,0 +1,17 @@
+import { featureShareCelebrations } from '../lib/featureManagement';
+import { useConditionalFeature } from './useConditionalFeature';
+import { useSharingVisibility } from './useSharingVisibility';
+
+// Resolves whether celebration surfaces (achievements, unlock modal, streak
+// milestone) may render share/download affordances. Gated on the initiative's
+// master kill-switch AND the per-topic `share_celebrations` flag, so either one
+// can turn the surfaces back to their current, share-free rendering.
+export const useShareCelebrations = (shouldEvaluate = true): boolean => {
+  const { isEnabled } = useSharingVisibility(shouldEvaluate);
+  const { value } = useConditionalFeature({
+    feature: featureShareCelebrations,
+    shouldEvaluate: shouldEvaluate && isEnabled,
+  });
+
+  return isEnabled && value;
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,13 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Adds share/download affordances to celebration surfaces: per-achievement
+// share + badge download (achievement card, showcase picker, unlock modal), a
+// share row on the streak milestone modal, and a page-level share on the
+// profile achievements tab. Keep the default `false` — GrowthBook ramps it, and
+// control must render the surfaces exactly as they are today.
+export const featureShareCelebrations = new Feature(
+  'share_celebrations',
+  false,
+);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -531,11 +531,9 @@ export enum LogEvent {
   SubmitGivebackCauseSuggestionError = 'submit giveback cause suggestion error',
   // Daily homepage
   DailyFeedback = 'daily feedback',
-  // Sharing visibility — celebrations
+  // Sharing visibility — celebrations (page vs card distinguished by target_type)
   ShareAchievement = 'share achievement',
   DownloadAchievement = 'download achievement',
-  ShareStreakMilestone = 'share streak milestone',
-  ShareAchievements = 'share achievements',
 }
 
 export enum TargetType {

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -531,6 +531,11 @@ export enum LogEvent {
   SubmitGivebackCauseSuggestionError = 'submit giveback cause suggestion error',
   // Daily homepage
   DailyFeedback = 'daily feedback',
+  // Sharing visibility — celebrations
+  ShareAchievement = 'share achievement',
+  DownloadAchievement = 'download achievement',
+  ShareStreakMilestone = 'share streak milestone',
+  ShareAchievements = 'share achievements',
 }
 
 export enum TargetType {

--- a/packages/storybook/stories/components/AchievementShare.stories.tsx
+++ b/packages/storybook/stories/components/AchievementShare.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fn } from 'storybook/test';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { FeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+import type { UserAchievement } from '@dailydotdev/shared/src/graphql/user/achievements';
+import { AchievementType } from '@dailydotdev/shared/src/graphql/user/achievements';
+import { AchievementCard } from '@dailydotdev/shared/src/features/profile/components/achievements/AchievementCard';
+import { AchievementShareCard } from '@dailydotdev/shared/src/features/profile/components/achievements/AchievementShareCard';
+import { AchievementShareActions } from '@dailydotdev/shared/src/features/profile/components/achievements/AchievementShareActions';
+import { Origin } from '@dailydotdev/shared/src/lib/log';
+
+const mockUser = {
+  id: 'u1',
+  name: 'Ada Lovelace',
+  username: 'ada',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+} as unknown as LoggedUser;
+
+const buildAchievement = (
+  overrides: Partial<UserAchievement['achievement']> = {},
+  unlocked = true,
+): UserAchievement => ({
+  achievement: {
+    id: 'ach-1',
+    name: 'Night owl',
+    description: 'Read 100 posts between midnight and 5am',
+    image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+    type: AchievementType.Milestone,
+    criteria: { targetCount: 100 },
+    points: 250,
+    rarity: 3,
+    unit: null,
+    ...overrides,
+  },
+  progress: unlocked ? 100 : 42,
+  unlockedAt: unlocked ? '2026-05-04T10:00:00.000Z' : null,
+  createdAt: null,
+  updatedAt: null,
+});
+
+// The Storybook GrowthBook mock returns the string 'control' for any falsy
+// default, so a flag whose default is `false` always resolves truthy. The only
+// honest way to render the control experience is to hold FeaturesReadyContext
+// as not-ready, which makes `useConditionalFeature` return the default.
+const withProviders =
+  (featuresReady: boolean) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+    const LogContext = getLogContextStatic();
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={
+            {
+              user: mockUser,
+              isLoggedIn: true,
+              isAuthReady: true,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              refetchBoot: fn(),
+              squads: [],
+            } as never
+          }
+        >
+          <LogContext.Provider
+            value={{
+              logEvent: fn(),
+              logEventStart: fn(),
+              logEventEnd: fn(),
+              sendBeacon: () => false,
+            }}
+          >
+            <FeaturesReadyContext.Provider
+              value={
+                {
+                  ready: featuresReady,
+                  getFeatureValue: fn(),
+                } as never
+              }
+            >
+              <div className="max-w-[34rem] p-4">
+                <Story />
+              </div>
+            </FeaturesReadyContext.Provider>
+          </LogContext.Provider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+
+const meta: Meta = {
+  title: 'Components/Share/AchievementShare',
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// Flag on: an unlocked achievement on the profile achievements tab gets a
+// download + share pair next to its "Unlocked" meta line.
+export const UnlockedCardWithShare: Story = {
+  decorators: [withProviders(true)],
+  render: () => (
+    <AchievementCard
+      userAchievement={buildAchievement()}
+      isOwner
+      shareUser={{ username: mockUser.username, name: mockUser.name }}
+    />
+  ),
+};
+
+// Control: identical to what ships on main today — no share, no download.
+export const UnlockedCardFlagOff: Story = {
+  decorators: [withProviders(false)],
+  render: () => (
+    <AchievementCard
+      userAchievement={buildAchievement()}
+      isOwner
+      shareUser={{ username: mockUser.username, name: mockUser.name }}
+    />
+  ),
+};
+
+// Locked achievements have nothing to celebrate, so they never get the row.
+export const LockedCard: Story = {
+  decorators: [withProviders(true)],
+  render: () => (
+    <AchievementCard
+      userAchievement={buildAchievement({}, false)}
+      isOwner
+      onTrack={fn()}
+      shareUser={{ username: mockUser.username, name: mockUser.name }}
+    />
+  ),
+};
+
+// The labelled pair used at the peak of the unlock celebration modal.
+export const CelebrationActions: Story = {
+  decorators: [withProviders(true)],
+  render: () => (
+    <AchievementShareActions
+      achievement={buildAchievement().achievement}
+      username={mockUser.username}
+      name={mockUser.name}
+      isOwner
+      withLabels
+      origin={Origin.Achievements}
+    />
+  ),
+};
+
+// What the backend screenshot service renders at
+// /image-generator/achievement/<userId>/<achievementId>.
+export const ShareImageCard: Story = {
+  decorators: [withProviders(true)],
+  render: () => (
+    <AchievementShareCard userAchievement={buildAchievement()} user={mockUser} />
+  ),
+};
+
+// Rarest tier — the generated image picks up the emerald glow treatment.
+export const ShareImageCardEmerald: Story = {
+  decorators: [withProviders(true)],
+  render: () => (
+    <AchievementShareCard
+      userAchievement={buildAchievement({ rarity: 0.4, name: 'Trailblazer' })}
+      user={mockUser}
+    />
+  ),
+};

--- a/packages/webapp/pages/image-generator/achievement/[...params].tsx
+++ b/packages/webapp/pages/image-generator/achievement/[...params].tsx
@@ -1,0 +1,74 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { UserAchievement } from '@dailydotdev/shared/src/graphql/user/achievements';
+import { getUserAchievements } from '@dailydotdev/shared/src/graphql/user/achievements';
+import { getProfile } from '@dailydotdev/shared/src/lib/user';
+import type { AchievementShareCardUser } from '@dailydotdev/shared/src/features/profile/components/achievements/AchievementShareCard';
+import { AchievementShareCard } from '@dailydotdev/shared/src/features/profile/components/achievements/AchievementShareCard';
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  return { paths: [], fallback: 'blocking' };
+}
+
+interface PageProps {
+  userAchievement: UserAchievement;
+  user: AchievementShareCardUser;
+}
+
+const notFound = { notFound: true, revalidate: false } as const;
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
+  const [userId, achievementId] = (params?.params as string[]) ?? [];
+
+  if (!userId || !achievementId) {
+    return notFound;
+  }
+
+  try {
+    const [profile, achievements] = await Promise.all([
+      getProfile(userId),
+      getUserAchievements(userId),
+    ]);
+    const userAchievement = achievements?.find(
+      (item) => item.achievement.id === achievementId,
+    );
+
+    // Only unlocked achievements have something to celebrate — a locked one
+    // would render a card claiming an achievement the user does not have.
+    if (!profile || !userAchievement?.unlockedAt) {
+      return notFound;
+    }
+
+    return {
+      props: {
+        userAchievement,
+        user: {
+          name: profile.name ?? null,
+          username: profile.username ?? null,
+          image: profile.image ?? null,
+        },
+      },
+      revalidate: 60,
+    };
+  } catch {
+    return notFound;
+  }
+}
+
+const AchievementImagePage = ({
+  userAchievement,
+  user,
+}: PageProps): ReactElement => (
+  <div id="screenshot_wrapper" className="w-fit">
+    <AchievementShareCard userAchievement={userAchievement} user={user} />
+  </div>
+);
+
+export default AchievementImagePage;


### PR DESCRIPTION
Part of the **sharing visibility** initiative. Stacked on PR 1 (#6343) — base is `claude/website-sharing-visibility-be6b32`, **not** `main`.

Adds share/download affordances to the celebration + achievement surfaces, all behind one flag. Control is pixel-identical to the PR 1 branch.

## Flag

`share_celebrations` (default `false`, appended at the end of `featureManagement.ts`).

Every surface gates on `useShareCelebrations()`, which requires **both** the initiative's master kill-switch (`sharing_visibility`) **and** `share_celebrations`, evaluated through `useConditionalFeature` with `shouldEvaluate` so GrowthBook is only hit when the surface would actually render. `useShareCelebrations.spec.tsx` asserts the full truth table (off/off, off/on, on/off, on/on, opted-out).

## Per-item status

### #13 — per-achievement image + Download/Share (headline) — **shipped, with one backend dependency**

- New page `packages/webapp/pages/image-generator/achievement/[...params].tsx` (`/image-generator/achievement/<userId>/<achievementId>`), following the existing screenshot pattern exactly: `getStaticPaths` with `fallback: 'blocking'`, `revalidate: 60`, and a single `id="screenshot_wrapper"` wrapper — same shape as `devcards/[userId].tsx` and `badges/[badgeId].tsx`. No OG-image library was added; there is none in this repo.
- It fetches the profile (`getProfile`) and achievements (`getUserAchievements`) server-side and 404s for a locked achievement, so the page can never render a card claiming an achievement the user does not have.
- It renders the new `AchievementShareCard` — a static, self-contained render (badge art, name, description, points, rarity tier glow, owner, unlock date, daily.dev logo) with no viewport/hover/client-only dependencies.
- **Backend dependency:** the screenshot service does not know this route yet, so there is no generated PNG URL to hand out. Until it does, the **Download** button downloads the achievement's own badge image (`achievement.image`) — which works today with no backend change. Once the service learns `/image-generator/achievement/<userId>/<achievementId>` and exposes the resulting URL on the achievement payload, Download can point at the richer card with a one-line change. The frontend renders the `screenshot_wrapper` page regardless.
- Download + Share are wired via the new `AchievementShareActions` component into:
  - `AchievementCard.tsx` — **opt-in via a new `shareUser` prop**. Only `AchievementsList` (the achievements tab) passes it, so the card's other consumers (Game Center, `AchievementsWidget`, `ProfileAchievementShowcase` hover card, `AchievementTrackerButton` ×2) keep their current DOM and get no share control. Only unlocked achievements get the row.
  - `AchievementShowcaseModal.tsx` — the share control is rendered as a **sibling of** the row toggle, never inside it (a `<button>` nested in a `<button>` is invalid and would swallow row selection). With the flag off the row renders inside a `React.Fragment`, i.e. byte-identical DOM.

### #12 — share on celebration completion — **partially shipped, quests deferred**

Covered, each with a deliberate copy choice:

| Moment | Treatment | Why |
| --- | --- | --- |
| **Achievement unlocked** (`AchievementCompletionModal`, celebrate phase) | Labelled **Download badge** + share, placed directly under the `+N points` chip — the visual peak, before "Choose next goal" | The only celebration with a real artifact (badge art) *and* a public destination (the profile achievements tab). Deserves the heaviest treatment. |
| **Streak milestone** (`NewStreakModal`) | "Share your streak" + a share icon; **copy-text flavoured** — the milestone lives in the share *text*, the link is just `daily.dev` | A streak has no per-user public page and no per-user image, so linking a profile URL would be a dead end. The brag is the text. |

**Deferred: quest / task claim and level-up.** Reasons, stated plainly rather than shipped half-done:
1. There is no completion *modal*. Quest claims celebrate inline inside `QuestButton.tsx` (~1250 lines) via a flying-reward particle layer plus a level-up firework overlay, rendered from **two** places (the header button and the `panelOnly` daily-quests page) — a share row bolted in there would double-render or fight the animation, exactly the composition trap this batch was warned about.
2. There is no public artifact or destination: `/daily-quests` is `ProtectedPage` + `noindex`, so anyone who followed the link would hit a login wall.

Doing it properly means a real completion surface, which is a product decision, not a wiring change. Flagged rather than faked.

### #17 — page-level share on profile → achievements — **shipped**

`ProfileAchievements.tsx` gets one share control next to the points/count line ("Share achievements"). It only evaluates the flag once achievements have loaded, are non-empty, and the profile has a username. Per-card controls use a distinct label ("Share this achievement"), so the page never presents two identically-labelled affordances.

### #16 — page-level share on Game Center — **skipped: the page is not public**

Verified before building anything: `packages/webapp/pages/game-center/index.tsx` wraps its whole tree in `<ProtectedPage>` and its SEO sets `noindex: true` / `nofollow`. Anyone receiving a Game Center link would hit an auth wall, so a share button there would ship a broken promise. Skipped deliberately, per the plan's instruction to verify first. If Game Center is ever made public, the same `ShareActions` + `Origin.GameCenter` (already added in PR 1) drop in as a two-line change.

## Composition-trap audit

Every render site of every touched component was read. Exactly one share control per surface:

- `/[userId]/achievements`: one page-level control (`ProfileAchievements`) + one per unlocked card (`AchievementsList` → `AchievementCard`). No nesting, distinct labels.
- `/[userId]`: `ProfileAchievementShowcase` renders `AchievementCard` **without** `shareUser` → no control; the showcase edit modal (owner-only) has one per row.
- Game Center, `AchievementsWidget`, `AchievementTrackerButton`: no `shareUser` → unchanged.
- `AchievementShowcaseModal` does **not** compose `AchievementCard` (it builds its own rows), so there is no double render.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — pass
- `pnpm --filter shared lint` — pass
- `pnpm --filter webapp lint` — pass
- `NODE_ENV=test pnpm --filter shared test` — **298 suites / 2004 tests pass**
- `NODE_ENV=test pnpm --filter webapp test` — **44 suites / 297 tests pass**
- `tsc --noEmit` on the storybook package reports no errors in the new story (the package has a pre-existing strict backlog elsewhere)
- `build` not run, per the batch instructions

New tests assert:
- copy → `navigator.clipboard.writeText` **and** the "Copied link to clipboard" toast
- mobile → `navigator.share` (native path), and that clipboard is *not* used in that case
- exactly one download + one share control per surface (card, page, streak modal)
- **flag-off preserves the current UI exactly** on the card, the page and the streak modal, plus the real two-flag gate in `useShareCelebrations.spec.tsx`

## Storybook

`packages/storybook/stories/components/AchievementShare.stories.tsx` covers the unlocked card with share, the same card with the flag off, a locked card, the labelled celebration pair, and the generated share image in both a normal and a rarest (emerald) tier.

Note for reviewers: the repo-wide Storybook GrowthBook mock (`mock/gb.ts`) does `return value || 'control'`, so a flag defaulting to `false` resolves to the truthy string `'control'` and always reads as ON. The flag-off story therefore holds `FeaturesReadyContext` as **not ready**, which is the only honest way to render control in Storybook. Jest is unaffected and is the real flag-off guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-celebrations.preview.app.daily.dev