### PR TITLE
chore: remove reader modal nudge flag

### DIFF
--- a/packages/shared/src/components/post/reader/hooks/useReaderModalEligibility.ts
+++ b/packages/shared/src/components/post/reader/hooks/useReaderModalEligibility.ts
@@ -1,8 +1,6 @@
 import { useAuthContext } from '../../../../contexts/AuthContext';
 import { useSettingsContext } from '../../../../contexts/SettingsContext';
-import { useConditionalFeature } from '../../../../hooks/useConditionalFeature';
 import { useViewSize, ViewSize } from '../../../../hooks/useViewSize';
-import { featureReaderModalNudge } from '../../../../lib/featureManagement';
 import { isExtensionCapableBrowser } from '../../../../lib/func';
 
 export type UseReaderModalEligibilityResult = {
@@ -13,10 +11,10 @@ export type UseReaderModalEligibilityResult = {
    */
   isReaderEnabled: boolean;
   /**
-   * Enrolled in the reader_modal_v3 nudge experiment — eligible to be shown
-   * the intermediate install prompt once (see `readerInstallPromptSeen`).
+   * Eligible to be shown the intermediate install prompt on the next Read
+   * click.
    */
-  isReaderModalNudgeEnabled: boolean;
+  canShowReaderInstallPrompt: boolean;
 };
 
 /**
@@ -29,11 +27,9 @@ export type UseReaderModalEligibilityResult = {
  * 3. **Tablet or larger**: the embedded reader is a desktop/tablet flow, so
  *    mobile users are never enrolled.
  *
- * The reader_modal_v2 experiment that used to gate "is the reader on" has
- * graduated: the reader is now a pure user preference (`isReaderEnabled`) that
- * persists for users who already gave permission, while the new
- * reader_modal_v3 experiment (`isReaderModalNudgeEnabled`) gates only the
- * one-time intermediate install prompt for users who haven't enabled it yet.
+ * The reader is a pure user preference (`isReaderEnabled`) that persists for
+ * users who already gave permission. Eligible users who have not made that
+ * choice yet can see the intermediate install prompt once.
  */
 export function useReaderModalEligibility(): UseReaderModalEligibilityResult {
   const { user } = useAuthContext();
@@ -43,23 +39,15 @@ export function useReaderModalEligibility(): UseReaderModalEligibilityResult {
 
   const isAcknowledged = flags?.readerInstallPromptAcknowledged ?? false;
   const isOptedOut = flags?.legacyPostLayoutOptOut ?? false;
+  const isInstallPromptSeen = flags?.readerInstallPromptSeen ?? false;
   const isReaderEnabled = isEligible && isAcknowledged && !isOptedOut;
 
-  // The nudge only targets users who haven't decided yet — never those who
-  // already enabled the reader or explicitly opted out.
-  const isNudgeCandidate = isEligible && !isAcknowledged && !isOptedOut;
-  const { value: nudgeFlag } = useConditionalFeature({
-    feature: featureReaderModalNudge,
-    shouldEvaluate: isNudgeCandidate,
-  });
-  // useConditionalFeature falls back to the feature's default value when it
-  // doesn't evaluate, so a non-candidate would otherwise inherit the `true`
-  // default. Gate on the candidate check to keep non-candidates strictly off.
-  const isReaderModalNudgeEnabled = isNudgeCandidate && nudgeFlag;
+  const canShowReaderInstallPrompt =
+    isEligible && !isAcknowledged && !isOptedOut && !isInstallPromptSeen;
 
   return {
     isEligible,
     isReaderEnabled,
-    isReaderModalNudgeEnabled,
+    canShowReaderInstallPrompt,
   };
 }

--- a/packages/shared/src/graphql/settings.ts
+++ b/packages/shared/src/graphql/settings.ts
@@ -34,14 +34,13 @@ export type SettingsFlags = {
   defaultWriteTab?: WriteFormTab;
   legacyPostLayoutOptOut?: boolean;
   highlightCardsOptOut?: boolean;
-  // Persists that the user already chose to engage with the reader install
-  // prompt (clicked "Enable permissions & read inside"). Future read clicks
-  // skip the prompt and open the reader modal directly. Dismissing the prompt
-  // without choosing an option leaves this unset so the prompt reappears.
+  // Persists that the user chose to enable reader permissions from an install
+  // prompt. Future read clicks skip the prompt and open the reader modal
+  // directly unless the user later opts out.
   readerInstallPromptAcknowledged?: boolean;
-  // Persists that the reader_modal_v3 nudge (the intermediate install prompt)
-  // has been surfaced to this user. Once set, the prompt never auto-opens
-  // again regardless of whether the user accepted or dismissed it.
+  // Persists that the intermediate install prompt has been surfaced to this
+  // user. Once set, the prompt never auto-opens again regardless of whether the
+  // user accepted or dismissed it.
   readerInstallPromptSeen?: boolean;
   shortcutMeta?: Record<string, ShortcutMeta>;
   shortcutsMode?: ShortcutsMode;

--- a/packages/shared/src/hooks/useReaderInstallPromptGate.ts
+++ b/packages/shared/src/hooks/useReaderInstallPromptGate.ts
@@ -39,21 +39,14 @@ export function useReaderInstallPromptGate(
   { onCloseParent }: UseReaderInstallPromptGateOptions = {},
 ): UseReaderInstallPromptGateResult {
   const { openModal } = useLazyModal();
-  const { isEligible, isReaderEnabled, isReaderModalNudgeEnabled } =
+  const { isReaderEnabled, canShowReaderInstallPrompt } =
     useReaderModalEligibility();
-  const { flags, updateFlag } = useSettingsContext();
-  const isInstallPromptSeen = flags?.readerInstallPromptSeen ?? false;
-
-  // The reader_modal_v3 nudge surfaces the intermediate install prompt at most
-  // once ever. After it has been seen we stop intercepting reads for users who
-  // never enabled the reader and fall back to the default new-tab navigation.
-  const canShowNudge = isReaderModalNudgeEnabled && !isInstallPromptSeen;
+  const { updateFlag } = useSettingsContext();
 
   const isGated =
     !!post &&
-    isEligible &&
     READER_GATE_ELIGIBLE_TYPES.has(post.type) &&
-    (isReaderEnabled || canShowNudge);
+    (isReaderEnabled || canShowReaderInstallPrompt);
 
   const onReadClick = useCallback(
     (event: MouseEvent): boolean => {
@@ -73,8 +66,7 @@ export function useReaderInstallPromptGate(
       event.preventDefault();
       event.stopPropagation();
       // Users who already enabled the reader go straight to it. Everyone else
-      // is here via the v3 nudge: show the intermediate prompt exactly once and
-      // persist that it was seen so it never auto-opens again.
+      // is here for the one-time install prompt, so persist that it was seen.
       if (isReaderEnabled) {
         openModal({
           type: LazyModal.ReaderPreview,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -186,11 +186,6 @@ export const featureOnboardingPersonas = new Feature(
 
 export const featurePostSignupWidget = new Feature('post_signup_widget', false);
 
-// Gates the one-time intermediate "read inside daily.dev" install prompt for
-// users who haven't enabled the reader yet. Unlike the retired reader_modal_v2,
-// this nudge is shown at most once ever (see readerInstallPromptSeen).
-export const featureReaderModalNudge = new Feature('reader_modal_v3', false);
-
 export const featureShortcutsHub = new Feature('shortcuts_hub_v2', false);
 
 export const featureGiveback = new Feature('giveback', isDevelopment);


### PR DESCRIPTION
## Summary
- remove the `reader_modal_v3` feature flag definition and all `featureReaderModalNudge` usage
- make the treatment behavior the permanent default for eligible users
- keep the one-time reader install prompt gated by existing eligibility, opt-out, acknowledged, and seen state
- update reader prompt settings comments to reflect the permanent behavior

## Verification
- `git diff --check origin/main...HEAD`
- targeted shared ESLint on impacted files
- `node ./scripts/typecheck-strict-changed.js`
- shared related Jest: 203 suites, 1397 tests passed
- webapp related Jest for the impacted settings page exited cleanly with no related tests

Linear: https://linear.app/dailydev/issue/ENG-1899/remove-reader-modal-v3-feature-flag-apply-treatment

Closes ENG-1899

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1899-remove-reader-modal-v3.preview.app.daily.dev