### PR TITLE
feat(share): copy-link on discovery feeds and best-of archive (PR 16)

### DIFF
--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -95,6 +95,8 @@ import { useTrackQuestClientEvent } from '../hooks/useTrackQuestClientEvent';
 import { useLayoutVariant } from '../hooks/layout/useLayoutVariant';
 import { ExploreSectionTabs } from './header/ExploreSectionTabs';
 import { ExploreSortDropdown } from './header/ExploreSortDropdown';
+import { ExploreFeedShareButton } from './header/ExploreFeedShareButton';
+import { ButtonSize, ButtonVariant } from './buttons/Button';
 
 const FeedExploreHeader = dynamic(
   () =>
@@ -764,6 +766,16 @@ export default function MainFeedLayout({
       {showExploreV2PageHeader && (
         <header className={classNames(pageHeaderClassName, '!py-0')}>
           <ExploreSectionTabs />
+          {/* The share affordance joins the sort controls' right-side cluster;
+              the header's own gap-2 spaces it, and it self-gates on the
+              share_discovery flag so flag-off DOM is unchanged. */}
+          {isAnyExplore && (
+            <ExploreFeedShareButton
+              sharePath={tabToUrl[urlToTab[router.pathname] ?? tab]}
+              buttonVariant={ButtonVariant.Float}
+              buttonSize={ButtonSize.Small}
+            />
+          )}
           {isAnyExplore && <ExploreSortDropdown />}
         </header>
       )}

--- a/packages/shared/src/components/archive/ArchiveFeedPage.spec.tsx
+++ b/packages/shared/src/components/archive/ArchiveFeedPage.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import { ArchiveFeedPage } from './ArchiveFeedPage';
+import { ArchivePeriodType, ArchiveScopeType } from '../../graphql/archive';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+const logEvent = jest.fn();
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const gbWithFeatures = (features: Record<string, boolean>): GrowthBook =>
+  new GrowthBook({
+    features: Object.fromEntries(
+      Object.entries(features).map(([id, value]) => [
+        id,
+        { defaultValue: value },
+      ]),
+    ),
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+const renderComponent = (gb?: GrowthBook): RenderResult => {
+  const client = new QueryClient();
+
+  return render(
+    <TestBootProvider client={client} gb={gb} log={{ logEvent }}>
+      <ArchiveFeedPage
+        archive={null}
+        scopeType={ArchiveScopeType.Tag}
+        scopeId="react"
+        scopeName="react"
+        periodType={ArchivePeriodType.Month}
+        year={2026}
+        month={5}
+      />
+    </TestBootProvider>,
+  );
+};
+
+it('keeps the original heading and renders no share control when flags are off', () => {
+  renderComponent();
+
+  expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+  const heading = screen.getByRole('heading', { level: 1 });
+  expect(heading).toHaveClass('mx-4 font-bold typo-title2 tablet:typo-title1', {
+    exact: true,
+  });
+});
+
+it('copies the canonical archive page url and logs when flags are on', async () => {
+  renderComponent(
+    gbWithFeatures({ sharing_visibility: true, share_discovery: true }),
+  );
+
+  const controls = screen.getAllByLabelText('Copy link');
+  expect(controls).toHaveLength(1);
+
+  await act(async () => {
+    fireEvent.click(controls[0]);
+  });
+
+  // webappUrl is '/' under Jest, so the canonical link is the bare path
+  await waitFor(() =>
+    expect(writeText).toHaveBeenCalledWith('/tags/react/best-of/2026/05'),
+  );
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ShareLog,
+    target_id: '/tags/react/best-of/2026/05',
+    extra: JSON.stringify({
+      origin: Origin.BestOfArchive,
+      provider: ShareProvider.CopyLink,
+    }),
+  });
+});

--- a/packages/shared/src/components/archive/ArchiveFeedPage.spec.tsx
+++ b/packages/shared/src/components/archive/ArchiveFeedPage.spec.tsx
@@ -54,7 +54,7 @@ const renderComponent = (gb?: GrowthBook): RenderResult => {
 it('keeps the original heading and renders no share control when flags are off', () => {
   renderComponent();
 
-  expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Share this archive')).not.toBeInTheDocument();
   const heading = screen.getByRole('heading', { level: 1 });
   expect(heading).toHaveClass('mx-4 font-bold typo-title2 tablet:typo-title1', {
     exact: true,
@@ -66,7 +66,7 @@ it('copies the canonical archive page url and logs when flags are on', async () 
     gbWithFeatures({ sharing_visibility: true, share_discovery: true }),
   );
 
-  const controls = screen.getAllByLabelText('Copy link');
+  const controls = screen.getAllByLabelText('Share this archive');
   expect(controls).toHaveLength(1);
 
   await act(async () => {

--- a/packages/shared/src/components/archive/ArchiveFeedPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveFeedPage.tsx
@@ -4,13 +4,24 @@ import classNames from 'classnames';
 import type { Archive, ArchiveItem } from '../../graphql/archive';
 import { ArchivePeriodType } from '../../graphql/archive';
 import type { ArchiveScopeInfo } from '../../lib/archive';
-import { getArchiveTitle, getArchiveIndexUrl } from '../../lib/archive';
+import {
+  getArchiveDescription,
+  getArchiveIndexUrl,
+  getArchiveTitle,
+  getArchiveUrl,
+} from '../../lib/archive';
 import { ArchiveNavigation } from './ArchiveNavigation';
 import { ArchivePostItem } from './ArchivePostItem';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 import Link from '../utilities/Link';
 import { ArrowIcon } from '../icons';
 import { IconSize } from '../Icon';
+import { ShareActions } from '../share/ShareActions';
+import { ButtonSize } from '../buttons/Button';
+import { useShareDiscovery } from '../../hooks/useShareDiscovery';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, Origin } from '../../lib/log';
+import { webappUrl } from '../../lib/constants';
 
 interface ArchiveFeedPageProps {
   scopeType: ArchiveScopeInfo['scopeType'];
@@ -95,6 +106,26 @@ export function ArchiveFeedPage({
     scopeId,
   } as ArchiveScopeInfo);
   const items = (archive?.items ?? []).filter((item) => item.post);
+  const { isEnabled: canShare } = useShareDiscovery();
+  const { logEvent } = useLogContext();
+  const archivePath = getArchiveUrl(
+    { scopeType, scopeId } as ArchiveScopeInfo,
+    periodType,
+    year,
+    month,
+  );
+  const heading = (
+    <h1
+      className={classNames(
+        // The share row takes over the horizontal inset when it renders, so
+        // flag-off keeps the original class list byte-for-byte.
+        !canShare && 'mx-4',
+        'font-bold typo-title2 tablet:typo-title1',
+      )}
+    >
+      Best of {scopeName} &mdash; {title.replace('Best of ', '')}
+    </h1>
+  );
 
   return (
     <div
@@ -104,9 +135,28 @@ export function ArchiveFeedPage({
       )}
     >
       {/* Header */}
-      <h1 className="mx-4 font-bold typo-title2 tablet:typo-title1">
-        Best of {scopeName} &mdash; {title.replace('Best of ', '')}
-      </h1>
+      {canShare ? (
+        <div className="mx-4 flex items-center justify-between gap-2">
+          {heading}
+          <ShareActions
+            link={`${webappUrl}${archivePath.slice(1)}`}
+            text={getArchiveDescription(scopeName, periodType, year, month)}
+            buttonSize={ButtonSize.Medium}
+            onShare={(provider) =>
+              logEvent({
+                event_name: LogEvent.ShareLog,
+                target_id: archivePath,
+                extra: JSON.stringify({
+                  origin: Origin.BestOfArchive,
+                  provider,
+                }),
+              })
+            }
+          />
+        </div>
+      ) : (
+        heading
+      )}
 
       {/* Top navigation */}
       <ArchiveNavigation

--- a/packages/shared/src/components/archive/ArchiveFeedPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveFeedPage.tsx
@@ -22,6 +22,7 @@ import { useShareDiscovery } from '../../hooks/useShareDiscovery';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent, Origin } from '../../lib/log';
 import { webappUrl } from '../../lib/constants';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 interface ArchiveFeedPageProps {
   scopeType: ArchiveScopeInfo['scopeType'];
@@ -141,6 +142,8 @@ export function ArchiveFeedPage({
           <ShareActions
             link={`${webappUrl}${archivePath.slice(1)}`}
             text={getArchiveDescription(scopeName, periodType, year, month)}
+            label="Share this archive"
+            cid={ReferralCampaignKey.Generic}
             buttonSize={ButtonSize.Medium}
             onShare={(provider) =>
               logEvent({

--- a/packages/shared/src/components/archive/ArchiveIndexPage.spec.tsx
+++ b/packages/shared/src/components/archive/ArchiveIndexPage.spec.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import { ArchiveIndexPage } from './ArchiveIndexPage';
+import type { Archive } from '../../graphql/archive';
+import {
+  ArchivePeriodType,
+  ArchiveRankingType,
+  ArchiveScopeType,
+  ArchiveSubjectType,
+} from '../../graphql/archive';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+const logEvent = jest.fn();
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const archive: Archive = {
+  id: 'a1',
+  subjectType: ArchiveSubjectType.Post,
+  rankingType: ArchiveRankingType.Best,
+  scopeType: ArchiveScopeType.Global,
+  scopeId: null,
+  periodType: ArchivePeriodType.Month,
+  periodStart: '2026-05-01T00:00:00.000Z',
+  items: [],
+};
+
+const gbWithFeatures = (features: Record<string, boolean>): GrowthBook =>
+  new GrowthBook({
+    features: Object.fromEntries(
+      Object.entries(features).map(([id, value]) => [
+        id,
+        { defaultValue: value },
+      ]),
+    ),
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.assign(navigator, { clipboard: { writeText } });
+});
+
+const renderComponent = (gb?: GrowthBook): RenderResult => {
+  const client = new QueryClient();
+
+  return render(
+    <TestBootProvider client={client} gb={gb} log={{ logEvent }}>
+      <ArchiveIndexPage
+        archives={[archive]}
+        scopeType={ArchiveScopeType.Global}
+        scopeName="daily.dev"
+      />
+    </TestBootProvider>,
+  );
+};
+
+it('keeps the original heading and renders no share control when flags are off', () => {
+  renderComponent();
+
+  expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+  const heading = screen.getByRole('heading', { level: 1 });
+  expect(heading).toHaveClass('mx-4 font-bold typo-title2 tablet:typo-title1', {
+    exact: true,
+  });
+});
+
+it('copies the canonical archive index url and logs when flags are on', async () => {
+  renderComponent(
+    gbWithFeatures({ sharing_visibility: true, share_discovery: true }),
+  );
+
+  const controls = screen.getAllByLabelText('Copy link');
+  expect(controls).toHaveLength(1);
+
+  await act(async () => {
+    fireEvent.click(controls[0]);
+  });
+
+  // webappUrl is '/' under Jest, so the canonical link is the bare path
+  await waitFor(() => expect(writeText).toHaveBeenCalledWith('/posts/best-of'));
+  expect(logEvent).toHaveBeenCalledWith({
+    event_name: LogEvent.ShareLog,
+    target_id: '/posts/best-of',
+    extra: JSON.stringify({
+      origin: Origin.BestOfArchive,
+      provider: ShareProvider.CopyLink,
+    }),
+  });
+});

--- a/packages/shared/src/components/archive/ArchiveIndexPage.spec.tsx
+++ b/packages/shared/src/components/archive/ArchiveIndexPage.spec.tsx
@@ -67,7 +67,7 @@ const renderComponent = (gb?: GrowthBook): RenderResult => {
 it('keeps the original heading and renders no share control when flags are off', () => {
   renderComponent();
 
-  expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Share this archive')).not.toBeInTheDocument();
   const heading = screen.getByRole('heading', { level: 1 });
   expect(heading).toHaveClass('mx-4 font-bold typo-title2 tablet:typo-title1', {
     exact: true,
@@ -79,7 +79,7 @@ it('copies the canonical archive index url and logs when flags are on', async ()
     gbWithFeatures({ sharing_visibility: true, share_discovery: true }),
   );
 
-  const controls = screen.getAllByLabelText('Copy link');
+  const controls = screen.getAllByLabelText('Share this archive');
   expect(controls).toHaveLength(1);
 
   await act(async () => {

--- a/packages/shared/src/components/archive/ArchiveIndexPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveIndexPage.tsx
@@ -20,6 +20,7 @@ import { useShareDiscovery } from '../../hooks/useShareDiscovery';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent, Origin } from '../../lib/log';
 import { webappUrl } from '../../lib/constants';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 interface ArchiveIndexPageProps {
   scopeType: ArchiveScopeInfo['scopeType'];
@@ -194,6 +195,8 @@ export function ArchiveIndexPage({
           <ShareActions
             link={`${webappUrl}${indexPath.slice(1)}`}
             text={`The most upvoted ${scopeName} posts by month and year, curated by the daily.dev community.`}
+            label="Share this archive"
+            cid={ReferralCampaignKey.Generic}
             buttonSize={ButtonSize.Medium}
             onShare={(provider) =>
               logEvent({

--- a/packages/shared/src/components/archive/ArchiveIndexPage.tsx
+++ b/packages/shared/src/components/archive/ArchiveIndexPage.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import type { Archive } from '../../graphql/archive';
 import type { ArchiveScopeInfo, ArchivesByYear } from '../../lib/archive';
 import {
+  getArchiveIndexUrl,
   getArchiveUrlFromArchive,
   getMonthName,
   groupArchivesByYear,
@@ -13,6 +14,12 @@ import Link from '../utilities/Link';
 import { ArrowIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { ElementPlaceholder } from '../ElementPlaceholder';
+import { ShareActions } from '../share/ShareActions';
+import { ButtonSize } from '../buttons/Button';
+import { useShareDiscovery } from '../../hooks/useShareDiscovery';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, Origin } from '../../lib/log';
+import { webappUrl } from '../../lib/constants';
 
 interface ArchiveIndexPageProps {
   scopeType: ArchiveScopeInfo['scopeType'];
@@ -159,13 +166,50 @@ export function ArchiveIndexPage({
   className,
 }: ArchiveIndexPageProps): ReactElement {
   const groups = groupArchivesByYear(archives);
+  const { isEnabled: canShare } = useShareDiscovery();
+  const { logEvent } = useLogContext();
+  const indexPath = getArchiveIndexUrl({
+    scopeType,
+    scopeId,
+  } as ArchiveScopeInfo);
+  const heading = (
+    <h1
+      className={classNames(
+        // The share row takes over the horizontal inset when it renders, so
+        // flag-off keeps the original class list byte-for-byte.
+        !canShare && 'mx-4',
+        'font-bold typo-title2 tablet:typo-title1',
+      )}
+    >
+      Best of {scopeName} &mdash; Archive
+    </h1>
+  );
 
   return (
     <div className={classNames('flex flex-col', className)}>
       {/* Header */}
-      <h1 className="mx-4 font-bold typo-title2 tablet:typo-title1">
-        Best of {scopeName} &mdash; Archive
-      </h1>
+      {canShare ? (
+        <div className="mx-4 flex items-center justify-between gap-2">
+          {heading}
+          <ShareActions
+            link={`${webappUrl}${indexPath.slice(1)}`}
+            text={`The most upvoted ${scopeName} posts by month and year, curated by the daily.dev community.`}
+            buttonSize={ButtonSize.Medium}
+            onShare={(provider) =>
+              logEvent({
+                event_name: LogEvent.ShareLog,
+                target_id: indexPath,
+                extra: JSON.stringify({
+                  origin: Origin.BestOfArchive,
+                  provider,
+                }),
+              })
+            }
+          />
+        </div>
+      ) : (
+        heading
+      )}
 
       {/* Archive grid by year */}
       <ArchiveGrid

--- a/packages/shared/src/components/header/ExploreFeedShareButton.tsx
+++ b/packages/shared/src/components/header/ExploreFeedShareButton.tsx
@@ -6,6 +6,7 @@ import { useShareDiscovery } from '../../hooks/useShareDiscovery';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent, Origin } from '../../lib/log';
 import { webappUrl } from '../../lib/constants';
+import { ReferralCampaignKey } from '../../lib/referral';
 
 interface ExploreFeedShareButtonProps {
   /** Bare app path of the active Explore sort, e.g. `/posts/upvoted`. */
@@ -38,7 +39,8 @@ export function ExploreFeedShareButton({
       text="Explore what millions of developers are reading on daily.dev"
       // Feed cards ship their own per-post "Copy link" buttons, so the header
       // control needs a distinct accessible name.
-      label="Copy link to feed"
+      label="Share this feed"
+      cid={ReferralCampaignKey.Generic}
       buttonVariant={buttonVariant}
       buttonSize={buttonSize}
       className={className}

--- a/packages/shared/src/components/header/ExploreFeedShareButton.tsx
+++ b/packages/shared/src/components/header/ExploreFeedShareButton.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { ShareActions } from '../share/ShareActions';
+import type { ButtonSize, ButtonVariant } from '../buttons/Button';
+import { useShareDiscovery } from '../../hooks/useShareDiscovery';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, Origin } from '../../lib/log';
+import { webappUrl } from '../../lib/constants';
+
+interface ExploreFeedShareButtonProps {
+  /** Bare app path of the active Explore sort, e.g. `/posts/upvoted`. */
+  sharePath: string;
+  buttonVariant?: ButtonVariant;
+  buttonSize?: ButtonSize;
+  className?: string;
+}
+
+// Copy-link/share affordance for the Explore (discovery) feed headers. Always
+// shares the canonical webapp URL of the active sort so links copied from the
+// extension resolve too. Renders nothing unless the sharing-visibility +
+// share_discovery flags are on, keeping flag-off DOM identical.
+export function ExploreFeedShareButton({
+  sharePath,
+  buttonVariant,
+  buttonSize,
+  className,
+}: ExploreFeedShareButtonProps): ReactElement | null {
+  const { isEnabled } = useShareDiscovery();
+  const { logEvent } = useLogContext();
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <ShareActions
+      link={`${webappUrl}${sharePath.slice(1)}`}
+      text="Explore what millions of developers are reading on daily.dev"
+      // Feed cards ship their own per-post "Copy link" buttons, so the header
+      // control needs a distinct accessible name.
+      label="Copy link to feed"
+      buttonVariant={buttonVariant}
+      buttonSize={buttonSize}
+      className={className}
+      onShare={(provider) =>
+        logEvent({
+          event_name: LogEvent.ShareLog,
+          target_id: sharePath,
+          extra: JSON.stringify({ origin: Origin.ExploreFeed, provider }),
+        })
+      }
+    />
+  );
+}

--- a/packages/shared/src/components/header/FeedExploreHeader.spec.tsx
+++ b/packages/shared/src/components/header/FeedExploreHeader.spec.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { ExploreTabs, FeedExploreHeader } from './FeedExploreHeader';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { LogEvent, Origin } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+const mockDisplayToast = jest.fn();
+jest.mock('../../hooks/useToastNotification', () => ({
+  ...jest.requireActual('../../hooks/useToastNotification'),
+  useToastNotification: () => ({
+    displayToast: mockDisplayToast,
+    dismissToast: jest.fn(),
+  }),
+}));
+
+const logEvent = jest.fn();
+const writeText = jest.fn().mockResolvedValue(undefined);
+
+const gbWithFeatures = (features: Record<string, boolean>): GrowthBook =>
+  new GrowthBook({
+    features: Object.fromEntries(
+      Object.entries(features).map(([id, value]) => [
+        id,
+        { defaultValue: value },
+      ]),
+    ),
+  });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.assign(navigator, { clipboard: { writeText } });
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        pathname: '/posts/upvoted',
+        asPath: '/posts/upvoted',
+        query: {},
+        push: jest.fn(),
+        replace: jest.fn(),
+      } as unknown as NextRouter),
+  );
+});
+
+const renderComponent = (gb?: GrowthBook): RenderResult => {
+  const client = new QueryClient();
+
+  return render(
+    <TestBootProvider client={client} gb={gb} log={{ logEvent }}>
+      <FeedExploreHeader tab={ExploreTabs.MostUpvoted} setTab={jest.fn()} />
+    </TestBootProvider>,
+  );
+};
+
+describe('FeedExploreHeader share affordance flag-off', () => {
+  it('renders no share control and keeps the original right-side span', () => {
+    renderComponent();
+
+    expect(
+      screen.queryByLabelText('Copy link to feed'),
+    ).not.toBeInTheDocument();
+    // The period dropdown trigger is the only button; its wrapper span must
+    // keep the pre-initiative class list so flag-off DOM stays identical.
+    const dropdownTrigger = screen.getByRole('button');
+    expect(dropdownTrigger.closest('span')?.className).toBe('ml-auto');
+  });
+
+  it('renders no share control when only the master flag is on', () => {
+    renderComponent(gbWithFeatures({ sharing_visibility: true }));
+
+    expect(
+      screen.queryByLabelText('Copy link to feed'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders no share control when only share_discovery is on', () => {
+    renderComponent(gbWithFeatures({ share_discovery: true }));
+
+    expect(
+      screen.queryByLabelText('Copy link to feed'),
+    ).not.toBeInTheDocument();
+  });
+});
+
+describe('FeedExploreHeader share affordance flag-on', () => {
+  const gb = gbWithFeatures({
+    sharing_visibility: true,
+    share_discovery: true,
+  });
+
+  it('renders exactly one copy-link control', () => {
+    renderComponent(gb);
+
+    expect(screen.getAllByLabelText('Copy link to feed')).toHaveLength(1);
+  });
+
+  it('copies the canonical explore url, toasts and logs on tap', async () => {
+    renderComponent(gb);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy link to feed'));
+    });
+
+    // webappUrl is '/' under Jest, so the canonical link is the bare path
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith('/posts/upvoted'),
+    );
+    expect(mockDisplayToast).toHaveBeenCalledWith(
+      '✅ Copied link to clipboard',
+      expect.anything(),
+    );
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.ShareLog,
+      target_id: '/posts/upvoted',
+      extra: JSON.stringify({
+        origin: Origin.ExploreFeed,
+        provider: ShareProvider.CopyLink,
+      }),
+    });
+  });
+
+  it('uses the native share sheet on mobile', async () => {
+    const share = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { share });
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: 2,
+      configurable: true,
+    });
+
+    renderComponent(gb);
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Copy link to feed'));
+    });
+
+    await waitFor(() =>
+      expect(share).toHaveBeenCalledWith({
+        text: expect.stringContaining('/posts/upvoted'),
+      }),
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.ShareLog,
+        extra: JSON.stringify({
+          origin: Origin.ExploreFeed,
+          provider: ShareProvider.Native,
+        }),
+      }),
+    );
+
+    Object.defineProperty(navigator, 'maxTouchPoints', {
+      value: 0,
+      configurable: true,
+    });
+    delete (navigator as { share?: unknown }).share;
+  });
+});

--- a/packages/shared/src/components/header/FeedExploreHeader.spec.tsx
+++ b/packages/shared/src/components/header/FeedExploreHeader.spec.tsx
@@ -67,9 +67,7 @@ describe('FeedExploreHeader share affordance flag-off', () => {
   it('renders no share control and keeps the original right-side span', () => {
     renderComponent();
 
-    expect(
-      screen.queryByLabelText('Copy link to feed'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Share this feed')).not.toBeInTheDocument();
     // The period dropdown trigger is the only button; its wrapper span must
     // keep the pre-initiative class list so flag-off DOM stays identical.
     const dropdownTrigger = screen.getByRole('button');
@@ -79,17 +77,13 @@ describe('FeedExploreHeader share affordance flag-off', () => {
   it('renders no share control when only the master flag is on', () => {
     renderComponent(gbWithFeatures({ sharing_visibility: true }));
 
-    expect(
-      screen.queryByLabelText('Copy link to feed'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Share this feed')).not.toBeInTheDocument();
   });
 
   it('renders no share control when only share_discovery is on', () => {
     renderComponent(gbWithFeatures({ share_discovery: true }));
 
-    expect(
-      screen.queryByLabelText('Copy link to feed'),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Share this feed')).not.toBeInTheDocument();
   });
 });
 
@@ -102,14 +96,14 @@ describe('FeedExploreHeader share affordance flag-on', () => {
   it('renders exactly one copy-link control', () => {
     renderComponent(gb);
 
-    expect(screen.getAllByLabelText('Copy link to feed')).toHaveLength(1);
+    expect(screen.getAllByLabelText('Share this feed')).toHaveLength(1);
   });
 
   it('copies the canonical explore url, toasts and logs on tap', async () => {
     renderComponent(gb);
 
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Copy link to feed'));
+      fireEvent.click(screen.getByLabelText('Share this feed'));
     });
 
     // webappUrl is '/' under Jest, so the canonical link is the bare path
@@ -141,7 +135,7 @@ describe('FeedExploreHeader share affordance flag-on', () => {
     renderComponent(gb);
 
     await act(async () => {
-      fireEvent.click(screen.getByLabelText('Copy link to feed'));
+      fireEvent.click(screen.getByLabelText('Share this feed'));
     });
 
     await waitFor(() =>

--- a/packages/shared/src/components/header/FeedExploreHeader.tsx
+++ b/packages/shared/src/components/header/FeedExploreHeader.tsx
@@ -10,10 +10,13 @@ import { Tab, TabContainer } from '../tabs/TabContainer';
 import { checkIsExtension } from '../../lib/func';
 import { getFeedName } from '../../lib/feed';
 import { Dropdown } from '../fields/Dropdown';
+import { ButtonSize, ButtonVariant } from '../buttons/Button';
+import { ExploreFeedShareButton } from './ExploreFeedShareButton';
 import { QueryStateKeys, useQueryState } from '../../hooks/utils/useQueryState';
 import { periodTexts } from '../layout/common';
 import { OtherFeedPage } from '../../lib/query';
 import { useFeedLayout } from '../../hooks';
+import { useShareDiscovery } from '../../hooks/useShareDiscovery';
 
 export enum ExploreTabs {
   Popular = 'Popular',
@@ -78,9 +81,13 @@ export function FeedExploreHeader({
     defaultValue: 0,
   });
   const { isListMode } = useFeedLayout();
+  const { isEnabled: canShareFeed } = useShareDiscovery();
   const shouldShowDropdown =
     withDateRange.includes(path as OtherFeedPage) ||
     withDateRange.includes(tab);
+  // Webapp derives the active sort from the URL; the extension drives it via
+  // the `tab` state instead, so fall back to that there.
+  const sharePath = tabToUrl[urlToTab[router.pathname] ?? tab];
 
   return (
     <div className={classNames('flex w-full flex-col', className.container)}>
@@ -125,7 +132,21 @@ export function FeedExploreHeader({
           </TabContainer>
         )}
         {showDropdown && (
-          <span className="ml-auto">
+          <span
+            className={classNames(
+              'ml-auto',
+              // Only becomes a flex cluster when the share affordance renders,
+              // so the flag-off DOM stays identical.
+              canShareFeed && 'flex flex-row items-center gap-2',
+            )}
+          >
+            {canShareFeed && (
+              <ExploreFeedShareButton
+                sharePath={sharePath}
+                buttonVariant={ButtonVariant.Float}
+                buttonSize={ButtonSize.Large}
+              />
+            )}
             {shouldShowDropdown && (
               <Dropdown
                 iconOnly

--- a/packages/shared/src/hooks/useShareDiscovery.ts
+++ b/packages/shared/src/hooks/useShareDiscovery.ts
@@ -1,0 +1,21 @@
+import { featureShareDiscovery } from '../lib/featureManagement';
+import { useConditionalFeature } from './useConditionalFeature';
+import { useSharingVisibility } from './useSharingVisibility';
+
+interface UseShareDiscovery {
+  isEnabled: boolean;
+}
+
+// Per-topic gate for the discovery-surfaces share affordances (Explore feed
+// headers + best-of archive pages). Both the `sharing_visibility` master
+// kill-switch AND `share_discovery` must be on; the per-topic flag is only
+// evaluated once the master gate passes so GrowthBook exposure stays clean.
+export const useShareDiscovery = (shouldEvaluate = true): UseShareDiscovery => {
+  const { isEnabled: isSharingEnabled } = useSharingVisibility(shouldEvaluate);
+  const { value } = useConditionalFeature({
+    feature: featureShareDiscovery,
+    shouldEvaluate: shouldEvaluate && isSharingEnabled,
+  });
+
+  return { isEnabled: isSharingEnabled && value };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -308,3 +308,9 @@ export const featureSharingVisibility = new Feature(
 // high-traffic icon, so it ramps on its own flag to watch share/copy metrics.
 // Keep the default `false` (control = existing `LinkIcon`).
 export const featureShareCopyIcon = new Feature('share_copy_icon', false);
+
+// Sharing-visibility per-topic flag: copy-link/share on discovery surfaces —
+// the Explore feed headers and the best-of archive pages. Also gated by the
+// `sharing_visibility` master kill-switch. Keep the default `false` —
+// GrowthBook ramps it.
+export const featureShareDiscovery = new Feature('share_discovery', false);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -108,6 +108,8 @@ export enum Origin {
   GameCenter = 'game center',
   DevCard = 'devcard',
   CopyMyFeed = 'copy my feed',
+  ExploreFeed = 'explore feed',
+  BestOfArchive = 'best of archive',
 }
 
 export enum LogEvent {

--- a/packages/webapp/__tests__/ShareDiscoverySurfaces.tsx
+++ b/packages/webapp/__tests__/ShareDiscoverySurfaces.tsx
@@ -71,5 +71,5 @@ it('does not render the copy-link control on non-explore feed pages with flags o
 
   const elements = await screen.findAllByTestId('postItem');
   expect(elements.length).toBeTruthy();
-  expect(screen.queryByLabelText('Copy link to feed')).not.toBeInTheDocument();
+  expect(screen.queryByLabelText('Share this feed')).not.toBeInTheDocument();
 });

--- a/packages/webapp/__tests__/ShareDiscoverySurfaces.tsx
+++ b/packages/webapp/__tests__/ShareDiscoverySurfaces.tsx
@@ -1,0 +1,75 @@
+import type { FeedData } from '@dailydotdev/shared/src/graphql/posts';
+import {
+  ANONYMOUS_FEED_QUERY,
+  RankingAlgorithm,
+} from '@dailydotdev/shared/src/graphql/feed';
+import nock from 'nock';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import ad from '@dailydotdev/shared/__tests__/fixture/ad';
+import defaultFeedPage from '@dailydotdev/shared/__tests__/fixture/feed';
+import type { MockedGraphQLResponse } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { mockGraphQL } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import Popular from '../pages/popular';
+
+// The share_discovery control must only render on the Explore (discovery)
+// surfaces — its component-level coverage lives in the shared
+// FeedExploreHeader/Archive specs. This guards the composition: a non-explore
+// feed page must not grow the control even with the gate forced fully on.
+jest.mock('@dailydotdev/shared/src/hooks/useShareDiscovery', () => ({
+  useShareDiscovery: () => ({ isEnabled: true }),
+}));
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  jest.clearAllMocks();
+  nock.cleanAll();
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        pathname: '/popular',
+        query: {},
+        replace: jest.fn(),
+        push: jest.fn(),
+      } as unknown as NextRouter),
+  );
+});
+
+const createFeedMock = (): MockedGraphQLResponse<FeedData> => ({
+  request: {
+    query: ANONYMOUS_FEED_QUERY,
+    variables: {
+      first: 7,
+      after: '',
+      loggedIn: false,
+      version: 15,
+      ranking: RankingAlgorithm.Popularity,
+      columns: 1,
+    },
+  },
+  result: {
+    data: {
+      page: defaultFeedPage,
+    },
+  },
+});
+
+it('does not render the copy-link control on non-explore feed pages with flags on', async () => {
+  const client = new QueryClient();
+  mockGraphQL(createFeedMock());
+  nock('http://localhost:3000').get('/v1/a').reply(200, [ad]);
+
+  render(
+    <TestBootProvider client={client} auth={{ user: undefined }}>
+      {Popular.getLayout(<Popular />, {}, Popular.layoutProps)}
+    </TestBootProvider>,
+  );
+
+  const elements = await screen.findAllByTestId('postItem');
+  expect(elements.length).toBeTruthy();
+  expect(screen.queryByLabelText('Copy link to feed')).not.toBeInTheDocument();
+});


### PR DESCRIPTION
Part of the sharing-visibility initiative (builds on PR 1 / #6343, based on `claude/website-sharing-visibility-be6b32`).

## What

Adds the copy-link/share affordance to the discovery surfaces (plan item #25):

- **Explore feed headers**
  - `FeedExploreHeader` (non-v2; laptop breadcrumb header and mobile sticky tab bar): a `ShareActions` icon control joins the existing right-side period-dropdown span (Float/Large to match the dropdown). The span only becomes a `flex ... gap-2` cluster when the flag is on, so flag-off DOM is unchanged.
  - `MainFeedLayout` v2 explore strip: the control renders between `ExploreSectionTabs` and `ExploreSortDropdown`, spaced by the page header's own `gap-2`, and only when `isAnyExplore` — the strip's `/discussed` instance does not get it (it is the Discussions feed, not an Explore sort; keeps v2/non-v2 surface parity).
  - Both call sites share the new `ExploreFeedShareButton`, which resolves the canonical webapp URL of the active sort (URL-derived on webapp, `tab`-state fallback for the extension) so links copied from the extension resolve. Distinct accessible name "Copy link to feed" (feed cards already own per-post "Copy link" buttons).
- **Best-of archive** (shared components, rendered by all nine webapp best-of routes: `/posts/best-of*`, `/tags/[tag]/best-of*`, `/sources/[source]/best-of*`)
  - `ArchiveIndexPage` and `ArchiveFeedPage`: control next to the `h1`, sharing the canonical archive URL (`getArchiveIndexUrl` / `getArchiveUrl`). Flag-off renders the exact original heading markup.

## Logging

One event per entity, per the initiative convention: generic `LogEvent.ShareLog` with `target_id` = the page path and `extra.origin` = new `Origin.ExploreFeed` / `Origin.BestOfArchive` (appended at the end of the enum), `extra.provider` = share provider. No post-shaped events minted.

## Flag

`share_discovery`, default `false`, appended at the end of `featureManagement.ts`. Gated via the new `useShareDiscovery` hook: `useSharingVisibility()` (master kill-switch) AND the per-topic flag through `useConditionalFeature`, with the per-topic flag only evaluated once the master gate passes. **Flag-off is DOM-identical to the base branch** (asserted in Jest via exact class-list checks).

## Surfaces that did NOT get the control (and why)

- `/discussed` (v2 explore strip instance): Discussions feed, not a discovery sort — kept parity with non-v2 where the header doesn't render there.
- Explore hub directory pages (`/tags`, `/sources`, `/users` via `ExploreHubHeader`): out of this PR's scope (#25 covers the discovery feeds + best-of archive only).
- Non-explore feed pages (`/`, `/my-feed`, `/popular`, custom feeds…): guarded by a webapp Jest test that forces the gate on and asserts the control never composes there.

## Verification

- `node ./scripts/typecheck-strict-changed.js` — pass
- `pnpm --filter shared lint` / `pnpm --filter webapp lint` — pass
- `NODE_ENV=test pnpm --filter shared test` — 297 suites / 1995 tests passed
- `NODE_ENV=test pnpm --filter webapp test` — 45 suites / 298 tests passed
- New tests: copy → clipboard + toast; mobile → `navigator.share`; AND-gating (each flag alone = off); exactly one control; flag-off class-list parity; non-explore composition guard.

## Notes

- The prompt's `packages/webapp/components/archive/*` paths don't exist — the archive pages live in `packages/shared/src/components/archive/` (verified real paths).
- No Storybook story: the repo's Storybook only aliases `@growthbook/growthbook` (not `-react`), so a genuine flag-gated story can't be expressed; Jest is the flag guarantee per the initiative convention. The `ShareActions` primitive already has stories from PR 1.
- No referral `cid` on these links (no matching `ReferralCampaignKey` for feed/archive pages); plain canonical URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-share-discovery.preview.app.daily.dev