### PR TITLE
feat: show community sentiment on social twitter post pages

### DIFF
--- a/packages/shared/src/components/post/SocialTwitterPostContent.spec.tsx
+++ b/packages/shared/src/components/post/SocialTwitterPostContent.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import { render, screen } from '@testing-library/react';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { postWithCommunitySentiment } from '../../../__tests__/fixture/post';
+import type { Post } from '../../graphql/posts';
+import { PostType } from '../../graphql/posts';
+import { Origin } from '../../lib/log';
+import { featureCommunitySentiment } from '../../lib/featureManagement';
+import { SocialTwitterPostContentRaw } from './SocialTwitterPostContent';
+
+const tweetPost: Post = {
+  ...postWithCommunitySentiment,
+  type: PostType.SocialTwitter,
+  subType: 'thread',
+  title: 'A tweet about testing',
+  contentHtml: '<p>Thread body</p>',
+};
+
+const renderContent = (
+  post: Post,
+  options: { gb?: GrowthBook; isPostPage?: boolean; onClose?: () => void } = {},
+) =>
+  render(
+    <TestBootProvider client={new QueryClient()} gb={options.gb}>
+      <SocialTwitterPostContentRaw
+        post={post}
+        origin={Origin.ArticlePage}
+        isPostPage={options.isPostPage ?? true}
+        onClose={options.onClose}
+      />
+    </TestBootProvider>,
+  );
+
+const enabledGrowthBook = () => {
+  const gb = new GrowthBook();
+  gb.setFeatures({
+    [featureCommunitySentiment.id]: {
+      defaultValue: true,
+    },
+  });
+  return gb;
+};
+
+describe('SocialTwitterPostContent community sentiment', () => {
+  it('renders on the tweet post page when the flag is enabled', () => {
+    renderContent(tweetPost, { gb: enabledGrowthBook() });
+
+    expect(
+      screen.getByRole('region', { name: 'What the community thinks' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Most agree it is worth reading.')).toBeVisible();
+  });
+
+  it('renders in the tweet preview modal when the flag is enabled', () => {
+    renderContent(tweetPost, {
+      gb: enabledGrowthBook(),
+      isPostPage: false,
+      onClose: jest.fn(),
+    });
+
+    expect(
+      screen.getByRole('region', { name: 'What the community thinks' }),
+    ).toBeInTheDocument();
+  });
+
+  it('stays hidden when the post has no take', () => {
+    renderContent(
+      { ...tweetPost, communitySentiment: undefined },
+      { gb: enabledGrowthBook() },
+    );
+
+    expect(
+      screen.queryByRole('region', { name: 'What the community thinks' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('stays hidden when the flag is disabled', () => {
+    renderContent(tweetPost);
+
+    expect(
+      screen.queryByRole('region', { name: 'What the community thinks' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/SocialTwitterPostContent.tsx
+++ b/packages/shared/src/components/post/SocialTwitterPostContent.tsx
@@ -31,12 +31,19 @@ import {
   getSocialTwitterMetadataLabel,
 } from '../cards/socialTwitter/socialTwitterHelpers';
 import { Separator } from '../cards/common/common';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { featureCommunitySentiment } from '../../lib/featureManagement';
+import { isDevelopment } from '../../lib/constants';
+import {
+  CommunitySentiment,
+  mapCommunitySentimentPost,
+} from './focus/CommunitySentiment';
 
 type SocialTwitterPostContentRawProps = Omit<PostContentProps, 'post'> & {
   post: Post;
 };
 
-function SocialTwitterPostContentRaw({
+export function SocialTwitterPostContentRaw({
   post,
   isFallback,
   shouldOnboardAuthor,
@@ -104,6 +111,18 @@ function SocialTwitterPostContentRaw({
     !post.content?.trim();
   const metadataLabel = getSocialTwitterMetadataLabel();
   const socialTextDirectionProps = getSocialTextDirectionProps(post.language);
+  const communitySentimentData = post.communitySentiment
+    ? mapCommunitySentimentPost(post.communitySentiment)
+    : undefined;
+  // Conditional enrollment: only evaluate (and log exposure for) the
+  // community_sentiment experiment on posts that actually have a take, so
+  // take-less posts don't dilute the treatment/control split.
+  const { value: communitySentimentEnabled } = useConditionalFeature({
+    feature: featureCommunitySentiment,
+    shouldEvaluate: !!communitySentimentData,
+  });
+  const showCommunitySentiment =
+    !!communitySentimentData && (communitySentimentEnabled || isDevelopment);
 
   return (
     <PostContentContainer
@@ -224,6 +243,12 @@ function SocialTwitterPostContentRaw({
               textClampClass=""
               bodyClassName="typo-markdown"
               showImage
+            />
+          )}
+          {showCommunitySentiment && (
+            <CommunitySentiment
+              data={communitySentimentData}
+              className={isCompactModalSpacing ? 'mb-4' : 'mb-6'}
             />
           )}
         </BasePostContent>


### PR DESCRIPTION
## What

Completes the X community-takes chain on the frontend: tweet posts now render the `CommunitySentiment` surface. The backend generates takes for tweets from their X reply threads (dailydotdev/yggdrasil#711 + dailydotdev/bragi#262 + dailydotdev/daily-api#4024), but tweets use the dedicated `SocialTwitterPostContent` layout, which never showed the take.

> **Rebased & slimmed down (Aug 27).** The original version extracted `PostFocusCard`'s gating into a shared `useCommunitySentiment` hook with full-page-only semantics. Main has since moved: #6507 added the take to the legacy `PostContent` layout, and #6520/#6523 changed `PostFocusCard` to show takes in post modals too (with `withPostById` cache hydration). This PR now touches only the tweet layout and follows those newer semantics — no refactor, no `PostFocusCard` changes.

## Changes

- `SocialTwitterPostContent`: renders `<CommunitySentiment>` after the tweet body (thread markdown / embedded quote preview), using the same inline gating as `PostContent` on main: maps the wire shape, conditionally enrolls in the `community_sentiment` experiment **only when a take exists** (no enrollment dilution from take-less posts), with the `isDevelopment` local-preview escape hatch, and the compact `mb-4` spacing in modals. Shown on both the full post page and the preview modal, matching the direction set by #6520/#6523.
- No GraphQL changes: `communitySentiment` already rides `SHARED_POST_INFO_FRAGMENT`, and both `POST_BY_ID_QUERY` and `POST_BY_ID_STATIC_FIELDS_QUERY` (which the tweet post page uses) spread it. The layout is already wrapped in `withPostById`, so feed-opened modals hydrate the take from the post-by-id cache like the other surfaces.

## Tests / verification

- New `SocialTwitterPostContent.spec.tsx` (4 tests), mirroring the `PostContent.spec.tsx` pattern (raw component, real GrowthBook via `TestBootProvider`, no mocks): renders on the post page with take + flag; renders in the preview modal; hidden without a take; hidden with the flag off.
- Full `shared` suite: 2635 passed (only failures are the 3 pre-existing `numberFormat` locale assertions that fail on non-en-US machines — untouched here, green in CI). `webapp` suite: 602 passed (only failure is the pre-existing `WorldGuideSheet` locale assertion, verified failing on clean main). `typecheck-strict-changed` and eslint clean.

## Rollout

Nothing new to flip: the surface obeys the existing `community_sentiment` experiment. Tweets simply join the eligible surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-community-sentiment-twitter.preview.app.daily.dev
