### PR TITLE
feat(onboarding): play a demo video on the extension step

### DIFF
--- a/packages/shared/src/features/onboarding/steps/FunnelBrowserExtension.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelBrowserExtension.tsx
@@ -1,12 +1,16 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import type { FunnelStepBrowserExtension } from '../types/funnel';
 import { FunnelStepTransitionType } from '../types/funnel';
 import { useLogContext } from '../../../contexts/LogContext';
 import { useOnboardingExtension } from '../../../components/onboarding/Extension/useOnboardingExtension';
 import { BrowserName } from '../../../lib/func';
-import { cloudinaryOnboardingExtension } from '../../../lib/image';
+import { cloudinaryOnboardingExtensionVideo } from '../../../lib/image';
+import {
+  ThemeMode,
+  useSettingsContext,
+} from '../../../contexts/SettingsContext';
 import {
   Typography,
   TypographyColor,
@@ -41,29 +45,36 @@ const BrowserExtension = ({
     cta = BROWSER_EXTENSION_DEFAULTS.cta,
     skip = BROWSER_EXTENSION_DEFAULTS.skip,
     showReviews: showReviewsParam = BROWSER_EXTENSION_DEFAULTS.showReviews,
-    image,
+    video = cloudinaryOnboardingExtensionVideo,
   },
   onTransition,
 }: FunnelStepBrowserExtension): ReactElement => {
   const { logEvent } = useLogContext();
   const { browserName } = useOnboardingExtension();
+  const { applyThemeMode } = useSettingsContext();
   const isEdge = browserName === BrowserName.Edge;
   const browserLabel = isEdge ? 'Edge' : 'Chrome';
   const ctaText = cta.replace('{browser}', browserLabel);
-  const imageOverride = isEdge ? image?.edge : image?.chrome;
-  const imageUrls =
-    imageOverride ??
-    cloudinaryOnboardingExtension[
-      browserName as keyof typeof cloudinaryOnboardingExtension
-    ];
   const showReviews = showReviewsParam && !isEdge;
 
+  // The step is designed for a dark surface (dark funnel gradient, dark
+  // footage). FunnelStepBackground tries to force that with an `invert` class,
+  // but Tailwind's invert core plugin is disabled repo-wide, so in light mode
+  // the copy kept its light-theme colors and turned unreadable. Apply the dark
+  // theme for as long as the step is mounted, like the hero step does.
+  useEffect(() => {
+    applyThemeMode(ThemeMode.Dark);
+
+    return () => applyThemeMode();
+  }, [applyThemeMode]);
+
   return (
-    <div className="mt-10 flex flex-1 flex-col laptop:justify-between">
-      <div className="mb-14 flex flex-col items-center gap-6 justify-self-start text-center">
+    <div className="mt-10 flex flex-1 flex-col laptop:justify-center">
+      <div className="mb-10 flex flex-col items-center gap-6 justify-self-start text-center">
         <Typography
           tag={TypographyTag.H1}
           type={TypographyType.LargeTitle}
+          color={TypographyColor.Primary}
           bold
           className="!px-0"
           dangerouslySetInnerHTML={{
@@ -121,14 +132,17 @@ const BrowserExtension = ({
           }}
         />
       </div>
-      <figure className="pointer-events-none mx-auto w-full laptopL:w-2/3">
-        <img
-          alt="Amazing daily.dev extension screenshot"
-          className="w-full"
-          loading="lazy"
-          role="presentation"
-          src={imageUrls.default}
-          srcSet={`${imageUrls.default} 820w, ${imageUrls.retina} 1640w`}
+      <figure className="pointer-events-none mx-auto mb-10 w-full max-w-[48rem] px-4 laptop:px-6">
+        <video
+          aria-label="daily.dev feed running in a new tab on a laptop"
+          autoPlay
+          className="aspect-video w-full rounded-16 border border-border-subtlest-quaternary bg-background-subtle object-cover shadow-2"
+          controls={false}
+          disablePictureInPicture
+          loop
+          muted
+          playsInline
+          src={video}
         />
       </figure>
     </div>

--- a/packages/shared/src/features/onboarding/types/funnel.ts
+++ b/packages/shared/src/features/onboarding/types/funnel.ts
@@ -376,8 +376,6 @@ export interface FunnelStepPlusCards
   }>;
 }
 
-export type FunnelExtensionImage = { default: string; retina: string };
-
 export interface FunnelStepBrowserExtension
   extends FunnelStepCommon<{
     headline?: string;
@@ -385,10 +383,7 @@ export interface FunnelStepBrowserExtension
     cta?: string;
     skip?: string;
     showReviews?: boolean;
-    image?: {
-      chrome?: FunnelExtensionImage;
-      edge?: FunnelExtensionImage;
-    };
+    video?: string;
   }> {
   type: FunnelStepType.BrowserExtension;
   onTransition: FunnelStepTransitionCallback<{

--- a/packages/shared/src/lib/image.ts
+++ b/packages/shared/src/lib/image.ts
@@ -1,5 +1,3 @@
-import { BrowserName } from './func';
-
 const DAILY_MEDIA_HOST = 'media.daily.dev';
 const PLACEHOLDER_IMAGE_PATTERN = /placeholder/i;
 
@@ -249,20 +247,12 @@ export const cloudinaryAppIconV10 = cloudinaryAppIcons[9].url;
 export const cloudinaryAppIconV11 = cloudinaryAppIcons[10].url;
 export const cloudinaryAppIconV12 = cloudinaryAppIcons[11].url;
 
-export const cloudinaryOnboardingExtension = {
-  [BrowserName.Chrome]: {
-    default:
-      'https://media.daily.dev/image/upload/s--HjgXzokn--/c_scale,h_360,w_820/f_auto/dailydev-extenstion-mindblown_ggmkfg',
-    retina:
-      'https://media.daily.dev/image/upload/s--HjgXzokn--/f_auto/dailydev-extenstion-mindblown_ggmkfg',
-  },
-  [BrowserName.Edge]: {
-    default:
-      'https://media.daily.dev/image/upload/s--kvj5ZB_s--/c_scale,h_360,w_820/f_auto/dailydev-extenstion-mindblown-edge_svb0kv',
-    retina:
-      'https://media.daily.dev/image/upload/s--kvj5ZB_s--/f_auto/dailydev-extenstion-mindblown-edge_svb0kv',
-  },
-};
+// 1920×1080 VP9/WebM. Only the original derivative is available on the CDN
+// (strict transformations), so there is no mp4 fallback or generated poster.
+// The extension step only renders on desktop Chrome/Brave/Edge, which all
+// play VP9.
+export const cloudinaryOnboardingExtensionVideo =
+  'https://media.daily.dev/video/upload/v1783942037/1_3_nljcyu.webm';
 
 export const cloudinaryOnboardingActivationDemo =
   'https://media.daily.dev/video/upload/v1780303637/daily.dev_-_Keep_it_acphx8.mp4';


### PR DESCRIPTION
## Changes

Replaces the static "mind blown cat" screenshot on the browser-extension onboarding step with the new product film, and adapts the placement so a full 16:9 clip sits well on the page.

- `FunnelBrowserExtension` renders the clip as a centered card — `aspect-video`, `rounded-16`, hairline border (`border-subtlest-quaternary`), `shadow-2`, capped at `max-w-[48rem]`; muted / autoplay / loop / `playsInline`, no controls, `pointer-events-none`.
- Layout goes from `laptop:justify-between` (which bottom-bled the old cut-off still) to `laptop:justify-center`, so copy + video read as one composition. Fits without scrolling down to 1280×760.
- `cloudinaryOnboardingExtension` (chrome/edge stills) → `cloudinaryOnboardingExtensionVideo`; the step parameter `image.{chrome,edge}` → `video?: string`, so a funnel config can still override the URL.

### Drive-by fix: the headline was invisible

Pre-existing on `main`. The step is in `alwaysDarkSteps`, and `FunnelStepBackground` forces that look with an `invert` class — but `corePlugins: { invert: false }` in `packages/shared/tailwind.config.ts` has disabled that utility repo-wide since #2711, so `filter` computes to `none`. The funnel gradient painted dark while the copy kept light-theme tokens, and the `<h1>` (no `color` prop, so it inherited `body`'s `#0F1218`) landed dark-on-dark. The same mismatch made the video card's border read as a bright white line.

Fix, scoped to this step: apply the real dark theme while the step is mounted via `applyThemeMode(ThemeMode.Dark)` with restore on unmount — the pattern `OnboardingSignupHero` already uses for `forceDarkTheme` (visual only, does not persist the user's theme setting) — and give the headline an explicit `TypographyColor.Primary`.

The other `alwaysDarkSteps` (Signup, Checkout, OrganicSignup) are still affected by the dead `invert` and are left for a separate pass.

### Note on the asset

WebM/VP9 only: Cloudinary has strict transformations enabled on this account, so `.mp4` and a generated poster frame both 404. Fine here — the step only renders on desktop Chrome/Brave/Edge (`useOnboardingExtension`), which all play VP9 — but there is no fallback if the step is ever shown elsewhere.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Verified in Storybook (`Components/Onboarding/Steps/BrowserExtension`) at 1440×900 and 1280×760: headline visible, video autoplays and loops cleanly (7.1s, ends on its opening frame), no page scroll.

- [x] Have you done sanity checks in the webapp? (Storybook; the funnel step is desktop Chrome/Edge only)
- [ ] Have you done sanity checks in the extension? — n/a, step never renders in the extension
- [ ] Does this not break anything in companion? — n/a

Not tested on mobile/tablet breakpoints: `shouldShowExtensionOnboarding` gates the step to `ViewSize.Laptop` and up.

Suites run locally: 19 onboarding suites (153 tests) and 44 webapp suites (297 tests) pass; strict typecheck + ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-cat-video-onboarding-c4ae.preview.app.daily.dev