### PR TITLE
feat(ads): disclose ads as "Ad" behind the ad_label experiment

### DIFF
--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -11,6 +11,23 @@ import type { AdCardProps } from './common/common';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 import { ActiveFeedContext } from '../../../contexts';
 import { businessWebsiteUrl } from '../../../lib/constants';
+import { useFeature } from '../../GrowthBookProvider';
+import { AdLabelVariant, featureAdLabel } from '../../../lib/featureManagement';
+
+jest.mock('../../GrowthBookProvider', () => ({
+  ...(jest.requireActual('../../GrowthBookProvider') as Record<
+    string,
+    unknown
+  >),
+  useFeature: jest.fn(),
+}));
+
+const mockUseFeature = jest.mocked(useFeature);
+
+const mockAdLabelVariant = (variant: AdLabelVariant): void => {
+  mockUseFeature.mockImplementation(((feature: { id: string }) =>
+    feature?.id === featureAdLabel.id ? variant : undefined) as never);
+};
 
 const defaultProps: AdCardProps = {
   ad,
@@ -21,6 +38,8 @@ const defaultProps: AdCardProps = {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  // clearAllMocks keeps implementations, so reset the arm for every test.
+  mockAdLabelVariant(AdLabelVariant.Control);
 });
 
 const renderListComponent = (
@@ -230,6 +249,58 @@ it('should render Promoted attribution in grid variant', async () => {
 it('should render Promoted attribution in signal variant', async () => {
   renderSignalListComponent();
   expect(await screen.findByText(promotedMatcher)).toBeInTheDocument();
+});
+
+const adLabelMatcher = (_: string, element?: Element | null): boolean =>
+  getNormalizedText(element) === 'Ad';
+
+describe('ad_label experiment', () => {
+  const referralAd = { ...ad, referralLink: 'https://example.com/referral' };
+
+  it('should replace the advertiser attribution with "Ad" on the grid card', async () => {
+    mockAdLabelVariant(AdLabelVariant.Ad);
+    renderGridComponent({ ad: referralAd });
+
+    expect(await screen.findByText(adLabelMatcher)).toBeInTheDocument();
+    expect(screen.queryByText(promotedMatcher)).not.toBeInTheDocument();
+  });
+
+  it('should drop the advertiser referral link with the "Ad" label', async () => {
+    mockAdLabelVariant(AdLabelVariant.Ad);
+    renderListComponent({ ad: referralAd });
+
+    const attribution = await screen.findByText(adLabelMatcher);
+    expect(attribution.closest('a')).toBeNull();
+  });
+
+  it('should keep the advertise link on the ad arm', async () => {
+    mockAdLabelVariant(AdLabelVariant.Ad);
+    renderGridComponent({ ad: referralAd });
+
+    expect(
+      await screen.findByRole('link', { name: 'Advertise here' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should remove the advertise link on the ad_only arm', async () => {
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderListComponent({ ad: referralAd });
+
+    await screen.findByText(adLabelMatcher);
+    expect(
+      screen.queryByRole('link', { name: 'Advertise here' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should keep the control wording when the flag is off', async () => {
+    mockAdLabelVariant(AdLabelVariant.Control);
+    renderGridComponent({ ad: referralAd });
+
+    expect(await screen.findByText(promotedMatcher)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Advertise here' }),
+    ).toBeInTheDocument();
+  });
 });
 
 it('should render advertise link on list ad', () => {

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -29,6 +29,7 @@ import { adImprovementsV3Feature } from '../../../lib/featureManagement';
 import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
+import { useAdLabel } from '../../../features/monetization/useAdLabel';
 
 export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   { ad, onLinkClick, domProps, index, feedIndex },
@@ -37,6 +38,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   const { isPlus } = usePlusSubscription();
   const adImprovementsV3 = useFeature(adImprovementsV3Feature);
   const useGlass = useFeedCardGlassActions();
+  const { showAdvertiseLink } = useAdLabel();
   const { ref } = useAutoRotatingAds(
     ad,
     index,
@@ -80,11 +82,13 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
               {ad.callToAction}
             </Button>
           )}
-          <AdvertiseLink
-            targetId={TargetId.AdCard}
-            buttonStyle
-            size={ButtonSize.Small}
-          />
+          {showAdvertiseLink && (
+            <AdvertiseLink
+              targetId={TargetId.AdCard}
+              buttonStyle
+              size={ButtonSize.Small}
+            />
+          )}
           <div className="ml-auto flex items-center gap-2">
             {!isPlus && (
               <RemoveAd

--- a/packages/shared/src/components/cards/ad/AdList.tsx
+++ b/packages/shared/src/components/cards/ad/AdList.tsx
@@ -28,6 +28,7 @@ import { useFeature } from '../../GrowthBookProvider';
 import { adImprovementsV3Feature } from '../../../lib/featureManagement';
 import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
+import { useAdLabel } from '../../../features/monetization/useAdLabel';
 
 const getLinkProps = ({
   ad,
@@ -53,6 +54,7 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
 ): ReactElement {
   const { isPlus } = usePlusSubscription();
   const adImprovementsV3 = useFeature(adImprovementsV3Feature);
+  const { showAdvertiseLink } = useAdLabel();
   const { ref } = useAutoRotatingAds(
     ad,
     index,
@@ -104,11 +106,13 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
             {ad.callToAction}
           </Button>
         )}
-        <AdvertiseLink
-          targetId={TargetId.AdCard}
-          buttonStyle
-          size={ButtonSize.Small}
-        />
+        {showAdvertiseLink && (
+          <AdvertiseLink
+            targetId={TargetId.AdCard}
+            buttonStyle
+            size={ButtonSize.Small}
+          />
+        )}
         <div className="ml-auto">
           {!isPlus && (
             <RemoveAd

--- a/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from 'react';
 import classNames from 'classnames';
 import type { Ad } from '../../../../graphql/posts';
 import { useScrambler } from '../../../../hooks/useScrambler';
+import { useAdLabel } from '../../../../features/monetization/useAdLabel';
 
 interface AdClassName {
   main?: string;
@@ -18,16 +19,19 @@ export default function AdAttribution({
   ad,
   className,
 }: AdAttributionProps): ReactElement {
+  const { hideAdvertiser } = useAdLabel();
   const elementClass = classNames(
     'text-text-quaternary no-underline',
     className?.typo ?? 'typo-footnote',
     className?.main,
   );
 
-  const text = ad.referralLink ? `Promoted by ${ad.source}` : 'Promoted';
-  const promotedText = useScrambler(text);
+  const controlText = ad.referralLink ? `Promoted by ${ad.source}` : 'Promoted';
+  const promotedText = useScrambler(hideAdvertiser ? 'Ad' : controlText);
 
-  if (ad.referralLink) {
+  // The referral link points at the advertiser, so it only ships with the
+  // control wording that already names them.
+  if (ad.referralLink && !hideAdvertiser) {
     return (
       <a
         href={ad.referralLink}

--- a/packages/shared/src/features/monetization/useAdLabel.ts
+++ b/packages/shared/src/features/monetization/useAdLabel.ts
@@ -1,0 +1,17 @@
+import { useFeature } from '../../components/GrowthBookProvider';
+import { AdLabelVariant, featureAdLabel } from '../../lib/featureManagement';
+
+interface UseAdLabel {
+  /** Treatments disclose with a plain "Ad" instead of naming the advertiser. */
+  hideAdvertiser: boolean;
+  showAdvertiseLink: boolean;
+}
+
+export const useAdLabel = (): UseAdLabel => {
+  const variant = useFeature(featureAdLabel);
+
+  return {
+    hideAdvertiser: !!variant && variant !== AdLabelVariant.Control,
+    showAdvertiseLink: variant !== AdLabelVariant.AdOnly,
+  };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -155,6 +155,21 @@ export const boostSettingsFeature = new Feature('boost_settings', {
 
 export const adImprovementsV3Feature = new Feature('ad_improvements_v3', false);
 
+// Experiment: ad disclosure wording. Control names the advertiser ("Promoted by
+// Vercel"); the treatments drop the advertiser and disclose with a plain "Ad",
+// with the strictest arm also removing the "Advertise here" self-promo so the
+// card carries a single disclosure. Measured on ad CTR (see `adLogEvent`).
+// Default MUST stay Control — GrowthBook ramps the arms.
+export enum AdLabelVariant {
+  Control = 'control',
+  Ad = 'ad',
+  AdOnly = 'ad_only',
+}
+export const featureAdLabel = new Feature<AdLabelVariant>(
+  'ad_label',
+  AdLabelVariant.Control,
+);
+
 export const featureYearInReview = new Feature('year_in_review_2025', false);
 
 export const featureProfileCompletionIndicator = new Feature(

--- a/packages/storybook/.storybook/main.ts
+++ b/packages/storybook/.storybook/main.ts
@@ -25,6 +25,10 @@ const config: StorybookConfig = {
       __dirname,
       '../mock/GrowthBookProvider.tsx',
     );
+    const ConditionalFeatureMockPath = path.resolve(
+      __dirname,
+      '../mock/hooks/useConditionalFeature.ts',
+    );
 
     return mergeConfig(config, {
       core: {
@@ -45,7 +49,18 @@ const config: StorybookConfig = {
           ),
           'next/router': path.resolve(__dirname, '../mock/next-router.ts'),
           './GrowthBookProvider': GrowthBookMockPath,
+          '../GrowthBookProvider': GrowthBookMockPath,
           '../../GrowthBookProvider': GrowthBookMockPath,
+          '../../../GrowthBookProvider': GrowthBookMockPath,
+          '../components/GrowthBookProvider': GrowthBookMockPath,
+          '../../components/GrowthBookProvider': GrowthBookMockPath,
+          '../../../components/GrowthBookProvider': GrowthBookMockPath,
+          './useConditionalFeature': ConditionalFeatureMockPath,
+          '../useConditionalFeature': ConditionalFeatureMockPath,
+          '../hooks/useConditionalFeature': ConditionalFeatureMockPath,
+          '../../hooks/useConditionalFeature': ConditionalFeatureMockPath,
+          '../../../hooks/useConditionalFeature': ConditionalFeatureMockPath,
+          '../../../../hooks/useConditionalFeature': ConditionalFeatureMockPath,
           '@dailydotdev/shared/src/lib/boot': path.resolve(
             __dirname,
             '../mock/boot.ts',

--- a/packages/storybook/mock/GrowthBookProvider.tsx
+++ b/packages/storybook/mock/GrowthBookProvider.tsx
@@ -1,8 +1,38 @@
+import React, { createContext, useContext } from 'react';
+import type { PropsWithChildren, ReactElement } from 'react';
 import { fn } from 'storybook/test';
-import * as actual from '@dailydotdev/shared/src/components/GrowthBookProvider';
 
-export const useFeature = fn(actual.useFeature)
-  .mockName('useFeature')
-  .mockReturnValue('control');
+type FeatureLike = { id: string };
+type FeatureOverrideValues = Record<string, unknown>;
+
+const FeatureOverridesContext = createContext<FeatureOverrideValues>({});
+
+/**
+ * Pins specific flags for one subtree, so a single story can render several
+ * experiment arms next to each other. Flags left out keep the `control` value
+ * every other story relies on.
+ */
+export const FeatureOverrides = ({
+  values,
+  children,
+}: PropsWithChildren<{ values: FeatureOverrideValues }>): ReactElement => (
+  <FeatureOverridesContext.Provider value={values}>
+    {children}
+  </FeatureOverridesContext.Provider>
+);
+
+/** Returns the story-pinned value for a flag, or undefined when unpinned. */
+export const useFeatureOverride = (feature?: FeatureLike): unknown => {
+  const overrides = useContext(FeatureOverridesContext);
+
+  return feature && feature.id in overrides ? overrides[feature.id] : undefined;
+};
+
+export const useFeature = fn((feature?: FeatureLike) => {
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- runs during render
+  const override = useFeatureOverride(feature);
+
+  return override === undefined ? 'control' : override;
+}).mockName('useFeature');
 
 export * from '@dailydotdev/shared/src/components/GrowthBookProvider';

--- a/packages/storybook/mock/hooks/useConditionalFeature.ts
+++ b/packages/storybook/mock/hooks/useConditionalFeature.ts
@@ -1,6 +1,22 @@
-export const useConditionalFeature = () => {
+import { useFeatureOverride } from '../GrowthBookProvider';
+
+type FeatureLike = { id: string; defaultValue: unknown };
+
+/**
+ * Mirrors the real hook, minus GrowthBook: a story-pinned value when one is
+ * provided (see `FeatureOverrides`), otherwise the flag's own default — which
+ * is what the unmocked hook resolves to without a GrowthBook instance.
+ */
+export const useConditionalFeature = ({
+  feature,
+}: {
+  feature: FeatureLike;
+  shouldEvaluate?: boolean;
+}): { value: unknown; isLoading: boolean } => {
+  const override = useFeatureOverride(feature);
+
   return {
-    value: 'control',
+    value: override === undefined ? feature?.defaultValue : override,
     isLoading: false,
   };
 };

--- a/packages/storybook/stories/experiments/AdLabel.stories.tsx
+++ b/packages/storybook/stories/experiments/AdLabel.stories.tsx
@@ -1,0 +1,427 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { AdGrid } from '@dailydotdev/shared/src/components/cards/ad/AdGrid';
+import { AdList } from '@dailydotdev/shared/src/components/cards/ad/AdList';
+import { SignalAdList } from '@dailydotdev/shared/src/components/cards/ad/SignalAdList';
+import { PostSidebarAdWidget } from '@dailydotdev/shared/src/components/post/PostSidebarAdWidget';
+import { AdAsComment } from '@dailydotdev/shared/src/components/comments/AdAsComment';
+import type { Ad } from '@dailydotdev/shared/src/graphql/posts';
+import {
+  adImprovementsV3Feature,
+  featureFeedCardGlassActions,
+} from '@dailydotdev/shared/src/lib/featureManagement';
+import {
+  AdProviders,
+  Arm,
+  arms,
+  baseAd,
+  carbonAd,
+  COMMENT_POST_ID,
+  longCopyAd,
+  noCtaAd,
+  noop,
+  noReferralAd,
+  Page,
+  Section,
+  SIDEBAR_POST_ID,
+  taggedAd,
+  type ArmConfig,
+} from './adLabel.mocks';
+
+// ---------------------------------------------------------------------------
+// Experiment: `ad_label`
+//
+// Control names the advertiser under the ad ("Promoted by Vercel"). The
+// treatments hide the advertiser and disclose with a plain "Ad", to see how
+// disclosure wording moves ad CTR. Every ad surface and card use case is laid
+// out here, control first, so the arms can be compared side by side.
+// ---------------------------------------------------------------------------
+
+const feedProps = { index: 0, feedIndex: 0, onLinkClick: noop };
+
+const ArmRow = ({
+  render,
+  className,
+  overrides,
+}: {
+  render: (arm: ArmConfig) => ReactElement;
+  className?: string;
+  overrides?: Record<string, unknown>;
+}): ReactElement => (
+  <div className="flex flex-wrap items-start gap-8">
+    {arms.map((arm) => (
+      <Arm
+        key={arm.variant}
+        arm={arm}
+        className={className}
+        overrides={overrides}
+      >
+        {render(arm)}
+      </Arm>
+    ))}
+  </div>
+);
+
+const meta: Meta = {
+  title: 'Experiments/Ad label',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'A/B test `ad_label`: hide the advertiser on ad cards and disclose with a plain "Ad" instead of "Promoted by {advertiser}". Primary metric is ad CTR (clicks / impressions on `target_type: "ad"` events).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+export const Brief: StoryObj = {
+  name: '0. Experiment brief',
+  render: () => (
+    <Page>
+      <div className="flex max-w-[48rem] flex-col gap-4 typo-callout">
+        <h2 className="font-bold typo-title2">Ad label experiment</h2>
+        <p className="text-text-tertiary">
+          Ad cards currently name the advertiser under the creative
+          (&quot;Promoted by Vercel&quot;) and carry an &quot;Advertise
+          here&quot; self-promo. The hypothesis is that the advertiser name
+          reads as a disclosure of a paid placement twice over, and that a
+          single neutral &quot;Ad&quot; label lets the creative do the work —
+          moving CTR.
+        </p>
+        <div className="flex flex-col gap-2">
+          <span className="font-bold">Flag</span>
+          <code className="text-text-tertiary typo-footnote">
+            ad_label (string) — default: control
+          </code>
+        </div>
+        <div className="flex flex-col gap-2">
+          <span className="font-bold">Arms</span>
+          <ul className="flex list-disc flex-col gap-1 pl-4 text-text-tertiary">
+            {arms.map((arm) => (
+              <li key={arm.variant}>
+                <code>{arm.variant}</code> — {arm.summary}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="flex flex-col gap-2">
+          <span className="font-bold">Measurement</span>
+          <p className="text-text-tertiary">
+            All arms already emit the ad events built by <code>adLogEvent</code>{' '}
+            — <code>impression</code> and <code>click</code> with{' '}
+            <code>target_type: &quot;ad&quot;</code> and{' '}
+            <code>target_id: ad.source</code>. CTR = ad clicks / ad impressions,
+            split by experiment arm. Guardrails: revenue per mille, and the{' '}
+            <code>advertise here cta</code> click rate, which variant B removes
+            from the card entirely.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2">
+          <span className="font-bold">Coverage today</span>
+          <ul className="flex list-disc flex-col gap-1 pl-4 text-text-tertiary">
+            <li>
+              Feed grid + list cards — label swap and the &quot;Advertise
+              here&quot; removal.
+            </li>
+            <li>
+              Signal card and post sidebar widget — label swap only; both still
+              print the company name elsewhere on the card.
+            </li>
+            <li>
+              Ad as comment — <strong>not covered</strong>; it builds its own
+              attribution string.
+            </li>
+            <li>
+              The advertiser logo stays in every arm. Dropping it too would be a
+              stronger &quot;de-brand the ad&quot; test.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </Page>
+  ),
+};
+
+export const FeedGrid: StoryObj = {
+  name: '1. Feed card — grid',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="Feed ad card — grid"
+          description="The default feed card. The attribution sits under the title, above the creative."
+        >
+          <ArmRow
+            className="max-w-[24rem]"
+            render={() => <AdGrid ad={baseAd} {...feedProps} />}
+          />
+        </Section>
+        <Section
+          title="Feed ad card — grid, glass actions"
+          description="The `feed_card_glass_actions` layout moves the creative to the bottom of the card. Attribution and the advertise link keep the same behaviour in every arm."
+        >
+          <ArmRow
+            className="max-w-[24rem]"
+            overrides={{ [featureFeedCardGlassActions.id]: true }}
+            render={() => <AdGrid ad={baseAd} {...feedProps} />}
+          />
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};
+
+export const FeedList: StoryObj = {
+  name: '2. Feed card — list',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="Feed ad card — list"
+          description="List mode puts the creative on the right; the attribution sits below the title, outside the clamp."
+        >
+          <ArmRow
+            className="max-w-[40rem]"
+            render={() => <AdList ad={baseAd} {...feedProps} />}
+          />
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};
+
+export const SignalCard: StoryObj = {
+  name: '3. Signal feed card',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="Signal ad card"
+          description="The signal feed renders ads as a compact row: avatar, advertiser name, then the attribution after a separator."
+          note={
+            <>
+              <strong>Advertiser still named.</strong> This card prints the
+              company next to the avatar, so the treatments turn the line into
+              &quot;Vercel · Ad&quot;. Hiding the advertiser here needs the name
+              and avatar handled too — a product decision for the rollout.
+            </>
+          }
+        >
+          <ArmRow
+            className="max-w-[30rem]"
+            render={() => <SignalAdList ad={baseAd} {...feedProps} />}
+          />
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};
+
+export const SidebarWidget: StoryObj = {
+  name: '4. Post sidebar widget',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="Post sidebar ad — card"
+          description="The boxed widget on the post page sidebar. It shares `AdAttribution`, so the label swaps with the flag."
+          note={
+            <>
+              <strong>Advertiser still named.</strong> The company sits on its
+              own bold line above the attribution. The &quot;Advertise
+              here&quot; removal is scoped to the feed cards, so the link stays
+              here in every arm.
+            </>
+          }
+        >
+          <ArmRow
+            className="max-w-[22rem]"
+            render={() => <PostSidebarAdWidget postId={SIDEBAR_POST_ID} />}
+          />
+        </Section>
+        <Section
+          title="Post sidebar ad — inline"
+          description="The flat in-content variant: company on the favicon line, attribution and advertise link below it."
+        >
+          <ArmRow
+            className="max-w-[26rem]"
+            render={() => (
+              <PostSidebarAdWidget postId={SIDEBAR_POST_ID} variant="inline" />
+            )}
+          />
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};
+
+export const AdComment: StoryObj = {
+  name: '5. Ad as comment',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="Ad as comment"
+          description="The ad rendered inside the post's comment thread."
+          note={
+            <>
+              <strong>Not covered by the flag today.</strong> This component
+              builds its own &quot;Promoted by {'{advertiser}'}&quot; string
+              instead of using the shared <code>AdAttribution</code>, so all
+              three arms look identical. Moving it onto the shared component is
+              part of the product implementation.
+            </>
+          }
+        >
+          <ArmRow
+            className="max-w-[36rem]"
+            render={() => <AdAsComment postId={COMMENT_POST_ID} />}
+          />
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};
+
+const useCases: Array<{
+  title: string;
+  description: string;
+  ad: Ad;
+  overrides?: Record<string, unknown>;
+  isPlus?: boolean;
+}> = [
+  {
+    title: 'No call to action',
+    description:
+      'Without `callToAction` the row starts with the advertise link — so variant B leaves only "Remove".',
+    ad: noCtaAd,
+  },
+  {
+    title: 'No referral link',
+    description:
+      'Control degrades to a bare "Promoted" (no advertiser to name), which makes it the closest arm to the treatments.',
+    ad: noReferralAd,
+  },
+  {
+    title: 'Network creative (Carbon)',
+    description:
+      'Carbon and EthicalAds creatives render contained over a blurred copy of themselves.',
+    ad: carbonAd,
+  },
+  {
+    title: 'Long copy',
+    description: 'A description long enough to push the attribution down.',
+    ad: longCopyAd,
+  },
+  {
+    title: 'Matching tags (ad_improvements_v3)',
+    description:
+      'With `ad_improvements_v3` on, matched tags render between the copy and the attribution.',
+    ad: taggedAd,
+    overrides: { [adImprovementsV3Feature.id]: true },
+  },
+  {
+    title: 'Plus subscriber',
+    description: 'Plus members never see the "Remove" upsell.',
+    ad: baseAd,
+    isPlus: true,
+  },
+];
+
+export const UseCases: StoryObj = {
+  name: '6. Use cases',
+  render: () => (
+    <Page>
+      {useCases.map((useCase) => (
+        <AdProviders key={useCase.title} isPlus={useCase.isPlus}>
+          <Section title={useCase.title} description={useCase.description}>
+            <ArmRow
+              className="max-w-[24rem]"
+              overrides={useCase.overrides}
+              render={() => <AdGrid ad={useCase.ad} {...feedProps} />}
+            />
+          </Section>
+        </AdProviders>
+      ))}
+    </Page>
+  ),
+};
+
+export const ControlOnly: StoryObj = {
+  name: 'Reference — control, every surface',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="Today's production look"
+          description="Every ad surface as it renders on main, with the flag at its default."
+        >
+          <div className="flex flex-wrap items-start gap-8">
+            <div className="w-full max-w-[24rem]">
+              <AdGrid ad={baseAd} {...feedProps} />
+            </div>
+            <div className="w-full max-w-[40rem]">
+              <AdList ad={baseAd} {...feedProps} />
+            </div>
+            <div className="w-full max-w-[30rem]">
+              <SignalAdList ad={baseAd} {...feedProps} />
+            </div>
+            <div className="w-full max-w-[22rem]">
+              <PostSidebarAdWidget postId={SIDEBAR_POST_ID} />
+            </div>
+            <div className="w-full max-w-[26rem]">
+              <PostSidebarAdWidget postId={SIDEBAR_POST_ID} variant="inline" />
+            </div>
+            <div className="w-full max-w-[36rem]">
+              <AdAsComment postId={COMMENT_POST_ID} />
+            </div>
+          </div>
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};
+
+export const Treatment: StoryObj = {
+  name: 'Reference — variant B, every surface',
+  render: () => (
+    <AdProviders>
+      <Page>
+        <Section
+          title="ad_only, every surface"
+          description="The strictest arm: advertiser hidden behind a plain 'Ad', no advertise link on the feed cards."
+        >
+          <Arm arm={arms[2]} className="max-w-none">
+            <div className="flex flex-wrap items-start gap-8">
+              <div className="w-full max-w-[24rem]">
+                <AdGrid ad={baseAd} {...feedProps} />
+              </div>
+              <div className="w-full max-w-[40rem]">
+                <AdList ad={baseAd} {...feedProps} />
+              </div>
+              <div className="w-full max-w-[30rem]">
+                <SignalAdList ad={baseAd} {...feedProps} />
+              </div>
+              <div className="w-full max-w-[22rem]">
+                <PostSidebarAdWidget postId={SIDEBAR_POST_ID} />
+              </div>
+              <div className="w-full max-w-[26rem]">
+                <PostSidebarAdWidget
+                  postId={SIDEBAR_POST_ID}
+                  variant="inline"
+                />
+              </div>
+              <div className="w-full max-w-[36rem]">
+                <AdAsComment postId={COMMENT_POST_ID} />
+              </div>
+            </div>
+          </Arm>
+        </Section>
+      </Page>
+    </AdProviders>
+  ),
+};

--- a/packages/storybook/stories/experiments/adLabel.mocks.tsx
+++ b/packages/storybook/stories/experiments/adLabel.mocks.tsx
@@ -1,0 +1,277 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useMemo } from 'react';
+import classNames from 'classnames';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { AuthContextProvider } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
+import { ActiveFeedContext } from '@dailydotdev/shared/src/contexts';
+import SettingsContext from '@dailydotdev/shared/src/contexts/SettingsContext';
+import {
+  generateQueryKey,
+  RequestKey,
+} from '@dailydotdev/shared/src/lib/query';
+import type { Ad } from '@dailydotdev/shared/src/graphql/posts';
+import {
+  adImprovementsV3Feature,
+  AdLabelVariant,
+  featureAdLabel,
+  featureAutorotateAds,
+  featureFeedCardGlassActions,
+} from '@dailydotdev/shared/src/lib/featureManagement';
+import { FeatureOverrides } from '../../mock/GrowthBookProvider';
+
+export const noop = (): void => undefined;
+
+// `providers` is what makes AuthContext treat this as a signed-in user.
+const user = { id: 'sb-user', name: 'Dev Dana', providers: ['github'] };
+
+// Feed cards read layout settings through SettingsContext, which defaults to
+// null outside the app shell.
+const settings = {
+  insaneMode: false,
+  spaciness: 'roomy',
+  loadedSettings: true,
+  openNewTab: false,
+};
+
+/** Both ad widgets read their ad from the query cache, keyed by post id. */
+export const SIDEBAR_POST_ID = 'sb-post-sidebar';
+export const COMMENT_POST_ID = 'sb-post-comment';
+
+// ---------------------------------------------------------------------------
+// Ad fixtures — one per use case a reviewer needs to see.
+// ---------------------------------------------------------------------------
+
+export const baseAd: Ad = {
+  company: 'Vercel',
+  source: 'Vercel',
+  tagLine: 'Deploy without the ops.',
+  description:
+    'Ship your Next.js app in seconds. Zero-config deploys, preview URLs on every push.',
+  image:
+    'https://media.daily.dev/image/upload/v1675852969/squads/c0457b66-e89b-4fc0-b06d-48f920c7caa2.jpg',
+  link: 'https://vercel.com',
+  referralLink: 'https://vercel.com',
+  companyLogo: 'https://svgl.app/library/vercel.svg',
+  callToAction: 'Start deploying',
+  adDomain: 'vercel.com',
+  providerId: 'sb-provider',
+};
+
+export const noCtaAd: Ad = { ...baseAd, callToAction: undefined };
+
+/** No referral link — control says a bare "Promoted", with no advertiser. */
+export const noReferralAd: Ad = { ...baseAd, referralLink: undefined };
+
+/** Carbon and EthicalAds creatives render contained over a blurred backdrop. */
+export const carbonAd: Ad = {
+  ...baseAd,
+  company: 'Carbon',
+  source: 'Carbon',
+  companyLogo: undefined,
+  description:
+    'A network-served creative that keeps its original aspect ratio.',
+};
+
+export const longCopyAd: Ad = {
+  ...baseAd,
+  description:
+    'Observability for teams that ship daily: distributed tracing, log search, RUM and synthetic checks in one place, with alerts that route to the on-call engineer who owns the service.',
+};
+
+export const taggedAd: Ad = {
+  ...baseAd,
+  matchingTags: ['nextjs', 'react', 'devops', 'webdev'],
+};
+
+// ---------------------------------------------------------------------------
+// Providers
+// ---------------------------------------------------------------------------
+
+interface AdProvidersProps {
+  children: ReactNode;
+  /** Plus subscribers never see the "Remove" upsell. */
+  isPlus?: boolean;
+  /** Ad served to `PostSidebarAdWidget` / `AdAsComment` via the query cache. */
+  widgetAd?: Ad;
+}
+
+export const AdProviders = ({
+  children,
+  isPlus = false,
+  widgetAd = baseAd,
+}: AdProvidersProps): ReactElement => {
+  const LogContext = getLogContextStatic();
+  const queryClient = useMemo(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false, refetchOnWindowFocus: false },
+      },
+    });
+
+    // Seeded for both the signed-in and anonymous key, so the widgets read
+    // their ad from the cache instead of hitting the (unmocked) ad server.
+    [user, undefined].forEach((keyUser) => {
+      client.setQueryData(
+        generateQueryKey(
+          RequestKey.Ads,
+          keyUser,
+          SIDEBAR_POST_ID,
+          'post-sidebar',
+        ),
+        widgetAd,
+      );
+      client.setQueryData(
+        generateQueryKey(RequestKey.Ads, keyUser, COMMENT_POST_ID),
+        widgetAd,
+      );
+    });
+
+    return client;
+  }, [widgetAd]);
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <AuthContextProvider
+        user={{ ...user, isPlus } as never}
+        firstLoad={false}
+        isFetched
+        loadingUser={false}
+        tokenRefreshed
+        loadedUserFromCache
+        getRedirectUri={() => ''}
+        updateUser={noop as never}
+        refetchBoot={noop as never}
+        visit={{ visitId: 'sb', sessionId: 'sb' } as never}
+        accessToken={null as never}
+        squads={[]}
+        feeds={undefined}
+        geo={{} as never}
+        isAndroidApp={false}
+      >
+        <LogContext.Provider
+          value={{
+            logEvent: noop,
+            logEventStart: noop,
+            logEventEnd: noop,
+            sendBeacon: noop,
+          }}
+        >
+          <SettingsContext.Provider value={settings as never}>
+            <ActiveFeedContext.Provider value={{ items: [], queryKey: ['sb'] }}>
+              {children}
+            </ActiveFeedContext.Provider>
+          </SettingsContext.Provider>
+        </LogContext.Provider>
+      </AuthContextProvider>
+    </QueryClientProvider>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Experiment arms
+// ---------------------------------------------------------------------------
+
+export interface ArmConfig {
+  variant: AdLabelVariant;
+  name: string;
+  summary: string;
+}
+
+export const arms: ArmConfig[] = [
+  {
+    variant: AdLabelVariant.Control,
+    name: 'Control',
+    summary: '"Promoted by {advertiser}" + "Advertise here"',
+  },
+  {
+    variant: AdLabelVariant.Ad,
+    name: 'Variant A — ad',
+    summary: 'Advertiser hidden, disclosed as "Ad". "Advertise here" stays.',
+  },
+  {
+    variant: AdLabelVariant.AdOnly,
+    name: 'Variant B — ad_only',
+    summary: 'Advertiser hidden, disclosed as "Ad". "Advertise here" removed.',
+  },
+];
+
+// `control` is the blanket mock value for every flag, which would leave
+// autorotation on a NaN timer and force the v3 tag row on. Pin the flags that
+// change the ad card to their production defaults, so only `ad_label` differs.
+const baseOverrides: Record<string, unknown> = {
+  [featureAutorotateAds.id]: 0,
+  [adImprovementsV3Feature.id]: false,
+  [featureFeedCardGlassActions.id]: false,
+};
+
+interface ArmProps {
+  arm: ArmConfig;
+  className?: string;
+  /** Extra flags to pin for this column, e.g. glass actions or v3 tags. */
+  overrides?: Record<string, unknown>;
+  children: ReactNode;
+}
+
+export const Arm = ({
+  arm,
+  className,
+  overrides,
+  children,
+}: ArmProps): ReactElement => (
+  <div className={classNames('flex w-full flex-col gap-3', className)}>
+    <div className="flex flex-col gap-1">
+      <span className="font-bold typo-callout">{arm.name}</span>
+      <code className="text-text-tertiary typo-footnote">
+        ad_label = {arm.variant}
+      </code>
+      <span className="text-text-tertiary typo-footnote">{arm.summary}</span>
+    </div>
+    <FeatureOverrides
+      values={{
+        ...baseOverrides,
+        ...overrides,
+        [featureAdLabel.id]: arm.variant,
+      }}
+    >
+      {children}
+    </FeatureOverrides>
+  </div>
+);
+
+interface SectionProps {
+  title: string;
+  description?: ReactNode;
+  note?: ReactNode;
+  children: ReactNode;
+}
+
+export const Section = ({
+  title,
+  description,
+  note,
+  children,
+}: SectionProps): ReactElement => (
+  <section className="flex flex-col gap-4">
+    <div className="flex flex-col gap-1">
+      <h2 className="font-bold typo-title3">{title}</h2>
+      {description && (
+        <p className="max-w-[48rem] text-text-tertiary typo-callout">
+          {description}
+        </p>
+      )}
+      {note && (
+        <p className="max-w-[48rem] rounded-8 border border-border-subtlest-tertiary p-3 text-text-tertiary typo-footnote">
+          {note}
+        </p>
+      )}
+    </div>
+    {children}
+  </section>
+);
+
+export const Page = ({ children }: { children: ReactNode }): ReactElement => (
+  <div className="flex flex-col gap-10 bg-background-default p-6 text-text-primary">
+    {children}
+  </div>
+);


### PR DESCRIPTION
Ad cards name the advertiser under the creative ("Promoted by Vercel") and carry an "Advertise here" self-promo. This experiment hides the advertiser and discloses with a plain "Ad" instead, to measure what the disclosure wording does to ad CTR.

## Flag

`ad_label` (string) — default `control`, so nothing changes until GrowthBook ramps it.

| Arm | Attribution | "Advertise here" |
| --- | --- | --- |
| `control` | Promoted by {advertiser} | shown |
| `ad` | Ad | shown |
| `ad_only` | Ad | removed from the feed cards |

## Measurement

No new instrumentation. The cards already emit the impression and click events built by `adLogEvent` with `target_type: "ad"`, so CTR = ad clicks / ad impressions split by arm. Guardrails: revenue per mille, and the `advertise here cta` click rate that `ad_only` removes.

## Scope

The label swap lives in the shared `AdAttribution`, so it also covers the signal card and the post sidebar widget. The "Advertise here" removal is scoped to `AdGrid`/`AdList`, where CTR is measured.

Three gaps are deliberate and left for a follow-up once the direction is picked:

- `AdAsComment` builds its own "Promoted by {source}" string instead of using `AdAttribution`, so the flag does not reach it.
- The signal card and sidebar widget print `ad.company` separately, so the advertiser is still named there.
- The advertiser logo renders in every arm. Dropping it too would be a stronger "de-brand the ad" test.

## Review

Storybook → Experiments → Ad label. Nine stories render every ad surface and card use case (no CTA, no referral link, network creative, long copy, matching tags, Plus subscriber) with all three arms side by side, plus an experiment brief and control/treatment reference pages.

Per-arm rendering needed a `FeatureOverrides` provider in the Storybook GrowthBook mock; the `useConditionalFeature` mock now reads the same overrides and is aliased like the provider, falling back to each flag's own default so existing stories are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-ad-label-experiment.preview.app.daily.dev