### PR TITLE
fix(shared): make empty feed CTAs navigable

### DIFF
--- a/packages/shared/src/components/FollowingFeedEmptyScreen.spec.tsx
+++ b/packages/shared/src/components/FollowingFeedEmptyScreen.spec.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import FollowingFeedEmptyScreen from './FollowingFeedEmptyScreen';
+
+jest.mock('../lib/constants', () => ({
+  ...jest.requireActual('../lib/constants'),
+  webappUrl: 'https://daily.dev/',
+}));
+
+describe('FollowingFeedEmptyScreen', () => {
+  it('renders the find squads and discover sources CTAs as links', () => {
+    render(<FollowingFeedEmptyScreen />);
+
+    expect(screen.getByRole('link', { name: 'Find Squads' })).toHaveAttribute(
+      'href',
+      'https://daily.dev/squads',
+    );
+    expect(
+      screen.getByRole('link', { name: 'Discover Sources' }),
+    ).toHaveAttribute('href', 'https://daily.dev/sources');
+  });
+});

--- a/packages/shared/src/components/FollowingFeedEmptyScreen.tsx
+++ b/packages/shared/src/components/FollowingFeedEmptyScreen.tsx
@@ -1,14 +1,13 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import {
-  EmptyScreenButton,
   EmptyScreenContainer,
   EmptyScreenDescription,
   EmptyScreenIcon,
   EmptyScreenTitle,
 } from './EmptyScreen';
 import { PageContainer } from './utilities';
-import { ButtonSize, ButtonVariant } from './buttons/common';
+import { Button, ButtonSize, ButtonVariant } from './buttons/Button';
 import { SquadIcon } from './icons';
 import { webappUrl } from '../lib/constants';
 import Link from './utilities/Link';
@@ -27,18 +26,20 @@ function FollowingFeedEmptyScreen(): ReactElement {
           or there is not enough content. Explore more Squads and Sources
         </EmptyScreenDescription>
         <div className="flex flex-col gap-4 tablet:flex-row">
-          <Link href={`${webappUrl}squads`}>
-            <EmptyScreenButton size={ButtonSize.Large}>
+          <Link href={`${webappUrl}squads`} passHref>
+            <Button tag="a" className="mt-10" size={ButtonSize.Large}>
               Find Squads
-            </EmptyScreenButton>
+            </Button>
           </Link>
-          <Link href={`${webappUrl}sources`}>
-            <EmptyScreenButton
+          <Link href={`${webappUrl}sources`} passHref>
+            <Button
+              tag="a"
+              className="mt-10"
               size={ButtonSize.Large}
               variant={ButtonVariant.Secondary}
             >
               Discover Sources
-            </EmptyScreenButton>
+            </Button>
           </Link>
         </div>
       </EmptyScreenContainer>

--- a/packages/shared/src/components/history/ReadingHistoryEmptyScreen.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryEmptyScreen.spec.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReadingHistoryEmptyScreen from './ReadingHistoryEmptyScreen';
+
+const originalWebappUrl = process.env.NEXT_PUBLIC_WEBAPP_URL;
+
+describe('ReadingHistoryEmptyScreen', () => {
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_WEBAPP_URL = 'https://daily.dev/';
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_WEBAPP_URL = originalWebappUrl;
+  });
+
+  it('renders the back to feed CTA as a link', () => {
+    render(<ReadingHistoryEmptyScreen />);
+
+    expect(screen.getByRole('link', { name: 'Back to feed' })).toHaveAttribute(
+      'href',
+      'https://daily.dev/',
+    );
+  });
+});

--- a/packages/shared/src/components/history/ReadingHistoryEmptyScreen.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryEmptyScreen.tsx
@@ -2,13 +2,12 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import Link from '../utilities/Link';
 import {
-  EmptyScreenButton,
   EmptyScreenDescription,
   EmptyScreenIcon,
   EmptyScreenTitle,
 } from '../EmptyScreen';
 import { EyeIcon } from '../icons';
-import { ButtonSize } from '../buttons/common';
+import { Button, ButtonSize } from '../buttons/Button';
 
 function ReadingHistoryEmptyScreen(): ReactElement {
   return (
@@ -22,10 +21,10 @@ function ReadingHistoryEmptyScreen(): ReactElement {
         Go back to your feed and read posts that spark your interest. Each post
         you read will be listed here.
       </EmptyScreenDescription>
-      <Link href={process.env.NEXT_PUBLIC_WEBAPP_URL ?? '/'}>
-        <EmptyScreenButton size={ButtonSize.Large}>
+      <Link href={process.env.NEXT_PUBLIC_WEBAPP_URL ?? '/'} passHref>
+        <Button tag="a" className="mt-10" size={ButtonSize.Large}>
           Back to feed
-        </EmptyScreenButton>
+        </Button>
       </Link>
     </div>
   );

--- a/packages/shared/src/components/opportunity/NewOpportunityPopover.tsx
+++ b/packages/shared/src/components/opportunity/NewOpportunityPopover.tsx
@@ -36,6 +36,7 @@ export const NewOpportunityPopover = (): ReactElement => {
         </Typography>
         <Link href={`${webappUrl}jobs/${alerts.opportunityId}`} passHref>
           <Button
+            tag="a"
             size={ButtonSize.XSmall}
             onClick={logOpportunityNudgeClick}
             icon={


### PR DESCRIPTION
## Summary
- Render the Following feed empty-state CTAs as real anchors with `passHref` so extension cross-origin navigation has native browser behavior.
- Apply the same Link/Button anchor fix to the Reading History empty state and opportunity popover CTA.
- Add focused shared RTL coverage for the empty-state CTA hrefs under an extension-style absolute webapp URL.

## Key decisions
- Keep `next/link` so webapp-local routes can still use client-side navigation.
- Use the existing forward-ref `Button` directly for Link-wrapped empty-state CTAs instead of changing `EmptyScreenButton` globally.

## Verification
- `git diff --check origin/main`
- Targeted shared ESLint on impacted files
- Targeted Jest specs for Following and Reading History empty screens
- `node ./scripts/typecheck-strict-changed.js`

Closes ENG-1907

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1907-feedback-bug-report-cli.preview.app.daily.dev