### PR TITLE
feat: unified view logging – track article views on post open

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -1310,6 +1310,14 @@ describe('Feed logged in', () => {
       },
     }));
 
+    // Opening the post modal now logs a view for every post type (previously
+    // only some types tracked here); the `pmid` query param above opens the
+    // modal on mount, so this must be registered before render.
+    nock('http://localhost:3000')
+      .post('/graphql', (body: { query?: string }) =>
+        Boolean(body.query?.includes('mutation ViewPost(')),
+      )
+      .reply(200, { data: { viewPost: { _: true } } });
     renderComponent();
     await waitForNock();
     const [first] = await screen.findAllByLabelText('Comments');
@@ -1414,6 +1422,23 @@ describe('Feed logged in', () => {
     });
 
     const [firstPost, secondPost] = defaultFeedPage.edges;
+    // Opening the post modal now logs a view for every post type; the
+    // `pmid` query param above opens the modal on mount, and this test then
+    // navigates through three different post/id combinations, so mock
+    // persistently (registered before render) rather than one-off per post.
+    // Counts calls so the test can wait for the final navigation's view to
+    // actually fire before finishing — otherwise the request can resolve
+    // after this test ends and spuriously fail an unrelated later test.
+    let viewPostCallCount = 0;
+    nock('http://localhost:3000')
+      .persist()
+      .post('/graphql', (body: { query?: string }) =>
+        Boolean(body.query?.includes('mutation ViewPost(')),
+      )
+      .reply(200, () => {
+        viewPostCallCount += 1;
+        return { data: { viewPost: { _: true } } };
+      });
     renderComponent();
     await waitForNock();
 
