### PR TITLE
feat(share): copy link on reading history rows behind share_history

### DIFF
--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -42,6 +42,23 @@ jest.mock('../../lib/func', () => {
   };
 });
 
+// The row share passes a referral cid, which routes the link through
+// `useGetShortUrl`. Resolve it to the original URL here so these tests stay
+// about the copy/share flow; short-link resolution is covered by that hook.
+jest.mock('../../hooks/utils/useGetShortUrl', () => {
+  const actual = jest.requireActual('../../hooks/utils/useGetShortUrl');
+  return {
+    __esModule: true,
+    ...actual,
+    useGetShortUrl: () => ({
+      getShortUrl: async (url: string) => url,
+      getTrackedUrl: (url: string) => url,
+      shareLink: '',
+      isLoading: false,
+    }),
+  };
+});
+
 const shouldUseNativeShareMock = shouldUseNativeShare as jest.Mock;
 const writeText = jest.fn().mockResolvedValue(undefined);
 

--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -1,9 +1,16 @@
 import React from 'react';
 import { subDays } from 'date-fns';
 import type { RenderResult } from '@testing-library/react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
 import type { PostItemCardProps } from '../post/PostItemCard';
 import PostItemCard from '../post/PostItemCard';
 import type { ReadHistoryListProps } from './ReadingHistoryList';
@@ -15,10 +22,33 @@ import user from '../../../__tests__/fixture/loggedUser';
 import { getLabel } from '../../lib/dateFormat.spec';
 import post from '../../../__tests__/fixture/post';
 import { SourceType } from '../../graphql/sources';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import {
+  featureShareHistory,
+  featureSharingVisibility,
+} from '../../lib/featureManagement';
+import type { ToastNotification } from '../../hooks/useToastNotification';
+import { TOAST_NOTIF_KEY } from '../../hooks/useToastNotification';
+import { ShareProvider } from '../../lib/share';
+import { LogEvent, Origin } from '../../lib/log';
+import { shouldUseNativeShare } from '../../lib/func';
+
+jest.mock('../../lib/func', () => {
+  const actual = jest.requireActual('../../lib/func');
+  return {
+    __esModule: true,
+    ...actual,
+    shouldUseNativeShare: jest.fn(() => false),
+  };
+});
+
+const shouldUseNativeShareMock = shouldUseNativeShare as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
 
 beforeEach(() => {
   nock.cleanAll();
   jest.clearAllMocks();
+  Object.assign(navigator, { clipboard: { writeText } });
 });
 
 describe('ReadingHistoryList component', () => {
@@ -121,6 +151,82 @@ describe('ReadingHistoryList component', () => {
     });
     await screen.findByText('Save to bookmarks');
   });
