### PR TITLE
fix: link collection source avatars, and fix profile horizontal strips

### DIFF
--- a/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionGrid.spec.tsx
@@ -134,6 +134,27 @@ it('should display the collection source stack in the header', async () => {
   await screen.findByAltText('Avatar of src2');
 });
 
+it('should link each source in the stack to its source page', async () => {
+  renderComponent({
+    post: {
+      ...post,
+      collectionSources: [
+        {
+          id: 'src1',
+          handle: 'src1',
+          name: 'Source One',
+          image: 'https://daily.dev/src1.png',
+          permalink: 'https://daily.dev/sources/src1',
+        },
+      ],
+      numCollectionSources: 1,
+    } as Post,
+  });
+  const link = await screen.findByLabelText('Go to Source One');
+  expect(link).toHaveAttribute('href', 'https://daily.dev/sources/src1');
+  expect(link).toContainElement(screen.getByAltText('Avatar of src1'));
+});
+
 it('should show options button on hover when in laptop size', async () => {
   renderComponent();
   const header = await screen.findByLabelText('Options');

--- a/packages/shared/src/components/post/collection/CollectionPillSources.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPillSources.tsx
@@ -2,8 +2,8 @@ import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import { Pill } from '../../Pill';
-import type { SourceAvatarProps } from '../../profile/source';
-import { SourceAvatar } from '../../profile/source';
+import type { LinkableSource } from '../../profile/source/SourceAvatarLink';
+import { SourceAvatarLink } from '../../profile/source/SourceAvatarLink';
 import { ProfilePictureGroup } from '../../ProfilePictureGroup';
 import { ProfileImageSize } from '../../ProfilePicture';
 
@@ -12,7 +12,7 @@ interface CollectionPillSourcesProps {
     main?: string;
     avatar?: string;
   };
-  sources: SourceAvatarProps['source'][];
+  sources: LinkableSource[];
   alwaysShowSources?: boolean;
   totalSources: number;
   size?: ProfileImageSize;
@@ -49,8 +49,8 @@ export const CollectionPillSources = ({
           limit={limit}
         >
           {sources.map((source) => (
-            <SourceAvatar
-              className={classNames(
+            <SourceAvatarLink
+              avatarClassName={classNames(
                 '-my-0.5 !mr-0 box-content border-2 border-background-default',
                 className?.avatar,
               )}

--- a/packages/shared/src/components/post/collection/CollectionSourceStack.tsx
+++ b/packages/shared/src/components/post/collection/CollectionSourceStack.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import dynamic from 'next/dynamic';
-import { SourceAvatar } from '../../profile/source/SourceAvatar';
+import { SourceAvatarLink } from '../../profile/source/SourceAvatarLink';
 import { ProfileImageSize, sizeClasses } from '../../ProfilePicture';
 import HoverCard from '../../cards/common/HoverCard';
 import type { SourceTooltip } from '../../../graphql/sources';
@@ -139,16 +139,13 @@ export const CollectionSourceStack = ({
       {shown.map((source, index) =>
         withHoverCard(
           source,
-          <div
+          <SourceAvatarLink
             style={{ ...circleStyle(index), zIndex: shown.length - index }}
             className={classNames('relative rounded-full', marginClass)}
-          >
-            <SourceAvatar
-              className="!mr-0 box-content ring-2 ring-background-default"
-              source={source}
-              size={size}
-            />
-          </div>,
+            avatarClassName="!mr-0 box-content ring-2 ring-background-default"
+            source={source}
+            size={size}
+          />,
         ),
       )}
       {remaining > 0 && (

--- a/packages/shared/src/components/profile/source/SourceAvatarLink.tsx
+++ b/packages/shared/src/components/profile/source/SourceAvatarLink.tsx
@@ -1,0 +1,61 @@
+import type { AnchorHTMLAttributes, ReactElement, Ref } from 'react';
+import React, { forwardRef } from 'react';
+import classNames from 'classnames';
+import Link from '../../utilities/Link';
+import { SourceAvatar } from './SourceAvatar';
+import type { Source } from '../../../graphql/sources';
+import { ProfileImageSize } from '../../ProfilePicture';
+
+export type LinkableSource = Pick<Source, 'image' | 'handle'> &
+  Partial<Pick<Source, 'name' | 'permalink'>>;
+
+export interface SourceAvatarLinkProps
+  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  source: LinkableSource;
+  size?: ProfileImageSize;
+  avatarClassName?: string;
+  ref?: Ref<HTMLAnchorElement>;
+}
+
+/**
+ * A source avatar that navigates to the source (or squad) page, matching the
+ * behavior of the single source avatar on article cards. Falls back to a bare
+ * avatar when the query that produced the source did not select `permalink`.
+ */
+function SourceAvatarLinkComponent(
+  {
+    source,
+    size = ProfileImageSize.Medium,
+    className,
+    avatarClassName,
+    ...props
+  }: SourceAvatarLinkProps,
+  ref?: Ref<HTMLAnchorElement>,
+): ReactElement {
+  const avatar = (
+    <SourceAvatar className={avatarClassName} source={source} size={size} />
+  );
+
+  if (!source?.permalink) {
+    return (
+      <span {...props} className={classNames('flex', className)}>
+        {avatar}
+      </span>
+    );
+  }
+
+  return (
+    <Link href={source.permalink} passHref prefetch={false}>
+      <a
+        {...props}
+        ref={ref}
+        aria-label={`Go to ${source.name ?? source.handle}`}
+        className={classNames('pointer-events-auto flex', className)}
+      >
+        {avatar}
+      </a>
+    </Link>
+  );
+}
+
+export const SourceAvatarLink = forwardRef(SourceAvatarLinkComponent);

--- a/packages/shared/src/components/profile/source/SourceAvatarLink.tsx
+++ b/packages/shared/src/components/profile/source/SourceAvatarLink.tsx
@@ -1,4 +1,4 @@
-import type { AnchorHTMLAttributes, ReactElement, Ref } from 'react';
+import type { HTMLAttributes, ReactElement, Ref } from 'react';
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import Link from '../../utilities/Link';
@@ -9,12 +9,10 @@ import { ProfileImageSize } from '../../ProfilePicture';
 export type LinkableSource = Pick<Source, 'image' | 'handle'> &
   Partial<Pick<Source, 'name' | 'permalink'>>;
 
-export interface SourceAvatarLinkProps
-  extends Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+export interface SourceAvatarLinkProps extends HTMLAttributes<HTMLElement> {
   source: LinkableSource;
   size?: ProfileImageSize;
   avatarClassName?: string;
-  ref?: Ref<HTMLAnchorElement>;
 }
 
 /**
@@ -36,9 +34,17 @@ function SourceAvatarLinkComponent(
     <SourceAvatar className={avatarClassName} source={source} size={size} />
   );
 
+  // No permalink means nothing to link to, but the ref still has to reach a DOM
+  // node: Radix's hover card trigger composes one onto this component and never
+  // opens without it. A span (not an href-less anchor) also keeps the click
+  // falling through to the card link, since `.card a` gets pointer-events: all.
   if (!source?.permalink) {
     return (
-      <span {...props} className={classNames('flex', className)}>
+      <span
+        {...props}
+        ref={ref as Ref<HTMLSpanElement>}
+        className={classNames('flex', className)}
+      >
         {avatar}
       </span>
     );

--- a/packages/shared/src/features/profile/common.ts
+++ b/packages/shared/src/features/profile/common.ts
@@ -1,3 +1,12 @@
+/**
+ * The profile page wraps every section in `p-6`, so a horizontally scrolling
+ * strip clips 24px short of the page edge — the content looks abruptly cut off
+ * instead of continuing off-screen. Cancel that padding on the scroll container
+ * and re-apply it inside, so the strip clips at the card edge while its items
+ * stay aligned with the section heading.
+ */
+export const profileStripBleed = '-mx-6 px-6';
+
 export const profileSecondaryFieldStyles = {
   outerLabel: '!px-0 !typo-callout',
   baseField: '!h-12',

--- a/packages/shared/src/features/profile/components/Activity.helpers.tsx
+++ b/packages/shared/src/features/profile/components/Activity.helpers.tsx
@@ -70,8 +70,11 @@ export const MIN_ITEMS_FOR_SHOW_MORE = 3;
 // The bleed classes are the `profileStripBleed` pair scoped to the feed's own
 // scroll container, so the strip clips at the card edge rather than 24px short
 // of it. `scroll-px-6` keeps snapped cards aligned with the section heading.
+// They match on `.grid.snap-x` (only FeedContainer's horizontal scroller has
+// both) rather than plain `.grid`: a bare `grid` class also appears inside list
+// cards, and margins there would visibly break them.
 export const HORIZONTAL_FEED_CLASSES =
-  '[&_.grid]:!auto-cols-[17rem] tablet:[&_.grid]:!auto-cols-[20rem] [&_.grid]:gap-4 [&_.grid]:-mx-6 [&_.grid]:px-6 [&_.grid]:scroll-px-6';
+  '[&_.grid]:!auto-cols-[17rem] tablet:[&_.grid]:!auto-cols-[20rem] [&_.grid]:gap-4 [&_.grid.snap-x]:-mx-6 [&_.grid.snap-x]:px-6 [&_.grid.snap-x]:scroll-px-6';
 export const TAB_ITEMS = activityTabs.map((tab) => ({ label: tab.title }));
 
 export const ACTIVITY_QUERY_KEYS = {

--- a/packages/shared/src/features/profile/components/Activity.helpers.tsx
+++ b/packages/shared/src/features/profile/components/Activity.helpers.tsx
@@ -67,8 +67,11 @@ export const COMMENT_CLASS_NAME = {
 } as const;
 
 export const MIN_ITEMS_FOR_SHOW_MORE = 3;
+// The bleed classes are the `profileStripBleed` pair scoped to the feed's own
+// scroll container, so the strip clips at the card edge rather than 24px short
+// of it. `scroll-px-6` keeps snapped cards aligned with the section heading.
 export const HORIZONTAL_FEED_CLASSES =
-  '[&_.grid]:!auto-cols-[17rem] tablet:[&_.grid]:!auto-cols-[20rem] [&_.grid]:gap-4';
+  '[&_.grid]:!auto-cols-[17rem] tablet:[&_.grid]:!auto-cols-[20rem] [&_.grid]:gap-4 [&_.grid]:-mx-6 [&_.grid]:px-6 [&_.grid]:scroll-px-6';
 export const TAB_ITEMS = activityTabs.map((tab) => ({ label: tab.title }));
 
 export const ACTIVITY_QUERY_KEYS = {

--- a/packages/shared/src/features/profile/components/Activity.tsx
+++ b/packages/shared/src/features/profile/components/Activity.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useContext, useState, useMemo, useCallback } from 'react';
+import classNames from 'classnames';
 import type { PublicProfile } from '../../../lib/user';
 import AuthContext from '../../../contexts/AuthContext';
 import { ActivityTabIndex, activityTabs } from './Activity.helpers';
@@ -71,9 +72,18 @@ export const Activity = ({ user }: ActivityProps): ReactElement | null => {
   }
 
   return (
-    // No overflow guard here: the feed grid scrolls itself and bleeds past this
-    // box to the card edge (see HORIZONTAL_FEED_CLASSES), so clipping at the
-    // section's padding would cut the strip short of the page edge again.
-    <div className="mb-4 flex flex-col gap-3 pt-6">{renderContent()}</div>
+    <div
+      className={classNames(
+        'mb-4 flex flex-col gap-3 pt-6',
+        // The posts/upvoted feeds scroll themselves and bleed past this box to
+        // the card edge (see HORIZONTAL_FEED_CLASSES), so clipping here would
+        // cut them short of the page edge again. Replies are plain content with
+        // no scroller of their own, so they keep a guard against wide markdown
+        // widening the page. `clip` over `hidden` so popovers still escape on y.
+        selectedTabIndex === ActivityTabIndex.Replies && 'overflow-x-clip',
+      )}
+    >
+      {renderContent()}
+    </div>
   );
 };

--- a/packages/shared/src/features/profile/components/Activity.tsx
+++ b/packages/shared/src/features/profile/components/Activity.tsx
@@ -71,8 +71,9 @@ export const Activity = ({ user }: ActivityProps): ReactElement | null => {
   }
 
   return (
-    <div className="mb-4 flex flex-col gap-3 overflow-hidden pt-6">
-      {renderContent()}
-    </div>
+    // No overflow guard here: the feed grid scrolls itself and bleeds past this
+    // box to the card edge (see HORIZONTAL_FEED_CLASSES), so clipping at the
+    // section's padding would cut the strip short of the page edge again.
+    <div className="mb-4 flex flex-col gap-3 pt-6">{renderContent()}</div>
   );
 };

--- a/packages/shared/src/features/profile/components/ProfileWidgets/ProfileWidgets.tsx
+++ b/packages/shared/src/features/profile/components/ProfileWidgets/ProfileWidgets.tsx
@@ -23,6 +23,7 @@ import { useConditionalFeature } from '../../../../hooks/useConditionalFeature';
 import { achievementTrackingWidgetFeature } from '../../../../lib/featureManagement';
 import { useProfileAchievements } from '../../../../hooks/profile/useProfileAchievements';
 import { shouldShowAchievementTracker } from '../../../../lib/achievements';
+import { profileStripBleed } from '../../common';
 
 const BadgesAndAwards = dynamic(() =>
   import('./BadgesAndAwards').then((mod) => mod.BadgesAndAwards),
@@ -110,7 +111,12 @@ export function ProfileWidgets({
   return (
     <div
       className={classNames(
+        // Below laptop this is the profile page's scrolling "Highlights" strip,
+        // so it bleeds past the page's p-6 to clip at the card edge. At laptop
+        // it becomes the sidebar column and sits inside the padding again.
         'my-4 flex gap-2 laptop:my-0 laptop:flex-col',
+        profileStripBleed,
+        'laptop:mx-0 laptop:px-0',
         className,
       )}
     >

--- a/packages/shared/src/features/profile/components/achievements/ProfileAchievementShowcase.tsx
+++ b/packages/shared/src/features/profile/components/achievements/ProfileAchievementShowcase.tsx
@@ -66,7 +66,7 @@ export function ProfileAchievementShowcase({
   }
 
   return (
-    <div className="flex flex-col gap-4 py-4">
+    <div className="flex min-w-0 flex-col gap-4 py-4">
       <div className="flex items-center justify-between">
         <Typography
           type={TypographyType.Body}
@@ -88,7 +88,9 @@ export function ProfileAchievementShowcase({
       </div>
 
       {hasShowcase ? (
-        <div className="flex gap-3">
+        // negative margins cancel the padding that keeps the rarity glow and
+        // sparkles from being clipped by the scroll container
+        <div className="no-scrollbar -mx-2 -my-2 flex gap-3 overflow-x-auto px-2 py-2">
           {showcaseAchievements.map((userAchievement) => {
             const { achievement } = userAchievement;
             const rarityTier = getAchievementRarityTier(achievement.rarity);

--- a/packages/shared/src/features/profile/components/achievements/ProfileAchievementShowcase.tsx
+++ b/packages/shared/src/features/profile/components/achievements/ProfileAchievementShowcase.tsx
@@ -27,6 +27,7 @@ import { AchievementCard } from './AchievementCard';
 import { RaritySparkles } from './RaritySparkles';
 import { useLazyModal } from '../../../../hooks/useLazyModal';
 import { LazyModal } from '../../../../components/modals/common/types';
+import { profileStripBleed } from '../../common';
 
 interface ProfileAchievementShowcaseProps {
   user: PublicProfile;
@@ -88,9 +89,14 @@ export function ProfileAchievementShowcase({
       </div>
 
       {hasShowcase ? (
-        // negative margins cancel the padding that keeps the rarity glow and
-        // sparkles from being clipped by the scroll container
-        <div className="no-scrollbar -mx-2 -my-2 flex gap-3 overflow-x-auto px-2 py-2">
+        // -my-2/py-2 keeps the rarity glow and sparkles, which deliberately
+        // escape each tile, from being clipped by the scroll container
+        <div
+          className={classNames(
+            'no-scrollbar -my-2 flex gap-3 overflow-x-auto py-2',
+            profileStripBleed,
+          )}
+        >
           {showcaseAchievements.map((userAchievement) => {
             const { achievement } = userAchievement;
             const rarityTier = getAchievementRarityTier(achievement.rarity);

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -415,6 +415,8 @@ export const POST_BY_ID_QUERY = gql`
       collectionSources {
         handle
         image
+        name
+        permalink
       }
     }
     relatedCollectionPosts: relatedPosts(
@@ -502,6 +504,8 @@ export const POST_BY_ID_STATIC_FIELDS_QUERY = gql`
       collectionSources {
         handle
         image
+        name
+        permalink
       }
       sharedPost {
         ...SharedPostInfo


### PR DESCRIPTION
## Changes

Two unrelated bug fixes.

### 1. Collection/brief source avatars are not clickable

Article cards render their source avatar through `SourceButton` → `ProfileImageLink`, i.e. a real `<a href={source.permalink}>`. The collection and brief stacks rendered a bare `<img>` inside a `div`, so clicking a source circle fell through to the card's post link instead of going to the source.

- New `SourceAvatarLink` (`components/profile/source/SourceAvatarLink.tsx`) — a `forwardRef` anchor wrapping `SourceAvatar`, pointing at `source.permalink` (correct for squads too, whose permalink is `/squads/…`, not `/sources/…`). `forwardRef` is required because Radix's `HoverCard.Trigger asChild` clones it, so the existing hover cards keep working. Falls back to a bare avatar when the source has no `permalink`.
- Wired into `CollectionSourceStack` (collection grid + list cards, brief card) and `CollectionPillSources` (brief card, brief/digest post pages).
- `POST_BY_ID_QUERY` / `POST_BY_ID_STATIC_FIELDS_QUERY` only selected `collectionSources { handle image }`, so post-page avatars had no URL to link to — added `name` and `permalink`. The feed fragment already selected both.

No double navigation: the card's own link is an `absolute inset-0` sibling overlay and `Card.module.css` gives descendant anchors `z-index: 1`, so the avatar wins — the same mechanism article cards already rely on.

### 2. Achievement showcase makes the whole profile page scroll horizontally

`ProfileAchievementShowcase` rendered its tiles as a plain `flex gap-3` of `shrink-0` 64px items. A full showcase (5 tiles = 368px) is wider than the content column at mobile widths, and with nothing clipping it the overflow propagated to the document — the entire profile page scrolled sideways.

- The strip is now `no-scrollbar … overflow-x-auto` (the pattern already used by `ArchiveEntryCard`, `RelatedEntities`, `SquadsList`), plus `min-w-0` on the section root. No `overflow: hidden` anywhere on the page — only the strip scrolls.
- `overflow-x-auto` clips both axes, which would have cut the rarity glow and `RaritySparkles` that deliberately escape each tile. `px-2 py-2` gives them room and `-mx-2 -my-2` cancels it, so nothing shifts visually.

### 3. Horizontal strips clip short of the page edge

The profile page wraps every section in `p-6`, so each horizontally scrolling strip clipped 24px short of the page edge — the content read as abruptly cut off rather than continuing off-screen. Measured on the preview at 390px, all three strips ended at x=373/365 against a 390px viewport.

New `profileStripBleed` (`features/profile/common.ts`) cancels that padding and re-applies it inside the scroll container, so a strip clips at the card edge while its items stay aligned with the section heading. Applied to:

- `ProfileAchievementShowcase` — the showcase strip.
- `Activity` → `HORIZONTAL_FEED_CLASSES` — the posts/upvoted feed, scoped to the feed's own `.grid` scroll container, plus `scroll-px-6` so snapped cards still align with the heading. `Activity`'s `overflow-hidden` guard is removed: the feed grid scrolls itself, and the guard would have clipped the bleed straight back.
- `ProfileWidgets` — the mobile "Highlights" row, reset with `laptop:mx-0 laptop:px-0` because at laptop the same component is the sidebar column, not a strip.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Measured the old vs. new markup against the app's compiled CSS at 375px: the old markup gives the container a `scrollWidth` of 392 against a 375px viewport (the reported bug); the new markup stays at 375 with the strip itself scrolling (343px visible / 384px content) and the hidden scrollbar taking 0 height.

The profile page can't be loaded on a local dev server — `/joudawad` is SSG and fails on "Failed to load static props" without the backend — so the layout was verified on the preview deploy instead. Still worth a click-through on a collection card's source circles.


On the preview deploy at 390px, all three strips now span x=1→389 (the full card width) with the page itself still not scrolling horizontally (`document.scrollWidth` 390 = viewport). At 1280px the activity feed spans the card's inner edges (175→845) and the sidebar widgets are unchanged (862→1146, margin/padding 0).

- Added a `CollectionGrid` test asserting the avatar renders as an `<a href>` to the source permalink.
- `packages/shared`: 39 suites / 235 tests pass (cards + post).
- `packages/webapp`: 44 suites / 297 tests pass.
- ESLint clean; `scripts/typecheck-strict-changed.js` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://claude-source-images-achievement.preview.app.daily.dev