@@ -1441,9 +1466,24 @@ describe('Feed logged in', () => {
     fireEvent.click(previous);
     const firstTitle = await screen.findByTestId('post-modal-title');
     expect(firstTitle).toHaveTextContent(getPostTitle(firstPost.node, 'first'));
+
+    await waitFor(() => expect(viewPostCallCount).toBe(3));
   });
 
   it('should report irrelevant tags', async () => {
+    // The two preceding tests set a `pmid` router query to drive their own
+    // post-modal navigation, and `jest.clearAllMocks()` in `beforeEach` does
+    // not reset a `mockImplementation`. Reset it here so this test doesn't
+    // inherit that `pmid` and inadvertently auto-open the post modal (which,
+    // now that opening a post logs a view for every type, would otherwise
+    // fire an unmocked `viewPost` mutation).
+    jest.mocked(useRouter).mockImplementation(
+      () =>
+        ({
+          pathname: '/',
+          query: {},
+        } as unknown as NextRouter),
+    );
     let mutationCalled = false;
     renderComponent([
       createFeedMock({
@@ -1501,6 +1541,15 @@ describe('Feed logged in', () => {
   });
 
   it('should keep selected irrelevant tags when reason changes', async () => {
+    // See comment in the preceding test: reset the router mock so this test
+    // doesn't inherit a leftover `pmid` query and auto-open the post modal.
+    jest.mocked(useRouter).mockImplementation(
+      () =>
+        ({
+          pathname: '/',
+          query: {},
+        } as unknown as NextRouter),
+    );
     renderComponent([
       createFeedMock({
         pageInfo: defaultFeedPage.pageInfo,

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -134,7 +134,7 @@ export function PostContentRaw({
     hideSubscribeAction,
   };
 
-  useTrackPostView({ post, shouldTrack: isVideoType });
+  useTrackPostView({ post });
 
   const postMainColumn = (
     <PostContainer

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -69,13 +69,6 @@ const PostCodeSnippets = dynamic(() =>
 
 export type FocusCardLeftVariant = 'lean' | 'rich';
 
-const viewTrackedPostTypes = [
-  PostType.Share,
-  PostType.Collection,
-  PostType.Freeform,
-  PostType.Welcome,
-];
-
 interface PostFocusCardProps {
   post: Post;
   origin: PostOrigin;
@@ -289,10 +282,7 @@ export const PostFocusCard = ({
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
   const readHref = getReadArticleHref(post);
 
-  useTrackPostView({
-    post,
-    shouldTrack: isVideoPost(post) || viewTrackedPostTypes.includes(post.type),
-  });
+  useTrackPostView({ post });
 
   useEffect(() => {
     if (!isVideoType || isVideoExpanded) {

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -278,6 +278,17 @@ function renderPost(
       },
       result: () => ({ data: { _: true } }),
     },
+    // Opening any post (including articles) now logs a view on mount; tests
+    // that don't assert on this explicitly still need it mocked so the
+    // mutation doesn't fire an unmatched request against nock. Registered
+    // last so a test-supplied `mocks` entry for the same request wins.
+    {
+      request: {
+        query: VIEW_POST_MUTATION,
+        variables: { id: defaultProps.id },
+      },
+      result: () => ({ data: { viewPost: { _: true } } }),
+    },
   ];
 
   defaultMocks.forEach(mockGraphQL);
@@ -1034,6 +1045,39 @@ describe('article', () => {
         event_name: 'article page view',
       }),
     );
+  });
+
+  // Unified view logging: opening an article now logs a view on mount too,
+  // matching every other post type, rather than only on "Read article" click.
+  it('should log post view on mount', async () => {
+    let viewPostMutationCalled = false;
+    renderPost({}, [
+      createPostMock(),
+      createCommentsMock(),
+      {
+        request: {
+          query: VIEW_POST_MUTATION,
+          variables: {
+            id: '0e4005b2d3cf191f8c44c2718a457a1e',
+          },
+        },
+        result: () => {
+          viewPostMutationCalled = true;
+
+          return {
+            data: {
+              viewPost: {
+                _: true,
+              },
+            },
+          };
+        },
+      },
+    ]);
+
+    await waitFor(() => {
+      expect(viewPostMutationCalled).toBe(true);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- **Before**: opening an article's post page or modal did not count toward reading streaks/reading days — a view was only recorded server-side when the reader clicked "Read article" (the `api.daily.dev/r/:postId` link). Every other post type (freeform, welcome, share, collection, brief, digest, poll, social:twitter) already logged a view as soon as the page/modal opened.
- **After**: opening an article's post page or modal now logs a view too, via the same `viewPost` mutation (`useTrackPostView` / `useViewPost`) every other post type already uses. `PostContent.tsx` and `PostFocusCard.tsx` (the layout_v2 focus card) now call `useTrackPostView({ post })` unconditionally instead of gating on `isVideoType` / a hardcoded `viewTrackedPostTypes` list, which is now dead code and removed.
- This pairs with the companion backend PR dailydotdev/daily-api#4026: the backend does a server-side week-window dedup between the "opened post" view and the "clicked read article" view, so this change does not double-count reading streaks/reading days for millions of developers reading articles. No deploy-order constraint between the two PRs.
- No feature flag — this ships directly to everyone.

## Changes

- `packages/shared/src/components/post/PostContent.tsx`: `useTrackPostView({ post, shouldTrack: isVideoType })` → `useTrackPostView({ post })`. `isVideoType` is still used elsewhere in the file (layout/metadata), so it's untouched otherwise.
- `packages/shared/src/components/post/focus/PostFocusCard.tsx`: same change, plus deletion of the now-unused `viewTrackedPostTypes` array. `isVideoPost` and `PostType` are still used elsewhere in the file, so their imports are unchanged.
- Test updates (webapp `PostPage.tsx` spec, shared `Feed.spec.tsx`): added/adjusted `viewPost` mutation mocks now that opening an article's post page/modal fires that mutation. Added an explicit "should log post view on mount" test for articles in `PostPage.tsx`, mirroring the existing collection-type test. Also hardened two `Feed.spec.tsx` tests that were silently inheriting a leftover `pmid` router-mock query from a preceding test (a pre-existing test-isolation gap that only started mattering once articles began tracking views too).

## Test plan

- [x] `node ./scripts/typecheck-strict-changed.js` — passes on all changed files.
- [x] `NODE_ENV=test pnpm --filter shared test` — 2001/2004 pass. The 3 failures (`src/lib/numberFormat.spec.ts`, locale-formatting comma-vs-period) are pre-existing on `origin/main` and unrelated to this change (verified via `git stash`).
- [x] `NODE_ENV=test pnpm --filter webapp test` — 298/298 pass.
- [x] `eslint` on all changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-unified-post-view-logging.preview.app.daily.dev