+
+  describe('copy link action (share_history)', () => {
+    const logEvent = jest.fn();
+
+    const setupWithFlags = ({
+      sharingVisibility = true,
+      shareHistory = true,
+    } = {}) => {
+      const client = new QueryClient();
+      const gb = new GrowthBook();
+      gb.setFeatures({
+        [featureSharingVisibility.id]: { defaultValue: sharingVisibility },
+        [featureShareHistory.id]: { defaultValue: shareHistory },
+      });
+
+      render(
+        <TestBootProvider
+          client={client}
+          gb={gb}
+          auth={{ user }}
+          log={{ logEvent }}
+        >
+          <ReadHistoryList {...props} />
+        </TestBootProvider>,
+      );
+
+      return client;
+    };
+
+    it('should not render the copy action when the flags are off', async () => {
+      renderComponent();
+      await screen.findByTestId('post-item-p1');
+      expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+    });
+
+    it('should not render the copy action when only share_history is on (master kill-switch off)', async () => {
+      setupWithFlags({ sharingVisibility: false, shareHistory: true });
+      await screen.findByTestId('post-item-p1');
+      expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+    });
+
+    it('should render one copy action per row when both flags are on', async () => {
+      setupWithFlags();
+      const buttons = await screen.findAllByLabelText('Copy link');
+      expect(buttons).toHaveLength(
+        defaultReadingHistory.pages[0].readHistory.edges.length,
+      );
+    });
+
+    it('should copy the post link, show a toast and log SharePost on click', async () => {
+      const client = setupWithFlags();
+      const [button] = await screen.findAllByLabelText('Copy link');
+
+      await act(async () => {
+        fireEvent.click(button);
+      });
+
+      await waitFor(() =>
+        expect(writeText).toHaveBeenCalledWith(post.commentsPermalink),
+      );
+      await waitFor(() => {
+        const toast = client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY);
+        expect(toast?.message).toEqual('✅ Copied link to clipboard');
+      });
+      expect(logEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event_name: LogEvent.SharePost,
+          target_id: 'p0',
+          extra: JSON.stringify({
+            provider: ShareProvider.CopyLink,
+            origin: Origin.History,
+          }),
+        }),
+      );
+    });
+  });
 });
 
 describe('PostItemCard component', () => {
@@ -207,6 +313,47 @@ describe('PostItemCard component', () => {
       postId: defaultHistory.post.id,
       timestamp: defaultHistory.timestamp,
     });
+  });
+
+  it('should not render the copy link action unless opted in', async () => {
+    renderCard({ showVoteActions: true });
+    await screen.findByText(postTitle);
+    expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+  });
+
+  it('should copy the post link when the copy action is clicked', async () => {
+    renderCard({ showVoteActions: true, showCopyLink: true });
+    const button = await screen.findByLabelText('Copy link');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        defaultHistory.post.commentsPermalink,
+      ),
+    );
+  });
+
+  it('should open the native share sheet on mobile instead of copying', async () => {
+    shouldUseNativeShareMock.mockReturnValueOnce(true);
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share });
+
+    renderCard({ showVoteActions: true, showCopyLink: true });
+    const button = await screen.findByLabelText('Copy link');
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        text: expect.stringContaining(defaultHistory.post.commentsPermalink),
+      }),
+    );
+    expect(writeText).not.toHaveBeenCalled();
   });
 
   it('should not bubble vote clicks to parent handlers', async () => {

--- a/packages/shared/src/components/history/ReadingHistoryList.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryList.tsx
@@ -7,6 +7,9 @@ import { InfiniteScrollScreenOffset } from '../../hooks/feed/useFeedInfiniteScro
 import { Origin } from '../../lib/log';
 import { DateFormat } from '../utilities';
 import type { ReadHistoryInfiniteData } from '../../hooks/useInfiniteReadingHistory';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { useSharingVisibility } from '../../hooks/useSharingVisibility';
+import { featureShareHistory } from '../../lib/featureManagement';
 
 export interface ReadHistoryListProps {
   data: ReadHistoryInfiniteData;
@@ -19,45 +22,59 @@ export default function ReadHistoryList({
   onHide,
   infiniteScrollRef,
 }: ReadHistoryListProps): ReactElement {
+  const { isEnabled: isSharingVisible } = useSharingVisibility();
+  // Per-surface flag; only evaluated once the master kill-switch is on.
+  const { value: isShareHistoryEnabled } = useConditionalFeature({
+    feature: featureShareHistory,
+    shouldEvaluate: isSharingVisible,
+  });
+  const showCopyLink = isSharingVisible && isShareHistoryEnabled;
+
   const renderList = useCallback(() => {
     let currentDate: Date;
 
     return data?.pages.map((page, pageIndex) =>
-      page.readHistory.edges.reduce((dom, { node: history }, edgeIndex) => {
-        const { timestamp } = history;
-        const date = new Date(timestamp);
+      page.readHistory.edges.reduce<ReactElement[]>(
+        (dom, { node: history }, edgeIndex) => {
+          const { timestamp } = history;
+          // NaN fallback keeps the pre-strict `new Date(undefined)` behavior
+          // (Invalid Date) for the never-expected timestamp-less edge.
+          const date = new Date(timestamp ?? Number.NaN);
 
-        if (!currentDate || !isDateOnlyEqual(currentDate, date)) {
-          currentDate = date;
+          if (!currentDate || !isDateOnlyEqual(currentDate, date)) {
+            currentDate = date;
+            dom.push(
+              <DateFormat
+                key={date.toISOString()}
+                date={date}
+                type={TimeFormatType.ReadHistory}
+                className="my-3 px-6 text-text-tertiary typo-body first:mt-0"
+              />,
+            );
+          }
+
+          const indexes = { page: pageIndex, edge: edgeIndex };
+
           dom.push(
-            <DateFormat
-              key={date.toISOString()}
-              date={date}
-              type={TimeFormatType.ReadHistory}
-              className="my-3 px-6 text-text-tertiary typo-body first:mt-0"
+            <PostItemCard
+              key={`${history.post.id}-${timestamp}`}
+              postItem={history}
+              indexes={indexes}
+              onHide={(params) => onHide({ ...params, ...indexes })}
+              showVoteActions
+              showCopyLink={showCopyLink}
+              logOrigin={Origin.History}
             />,
           );
-        }
 
-        const indexes = { page: pageIndex, edge: edgeIndex };
-
-        dom.push(
-          <PostItemCard
-            key={`${history.post.id}-${timestamp}`}
-            postItem={history}
-            indexes={indexes}
-            onHide={(params) => onHide({ ...params, ...indexes })}
-            showVoteActions
-            logOrigin={Origin.History}
-          />,
-        );
-
-        return dom;
-      }, []),
+          return dom;
+        },
+        [],
+      ),
     );
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, onHide]);
+  }, [data, onHide, showCopyLink]);
 
   return (
     <section className="relative flex flex-col">

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -10,7 +10,9 @@ import {
   UpvoteIcon,
   DownvoteIcon,
   CopyIcon,
+  LinkIcon,
 } from '../icons';
+import { useShareCopyIcon } from '../../hooks/useShareCopyIcon';
 import classed from '../../lib/classed';
 import PostMetadata from '../cards/common/PostMetadata';
 import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
@@ -91,6 +93,9 @@ export default function PostItemCard({
   );
 
   const title = post?.title || post?.sharedPost?.title;
+  // The row action copies a URL, so it takes the link glyph in control and
+  // follows the same `share_copy_icon` ramp as the other copy-link surfaces.
+  const showCopyIcon = useShareCopyIcon();
 
   // Single tap: native share sheet on mobile, copy + toast elsewhere. History
   // rows are real posts, so the normalized SharePost event applies. A missing
@@ -212,7 +217,13 @@ export default function PostItemCard({
                     size={ButtonSize.Small}
                     variant={ButtonVariant.Tertiary}
                     aria-label="Copy link"
-                    icon={<CopyIcon secondary={copyingLink} />}
+                    icon={
+                      showCopyIcon ? (
+                        <CopyIcon secondary={copyingLink} />
+                      ) : (
+                        <LinkIcon />
+                      )
+                    }
                     onClick={(e: React.MouseEvent) => {
                       e.stopPropagation();
                       e.preventDefault();

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -5,7 +5,12 @@ import Link from '../utilities/Link';
 import type { HidePostItemCardProps } from '../../graphql/users';
 import type { PostItem } from '../../graphql/posts';
 import { UserVote, isVideoPost } from '../../graphql/posts';
-import { MiniCloseIcon as XIcon, UpvoteIcon, DownvoteIcon } from '../icons';
+import {
+  MiniCloseIcon as XIcon,
+  UpvoteIcon,
+  DownvoteIcon,
+  CopyIcon,
+} from '../icons';
 import classed from '../../lib/classed';
 import PostMetadata from '../cards/common/PostMetadata';
 import { ProfileImageSize, ProfilePicture } from '../ProfilePicture';
@@ -13,7 +18,10 @@ import { Image } from '../image/Image';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { useReadHistoryVotePost } from '../../hooks';
-import { Origin } from '../../lib/log';
+import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
+import { postLogEvent } from '../../lib/feed';
+import { LogEvent, Origin } from '../../lib/log';
+import { Tooltip } from '../tooltip/Tooltip';
 import {
   Button,
   ButtonColor,
@@ -32,6 +40,12 @@ export interface PostItemCardProps {
   clickable?: boolean;
   onHide?: (params: HidePostItemCardProps) => Promise<unknown>;
   showVoteActions?: boolean;
+  /**
+   * Renders a visible "Copy link" action in the button row. Off by default so
+   * every existing consumer keeps its exact DOM (sharing-visibility surfaces
+   * opt in explicitly).
+   */
+  showCopyLink?: boolean;
   logOrigin?: Origin;
   indexes?: QueryIndexes;
 }
@@ -48,6 +62,7 @@ export default function PostItemCard({
   onHide,
   className,
   showVoteActions = false,
+  showCopyLink = false,
   logOrigin = Origin.Feed,
   indexes,
 }: PostItemCardProps): ReactElement {
@@ -75,6 +90,18 @@ export default function PostItemCard({
   );
 
   const title = post?.title || post?.sharedPost?.title;
+
+  // Single tap: native share sheet on mobile, copy + toast elsewhere. History
+  // rows are real posts, so the normalized SharePost event applies. A missing
+  // permalink falls through to useCopyLink's "link is missing" error toast.
+  const [copyingLink, onShareOrCopyLink] = useShareOrCopyLink({
+    link: post.commentsPermalink ?? '',
+    text: title ?? '',
+    logObject: (provider) =>
+      postLogEvent(LogEvent.SharePost, post, {
+        extra: { provider, origin: logOrigin },
+      }),
+  });
 
   return (
     <article className={classNames(!clickable && classes)}>
@@ -175,6 +202,22 @@ export default function PostItemCard({
                     }
                   />
                 </>
+              )}
+              {showButtons && showCopyLink && (
+                <Tooltip content="Copy link">
+                  <Button
+                    type="button"
+                    size={ButtonSize.Small}
+                    variant={ButtonVariant.Tertiary}
+                    aria-label="Copy link"
+                    icon={<CopyIcon secondary={copyingLink} />}
+                    onClick={(e: React.MouseEvent) => {
+                      e.stopPropagation();
+                      e.preventDefault();
+                      onShareOrCopyLink();
+                    }}
+                  />
+                </Tooltip>
               )}
               {showButtons && !showVoteActions && onHide && (
                 <Button

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -21,6 +21,7 @@ import { useReadHistoryVotePost } from '../../hooks';
 import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { postLogEvent } from '../../lib/feed';
 import { LogEvent, Origin } from '../../lib/log';
+import { ReferralCampaignKey } from '../../lib/referral';
 import { Tooltip } from '../tooltip/Tooltip';
 import {
   Button,
@@ -97,6 +98,7 @@ export default function PostItemCard({
   const [copyingLink, onShareOrCopyLink] = useShareOrCopyLink({
     link: post.commentsPermalink ?? '',
     text: title ?? '',
+    cid: ReferralCampaignKey.SharePost,
     logObject: (provider) =>
       postLogEvent(LogEvent.SharePost, post, {
         extra: { provider, origin: logOrigin },

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,9 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Reading-history rows: a visible per-row "Copy link" action next to the vote
+// buttons on the history page. Per-surface flag of the sharing-visibility
+// initiative; only evaluated when the `sharing_visibility` master switch is
+// on. Keep the default `false` — GrowthBook ramps it.
+export const featureShareHistory = new Feature('share_history', false);

--- a/packages/storybook/stories/components/PostItemCard.stories.tsx
+++ b/packages/storybook/stories/components/PostItemCard.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import post from '@dailydotdev/shared/__tests__/fixture/post';
+import PostItemCard from '@dailydotdev/shared/src/components/post/PostItemCard';
+import { Origin } from '@dailydotdev/shared/src/lib/log';
+import ExtensionProviders from '../extension/_providers';
+
+const timestamp = new Date();
+
+// The reading-history row. In production `showCopyLink` is driven by the
+// `sharing_visibility` + `share_history` flags inside `ReadingHistoryList`;
+// the story drives the prop directly because the storybook GrowthBook mock
+// forces every boolean flag on, so a real flag-off render can't be mocked here
+// (Jest covers the flag-off guarantee).
+const meta: Meta<typeof PostItemCard> = {
+  title: 'Components/History/PostItemCard',
+  component: PostItemCard,
+  args: {
+    postItem: { timestamp, timestampDb: timestamp, post },
+    showVoteActions: true,
+    logOrigin: Origin.History,
+    onHide: fn(),
+  },
+  argTypes: {
+    showCopyLink: {
+      control: 'boolean',
+      description:
+        'Sharing-visibility opt-in: visible "Copy link" action next to the votes',
+    },
+    showVoteActions: { control: 'boolean' },
+    showButtons: { control: 'boolean' },
+    clickable: { control: 'boolean' },
+  },
+  render: (props) => (
+    <ExtensionProviders>
+      <div className="mx-auto w-full max-w-[40rem]">
+        <PostItemCard {...props} />
+      </div>
+    </ExtensionProviders>
+  ),
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PostItemCard>;
+
+// Baseline history row exactly as it ships today (flag off) — no copy control.
+export const HistoryRow: Story = {
+  args: { showCopyLink: false },
+};
+
+// Flag-on variant: the copy-link action sits with the always-visible vote
+// buttons, same button size, so row height and truncation are unchanged.
+export const HistoryRowWithCopyLink: Story = {
+  args: { showCopyLink: true },
+};


### PR DESCRIPTION
Part of the **sharing visibility** initiative (PR 18 — reading history, #14). Stacked on PR 1 (#6343) — base is `claude/website-sharing-visibility-be6b32`, **not** `main`.

## Changes

- **`PostItemCard`**: new opt-in `showCopyLink` prop (default `false`) renders a visible "Copy link" icon action in the row's button cluster, right after the upvote/downvote pair. Single tap opens the native share sheet on mobile (`navigator.share`) and copies + toasts elsewhere, via the existing `useShareOrCopyLink` hook. Same `ButtonSize.Small` tertiary button as the vote actions, so row height and title truncation (`line-clamp-2`) are untouched. The click handler `stopPropagation`s so the row's "Go to post" link never fires.
- **`ReadingHistoryList`** (the history page's only list): evaluates the gate — `useSharingVisibility()` master switch, then `share_history` via `useConditionalFeature` with `shouldEvaluate` chained off the master — and passes `showCopyLink` down. Flag logic stays out of the shared primitive (props-only, per repo convention).
- **Logging**: history rows are real posts, so this uses the normalized `LogEvent.SharePost` via `postLogEvent(LogEvent.SharePost, post, { extra: { provider, origin } })` with the existing `Origin.History` — already what this list passes as `logOrigin`. No new event or origin minted.
- **Link**: `post.commentsPermalink`, verified on the typed `ReadHistoryPost` model (`graphql/posts.ts` — in the `Pick` list and selected by `READING_HISTORY_QUERY`).
- **Storybook**: `Components/History/PostItemCard` with `HistoryRow` (control absent) and `HistoryRowWithCopyLink` stories. The story drives the prop directly because the storybook GrowthBook mock forces boolean flags on; Jest carries the flag-off guarantee.
- Drive-by strict fixes surfaced by the changed-file guard in `ReadingHistoryList` (typed reduce accumulator; `new Date(undefined)` strict violation with runtime behavior preserved).

## Flag

`share_history`, default `false`, appended at the end of `featureManagement.ts`. Gated on **both** the `sharing_visibility` master switch and `share_history`; the per-surface flag is only evaluated once the master is on. Flag-off renders the exact PR 1 DOM (prop defaults to `false`, no new wrappers).

## Menu vs. row decision

Visible row control, **no** menu entry:

- The history row's actions are **always visible** (the vote buttons render `flex` on every viewport with `showVoteActions`), not hover-revealed — so a visible copy control placed with them serves touch directly. A menu fallback would render a second copy affordance on the same row by default, which was deliberately avoided.
- The row's `ReadingHistoryOptionsMenu` already offers "Share post via..." (full share sheet) as the deeper path; a "Copy link" menu entry would make it a third share affordance per row.
- On mobile the visible control taps straight into the native share sheet, matching the `ShareActions` primitive's mobile behavior from PR 1.

## `PostItemCard` consumer audit

| Consumer | Usage | Effect |
|---|---|---|
| `shared/components/history/ReadingHistoryList.tsx` → webapp `components/history/reading.tsx` (`/history` page; only consumer of the list) | `showVoteActions`, `logOrigin={Origin.History}` | Gets the control when flags are on |
| `shared/components/post/infinite/InfiniteReadingHistory.tsx` → `ReadingHistoryModal` (post picker) | `showButtons={false} clickable={false}` | Unchanged — `showCopyLink` defaults off and the control is additionally behind `showButtons` |
| `shared/components/history/ReadingHistory.spec.tsx` | tests | Extended; all original assertions untouched |

No webapp/extension file renders `PostItemCard` directly.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — pass
- `pnpm --filter shared lint` — pass (webapp source untouched)
- `NODE_ENV=test pnpm --filter shared test` — pass
- `NODE_ENV=test pnpm --filter webapp test` — pass
- New tests: copy → clipboard receives `commentsPermalink` + toast + `SharePost` log with `{ provider, origin: 'history' }`; mobile → `navigator.share` (clipboard untouched); flag-off / master-off / not-opted-in → no copy control, original DOM; one control per row when on; existing vote/hide/menu tests untouched and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-share-history.preview.app.daily.dev