### PR TITLE
feat(share): copy-link control on squad directory cards

### DIFF
--- a/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.spec.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { SquadDirectoryShareButton } from './SquadDirectoryShareButton';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import loggedUser from '../../../../__tests__/fixture/loggedUser';
+import { generateTestSquad } from '../../../../__tests__/fixture/squads';
+import { getShortLinkProps } from '../../../hooks/utils/useGetShortUrl';
+import { ReferralCampaignKey } from '../../../lib/referral';
+import { TOAST_NOTIF_KEY } from '../../../hooks/useToastNotification';
+import { useViewSize } from '../../../hooks/useViewSize';
+import { LogEvent, Origin, TargetType } from '../../../lib/log';
+import { ShareProvider } from '../../../lib/share';
+
+jest.mock('../../../hooks/useViewSize', () => {
+  const actual = jest.requireActual('../../../hooks/useViewSize');
+  return { __esModule: true, ...actual, useViewSize: jest.fn() };
+});
+
+const useViewSizeMock = useViewSize as jest.Mock;
+const writeText = jest.fn().mockResolvedValue(undefined);
+const logEvent = jest.fn();
+const squad = generateTestSquad();
+const shortLink = 'https://dly.to/squad';
+
+let client: QueryClient;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useViewSizeMock.mockReturnValue(true); // default: laptop
+  Object.assign(navigator, { clipboard: { writeText } });
+
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  // Seed the resolved short URL so the copy path never hits the network.
+  const { queryKey } = getShortLinkProps(
+    squad.permalink,
+    ReferralCampaignKey.ShareSource,
+    loggedUser,
+  );
+  client.setQueryData(queryKey, shortLink);
+});
+
+afterEach(() => {
+  delete (navigator as { share?: unknown }).share;
+});
+
+const renderComponent = (): RenderResult =>
+  render(
+    <TestBootProvider
+      client={client}
+      auth={{ user: loggedUser }}
+      log={{ logEvent }}
+    >
+      <SquadDirectoryShareButton squad={squad} />
+    </TestBootProvider>,
+  );
+
+const expectedLog = (provider: ShareProvider) => ({
+  event_name: LogEvent.ShareSource,
+  target_type: TargetType.Source,
+  target_id: squad.id,
+  extra: JSON.stringify({ origin: Origin.SquadDirectory, provider }),
+});
+
+describe('SquadDirectoryShareButton on desktop', () => {
+  it('copies the squad permalink, shows a toast and logs a source share', async () => {
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy Squad link'));
+    });
+
+    await act(async () => {
+      fireEvent.click(await screen.findByText('Copy link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(shortLink));
+    expect(client.getQueryData(TOAST_NOTIF_KEY)).toMatchObject({
+      message: '✅ Copied link to clipboard',
+    });
+    expect(logEvent).toHaveBeenCalledWith(expectedLog(ShareProvider.CopyLink));
+  });
+});
+
+describe('SquadDirectoryShareButton on mobile', () => {
+  beforeEach(() => {
+    useViewSizeMock.mockReturnValue(false);
+  });
+
+  it('opens the native share sheet on a single tap when available', async () => {
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'share', {
+      configurable: true,
+      value: share,
+    });
+    // `shouldUseNativeShare` also requires a touch device.
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      configurable: true,
+      value: 5,
+    });
+
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy Squad link'));
+    });
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        text: `Check out ${squad.handle} on daily.dev\n${shortLink}`,
+      }),
+    );
+    expect(writeText).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith(expectedLog(ShareProvider.Native));
+  });
+
+  it('falls back to copying when native share is unavailable', async () => {
+    renderComponent();
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy Squad link'));
+    });
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith(shortLink));
+    expect(logEvent).toHaveBeenCalledWith(expectedLog(ShareProvider.CopyLink));
+  });
+});

