### PR TITLE
Improve community sentiment source status display

### DIFF
--- a/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.spec.tsx
+++ b/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.spec.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { CommunitySentimentData } from './CommunitySentiment';
+import { CommunitySentimentBreakdown } from './CommunitySentimentBreakdown';
+
+const createData = (
+  overrides: Partial<CommunitySentimentData> = {},
+): CommunitySentimentData => ({
+  breakdown: { positive: 20, mixed: 60, critical: 20 },
+  tldr: 'The community has thoughts.',
+  postCount: 1,
+  sources: ['Hacker News'],
+  pros: [],
+  cons: [],
+  bySource: [
+    {
+      source: 'hackernews',
+      lean: 'mixed',
+      note: 'No comments were present, so no community signal is available.',
+    },
+  ],
+  highlights: [],
+  openQuestions: [],
+  discussions: [
+    {
+      provider: 'hackernews',
+      url: 'https://news.ycombinator.com/item?id=1',
+      points: 2,
+      commentsCount: 0,
+    },
+  ],
+  ...overrides,
+});
+
+describe('CommunitySentimentBreakdown', () => {
+  it('hides the source lean and shows concise empty copy when a source has no comments', () => {
+    render(<CommunitySentimentBreakdown data={createData()} />);
+
+    expect(screen.getByText('Hacker News')).toBeInTheDocument();
+    expect(screen.queryByText('Mixed')).not.toBeInTheDocument();
+    expect(screen.getByText('No comments yet')).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'No comments were present, so no community signal is available.',
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the source lean when comments are available', () => {
+    render(
+      <CommunitySentimentBreakdown
+        data={createData({
+          bySource: [
+            {
+              source: 'hackernews',
+              lean: 'positive',
+              note: 'Developers are into this one.',
+            },
+          ],
+          discussions: [
+            {
+              provider: 'hackernews',
+              url: 'https://news.ycombinator.com/item?id=2',
+              points: 42,
+              commentsCount: 8,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('Positive')).toBeInTheDocument();
+    expect(
+      screen.getByText('Developers are into this one.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.tsx
+++ b/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.tsx
@@ -161,6 +161,8 @@ const SourceRow = ({
   // The narrative row may not carry its own url; the raw discussion entry for
   // the same provider is the same thread, so use it as the link fallback.
   const linkUrl = url ?? discussion?.url;
+  const hasNoComments = discussion?.commentsCount === 0;
+  const displayNote = hasNoComments ? 'No comments yet' : note;
 
   const content = (
     <>
@@ -174,14 +176,16 @@ const SourceRow = ({
           >
             {label}
           </Typography>
-          <span
-            className={classNames(
-              'inline-flex items-center rounded-6 px-1.5 py-0.5 font-bold typo-caption2',
-              chip.className,
-            )}
-          >
-            {chip.label}
-          </span>
+          {!hasNoComments && (
+            <span
+              className={classNames(
+                'inline-flex items-center rounded-6 px-1.5 py-0.5 font-bold typo-caption2',
+                chip.className,
+              )}
+            >
+              {chip.label}
+            </span>
+          )}
           {discussion && (
             <Typography
               type={TypographyType.Caption2}
@@ -197,7 +201,7 @@ const SourceRow = ({
           type={TypographyType.Caption1}
           color={TypographyColor.Tertiary}
         >
-          {note}
+          {displayNote}
         </Typography>
       </div>
       {/* Always reserve the link slot so rows without a link stay aligned. */}


### PR DESCRIPTION
## Summary
- Show “No comments yet” for community sources without comments
- Hide sentiment labels when no discussion comments are available
- Preserve source row alignment and link fallback behavior

## Testing
- Updated unit test coverage for community sentiment breakdown behavior

### Preview domain
https://feat-community-sentiment.preview.app.daily.dev