### PR TITLE
fix(sentiment): hide sources with no comments

### DIFF
--- a/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.spec.tsx
+++ b/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.spec.tsx
@@ -33,17 +33,63 @@ const createData = (
 });
 
 describe('CommunitySentimentBreakdown', () => {
-  it('hides the source lean and shows concise empty copy when a source has no comments', () => {
+  it('does not render a source row when that source has no comments', () => {
     render(<CommunitySentimentBreakdown data={createData()} />);
 
-    expect(screen.getByText('Hacker News')).toBeInTheDocument();
+    expect(screen.queryByText('Hacker News')).not.toBeInTheDocument();
     expect(screen.queryByText('Mixed')).not.toBeInTheDocument();
-    expect(screen.getByText('No comments yet')).toBeInTheDocument();
+    expect(screen.queryByText('No comments yet')).not.toBeInTheDocument();
     expect(
       screen.queryByText(
         'No comments were present, so no community signal is available.',
       ),
     ).not.toBeInTheDocument();
+  });
+
+  it('keeps the rest of the breakdown when one source has no comments', () => {
+    render(
+      <CommunitySentimentBreakdown
+        data={createData({
+          pros: ['Developers like the practical examples.'],
+          bySource: [
+            {
+              source: 'hackernews',
+              lean: 'mixed',
+              note: 'No comments were present, so no community signal is available.',
+            },
+            {
+              source: 'lobsters',
+              lean: 'skeptical',
+              note: 'Developers want stronger benchmarks.',
+            },
+          ],
+          discussions: [
+            {
+              provider: 'hackernews',
+              url: 'https://news.ycombinator.com/item?id=1',
+              points: 2,
+              commentsCount: 0,
+            },
+            {
+              provider: 'lobsters',
+              url: 'https://lobste.rs/s/example',
+              points: 12,
+              commentsCount: 5,
+            },
+          ],
+        })}
+      />,
+    );
+
+    expect(
+      screen.getByText('Developers like the practical examples.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Hacker News')).not.toBeInTheDocument();
+    expect(screen.getByText('Lobsters')).toBeInTheDocument();
+    expect(screen.getByText('Skeptical')).toBeInTheDocument();
+    expect(
+      screen.getByText('Developers want stronger benchmarks.'),
+    ).toBeInTheDocument();
   });
 
   it('keeps the source lean when comments are available', () => {

--- a/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.tsx
+++ b/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.tsx
@@ -161,8 +161,6 @@ const SourceRow = ({
   // The narrative row may not carry its own url; the raw discussion entry for
   // the same provider is the same thread, so use it as the link fallback.
   const linkUrl = url ?? discussion?.url;
-  const hasNoComments = discussion?.commentsCount === 0;
-  const displayNote = hasNoComments ? 'No comments yet' : note;
 
   const content = (
     <>
@@ -176,16 +174,14 @@ const SourceRow = ({
           >
             {label}
           </Typography>
-          {!hasNoComments && (
-            <span
-              className={classNames(
-                'inline-flex items-center rounded-6 px-1.5 py-0.5 font-bold typo-caption2',
-                chip.className,
-              )}
-            >
-              {chip.label}
-            </span>
-          )}
+          <span
+            className={classNames(
+              'inline-flex items-center rounded-6 px-1.5 py-0.5 font-bold typo-caption2',
+              chip.className,
+            )}
+          >
+            {chip.label}
+          </span>
           {discussion && (
             <Typography
               type={TypographyType.Caption2}
@@ -201,7 +197,7 @@ const SourceRow = ({
           type={TypographyType.Caption1}
           color={TypographyColor.Tertiary}
         >
-          {displayNote}
+          {note}
         </Typography>
       </div>
       {/* Always reserve the link slot so rows without a link stay aligned. */}
@@ -257,6 +253,10 @@ export const CommunitySentimentBreakdown = ({
       discussion,
     ]),
   );
+  const sourcesWithComments = bySource.filter((item) => {
+    const discussion = discussionByProvider.get(normalizeProvider(item.source));
+    return discussion?.commentsCount !== 0;
+  });
 
   return (
     <div className="flex animate-composer-in flex-col gap-4 border-t border-border-subtlest-tertiary pt-3">
@@ -271,11 +271,11 @@ export const CommunitySentimentBreakdown = ({
         </div>
       )}
 
-      {bySource.length > 0 && (
+      {sourcesWithComments.length > 0 && (
         <div className="flex flex-col gap-2.5">
           <BlockTitle>By community</BlockTitle>
           <div className="flex flex-col gap-1">
-            {bySource.map((item) => (
+            {sourcesWithComments.map((item) => (
               <SourceRow
                 key={item.source}
                 {...item}


### PR DESCRIPTION
## Summary
- Hide per-community sentiment rows when the matched source discussion has zero comments
- Keep the rest of the sentiment breakdown visible when only one source has no comments
- Update regression coverage for the zero-comment source case

## Testing
- NODE_ENV=test node_modules/.bin/jest src/components/post/focus/CommunitySentimentBreakdown.spec.tsx --runInBand
- node ./scripts/typecheck-strict-changed.js
- node_modules/.bin/prettier --check src/components/post/focus/CommunitySentimentBreakdown.tsx src/components/post/focus/CommunitySentimentBreakdown.spec.tsx
- git diff --check
- NODE_ENV=test node_modules/.bin/jest --runInBand (webapp)

### Preview domain
https://codex-hide-empty-sentiment-sourc.preview.app.daily.dev