--- a/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.spec.tsx
@@ -74,7 +74,7 @@ describe('SquadDirectoryShareButton on desktop', () => {
     renderComponent();
 
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Copy Squad link'));
+      fireEvent.click(screen.getByLabelText('Share Squad'));
     });
 
     await act(async () => {
@@ -109,7 +109,7 @@ describe('SquadDirectoryShareButton on mobile', () => {
     renderComponent();
 
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Copy Squad link'));
+      fireEvent.click(screen.getByLabelText('Share Squad'));
     });
 
     await waitFor(() =>
@@ -125,7 +125,7 @@ describe('SquadDirectoryShareButton on mobile', () => {
     renderComponent();
 
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Copy Squad link'));
+      fireEvent.click(screen.getByLabelText('Share Squad'));
     });
 
     await waitFor(() => expect(writeText).toHaveBeenCalledWith(shortLink));

--- a/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.tsx
+++ b/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { Squad } from '../../../graphql/sources';
+import { ShareActions } from '../../share/ShareActions';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { useLogContext } from '../../../contexts/LogContext';
+import { LogEvent, Origin, TargetType } from '../../../lib/log';
+import { ReferralCampaignKey } from '../../../lib/referral';
+
+interface SquadDirectoryShareButtonProps {
+  squad: Squad;
+  className?: string;
+}
+
+// Squads are sources in the data model, so directory shares reuse the existing
+// `ShareSource` event (same shape as `SourceActions`); this surface is
+// distinguished by `origin: squad directory` in `extra`.
+export const SquadDirectoryShareButton = ({
+  squad,
+  className,
+}: SquadDirectoryShareButtonProps): ReactElement => {
+  const { logEvent } = useLogContext();
+
+  return (
+    <ShareActions
+      link={squad.permalink}
+      text={`Check out ${squad.handle} on daily.dev`}
+      cid={ReferralCampaignKey.ShareSource}
+      buttonVariant={ButtonVariant.Float}
+      buttonSize={ButtonSize.Medium}
+      label="Copy Squad link"
+      className={className}
+      onShare={(provider) =>
+        logEvent({
+          event_name: LogEvent.ShareSource,
+          target_type: TargetType.Source,
+          target_id: squad.id,
+          extra: JSON.stringify({
+            origin: Origin.SquadDirectory,
+            provider,
+          }),
+        })
+      }
+    />
+  );
+};

--- a/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.tsx
+++ b/packages/shared/src/components/cards/squad/SquadDirectoryShareButton.tsx
@@ -28,7 +28,7 @@ export const SquadDirectoryShareButton = ({
       cid={ReferralCampaignKey.ShareSource}
       buttonVariant={ButtonVariant.Float}
       buttonSize={ButtonSize.Medium}
-      label="Copy Squad link"
+      label="Share Squad"
       className={className}
       onShare={(provider) =>
         logEvent({

--- a/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
@@ -1,6 +1,7 @@
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
 import React from 'react';
 import nock from 'nock';
 import { AuthContextProvider } from '../../../contexts/AuthContext';
@@ -28,6 +29,11 @@ import {
   CONTENT_PREFERENCE_STATUS_QUERY,
   ContentPreferenceType,
 } from '../../../graphql/contentPreference';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import {
+  featureSharingVisibility,
+  featureShareSquadDirectory,
+} from '../../../lib/featureManagement';
 
 const squads = [generateTestSquad()];
 const members = generateMembersList();
@@ -198,6 +204,98 @@ it('should render the component with a join squad button', async () => {
   btn.click();
   await waitForNock();
   await waitFor(async () => {
+    await waitFor(() => expect(queryCalled).toBeTruthy());
+  });
+});
+
+describe('squad directory share', () => {
+  const mockContentPreference = () =>
+    mockGraphQL({
+      request: {
+        query: CONTENT_PREFERENCE_STATUS_QUERY,
+        variables: {
+          id: admin.source.id,
+          entity: ContentPreferenceType.Source,
+        },
+      },
+      result: { data: { contentPreferenceStatus: null } },
+    });
+
+  const renderWithSharing = (enabled: boolean): RenderResult => {
+    const gb = new GrowthBook();
+    gb.setFeatures({
+      [featureSharingVisibility.id]: { defaultValue: enabled },
+      [featureShareSquadDirectory.id]: { defaultValue: enabled },
+    });
+
+    return render(
+      <TestBootProvider
+        client={new QueryClient()}
+        auth={{ user: loggedUser, squads }}
+        gb={gb}
+      >
+        <SquadGrid source={admin.source} />
+      </TestBootProvider>,
+    );
+  };
+
+  it('flag off: keeps the original full-width join button and no share control', async () => {
+    mockContentPreference();
+    renderWithSharing(false);
+
+    const button = await screen.findByTestId('squad-action');
+    expect(screen.queryByLabelText('Copy Squad link')).not.toBeInTheDocument();
+    expect(button).toHaveClass('w-full');
+    expect(button).not.toHaveClass('flex-1');
+    // No wrapper row is added: the button stays a direct child of the
+    // original column, with the exact original class list.
+    expect(button.parentElement!.className).toBe(
+      'flex flex-1 flex-col justify-between',
+    );
+  });
+
+  it('flag on: narrows the join button and adds the copy-link control', async () => {
+    mockContentPreference();
+    renderWithSharing(true);
+
+    const button = await screen.findByTestId('squad-action');
+    expect(screen.getByLabelText('Copy Squad link')).toBeInTheDocument();
+    expect(button).toHaveClass('flex-1');
+    expect(button).not.toHaveClass('w-full');
+    expect(button.parentElement!.className).toBe(
+      'z-0 flex w-full flex-row items-center gap-2',
+    );
+  });
+
+  it('flag on: joining the squad still works', async () => {
+    const currentMember = { ...admin.source.currentMember };
+    delete admin.source.currentMember;
+
+    mockContentPreference();
+    renderWithSharing(true);
+
+    let queryCalled = false;
+    mockGraphQL({
+      request: {
+        query: SQUAD_JOIN_MUTATION,
+        variables: { sourceId: admin.source.id },
+      },
+      result: () => {
+        queryCalled = true;
+        return { data: { source: { ...admin.source, currentMember } } };
+      },
+    });
+    mockGraphQL({
+      request: {
+        query: COMPLETE_ACTION_MUTATION,
+        variables: { type: ActionType.JoinSquad },
+      },
+      result: () => ({ data: { _: null } }),
+    });
+
+    const btn = await screen.findByText('Join Squad');
+    btn.click();
+    await waitForNock();
     await waitFor(() => expect(queryCalled).toBeTruthy());
   });
 });

--- a/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
@@ -244,7 +244,7 @@ describe('squad directory share', () => {
     renderWithSharing(false);
 
     const button = await screen.findByTestId('squad-action');
-    expect(screen.queryByLabelText('Copy Squad link')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Share Squad')).not.toBeInTheDocument();
     expect(button).toHaveClass('w-full');
     expect(button).not.toHaveClass('flex-1');
     // No wrapper row is added: the button stays a direct child of the
@@ -259,7 +259,7 @@ describe('squad directory share', () => {
     renderWithSharing(true);
 
     const button = await screen.findByTestId('squad-action');
-    expect(screen.getByLabelText('Copy Squad link')).toBeInTheDocument();
+    expect(screen.getByLabelText('Share Squad')).toBeInTheDocument();
     expect(button).toHaveClass('flex-1');
     expect(button).not.toHaveClass('w-full');
     expect(button.parentElement!.className).toBe(

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -26,6 +26,8 @@ import {
 } from '../../typography/Typography';
 import { useSquadsDirectoryLogging } from './common/useSquadsDirectoryLogging';
 import { useScrambler } from '../../../hooks/useScrambler';
+import { useSquadDirectoryShareEnabled } from '../../../hooks/squads/useSquadDirectoryShareEnabled';
+import { SquadDirectoryShareButton } from './SquadDirectoryShareButton';
 
 export enum SourceCardBorderColor {
   Avocado = 'avocado',
@@ -68,7 +70,8 @@ export const SquadGrid = ({
 }: PropsWithChildren<UnFeaturedSquadCardProps>): ReactElement => {
   const { user } = useAuthContext();
   const campaignId = ad?.data?.source?.flags?.campaignId;
-  const { data: campaign } = useCampaignById(campaignId);
+  // The campaign query is disabled on a falsy id, so the fallback never runs.
+  const { data: campaign } = useCampaignById(campaignId ?? '');
   const {
     headerImage,
     image,
@@ -81,14 +84,36 @@ export const SquadGrid = ({
   } = source;
   const { data: members } = useQuery<BasicSourceMember[]>({
     queryKey: generateQueryKey(RequestKey.SquadMembers, user, source.id),
-    queryFn: () => getSquadMembers(source.id),
+    queryFn: () => getSquadMembers(source.id ?? ''),
     staleTime: StaleTime.OneHour,
   });
-  const borderColor = border || color || SourceCardBorderColor.Avocado;
+  const borderColor =
+    border || (color as SourceCardBorderColor) || SourceCardBorderColor.Avocado;
+  const canShare = useSquadDirectoryShareEnabled();
   const { ref, onClickAd } = useSquadsDirectoryLogging(ad);
   const promotedText = useScrambler('Promoted');
   const promotedByTooltip = useScrambler(
-    campaign ? `Promoted by @${campaign.user.username}` : null,
+    campaign ? `Promoted by @${campaign.user.username}` : undefined,
+  );
+
+  // Flag-off must keep the exact original DOM (full-width Join, no wrapper);
+  // the share row only exists when the sharing flags are on.
+  const joinButton = (
+    <SquadActionButton
+      className={{ button: classNames('z-0', canShare ? 'flex-1' : 'w-full') }}
+      squad={source}
+      origin={Origin.SquadDirectory}
+      data-testid="squad-action"
+      buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
+    />
+  );
+  const actionButton = canShare ? (
+    <div className="z-0 flex w-full flex-row items-center gap-2">
+      {joinButton}
+      <SquadDirectoryShareButton squad={source} />
+    </div>
+  ) : (
+    joinButton
   );
 
   return (
@@ -125,7 +150,7 @@ export const SquadGrid = ({
             type={ImageType.Squad}
           />
           {membersCount > 0 && (
-            <SquadMemberShortList squad={source} members={members} />
+            <SquadMemberShortList squad={source} members={members ?? []} />
           )}
         </div>
         <div className="flex flex-1 flex-col justify-between">
@@ -157,13 +182,7 @@ export const SquadGrid = ({
             )}
           </div>
 
-          <SquadActionButton
-            className={{ button: 'z-0 w-full' }}
-            squad={source}
-            origin={Origin.SquadDirectory}
-            data-testid="squad-action"
-            buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
-          />
+          {actionButton}
         </div>
       </div>
       {children}

--- a/packages/shared/src/components/cards/squad/SquadList.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.spec.tsx
@@ -1,6 +1,7 @@
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
 import React from 'react';
 import nock from 'nock';
 import { AuthContextProvider } from '../../../contexts/AuthContext';
@@ -21,6 +22,11 @@ import {
   CONTENT_PREFERENCE_STATUS_QUERY,
   ContentPreferenceType,
 } from '../../../graphql/contentPreference';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import {
+  featureSharingVisibility,
+  featureShareSquadDirectory,
+} from '../../../lib/featureManagement';
 
 const squadsList = [generateTestSquad()];
 const members = generateMembersList();
@@ -144,5 +150,47 @@ it('should render the component with a join squad button', async () => {
   await waitForNock();
   await waitFor(async () => {
     await waitFor(() => expect(queryCalled).toBeTruthy());
+  });
+});
+
+describe('squad directory share', () => {
+  const renderWithSharing = (enabled: boolean): RenderResult => {
+    const gb = new GrowthBook();
+    gb.setFeatures({
+      [featureSharingVisibility.id]: { defaultValue: enabled },
+      [featureShareSquadDirectory.id]: { defaultValue: enabled },
+    });
+
+    return render(
+      <TestBootProvider
+        client={new QueryClient()}
+        auth={{ user: loggedUser, squads: squadsList }}
+        gb={gb}
+      >
+        <SquadList squad={admin.source} />
+      </TestBootProvider>,
+    );
+  };
+
+  const getTextColumn = (): HTMLElement =>
+    screen.getByText('Test').parentElement!;
+
+  it('flag off: keeps the original text column width and no share control', () => {
+    renderWithSharing(false);
+
+    expect(screen.queryByLabelText('Copy Squad link')).not.toBeInTheDocument();
+    // Exact original class list, byte for byte.
+    expect(getTextColumn().className).toBe(
+      'flex max-w-[calc(100%-10rem)] flex-1 flex-col',
+    );
+  });
+
+  it('flag on: adds the copy-link control and reserves room for it', () => {
+    renderWithSharing(true);
+
+    expect(screen.getByLabelText('Copy Squad link')).toBeInTheDocument();
+    expect(getTextColumn().className).toBe(
+      'flex max-w-[calc(100%-13.5rem)] flex-1 flex-col',
+    );
   });
 });

--- a/packages/shared/src/components/cards/squad/SquadList.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.spec.tsx
@@ -178,7 +178,7 @@ describe('squad directory share', () => {
   it('flag off: keeps the original text column width and no share control', () => {
     renderWithSharing(false);
 
-    expect(screen.queryByLabelText('Copy Squad link')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Share Squad')).not.toBeInTheDocument();
     // Exact original class list, byte for byte.
     expect(getTextColumn().className).toBe(
       'flex max-w-[calc(100%-10rem)] flex-1 flex-col',
@@ -188,7 +188,7 @@ describe('squad directory share', () => {
   it('flag on: adds the copy-link control and reserves room for it', () => {
     renderWithSharing(true);
 
-    expect(screen.getByLabelText('Copy Squad link')).toBeInTheDocument();
+    expect(screen.getByLabelText('Share Squad')).toBeInTheDocument();
     expect(getTextColumn().className).toBe(
       'flex max-w-[calc(100%-13.5rem)] flex-1 flex-col',
     );

--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import Link from '../../utilities/Link';
 import type { Squad } from '../../../graphql/sources';
 import {
@@ -17,6 +18,8 @@ import { ButtonVariant } from '../../buttons/common';
 import type { Ad } from '../../../graphql/posts';
 import { useSquadsDirectoryLogging } from './common/useSquadsDirectoryLogging';
 import { useScrambler } from '../../../hooks/useScrambler';
+import { useSquadDirectoryShareEnabled } from '../../../hooks/squads/useSquadDirectoryShareEnabled';
+import { SquadDirectoryShareButton } from './SquadDirectoryShareButton';
 
 interface SquadListProps extends ComponentProps<'div'> {
   squad: Squad;
@@ -34,6 +37,7 @@ export const SquadList = ({
 }: SquadListProps): ReactElement => {
   const { image, name, permalink } = squad;
   const campaignId = ad?.data?.source?.flags?.campaignId;
+  const canShare = useSquadDirectoryShareEnabled();
   const { ref, onClickAd } = useSquadsDirectoryLogging(ad);
   const promotedText = useScrambler('Promoted');
 
@@ -56,7 +60,15 @@ export const SquadList = ({
         alt={`${name} source`}
         type={ImageType.Squad}
       />
-      <div className="flex max-w-[calc(100%-10rem)] flex-1 flex-col">
+      <div
+        className={classNames(
+          'flex',
+          // The share icon (2.5rem + 1rem row gap) eats into the space the
+          // truncating text column may occupy.
+          canShare ? 'max-w-[calc(100%-13.5rem)]' : 'max-w-[calc(100%-10rem)]',
+          'flex-1 flex-col',
+        )}
+      >
         <Typography type={TypographyType.Callout} bold truncate>
           {name}
         </Typography>
@@ -87,6 +99,7 @@ export const SquadList = ({
         data-testid="squad-action"
         buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
       />
+      {canShare && <SquadDirectoryShareButton className="z-0" squad={squad} />}
       {children}
     </div>
   );

--- a/packages/shared/src/components/cards/squad/UnfeaturedSquadGrid.spec.tsx
+++ b/packages/shared/src/components/cards/squad/UnfeaturedSquadGrid.spec.tsx
@@ -1,6 +1,7 @@
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
 import React from 'react';
 import nock from 'nock';
 import { AuthContextProvider } from '../../../contexts/AuthContext';
@@ -20,6 +21,11 @@ import {
   CONTENT_PREFERENCE_STATUS_QUERY,
   ContentPreferenceType,
 } from '../../../graphql/contentPreference';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import {
+  featureSharingVisibility,
+  featureShareSquadDirectory,
+} from '../../../lib/featureManagement';
 
 const squads = [generateTestSquad()];
 const members = generateMembersList();
@@ -139,5 +145,63 @@ it('should render the component with a join squad button', async () => {
   await waitForNock();
   await waitFor(async () => {
     await waitFor(() => expect(queryCalled).toBeTruthy());
+  });
+});
+
+describe('squad directory share', () => {
+  const mockContentPreference = () =>
+    mockGraphQL({
+      request: {
+        query: CONTENT_PREFERENCE_STATUS_QUERY,
+        variables: {
+          id: admin.source.id,
+          entity: ContentPreferenceType.Source,
+        },
+      },
+      result: { data: { contentPreferenceStatus: null } },
+    });
+
+  const renderWithSharing = (enabled: boolean): RenderResult => {
+    const gb = new GrowthBook();
+    gb.setFeatures({
+      [featureSharingVisibility.id]: { defaultValue: enabled },
+      [featureShareSquadDirectory.id]: { defaultValue: enabled },
+    });
+
+    return render(
+      <TestBootProvider
+        client={new QueryClient()}
+        auth={{ user: loggedUser, squads }}
+        gb={gb}
+      >
+        <UnfeaturedSquadGrid source={admin.source} />
+      </TestBootProvider>,
+    );
+  };
+
+  it('flag off: keeps the join button alone in the header row', async () => {
+    mockContentPreference();
+    renderWithSharing(false);
+
+    const button = await screen.findByTestId('squad-action');
+    expect(screen.queryByLabelText('Copy Squad link')).not.toBeInTheDocument();
+    // No wrapper is added: the button stays a direct child of the original
+    // header row, with the exact original class list.
+    expect(button.parentElement!.className).toBe(
+      'mb-3 flex items-center justify-between',
+    );
+  });
+
+  it('flag on: renders the copy-link control next to the join button', async () => {
+    mockContentPreference();
+    renderWithSharing(true);
+
+    const button = await screen.findByTestId('squad-action');
+    expect(screen.getByLabelText('Copy Squad link')).toBeInTheDocument();
+    const wrapper = button.parentElement!;
+    expect(wrapper.className).toBe('z-0 flex flex-row items-center gap-2');
+    expect(wrapper.parentElement!.className).toBe(
+      'mb-3 flex items-center justify-between',
+    );
   });
 });

--- a/packages/shared/src/components/cards/squad/UnfeaturedSquadGrid.spec.tsx
+++ b/packages/shared/src/components/cards/squad/UnfeaturedSquadGrid.spec.tsx
@@ -184,7 +184,7 @@ describe('squad directory share', () => {
     renderWithSharing(false);
 
     const button = await screen.findByTestId('squad-action');
-    expect(screen.queryByLabelText('Copy Squad link')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Share Squad')).not.toBeInTheDocument();
     // No wrapper is added: the button stays a direct child of the original
     // header row, with the exact original class list.
     expect(button.parentElement!.className).toBe(
@@ -197,7 +197,7 @@ describe('squad directory share', () => {
     renderWithSharing(true);
 
     const button = await screen.findByTestId('squad-action');
-    expect(screen.getByLabelText('Copy Squad link')).toBeInTheDocument();
+    expect(screen.getByLabelText('Share Squad')).toBeInTheDocument();
     const wrapper = button.parentElement!;
     expect(wrapper.className).toBe('z-0 flex flex-row items-center gap-2');
     expect(wrapper.parentElement!.className).toBe(

--- a/packages/shared/src/components/cards/squad/UnfeaturedSquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/UnfeaturedSquadGrid.tsx
@@ -15,12 +15,27 @@ import { Origin } from '../../../lib/log';
 import { SquadActionButton } from '../../squads/SquadActionButton';
 import { ButtonVariant } from '../../buttons/common';
 import { Image, ImageType } from '../../image/Image';
+import { useSquadDirectoryShareEnabled } from '../../../hooks/squads/useSquadDirectoryShareEnabled';
+import { SquadDirectoryShareButton } from './SquadDirectoryShareButton';
 
 export const UnfeaturedSquadGrid = ({
   source,
   className,
 }: UnFeaturedSquadCardProps): ReactElement => {
   const title = source.name;
+  const canShare = useSquadDirectoryShareEnabled();
+
+  // Flag-off must keep the exact original DOM (Join alone in the header row);
+  // the share control and its wrapper only exist when the sharing flags are on.
+  const joinButton = (
+    <SquadActionButton
+      className={{ button: 'z-0' }}
+      squad={source}
+      origin={Origin.SquadDirectory}
+      data-testid="squad-action"
+      buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
+    />
+  );
 
   return (
     <Card className={classNames('overflow-hidden border-0 p-4', className)}>
@@ -36,13 +51,14 @@ export const UnfeaturedSquadGrid = ({
           className="size-16 rounded-full"
           type={ImageType.Squad}
         />
-        <SquadActionButton
-          className={{ button: 'z-0' }}
-          squad={source}
-          origin={Origin.SquadDirectory}
-          data-testid="squad-action"
-          buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
-        />
+        {canShare ? (
+          <div className="z-0 flex flex-row items-center gap-2">
+            {joinButton}
+            <SquadDirectoryShareButton squad={source} />
+          </div>
+        ) : (
+          joinButton
+        )}
       </div>
       <Typography
         tag={TypographyTag.H1}

--- a/packages/shared/src/hooks/squads/useSquadDirectoryShareEnabled.spec.tsx
+++ b/packages/shared/src/hooks/squads/useSquadDirectoryShareEnabled.spec.tsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import { useSquadDirectoryShareEnabled } from './useSquadDirectoryShareEnabled';
+import { useConditionalFeature } from '../useConditionalFeature';
+import type { Feature } from '../../lib/featureManagement';
+import {
+  featureSharingVisibility,
+  featureShareSquadDirectory,
+} from '../../lib/featureManagement';
+
+jest.mock('../useConditionalFeature', () => ({
+  useConditionalFeature: jest.fn(),
+}));
+
+const conditionalFeatureMock = useConditionalFeature as jest.Mock;
+const evaluated: string[] = [];
+
+const mockFlags = (flags: Record<string, boolean>) =>
+  conditionalFeatureMock.mockImplementation(
+    ({
+      feature,
+      shouldEvaluate,
+    }: {
+      feature: Feature<boolean>;
+      shouldEvaluate?: boolean;
+    }) => {
+      if (shouldEvaluate !== false) {
+        evaluated.push(feature.id);
+      }
+
+      return {
+        value:
+          shouldEvaluate === false ? feature.defaultValue : flags[feature.id],
+        isLoading: false,
+      };
+    },
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  evaluated.length = 0;
+});
+
+describe('useSquadDirectoryShareEnabled', () => {
+  it('is off while the sharing-visibility kill switch is off', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: false,
+      [featureShareSquadDirectory.id]: true,
+    });
+
+    const { result } = renderHook(() => useSquadDirectoryShareEnabled());
+
+    expect(result.current).toBe(false);
+    // The per-topic flag must not be evaluated for control users.
+    expect(evaluated).not.toContain(featureShareSquadDirectory.id);
+  });
+
+  it('is off when the per-topic flag is off', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: true,
+      [featureShareSquadDirectory.id]: false,
+    });
+
+    const { result } = renderHook(() => useSquadDirectoryShareEnabled());
+
+    expect(result.current).toBe(false);
+  });
+
+  it('is on only when both flags are on', () => {
+    mockFlags({
+      [featureSharingVisibility.id]: true,
+      [featureShareSquadDirectory.id]: true,
+    });
+
+    const { result } = renderHook(() => useSquadDirectoryShareEnabled());
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/packages/shared/src/hooks/squads/useSquadDirectoryShareEnabled.ts
+++ b/packages/shared/src/hooks/squads/useSquadDirectoryShareEnabled.ts
@@ -1,0 +1,16 @@
+import { featureShareSquadDirectory } from '../../lib/featureManagement';
+import { useConditionalFeature } from '../useConditionalFeature';
+import { useSharingVisibility } from '../useSharingVisibility';
+
+// Gate for the copy-link/share control on the squad directory cards. The
+// per-topic flag is only evaluated once the sharing-visibility master switch
+// is on, so control users never get bucketed into the experiment.
+export const useSquadDirectoryShareEnabled = (): boolean => {
+  const { isEnabled: isSharingEnabled } = useSharingVisibility();
+  const { value } = useConditionalFeature({
+    feature: featureShareSquadDirectory,
+    shouldEvaluate: isSharingEnabled,
+  });
+
+  return isSharingEnabled && value;
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,12 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Copy-link/share control on the squad directory cards (featured grid,
+// unfeatured grid and the mobile list), rendered next to the Join Squad
+// button. Also gated by the `sharing_visibility` master flag. Keep the default
+// `false` — control is the directory as it ships today; GrowthBook ramps it.
+export const featureShareSquadDirectory = new Feature(
+  'share_squad_directory',
+  false,
+);

--- a/packages/storybook/stories/components/cards/Squad/SquadDirectoryShare.stories.tsx
+++ b/packages/storybook/stories/components/cards/Squad/SquadDirectoryShare.stories.tsx
@@ -222,7 +222,7 @@ export const FlagOnCopying: Story = {
     });
 
     const canvas = within(canvasElement);
-    const triggers = canvas.getAllByLabelText('Copy Squad link');
+    const triggers = canvas.getAllByLabelText('Share Squad');
     await expect(triggers).toHaveLength(3);
     await userEvent.click(triggers[0]);
 

--- a/packages/storybook/stories/components/cards/Squad/SquadDirectoryShare.stories.tsx
+++ b/packages/storybook/stories/components/cards/Squad/SquadDirectoryShare.stories.tsx
@@ -1,0 +1,233 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { SquadGrid } from '@dailydotdev/shared/src/components/cards/squad/SquadGrid';
+import { SquadList } from '@dailydotdev/shared/src/components/cards/squad/SquadList';
+import { UnfeaturedSquadGrid } from '@dailydotdev/shared/src/components/cards/squad/UnfeaturedSquadGrid';
+import type {
+  BasicSourceMember,
+  Squad,
+} from '@dailydotdev/shared/src/graphql/sources';
+import {
+  SourceMemberRole,
+  SourceType,
+} from '@dailydotdev/shared/src/graphql/sources';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import {
+  FeaturesReadyContext,
+  GrowthBookProvider,
+} from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import {
+  generateQueryKey,
+  RequestKey,
+} from '@dailydotdev/shared/src/lib/query';
+import { ContentPreferenceType } from '@dailydotdev/shared/src/graphql/contentPreference';
+import { getShortLinkProps } from '@dailydotdev/shared/src/hooks/utils/useGetShortUrl';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
+import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
+
+const mockUser = {
+  id: '1',
+  name: 'Test User',
+  username: 'testuser',
+  email: 'test@example.com',
+  image: 'https://daily-now-res.cloudinary.com/image/upload/placeholder.jpg',
+  providers: ['google'],
+  createdAt: '2024-01-01T00:00:00.000Z',
+  permalink: 'https://daily.dev/testuser',
+} as unknown as LoggedUser;
+
+const buildSquad = (id: string, name: string, handle: string): Squad =>
+  ({
+    id,
+    name,
+    handle,
+    permalink: `https://app.daily.dev/squads/${handle}`,
+    active: true,
+    public: true,
+    type: SourceType.Squad,
+    membersCount: 23209,
+    description:
+      'A place for developers who care about shipping fast without breaking prod. War stories, hot takes and the occasional postmortem.',
+    memberPostingRole: SourceMemberRole.Member,
+    memberInviteRole: SourceMemberRole.Member,
+    image: 'https://via.placeholder.com/150',
+    moderationRequired: false,
+    moderationPostCount: 0,
+  } as unknown as Squad);
+
+const featured = buildSquad('squad-1', 'Ship It', 'ship-it');
+const unfeatured = buildSquad('squad-2', 'Backend Bandits', 'backend-bandits');
+const listed = buildSquad('squad-3', 'Frontend Friends', 'frontend-friends');
+const squads = [featured, unfeatured, listed];
+
+const members: BasicSourceMember[] = [1, 2, 3].map((i) => ({
+  user: {
+    id: `member-${i}`,
+    name: `Member ${i}`,
+    image:
+      'https://media.daily.dev/image/upload/s--O0TOmw4y--/f_auto/v1715772965/public/noProfile',
+    permalink: `https://daily.dev/member-${i}`,
+  },
+}));
+
+const SHORT_LINK = 'https://dly.to/abc123';
+
+// Storybook aliases `@growthbook/growthbook` to a mock whose `getFeatureValue`
+// coerces every falsy default to the truthy string `'control'`, so a flag can't
+// be evaluated as `false` here. Flag-off is therefore simulated by holding the
+// features context as "not ready", which is the exact path
+// `useConditionalFeature` takes to fall back to the (false) default value.
+// Jest specs are the real flag-off guarantee.
+const withProviders =
+  (enabled: boolean) =>
+  (Story: React.ComponentType): React.ReactElement => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+    });
+
+    squads.forEach((squad) => {
+      // Seed the follow status so the Join Squad button actually renders.
+      queryClient.setQueryData(
+        generateQueryKey(RequestKey.ContentPreference, mockUser, {
+          id: squad.id,
+          entity: ContentPreferenceType.Source,
+        }),
+        null,
+      );
+      // Seed the member short-list used by the featured grid card.
+      queryClient.setQueryData(
+        generateQueryKey(RequestKey.SquadMembers, mockUser, squad.id),
+        members,
+      );
+      // Seed the resolved short URL so copy actions don't hit the network.
+      const { queryKey } = getShortLinkProps(
+        squad.permalink,
+        ReferralCampaignKey.ShareSource,
+        mockUser,
+      );
+      queryClient.setQueryData(queryKey, SHORT_LINK);
+    });
+
+    const LogContext = getLogContextStatic();
+
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuthContext.Provider
+          value={
+            {
+              user: mockUser,
+              isLoggedIn: true,
+              isAuthReady: true,
+              tokenRefreshed: true,
+              shouldShowLogin: false,
+              showLogin: fn(),
+              closeLogin: fn(),
+              logout: fn(),
+              updateUser: fn(),
+              getRedirectUri: fn(),
+              loadingUser: false,
+              loadedUserFromCache: true,
+              refetchBoot: fn(),
+              squads: [],
+              isAndroidApp: false,
+              // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any
+          }
+        >
+          <GrowthBookProvider
+            app={BootApp.Webapp}
+            user={mockUser}
+            deviceId="storybook"
+          >
+            <FeaturesReadyContext.Provider
+              value={{
+                ready: enabled,
+                getFeatureValue: (feature) =>
+                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                  feature.defaultValue as any,
+              }}
+            >
+              <LogContext.Provider
+                value={{
+                  logEvent: fn(),
+                  logEventStart: fn(),
+                  logEventEnd: fn(),
+                  sendBeacon: () => false,
+                }}
+              >
+                <Story />
+              </LogContext.Provider>
+            </FeaturesReadyContext.Provider>
+          </GrowthBookProvider>
+        </AuthContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+
+// All three directory card variants side by side: featured grid, unfeatured
+// grid, and the mobile list row.
+const DirectoryShowcase = (): React.ReactElement => (
+  <div className="flex max-w-[44rem] flex-col gap-6 p-4">
+    <div className="flex flex-row items-stretch gap-6">
+      <SquadGrid className="w-80" source={featured} />
+      <UnfeaturedSquadGrid className="w-80" source={unfeatured} />
+    </div>
+    <div className="rounded-16 border border-border-subtlest-tertiary p-4">
+      <SquadList squad={listed} />
+    </div>
+  </div>
+);
+
+const meta: Meta<typeof DirectoryShowcase> = {
+  title: 'Components/Cards/Squad/SquadDirectoryShare',
+  component: DirectoryShowcase,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Copy-link/share control on the squad directory cards, next to a slightly-narrowed Join Squad button. Gated by `share_squad_directory` AND the `sharing_visibility` master flag; control renders the directory exactly as it ships today.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DirectoryShowcase>;
+
+// Flag on — every card variant gains the copy-link trigger next to Join.
+export const FlagOn: Story = {
+  decorators: [withProviders(true)],
+};
+
+// Flag off — must render exactly what ships today (full-width Join on the
+// featured grid, no share control anywhere).
+export const FlagOff: Story = {
+  decorators: [withProviders(false)],
+};
+
+// Desktop copy flow: the trigger opens the share popover; Copy link flips to
+// Copied! The clipboard is stubbed because the Storybook iframe isn't allowed
+// to write to the real one.
+export const FlagOnCopying: Story = {
+  decorators: [withProviders(true)],
+  play: async ({ canvasElement }) => {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => undefined },
+    });
+
+    const canvas = within(canvasElement);
+    const triggers = canvas.getAllByLabelText('Copy Squad link');
+    await expect(triggers).toHaveLength(3);
+    await userEvent.click(triggers[0]);
+
+    const body = within(globalThis.document.body);
+    await userEvent.click(await body.findByText('Copy link'));
+    await waitFor(() => expect(body.getByText('Copied!')).toBeInTheDocument());
+  },
+};


### PR DESCRIPTION
Part of the sharing-visibility initiative (PR 15 / #18): a small copy-link/share button next to a slightly-narrowed **Join Squad** button on the squad directory cards.

## Changes
- **`SquadDirectoryShareButton`** (new, `packages/shared/src/components/cards/squad/`): wraps the Phase-0 `ShareActions` primitive with the squad `permalink` (verified on the typed `Source` model), the `share_source` referral cid, and share logging. Desktop opens the share popover; mobile is a single tap to native share / copy.
- **`useSquadDirectoryShareEnabled`** (new hook): per-topic `share_squad_directory` flag evaluated only once the `sharing_visibility` master switch is on (`useConditionalFeature` + `shouldEvaluate`), so control users are never bucketed.
- **Per-variant wiring** (grid/list density respected, no card height change, no hover layout shift):
  - `SquadGrid`: full-width Join becomes `flex-1` inside a `gap-2` row with the icon control.
  - `SquadList`: control appended to the row (inherits the existing `gap-4` on both sides); the truncating text column reserves the extra `3.5rem` only when the flag is on.
  - `UnfeaturedSquadGrid`: Join + control paired in the header row.
- **Flag-off is byte-identical to the base branch** — the original button/column class strings and DOM structure are asserted exactly in the specs.
- Storybook: `SquadDirectoryShare.stories.tsx` showcases all three variants, flag on/off (flag-off simulated by holding `FeaturesReadyContext` not-ready since the repo-wide gb mock coerces flags truthy), plus a copy-flow play test.
- Drive-by (required to pass the strict changed-file guard): cleared pre-existing strict-tsc looseness in `SquadGrid.tsx` (nullable id/campaign/members handling) with no behavior change.

## Flag
`share_squad_directory`, default `false`, appended at the end of `featureManagement.ts`; additionally gated by the `sharing_visibility` master kill-switch via `useSharingVisibility`.

## Log event
Reuses **`LogEvent.ShareSource`** with `target_type: source`, `target_id: <squad id>`, and `extra: { origin: "squad directory", provider }`. Squads are sources in the data model and `ShareSource` is the existing source-share event (`SourceActions`, source menu); the surface is distinguished by `Origin.SquadDirectory` per the initiative's one-event-per-entity convention — no new event name minted, `SharePost` avoided (post-shaped).

## Verification
- `node ./scripts/typecheck-strict-changed.js` — passes.
- `pnpm --filter shared lint` — passes (after `lint:fix` formatting).
- `NODE_ENV=test pnpm --filter shared test` — 296 suites / 1998 tests passed.
- `NODE_ENV=test pnpm --filter webapp test` — 44 suites / 297 tests passed.
- Specs assert: copy → clipboard + toast; mobile single tap → `navigator.share` (and copy fallback); flag-off DOM byte-identical (exact class strings + no wrapper); Join Squad mutation still fires with the flag on; master-gate short-circuit (per-topic flag never evaluated when the kill-switch is off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-share-squad-directory.preview.app.daily.dev