### PR TITLE
feat(share): copy-my-feed digest button in the feed nav

### DIFF
--- a/packages/shared/src/components/feeds/CopyMyFeedButton.spec.tsx
+++ b/packages/shared/src/components/feeds/CopyMyFeedButton.spec.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { CopyMyFeedButton } from './CopyMyFeedButton';
+import {
+  buildFeedDigest,
+  MAX_COPY_MY_FEED_POSTS,
+} from '../../hooks/feed/useCopyMyFeed';
+import { useCopyMyFeedEnabled } from '../../hooks/feed/useCopyMyFeedEnabled';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import loggedUser from '../../../__tests__/fixture/loggedUser';
+import { ActiveFeedNameContext } from '../../contexts/ActiveFeedNameContext';
+import { SharedFeedPage } from '../utilities';
+import { generateQueryKey } from '../../lib/query';
+import type { FeedItemData } from '../../graphql/feed';
+import type { Post } from '../../graphql/posts';
+import type { ToastNotification } from '../../hooks/useToastNotification';
+import { TOAST_NOTIF_KEY } from '../../hooks/useToastNotification';
+import { shouldUseNativeShare } from '../../lib/func';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+jest.mock('../../hooks/feed/useCopyMyFeedEnabled', () => ({
+  useCopyMyFeedEnabled: jest.fn(),
+}));
+
+jest.mock('../../lib/func', () => {
+  const actual = jest.requireActual('../../lib/func');
+  return { __esModule: true, ...actual, shouldUseNativeShare: jest.fn() };
+});
+
+const enabledMock = useCopyMyFeedEnabled as jest.Mock;
+const nativeShareMock = shouldUseNativeShare as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+const nativeShare = jest.fn().mockResolvedValue(undefined);
+const logEvent = jest.fn();
+
+let client: QueryClient;
+
+const makePost = (index: number): Post =>
+  ({
+    id: `p${index}`,
+    title: `Post ${index}`,
+    commentsPermalink: `https://app.daily.dev/posts/p${index}`,
+  } as Post);
+
+const toFeedPage = (posts: Post[]): FeedItemData => ({
+  page: {
+    pageInfo: { hasNextPage: true, endCursor: 'cursor' },
+    edges: posts.map((post) => ({
+      node: { itemType: 'post', post, feedMeta: null },
+    })),
+  },
+});
+
+// Seed the cache exactly how `MainFeedLayout` keys the feed query:
+// `[feedName, userId, ...variables]` — the button must prefix-match it.
+const seedFeed = (pages: Post[][]): void => {
+  client.setQueryData(
+    generateQueryKey(SharedFeedPage.MyFeed, loggedUser, 'popularity'),
+    { pages: pages.map(toFeedPage), pageParams: pages.map(() => '') },
+  );
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  enabledMock.mockReturnValue(true);
+  nativeShareMock.mockReturnValue(false);
+  Object.assign(navigator, {
+    clipboard: { writeText },
+    share: nativeShare,
+  });
+  client = new QueryClient();
+});
+
+const renderComponent = (): RenderResult =>
+  render(
+    <TestBootProvider
+      client={client}
+      auth={{ user: loggedUser }}
+      log={{ logEvent }}
+    >
+      <ActiveFeedNameContext.Provider
+        value={{ feedName: SharedFeedPage.MyFeed }}
+      >
+        <CopyMyFeedButton />
+      </ActiveFeedNameContext.Provider>
+    </TestBootProvider>,
+  );
+
+describe('buildFeedDigest', () => {
+  it('formats a header line plus one bullet per post', () => {
+    const digest = buildFeedDigest([makePost(1), makePost(2)]);
+
+    expect(digest).toBe(
+      [
+        'My daily.dev feed today:',
+        '',
+        '• Post 1 https://app.daily.dev/posts/p1',
+        '• Post 2 https://app.daily.dev/posts/p2',
+      ].join('\n'),
+    );
+  });
+
+  it('runs every link through the provided tracker', () => {
+    const digest = buildFeedDigest([makePost(1)], (url) => `${url}?cid=x`);
+
+    expect(digest).toContain('https://app.daily.dev/posts/p1?cid=x');
+  });
+});
+
+describe('CopyMyFeedButton gating', () => {
+  it('renders nothing at all while the flag is off', () => {
+    enabledMock.mockReturnValue(false);
+    seedFeed([[makePost(1)]]);
+
+    const { container } = renderComponent();
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('is disabled while the feed has no loaded posts', () => {
+    renderComponent();
+
+    expect(screen.getByLabelText('Copy my feed')).toBeDisabled();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('CopyMyFeedButton copy on desktop', () => {
+  it('copies titles and tracked links of the loaded posts and shows a toast', async () => {
+    seedFeed([[makePost(1), makePost(2)]]);
+    renderComponent();
+
+    const button = screen.getByLabelText('Copy my feed');
+    expect(button).toBeEnabled();
+
+    await act(async () => {
+      fireEvent.click(button);
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('My daily.dev feed today:');
+    expect(copied).toContain('• Post 1 https://app.daily.dev/posts/p1');
+    expect(copied).toContain('• Post 2 https://app.daily.dev/posts/p2');
+    expect(copied).toContain('cid=copy_my_feed');
+    expect(copied).toContain(`userid=${loggedUser.id}`);
+
+    const toast = client.getQueryData<ToastNotification>(TOAST_NOTIF_KEY);
+    expect(toast?.message).toBe('✅ Copied your feed to clipboard');
+
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ event_name: LogEvent.ShareLog }),
+    );
+    expect(JSON.parse(logEvent.mock.calls[0][0].extra)).toEqual({
+      origin: Origin.CopyMyFeed,
+      provider: ShareProvider.CopyLink,
+      postCount: 2,
+    });
+  });
+
+  it('caps the digest at the top posts across pages', async () => {
+    const pageOne = Array.from({ length: 15 }, (_, i) => makePost(i + 1));
+    const pageTwo = Array.from({ length: 10 }, (_, i) => makePost(i + 16));
+    seedFeed([pageOne, pageTwo]);
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy my feed'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copied = writeText.mock.calls[0][0] as string;
+    const bullets = copied.split('\n').filter((line) => line.startsWith('•'));
+    expect(bullets).toHaveLength(MAX_COPY_MY_FEED_POSTS);
+    expect(copied).toContain('• Post 20 ');
+    expect(copied).not.toContain('• Post 21 ');
+  });
+});
+
+describe('CopyMyFeedButton native share on mobile', () => {
+  it('opens the native share sheet with the digest text', async () => {
+    nativeShareMock.mockReturnValue(true);
+    seedFeed([[makePost(1)]]);
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy my feed'));
+    });
+
+    await waitFor(() => expect(nativeShare).toHaveBeenCalledTimes(1));
+    expect(nativeShare.mock.calls[0][0].text).toContain('• Post 1 ');
+    expect(writeText).not.toHaveBeenCalled();
+    expect(JSON.parse(logEvent.mock.calls[0][0].extra)).toEqual({
+      origin: Origin.CopyMyFeed,
+      provider: ShareProvider.Native,
+      postCount: 1,
+    });
+  });
+});

--- a/packages/shared/src/components/feeds/CopyMyFeedButton.tsx
+++ b/packages/shared/src/components/feeds/CopyMyFeedButton.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { Button, ButtonVariant } from '../buttons/Button';
+import { CopyIcon } from '../icons';
+import { Tooltip } from '../tooltip/Tooltip';
+import { useCopyMyFeed } from '../../hooks/feed/useCopyMyFeed';
+import { useCopyMyFeedEnabled } from '../../hooks/feed/useCopyMyFeedEnabled';
+
+const LABEL = 'Copy my feed';
+
+interface CopyMyFeedButtonProps {
+  className?: string;
+}
+
+// Feed-nav affordance that copies (or natively shares, on mobile) a text
+// digest of the posts currently loaded in the active feed. Renders nothing
+// while the `share_copy_my_feed` / `sharing_visibility` flags are off so the
+// nav chrome stays byte-identical for control users.
+export function CopyMyFeedButton({
+  className,
+}: CopyMyFeedButtonProps): ReactElement | null {
+  const isEnabled = useCopyMyFeedEnabled();
+  const { hasPosts, isCopying, copyMyFeed } = useCopyMyFeed({
+    enabled: isEnabled,
+  });
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <Tooltip content={LABEL}>
+      <Button
+        type="button"
+        variant={ButtonVariant.Tertiary}
+        icon={<CopyIcon secondary={isCopying} />}
+        aria-label={LABEL}
+        disabled={!hasPosts}
+        className={className}
+        onClick={copyMyFeed}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/shared/src/components/feeds/FeedNav.tsx
+++ b/packages/shared/src/components/feeds/FeedNav.tsx
@@ -19,6 +19,8 @@ import {
   DEFAULT_ALGORITHM_KEY,
 } from '../layout/common';
 import { MobileFeedActions } from './MobileFeedActions';
+import { CopyMyFeedButton } from './CopyMyFeedButton';
+import { useCopyMyFeedEnabled } from '../../hooks/feed/useCopyMyFeedEnabled';
 import { useFeedName } from '../../hooks/feed/useFeedName';
 import { useSettingsContext } from '../../contexts/SettingsContext';
 import { Dropdown } from '../fields/Dropdown';
@@ -71,6 +73,10 @@ function FeedNav(): ReactElement | null {
   // header/rail; the tablet feed header is the only gap, so it renders its own.
   // JS-gated (not CSS) so it never mounts alongside the other placements.
   const isTablet = isBelowLaptop && !isMobile;
+  // The copy-my-feed button widens the tablet corner overlay, so the last tab
+  // needs a larger clearance margin — but only when the flag is on, keeping
+  // flag-off pixel-identical.
+  const isCopyMyFeedEnabled = useCopyMyFeedEnabled(isTablet);
   const { value: feedChipsVariant } = useConditionalFeature({
     feature: featureFeedChips,
     shouldEvaluate: isBelowLaptop,
@@ -172,7 +178,12 @@ function FeedNav(): ReactElement | null {
             tabListProps={{
               className: {
                 indicator: '!w-6',
-                item: 'px-1 tablet:last-of-type:mr-24',
+                item: classNames(
+                  'px-1',
+                  isCopyMyFeedEnabled
+                    ? 'tablet:last-of-type:mr-36'
+                    : 'tablet:last-of-type:mr-24',
+                ),
               },
               autoScrollActive: true,
             }}
@@ -224,6 +235,9 @@ function FeedNav(): ReactElement | null {
           </StickyNavIconWrapper>
         )}
         <div className="hidden items-center gap-2 bg-background-default tablet:absolute tablet:inset-y-0 tablet:right-0 tablet:flex laptop:hidden">
+          {/* JS-gated like the giveback entry: phones already mount the button
+              via MobileFeedActions, so don't mount a hidden duplicate here. */}
+          {isTablet && <CopyMyFeedButton />}
           {isTablet && <GivebackGiftEntry compact />}
           <NotificationsBell compact />
         </div>

--- a/packages/shared/src/components/feeds/MobileFeedActions.spec.tsx
+++ b/packages/shared/src/components/feeds/MobileFeedActions.spec.tsx
@@ -100,4 +100,12 @@ describe('MobileFeedActions', () => {
 
     expect(screen.queryByTestId('quest-button')).not.toBeInTheDocument();
   });
+
+  // Real (unmocked) flag path: `share_copy_my_feed` defaults to false, so the
+  // nav must render exactly what shipped before the button existed.
+  it('should not render the copy-my-feed button while its flag is off', () => {
+    renderComponent();
+
+    expect(screen.queryByLabelText('Copy my feed')).not.toBeInTheDocument();
+  });
 });

--- a/packages/shared/src/components/feeds/MobileFeedActions.tsx
+++ b/packages/shared/src/components/feeds/MobileFeedActions.tsx
@@ -16,6 +16,7 @@ import { SettingsIcon } from '../icons';
 import { RootPortal } from '../tooltips/Portal';
 import { QuestHeaderButton } from '../header/QuestHeaderButton';
 import { GivebackGiftEntry } from '../../features/giveback/components/GivebackGiftEntry';
+import { CopyMyFeedButton } from './CopyMyFeedButton';
 
 const ProfileSettingsMenuMobile = dynamic(
   () =>
@@ -48,6 +49,7 @@ export function MobileFeedActions(): ReactElement {
         )}
         <QuestHeaderButton compact />
         <GivebackGiftEntry compact />
+        <CopyMyFeedButton />
         {user && (
           <>
             <Button

--- a/packages/shared/src/hooks/feed/useCopyMyFeed.ts
+++ b/packages/shared/src/hooks/feed/useCopyMyFeed.ts
@@ -1,0 +1,195 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import type {
+  InfiniteData,
+  QueryClient,
+  QueryKey,
+} from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
+import { useActiveFeedNameContext } from '../../contexts/ActiveFeedNameContext';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useLogContext } from '../../contexts/LogContext';
+import type { FeedItemData } from '../../graphql/feed';
+import { getFeedApiItemPost } from '../../graphql/feed';
+import type { Post } from '../../graphql/posts';
+import { SharedFeedPage } from '../../components/utilities';
+import { shouldUseNativeShare } from '../../lib/func';
+import { LogEvent, Origin } from '../../lib/log';
+import { ReferralCampaignKey } from '../../lib/referral';
+import { ShareProvider } from '../../lib/share';
+import { useCopyText } from '../useCopy';
+import { useGetShortUrl } from '../utils/useGetShortUrl';
+import useCustomDefaultFeed from './useCustomDefaultFeed';
+
+export const MAX_COPY_MY_FEED_POSTS = 20;
+
+export type CopyMyFeedPost = Pick<Post, 'id' | 'title' | 'commentsPermalink'>;
+
+// Something a dev would paste in Slack: a short header, then one bullet per
+// post. Links go through the tracker so shares are attributable.
+export const buildFeedDigest = (
+  posts: CopyMyFeedPost[],
+  getLink: (url: string) => string = (url) => url,
+): string =>
+  [
+    'My daily.dev feed today:',
+    '',
+    ...posts.map(
+      (post) => `• ${post.title} ${getLink(post.commentsPermalink)}`,
+    ),
+  ].join('\n');
+
+const isLoadedFeedData = (
+  data: unknown,
+): data is InfiniteData<FeedItemData> => {
+  const pages = (data as InfiniteData<FeedItemData>)?.pages;
+
+  return (
+    Array.isArray(pages) && pages.some((page) => !!page?.page?.edges?.length)
+  );
+};
+
+// The feed queries this surface may digest, newest first. Feed query keys are
+// `[feedName, userId, ...variables]` (see `generateQueryKey` +
+// `MainFeedLayout`); we prefix-match so variable-suffixed variants (ranking,
+// period, feed id) all resolve without re-deriving the exact variables here.
+const findNewestFeedQuery = (queryClient: QueryClient, prefixes: QueryKey[]) =>
+  prefixes
+    .flatMap((queryKey) => queryClient.getQueryCache().findAll({ queryKey }))
+    .filter((query) => isLoadedFeedData(query.state.data))
+    .sort((a, b) => b.state.dataUpdatedAt - a.state.dataUpdatedAt)[0];
+
+export const collectLoadedFeedPosts = (
+  queryClient: QueryClient,
+  prefixes: QueryKey[],
+): CopyMyFeedPost[] => {
+  const newest = findNewestFeedQuery(queryClient, prefixes);
+
+  if (!newest) {
+    return [];
+  }
+
+  const data = newest.state.data as InfiniteData<FeedItemData>;
+  const seen = new Set<string>();
+
+  return data.pages
+    .flatMap((page) => page?.page?.edges ?? [])
+    .map(({ node }) => getFeedApiItemPost(node))
+    .filter((post): post is Post => {
+      if (!post?.title || !post?.commentsPermalink || seen.has(post.id)) {
+        return false;
+      }
+
+      seen.add(post.id);
+
+      return true;
+    })
+    .slice(0, MAX_COPY_MY_FEED_POSTS);
+};
+
+interface UseCopyMyFeedProps {
+  /** Skip all cache work (subscription included) while the flag is off. */
+  enabled?: boolean;
+}
+
+interface UseCopyMyFeed {
+  /** Whether the active feed has any loaded posts to digest. */
+  hasPosts: boolean;
+  isCopying: boolean;
+  copyMyFeed: () => Promise<void>;
+}
+
+export const useCopyMyFeed = ({
+  enabled = true,
+}: UseCopyMyFeedProps = {}): UseCopyMyFeed => {
+  const queryClient = useQueryClient();
+  const { feedName } = useActiveFeedNameContext();
+  const { user } = useAuthContext();
+  const { isCustomDefaultFeed, defaultFeedId } = useCustomDefaultFeed();
+  const { getTrackedUrl } = useGetShortUrl();
+  const { logEvent } = useLogContext();
+  const [isCopying, copyText] = useCopyText();
+
+  const userId = user?.id ?? 'anonymous';
+  const getPrefixes = useCallback((): QueryKey[] => {
+    if (!feedName) {
+      return [];
+    }
+
+    const prefixes: QueryKey[] = [[feedName, userId]];
+
+    // On `/` with a custom default feed the rendered feed is cached under the
+    // `custom` key while the active feed name still resolves to `my-feed`.
+    if (
+      feedName === SharedFeedPage.MyFeed &&
+      isCustomDefaultFeed &&
+      defaultFeedId
+    ) {
+      prefixes.push([SharedFeedPage.Custom, userId, defaultFeedId]);
+    }
+
+    return prefixes;
+  }, [feedName, userId, isCustomDefaultFeed, defaultFeedId]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      if (!enabled) {
+        return () => undefined;
+      }
+
+      return queryClient.getQueryCache().subscribe(onStoreChange);
+    },
+    [enabled, queryClient],
+  );
+  // Cheap primitive snapshot (newest matching feed query's dataUpdatedAt) so
+  // the button only re-renders when the loaded feed actually changes.
+  const getSnapshot = useCallback(() => {
+    if (!enabled) {
+      return 0;
+    }
+
+    return (
+      findNewestFeedQuery(queryClient, getPrefixes())?.state.dataUpdatedAt ?? 0
+    );
+  }, [enabled, queryClient, getPrefixes]);
+  const dataUpdatedAt = useSyncExternalStore(subscribe, getSnapshot, () => 0);
+
+  const copyMyFeed = useCallback(async () => {
+    const posts = collectLoadedFeedPosts(queryClient, getPrefixes());
+
+    if (!posts.length) {
+      return;
+    }
+
+    const digest = buildFeedDigest(posts, (url) =>
+      getTrackedUrl(url, ReferralCampaignKey.CopyMyFeed),
+    );
+    const logShare = (provider: ShareProvider) =>
+      logEvent({
+        event_name: LogEvent.ShareLog,
+        extra: JSON.stringify({
+          origin: Origin.CopyMyFeed,
+          provider,
+          postCount: posts.length,
+        }),
+      });
+
+    if (shouldUseNativeShare()) {
+      try {
+        await navigator.share({ text: digest });
+        logShare(ShareProvider.Native);
+      } catch {
+        // the user dismissed the share sheet — nothing happened, nothing to log
+      }
+
+      return;
+    }
+
+    await copyText({
+      textToCopy: digest,
+      message: '✅ Copied your feed to clipboard',
+    });
+    logShare(ShareProvider.CopyLink);
+  }, [queryClient, getPrefixes, getTrackedUrl, logEvent, copyText]);
+
+  return { hasPosts: dataUpdatedAt > 0, isCopying, copyMyFeed };
+};

--- a/packages/shared/src/hooks/feed/useCopyMyFeedEnabled.ts
+++ b/packages/shared/src/hooks/feed/useCopyMyFeedEnabled.ts
@@ -1,0 +1,16 @@
+import { featureShareCopyMyFeed } from '../../lib/featureManagement';
+import { useConditionalFeature } from '../useConditionalFeature';
+import { useSharingVisibility } from '../useSharingVisibility';
+
+// Gate for the "Copy my feed" affordance in the feed navigation. The per-topic
+// flag is only evaluated once the sharing-visibility master switch is on, so
+// control users never get bucketed into the experiment.
+export const useCopyMyFeedEnabled = (shouldEvaluate = true): boolean => {
+  const { isEnabled: isSharingEnabled } = useSharingVisibility(shouldEvaluate);
+  const { value } = useConditionalFeature({
+    feature: featureShareCopyMyFeed,
+    shouldEvaluate: isSharingEnabled,
+  });
+
+  return isSharingEnabled && value;
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,9 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// "Copy my feed" button in the feed navigation: copies a text digest (titles +
+// tracked links) of the posts currently loaded in the active feed. Gated
+// together with the sharing-visibility master switch. Keep the default `false`
+// — GrowthBook ramps it.
+export const featureShareCopyMyFeed = new Feature('share_copy_my_feed', false);

--- a/packages/shared/src/lib/referral.ts
+++ b/packages/shared/src/lib/referral.ts
@@ -6,4 +6,5 @@ export enum ReferralCampaignKey {
   ShareProfile = 'share_profile',
   ShareSource = 'share_source',
   ShareTag = 'share_tag',
+  CopyMyFeed = 'copy_my_feed',
 }

--- a/packages/storybook/stories/components/CopyMyFeedButton.stories.tsx
+++ b/packages/storybook/stories/components/CopyMyFeedButton.stories.tsx
@@ -1,0 +1,200 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { CopyMyFeedButton } from '@dailydotdev/shared/src/components/feeds/CopyMyFeedButton';
+import { buildFeedDigest } from '@dailydotdev/shared/src/hooks/feed/useCopyMyFeed';
+import type { FeedItemData } from '@dailydotdev/shared/src/graphql/feed';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import { ActiveFeedNameContext } from '@dailydotdev/shared/src/contexts/ActiveFeedNameContext';
+import {
+  FeaturesReadyContext,
+  GrowthBookProvider,
+} from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import { generateQueryKey } from '@dailydotdev/shared/src/lib/query';
+import { SharedFeedPage } from '@dailydotdev/shared/src/components/utilities';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+
+const mockUser = {
+  id: '1',
+  name: 'Test User',
+  username: 'testuser',
+  email: 'test@example.com',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/testuser',
+} as unknown as LoggedUser;
+
+const samplePosts = [
+  {
+    id: 'p1',
+    title: 'The pragmatic guide to shipping fast without breaking prod',
+    commentsPermalink: 'https://app.daily.dev/posts/p1',
+  },
+  {
+    id: 'p2',
+    title: 'Postgres indexing mistakes that cost us 400ms per query',
+    commentsPermalink: 'https://app.daily.dev/posts/p2',
+  },
+  {
+    id: 'p3',
+    title: 'Why we moved our monorepo to pnpm (and what broke)',
+    commentsPermalink: 'https://app.daily.dev/posts/p3',
+  },
+] as Post[];
+
+const feedPage: FeedItemData = {
+  page: {
+    pageInfo: { hasNextPage: true, endCursor: 'cursor' },
+    edges: samplePosts.map((post) => ({
+      node: { itemType: 'post', post, feedMeta: null },
+    })),
+  },
+};
+
+// Storybook aliases `@growthbook/growthbook` to a mock whose `getFeatureValue`
+// coerces every falsy default to the truthy string `'control'`, so a flag can't
+// be evaluated as `false` here. Flag-off is therefore simulated by holding the
+// features context as "not ready", which is the exact path
+// `useConditionalFeature` takes to fall back to the (false) default value.
+const withProviders =
+  (enabled: boolean, seedFeed: boolean) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    if (seedFeed) {
+      // The button prefix-matches `[feedName, userId, ...variables]`, exactly
+      // how `MainFeedLayout` keys the feed query it renders.
+      queryClient.setQueryData(
+        generateQueryKey(SharedFeedPage.MyFeed, mockUser, 'popularity'),
+        { pages: [feedPage], pageParams: [''] },
+      );
+    }
+
+    const LogContext = getLogContextStatic();
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={
+            {
+              user: mockUser,
+              isLoggedIn: true,
+              isAuthReady: true,
+              tokenRefreshed: true,
+              shouldShowLogin: false,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              getRedirectUri: fn(),
+              loadingUser: false,
+              loadedUserFromCache: true,
+              refetchBoot: fn(),
+              squads: [],
+              isAndroidApp: false,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any
+          }
+        >
+          <ActiveFeedNameContext.Provider
+            value={{ feedName: SharedFeedPage.MyFeed }}
+          >
+            <GrowthBookProvider
+              app={BootApp.Webapp}
+              user={mockUser}
+              deviceId="storybook"
+            >
+              <FeaturesReadyContext.Provider
+                value={{
+                  ready: enabled,
+                  getFeatureValue: (feature) =>
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    feature.defaultValue as any,
+                }}
+              >
+                <LogContext.Provider
+                  value={{
+                    logEvent: fn(),
+                    logEventStart: fn(),
+                    logEventEnd: fn(),
+                    sendBeacon: () => false,
+                  }}
+                >
+                  <div className="flex flex-col items-start gap-4 p-4">
+                    <Story />
+                  </div>
+                </LogContext.Provider>
+              </FeaturesReadyContext.Provider>
+            </GrowthBookProvider>
+          </ActiveFeedNameContext.Provider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+
+const meta: Meta<typeof CopyMyFeedButton> = {
+  title: 'Components/Share/CopyMyFeedButton',
+  component: CopyMyFeedButton,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Feed-nav "Copy my feed" affordance (`share_copy_my_feed`, also gated by the `sharing_visibility` master flag). Copies — or natively shares on mobile — a Slack-pasteable text digest of the top ~20 posts loaded in the active feed, one bullet per post with a tracked link.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CopyMyFeedButton>;
+
+// Flag on, feed loaded — the enabled button next to a preview of the exact
+// text it produces (untracked links; the real button appends tracking params).
+export const FeedLoaded: Story = {
+  decorators: [withProviders(true, true)],
+  render: () => (
+    <>
+      <CopyMyFeedButton />
+      <pre className="whitespace-pre-wrap rounded-12 border border-border-subtlest-tertiary bg-surface-float p-4 text-text-secondary typo-footnote">
+        {buildFeedDigest(samplePosts)}
+      </pre>
+    </>
+  ),
+};
+
+// Flag on but nothing loaded in the active feed yet — the button disables
+// itself so users can never copy an empty digest.
+export const EmptyFeed: Story = {
+  decorators: [withProviders(true, false)],
+};
+
+// Flag off — must render exactly what ships today: nothing.
+export const Control: Story = {
+  decorators: [withProviders(false, true)],
+};
+
+// Clicking copies the digest to the clipboard. The clipboard is stubbed
+// because the Storybook iframe isn't allowed to write to the real one.
+export const CopyInteraction: Story = {
+  decorators: [withProviders(true, true)],
+  play: async ({ canvasElement }) => {
+    const writeText = fn().mockResolvedValue(undefined);
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    });
+
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByLabelText('Copy my feed'));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+    await expect(writeText.mock.calls[0][0]).toContain(samplePosts[0].title);
+  },
+};


### PR DESCRIPTION
Part of the sharing-visibility initiative (builds on PR 1, #6343). Adds a "Copy my feed" button to the feed navigation that generates a copyable text digest of the top ~20 posts from the current feed.

## What changed

- **`CopyMyFeedButton`** (`packages/shared/src/components/feeds/CopyMyFeedButton.tsx`): icon-only Tertiary button (tooltip + `aria-label`, `type="button"`), disabled while the active feed has no loaded posts, renders `null` while the flag is off.
- **Placement** — the two feed-nav surfaces this PR owns:
  - Phones: `MobileFeedActions` right-side action row (next to quests/giveback).
  - Tablets: the `FeedNav` corner overlay (JS-gated with `isTablet` like the giveback entry, so phones never mount a hidden duplicate). The last tab's clearance margin bumps `mr-24 → mr-36` only when the flag is on, following the precedent from the giveback entry (76898035b).
  - Note: `FeedNav` only renders below laptop (`MainLayoutHeader` gates it with `isMobile`). The laptop+ feed header lives in `MainFeedLayout.tsx`, which sibling PR 16 owns — a desktop placement is intentionally left out of this PR (see below).
- **`useCopyMyFeed`**: reads the posts straight from the TanStack Query cache — **no duplicate feed request**. Feed queries are keyed `[feedName, userId, ...variables]` (`generateQueryKey` + `MainFeedLayout`), so the hook prefix-matches `[activeFeedName, userId]` (plus `[custom, userId, defaultFeedId]` for the custom-default-feed-on-`/` case) and digests the newest matching query with data. Button enablement subscribes to the query cache via `useSyncExternalStore` with a cheap primitive snapshot (`dataUpdatedAt`), gated off entirely while the flag is off.
- **Digest format** (dev-pastes-it-in-Slack voice):
  ```
  My daily.dev feed today:

  • {title} {trackedLink}
  ```
  Capped at 20 posts across loaded pages, deduped by id, highlight/ad items skipped. If fewer than 20 posts are loaded we copy what's there — no forced fetching.
- **Behavior**: mobile → native share sheet (`navigator.share({ text })`, feature-detected via `shouldUseNativeShare`); otherwise copy to clipboard + toast.
- **Logging**: generic `LogEvent.ShareLog` with `extra: { origin: Origin.CopyMyFeed, provider, postCount }` (one event per entity, no per-surface event). `Origin.CopyMyFeed` comes from PR 1.
- **Storybook**: `CopyMyFeedButton.stories.tsx` — loaded-feed state with a preview of the exact composed text, empty-feed (disabled), flag-off control (renders nothing, simulated by holding `FeaturesReadyContext` not-ready since the Storybook GB mock can't evaluate false), and a clipboard interaction play test.

## Tracked-link approach: long links, not short links

Per-link shortening would cost ~20 sequential GraphQL calls per copy, so links go through `addLogQueryParams`-style tracked long links instead (`getTrackedUrl` with the new `ReferralCampaignKey.CopyMyFeed` → `?userid=…&cid=copy_my_feed`). Tradeoff: URLs are longer/uglier than `dly.to` links, but the copy is instant and attribution is preserved.

## Flag

`share_copy_my_feed`, default `false`, appended at the end of `featureManagement.ts`. Gated together with the `sharing_visibility` master switch via `useConditionalFeature` + `shouldEvaluate` (the per-topic flag is only evaluated once the master is on). Flag-off renders nothing — nav DOM/pixels identical to the base branch, asserted in Jest.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — pass
- `pnpm --filter shared lint` — pass (0 warnings)
- `NODE_ENV=test pnpm --filter shared test` — 295 suites, 1993 tests, all pass
- `NODE_ENV=test pnpm --filter webapp test` — 44 suites, 297 tests, all pass
- New tests assert: digest contains titles + tracked links of loaded posts; 20-post cap across pages; copy → clipboard + toast + ShareLog(provider=copy link, postCount); mobile → `navigator.share` with the digest text + ShareLog(provider=native); empty feed → disabled button, no copy; flag-off → empty DOM (component spec) and unmocked-flag-off surface assertion in `MobileFeedActions.spec.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-share-copy-my-feed.preview.app.daily.dev