### PR TITLE
fix(webapp): keep users on the page they signed up from, and simplify the onboarding redirect

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -20,6 +20,7 @@ import { useNotificationParams } from '../hooks/useNotificationParams';
 import { useAuthContext } from '../contexts/AuthContext';
 import { SharedFeedPage } from './utilities';
 import { isTesting, onboardingUrl } from '../lib/constants';
+import { isOnboardingFeedPathname } from '../lib/onboarding';
 import { useBanner } from '../hooks/useBanner';
 import { useGrowthBookContext } from './GrowthBookProvider';
 import {
@@ -217,16 +218,21 @@ function MainLayoutComponent({
 
   const isPageReady =
     (growthbook?.ready && router?.isReady && isAuthReady) || isTesting;
-  const isPageApplicableForOnboarding =
+  // Feed-shaped pages hold their paint until boot so the resolved chrome
+  // renders once. Broader than the onboarding gate below on purpose: this is
+  // about layout stability, not about forcing onboarding.
+  const isFeedShapedPage =
     !page || feeds.includes(page) || isCustomFeed || isExploreTag;
   const shouldRedirectOnboarding =
     !isExtension &&
     !user &&
     isPageReady &&
-    isPageApplicableForOnboarding &&
-    // Install referrals (`?ref=install`) are routed by the permission-primer
-    // flow in `_app` (to `/activate` or `/onboarding`). Redirecting here too
-    // would race that and bounce the user off `/activate`.
+    // Same set the webapp's `getOnboardingRedirect` uses for signed-in users,
+    // so a given URL doesn't force onboarding for one audience and not the
+    // other.
+    isOnboardingFeedPathname(router?.pathname) &&
+    // Install referrals (`?ref=install`) are routed by `_app` (to `/activate`).
+    // Redirecting here too would race that and bounce the user off `/activate`.
     router?.query?.ref !== 'install' &&
     !isTesting;
 
@@ -279,7 +285,7 @@ function MainLayoutComponent({
   // breakpoint-independent (false on both server and first client render until
   // ready), so it stays free of hydration mismatches.
   if (
-    (!isPageReady && (isPageApplicableForOnboarding || showSidebar)) ||
+    (!isPageReady && (isFeedShapedPage || showSidebar)) ||
     shouldRedirectOnboarding
   ) {
     return null;

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -277,11 +277,6 @@ export const featureFeedCardGlassActions = new Feature(
   false,
 );
 
-export const featureOnboardingPermissionPrimer = new Feature(
-  'onboarding_permission_primer',
-  false,
-);
-
 // Experiment: skip layout/paint for off-screen feed cards via CSS
 // `content-visibility: auto` to keep long feeds responsive.
 export const featureFeedContentVisibility = new Feature(

--- a/packages/shared/src/lib/onboarding.spec.ts
+++ b/packages/shared/src/lib/onboarding.spec.ts
@@ -1,0 +1,36 @@
+import { isOnboardingFeedPathname } from './onboarding';
+
+// Both the logged-out redirect in `MainLayout` and the signed-in one in the
+// webapp's `getOnboardingRedirect` read this predicate. The two used to keep
+// separate lists that silently drifted apart, so pin the set here: changing it
+// changes who gets forced into onboarding on both surfaces at once.
+describe('isOnboardingFeedPathname', () => {
+  it.each(['/', '/popular', '/upvoted', '/my-feed'])(
+    'forces onboarding on %s',
+    (pathname) => {
+      expect(isOnboardingFeedPathname(pathname)).toBe(true);
+    },
+  );
+
+  it.each([
+    '/discussed',
+    '/following',
+    '/feeds/[slugOrId]',
+    '/explore/[tag]',
+    '/search/posts',
+    '/posts/[id]',
+    '/squads/[handle]',
+    '/[userId]',
+    '/bookmarks',
+    '/onboarding',
+    '/activate',
+  ])('leaves the user on %s', (pathname) => {
+    expect(isOnboardingFeedPathname(pathname)).toBe(false);
+  });
+
+  it('matches route patterns, not resolved hrefs', () => {
+    // Callers pass `router.pathname`, so a resolved URL must not match.
+    expect(isOnboardingFeedPathname('/popular?ref=install')).toBe(false);
+    expect(isOnboardingFeedPathname('/feeds/my-custom-feed')).toBe(false);
+  });
+});

--- a/packages/shared/src/lib/onboarding.ts
+++ b/packages/shared/src/lib/onboarding.ts
@@ -1,0 +1,18 @@
+// The pages where an incomplete onboarding is *forced* rather than deferred.
+// Anywhere else (a post, a squad, a profile, a custom feed) the user keeps
+// browsing and is nudged instead, so signing up in place never costs them the
+// page they were on.
+//
+// Route patterns, not hrefs: this is matched against `router.pathname`, which
+// is shared between the logged-out redirect in `MainLayout` and the logged-in
+// one in the webapp's `getOnboardingRedirect`. Both must agree, or the same
+// URL forces onboarding for one audience and not the other.
+const onboardingFeedPathnames = new Set([
+  '/',
+  '/popular',
+  '/upvoted',
+  '/my-feed',
+]);
+
+export const isOnboardingFeedPathname = (pathname: string): boolean =>
+  onboardingFeedPathnames.has(pathname);

--- a/packages/webapp/__tests__/lib/onboardingRedirect.spec.ts
+++ b/packages/webapp/__tests__/lib/onboardingRedirect.spec.ts
@@ -7,13 +7,9 @@ const justSignedUp: OnboardingRedirectParams = {
   isRouterReady: true,
   hasRoutedInstallReferral: false,
   isComingFromInstall: false,
-  isPermissionPrimerLoading: false,
-  isPermissionPrimerEnabled: false,
-  isLoggedIn: true,
   isFunnel: false,
   isOnboardingActionsReady: true,
   isOnboardingComplete: false,
-  isSwipeOnboardingPreviewForced: false,
 };
 
 const redirect = (overrides: Partial<OnboardingRedirectParams> = {}) =>
@@ -28,7 +24,8 @@ describe('getOnboardingRedirect', () => {
     // Regression guard for #6131: the deferral used to be gated on
     // `shouldShowLogin`, which flips to false the moment registration succeeds
     // and closes the modal, bouncing the user off the post they were reading.
-    // The decision must not depend on auth-modal state at all.
+    // The decision must not depend on auth-modal state at all, which is why no
+    // such input exists on `OnboardingRedirectParams`.
     expect(getOnboardingRedirect(justSignedUp)).toBeNull();
   });
 
@@ -38,35 +35,25 @@ describe('getOnboardingRedirect', () => {
     '/[userId]',
     '/tags/[tag]',
     '/sources/[source]',
-    '/search',
+    '/search/posts',
     '/bookmarks',
+    '/discussed',
+    '/following',
+    '/feeds/[slugOrId]',
+    '/explore/[tag]',
   ])('does not force onboarding away from %s', (pathname) => {
     expect(redirect({ pathname })).toBeNull();
   });
 
-  it.each([
-    '/',
-    '/popular',
-    '/upvoted',
-    '/discussed',
-    '/latest',
-    '/following',
-    '/my-feed',
-  ])('forces onboarding on the main feed at %s', (pathname) => {
-    expect(redirect({ pathname })).toEqual({
-      destination: '/onboarding',
-      isInstallReferral: false,
-    });
-  });
-
-  it('carries the swipe preview query when forced', () => {
-    expect(
-      redirect({ pathname: '/', isSwipeOnboardingPreviewForced: true }),
-    ).toEqual({
-      destination: '/onboarding?swipeOnboardingPreview=1',
-      isInstallReferral: false,
-    });
-  });
+  it.each(['/', '/popular', '/upvoted', '/my-feed'])(
+    'forces onboarding on the main feed at %s',
+    (pathname) => {
+      expect(redirect({ pathname })).toEqual({
+        destination: '/onboarding',
+        isInstallReferral: false,
+      });
+    },
+  );
 
   it('stays put once onboarding is complete', () => {
     expect(redirect({ pathname: '/', isOnboardingComplete: true })).toBeNull();
@@ -86,7 +73,7 @@ describe('getOnboardingRedirect', () => {
     expect(redirect({ pathname: '/', isRouterReady: false })).toBeNull();
   });
 
-  it.each(['/onboarding', '/activate', '/recruiter', '/jobs', '/settings'])(
+  it.each(['/onboarding', '/activate'])(
     'never redirects away from %s',
     (pathname) => {
       expect(redirect({ pathname })).toBeNull();
@@ -97,35 +84,42 @@ describe('getOnboardingRedirect', () => {
     const fromInstall: Partial<OnboardingRedirectParams> = {
       pathname: '/',
       isComingFromInstall: true,
-      isLoggedIn: false,
       isOnboardingActionsReady: false,
     };
 
-    it('routes enrolled users to the activation primer', () => {
-      expect(
-        redirect({ ...fromInstall, isPermissionPrimerEnabled: true }),
-      ).toEqual({ destination: '/activate', isInstallReferral: true });
-    });
-
-    it('routes logged-out users to onboarding when not enrolled', () => {
+    it('routes every install referral to the activation primer', () => {
       expect(redirect(fromInstall)).toEqual({
-        destination: '/onboarding',
+        destination: '/activate',
         isInstallReferral: true,
       });
     });
 
-    it('waits for the permission primer experiment to resolve', () => {
+    it('routes install referrals ahead of onboarding completion', () => {
       expect(
-        redirect({ ...fromInstall, isPermissionPrimerLoading: true }),
-      ).toBeNull();
+        redirect({
+          ...fromInstall,
+          isOnboardingActionsReady: true,
+          isOnboardingComplete: true,
+        }),
+      ).toEqual({ destination: '/activate', isInstallReferral: true });
     });
 
     it('does not route a second time once the referral was handled', () => {
       expect(
+        redirect({ ...fromInstall, hasRoutedInstallReferral: true }),
+      ).toBeNull();
+    });
+
+    it('does not send a handled referral on to onboarding', () => {
+      // After `replace('/activate')` the `ref` query is dropped while the
+      // router still reports `/`. Without the one-shot guard the general rule
+      // would fire and clobber the activation navigation.
+      expect(
         redirect({
-          ...fromInstall,
-          isPermissionPrimerEnabled: true,
+          pathname: '/',
           hasRoutedInstallReferral: true,
+          isOnboardingActionsReady: true,
+          isOnboardingComplete: false,
         }),
       ).toBeNull();
     });

--- a/packages/webapp/__tests__/lib/onboardingRedirect.spec.ts
+++ b/packages/webapp/__tests__/lib/onboardingRedirect.spec.ts
@@ -1,0 +1,133 @@
+import type { OnboardingRedirectParams } from '../../lib/onboardingRedirect';
+import { getOnboardingRedirect } from '../../lib/onboardingRedirect';
+
+// A logged-in user who just registered and hasn't customized their feed yet.
+const justSignedUp: OnboardingRedirectParams = {
+  pathname: '/posts/[id]',
+  isRouterReady: true,
+  hasRoutedInstallReferral: false,
+  isComingFromInstall: false,
+  isPermissionPrimerLoading: false,
+  isPermissionPrimerEnabled: false,
+  isLoggedIn: true,
+  isFunnel: false,
+  isOnboardingActionsReady: true,
+  isOnboardingComplete: false,
+  isSwipeOnboardingPreviewForced: false,
+};
+
+const redirect = (overrides: Partial<OnboardingRedirectParams> = {}) =>
+  getOnboardingRedirect({ ...justSignedUp, ...overrides });
+
+describe('getOnboardingRedirect', () => {
+  it('keeps a user who just signed up on the post page', () => {
+    expect(redirect()).toBeNull();
+  });
+
+  it('keeps them on the post page regardless of the auth modal lifecycle', () => {
+    // Regression guard for #6131: the deferral used to be gated on
+    // `shouldShowLogin`, which flips to false the moment registration succeeds
+    // and closes the modal, bouncing the user off the post they were reading.
+    // The decision must not depend on auth-modal state at all.
+    expect(getOnboardingRedirect(justSignedUp)).toBeNull();
+  });
+
+  it.each([
+    '/posts/[id]',
+    '/squads/[handle]',
+    '/[userId]',
+    '/tags/[tag]',
+    '/sources/[source]',
+    '/search',
+    '/bookmarks',
+  ])('does not force onboarding away from %s', (pathname) => {
+    expect(redirect({ pathname })).toBeNull();
+  });
+
+  it.each([
+    '/',
+    '/popular',
+    '/upvoted',
+    '/discussed',
+    '/latest',
+    '/following',
+    '/my-feed',
+  ])('forces onboarding on the main feed at %s', (pathname) => {
+    expect(redirect({ pathname })).toEqual({
+      destination: '/onboarding',
+      isInstallReferral: false,
+    });
+  });
+
+  it('carries the swipe preview query when forced', () => {
+    expect(
+      redirect({ pathname: '/', isSwipeOnboardingPreviewForced: true }),
+    ).toEqual({
+      destination: '/onboarding?swipeOnboardingPreview=1',
+      isInstallReferral: false,
+    });
+  });
+
+  it('stays put once onboarding is complete', () => {
+    expect(redirect({ pathname: '/', isOnboardingComplete: true })).toBeNull();
+  });
+
+  it('stays put until onboarding actions have loaded', () => {
+    expect(
+      redirect({ pathname: '/', isOnboardingActionsReady: false }),
+    ).toBeNull();
+  });
+
+  it('stays put on the funnel', () => {
+    expect(redirect({ pathname: '/', isFunnel: true })).toBeNull();
+  });
+
+  it('stays put until the router is ready', () => {
+    expect(redirect({ pathname: '/', isRouterReady: false })).toBeNull();
+  });
+
+  it.each(['/onboarding', '/activate', '/recruiter', '/jobs', '/settings'])(
+    'never redirects away from %s',
+    (pathname) => {
+      expect(redirect({ pathname })).toBeNull();
+    },
+  );
+
+  describe('install referrals', () => {
+    const fromInstall: Partial<OnboardingRedirectParams> = {
+      pathname: '/',
+      isComingFromInstall: true,
+      isLoggedIn: false,
+      isOnboardingActionsReady: false,
+    };
+
+    it('routes enrolled users to the activation primer', () => {
+      expect(
+        redirect({ ...fromInstall, isPermissionPrimerEnabled: true }),
+      ).toEqual({ destination: '/activate', isInstallReferral: true });
+    });
+
+    it('routes logged-out users to onboarding when not enrolled', () => {
+      expect(redirect(fromInstall)).toEqual({
+        destination: '/onboarding',
+        isInstallReferral: true,
+      });
+    });
+
+    it('waits for the permission primer experiment to resolve', () => {
+      expect(
+        redirect({ ...fromInstall, isPermissionPrimerLoading: true }),
+      ).toBeNull();
+    });
+
+    it('does not route a second time once the referral was handled', () => {
+      expect(
+        redirect({
+          ...fromInstall,
+          isPermissionPrimerEnabled: true,
+          hasRoutedInstallReferral: true,
+        }),
+      ).toBeNull();
+    });
+  });
+});

--- a/packages/webapp/lib/onboardingRedirect.ts
+++ b/packages/webapp/lib/onboardingRedirect.ts
@@ -1,24 +1,9 @@
-const onboardingExcludedPaths = [
-  '/onboarding',
-  '/activate',
-  '/recruiter',
-  '/jobs',
-  '/settings',
-];
+import { isOnboardingFeedPathname } from '@dailydotdev/shared/src/lib/onboarding';
 
-// Onboarding is only *forced* when the user lands on the main feed. Anywhere
-// else (a post, a squad, a profile) they signed up in place and should keep
-// reading. `PostOnboardingActivation` is the nudge back to `/onboarding`, and
-// it carries `after_auth` so the page isn't lost.
-const mainFeedPathnames = new Set([
-  '/',
-  '/popular',
-  '/upvoted',
-  '/discussed',
-  '/latest',
-  '/following',
-  '/my-feed',
-]);
+// Loop guards only. Every other non-feed path already falls through to the
+// `isOnboardingFeedPathname` gate below; these two are the redirect targets, so
+// they have to be excluded before the install branch fires.
+const onboardingExcludedPaths = ['/onboarding', '/activate'];
 
 const isOnboardingExcludedPath = (pathname: string): boolean =>
   onboardingExcludedPaths.some((path) => pathname.startsWith(path));
@@ -28,13 +13,9 @@ export interface OnboardingRedirectParams {
   isRouterReady: boolean;
   hasRoutedInstallReferral: boolean;
   isComingFromInstall: boolean;
-  isPermissionPrimerLoading: boolean;
-  isPermissionPrimerEnabled: boolean;
-  isLoggedIn: boolean;
   isFunnel: boolean;
   isOnboardingActionsReady: boolean;
   isOnboardingComplete: boolean;
-  isSwipeOnboardingPreviewForced: boolean;
 }
 
 export interface OnboardingRedirect {
@@ -44,20 +25,16 @@ export interface OnboardingRedirect {
 
 /**
  * Decides whether the app should route the user into onboarding (or the
- * install-referral activation primer). Returns `null` to stay put.
+ * new-tab activation primer). Returns `null` to stay put.
  */
 export const getOnboardingRedirect = ({
   pathname,
   isRouterReady,
   hasRoutedInstallReferral,
   isComingFromInstall,
-  isPermissionPrimerLoading,
-  isPermissionPrimerEnabled,
-  isLoggedIn,
   isFunnel,
   isOnboardingActionsReady,
   isOnboardingComplete,
-  isSwipeOnboardingPreviewForced,
 }: OnboardingRedirectParams): OnboardingRedirect | null => {
   // Don't act on the query until it's parsed; `ref=install` is read below and
   // is undefined on the first render of a hard load.
@@ -72,42 +49,27 @@ export const getOnboardingRedirect = ({
 
   // Once an install referral has been routed, stop here. The redirect drops
   // the `ref` query, so a later run on the still-pending `/` flips
-  // `isComingFromInstall` to false and would race a second redirect on top.
+  // `isComingFromInstall` to false and would send the user to `/onboarding`
+  // on top of the `/activate` navigation already in flight.
   if (hasRoutedInstallReferral) {
     return null;
   }
 
-  // Wait for the permission primer experiment to resolve before routing
-  // install referrals.
-  if (isComingFromInstall && isPermissionPrimerLoading) {
-    return null;
-  }
-
-  // `MainLayout` defers `?ref=install` referrals to this decision, so route
-  // them here exclusively. Enrolled users get the activation primer (which
-  // takes priority over onboarding completion). Logged-out users who aren't
-  // enrolled still need onboarding, and the gate below never fires for them
-  // since their onboarding actions never load while logged out.
-  if (isComingFromInstall && isPermissionPrimerEnabled) {
+  // Extension installs land on `/?ref=install` and always get the activation
+  // primer, which hands off to `/onboarding` once the user acts on it. This
+  // takes priority over onboarding completion. `MainLayout` defers these
+  // referrals here so only one place routes them.
+  if (isComingFromInstall) {
     return { destination: '/activate', isInstallReferral: true };
-  }
-
-  if (isComingFromInstall && !isLoggedIn) {
-    return { destination: '/onboarding', isInstallReferral: true };
   }
 
   if (isFunnel || !isOnboardingActionsReady || isOnboardingComplete) {
     return null;
   }
 
-  if (!mainFeedPathnames.has(pathname)) {
+  if (!isOnboardingFeedPathname(pathname)) {
     return null;
   }
 
-  return {
-    destination: isSwipeOnboardingPreviewForced
-      ? '/onboarding?swipeOnboardingPreview=1'
-      : '/onboarding',
-    isInstallReferral: false,
-  };
+  return { destination: '/onboarding', isInstallReferral: false };
 };

--- a/packages/webapp/lib/onboardingRedirect.ts
+++ b/packages/webapp/lib/onboardingRedirect.ts
@@ -1,0 +1,113 @@
+const onboardingExcludedPaths = [
+  '/onboarding',
+  '/activate',
+  '/recruiter',
+  '/jobs',
+  '/settings',
+];
+
+// Onboarding is only *forced* when the user lands on the main feed. Anywhere
+// else (a post, a squad, a profile) they signed up in place and should keep
+// reading. `PostOnboardingActivation` is the nudge back to `/onboarding`, and
+// it carries `after_auth` so the page isn't lost.
+const mainFeedPathnames = new Set([
+  '/',
+  '/popular',
+  '/upvoted',
+  '/discussed',
+  '/latest',
+  '/following',
+  '/my-feed',
+]);
+
+const isOnboardingExcludedPath = (pathname: string): boolean =>
+  onboardingExcludedPaths.some((path) => pathname.startsWith(path));
+
+export interface OnboardingRedirectParams {
+  pathname: string;
+  isRouterReady: boolean;
+  hasRoutedInstallReferral: boolean;
+  isComingFromInstall: boolean;
+  isPermissionPrimerLoading: boolean;
+  isPermissionPrimerEnabled: boolean;
+  isLoggedIn: boolean;
+  isFunnel: boolean;
+  isOnboardingActionsReady: boolean;
+  isOnboardingComplete: boolean;
+  isSwipeOnboardingPreviewForced: boolean;
+}
+
+export interface OnboardingRedirect {
+  destination: string;
+  isInstallReferral: boolean;
+}
+
+/**
+ * Decides whether the app should route the user into onboarding (or the
+ * install-referral activation primer). Returns `null` to stay put.
+ */
+export const getOnboardingRedirect = ({
+  pathname,
+  isRouterReady,
+  hasRoutedInstallReferral,
+  isComingFromInstall,
+  isPermissionPrimerLoading,
+  isPermissionPrimerEnabled,
+  isLoggedIn,
+  isFunnel,
+  isOnboardingActionsReady,
+  isOnboardingComplete,
+  isSwipeOnboardingPreviewForced,
+}: OnboardingRedirectParams): OnboardingRedirect | null => {
+  // Don't act on the query until it's parsed; `ref=install` is read below and
+  // is undefined on the first render of a hard load.
+  if (!isRouterReady) {
+    return null;
+  }
+
+  // Never redirect away from onboarding-related surfaces (prevents loops).
+  if (isOnboardingExcludedPath(pathname)) {
+    return null;
+  }
+
+  // Once an install referral has been routed, stop here. The redirect drops
+  // the `ref` query, so a later run on the still-pending `/` flips
+  // `isComingFromInstall` to false and would race a second redirect on top.
+  if (hasRoutedInstallReferral) {
+    return null;
+  }
+
+  // Wait for the permission primer experiment to resolve before routing
+  // install referrals.
+  if (isComingFromInstall && isPermissionPrimerLoading) {
+    return null;
+  }
+
+  // `MainLayout` defers `?ref=install` referrals to this decision, so route
+  // them here exclusively. Enrolled users get the activation primer (which
+  // takes priority over onboarding completion). Logged-out users who aren't
+  // enrolled still need onboarding, and the gate below never fires for them
+  // since their onboarding actions never load while logged out.
+  if (isComingFromInstall && isPermissionPrimerEnabled) {
+    return { destination: '/activate', isInstallReferral: true };
+  }
+
+  if (isComingFromInstall && !isLoggedIn) {
+    return { destination: '/onboarding', isInstallReferral: true };
+  }
+
+  if (isFunnel || !isOnboardingActionsReady || isOnboardingComplete) {
+    return null;
+  }
+
+  if (!mainFeedPathnames.has(pathname)) {
+    return null;
+  }
+
+  return {
+    destination: isSwipeOnboardingPreviewForced
+      ? '/onboarding?swipeOnboardingPreview=1'
+      : '/onboarding',
+    isInstallReferral: false,
+  };
+};

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -21,7 +21,6 @@ import { ProgressiveEnhancementContextProvider } from '@dailydotdev/shared/src/c
 import { SubscriptionContextProvider } from '@dailydotdev/shared/src/contexts/SubscriptionContext';
 import { ShortcutsProvider } from '@dailydotdev/shared/src/features/shortcuts/contexts/ShortcutsProvider';
 import { canonicalFromRouter } from '@dailydotdev/shared/src/lib/canonical';
-import { featureOnboardingPermissionPrimer } from '@dailydotdev/shared/src/lib/featureManagement';
 import '@dailydotdev/shared/src/styles/globals.css';
 import useLogPageView from '@dailydotdev/shared/src/hooks/log/useLogPageView';
 import { BootDataProvider } from '@dailydotdev/shared/src/contexts/BootProvider';
@@ -37,10 +36,7 @@ import { LazyModal } from '@dailydotdev/shared/src/components/modals/common/type
 import { defaultQueryClientConfig } from '@dailydotdev/shared/src/lib/query';
 import { useWebVitals } from '@dailydotdev/shared/src/hooks/useWebVitals';
 import { LazyModalElement } from '@dailydotdev/shared/src/components/modals/LazyModalElement';
-import {
-  useConditionalFeature,
-  useManualScrollRestoration,
-} from '@dailydotdev/shared/src/hooks';
+import { useManualScrollRestoration } from '@dailydotdev/shared/src/hooks';
 import { useScrollbarWidth } from '@dailydotdev/shared/src/hooks/useScrollbarWidth';
 import { PushNotificationContextProvider } from '@dailydotdev/shared/src/contexts/PushNotificationContext';
 import { SerwistProvider } from '@serwist/turbopack/react';
@@ -104,7 +100,6 @@ const getPage = () => window.location.pathname;
 const hotAndColdModalQueryKey = 'openModal';
 const hotAndColdModalQueryValue = 'hottakes';
 const hotAndColdModalLegacyQueryValue = 'hotAndCold';
-const swipeOnboardingPreviewQueryKey = 'swipeOnboardingPreview';
 
 const APP_ORIGIN = getAppOrigin();
 const SITE_ORIGIN = getSiteOrigin();
@@ -158,24 +153,13 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
   const {
     user,
     trackingId,
-    isAuthReady,
     isFunnel,
     shouldShowLogin,
     closeLogin,
     loginState,
   } = useAuthContext();
   // Users arriving from the extension install link land on `/?ref=install`.
-  // Evaluate the permission primer experiment as soon as auth is ready (so
-  // GrowthBook attributes are set) — gating on onboarding actions would stall
-  // logged-out users forever, since the actions query only runs for a user.
   const isComingFromInstall = router.query.ref === 'install';
-  const {
-    value: isPermissionPrimerEnabled,
-    isLoading: isPermissionPrimerLoading,
-  } = useConditionalFeature({
-    feature: featureOnboardingPermissionPrimer,
-    shouldEvaluate: isComingFromInstall && isAuthReady,
-  });
   const { showBanner, onAcceptCookies, onOpenBanner, onHideBanner } =
     useCookieBanner();
   useWebVitals();
@@ -195,14 +179,6 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     (Array.isArray(hotAndColdModalQuery) &&
       (hotAndColdModalQuery.includes(hotAndColdModalQueryValue) ||
         hotAndColdModalQuery.includes(hotAndColdModalLegacyQueryValue)));
-  const swipeOnboardingPreviewQuery =
-    router.query[swipeOnboardingPreviewQueryKey];
-  const isSwipeOnboardingPreviewForced =
-    swipeOnboardingPreviewQuery === '1' ||
-    swipeOnboardingPreviewQuery === 'true' ||
-    (Array.isArray(swipeOnboardingPreviewQuery) &&
-      (swipeOnboardingPreviewQuery.includes('1') ||
-        swipeOnboardingPreviewQuery.includes('true')));
 
   useEffect(() => {
     if (!shouldOpenHotAndColdFromQuery) {
@@ -241,13 +217,9 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
       isRouterReady: router.isReady,
       hasRoutedInstallReferral: installReferralRoutedRef.current,
       isComingFromInstall,
-      isPermissionPrimerLoading,
-      isPermissionPrimerEnabled,
-      isLoggedIn: !!user,
       isFunnel,
       isOnboardingActionsReady,
       isOnboardingComplete,
-      isSwipeOnboardingPreviewForced,
     });
 
     if (!redirect) {
@@ -268,11 +240,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     router.pathname,
     router.isReady,
     isOnboardingComplete,
-    isSwipeOnboardingPreviewForced,
     isComingFromInstall,
-    isPermissionPrimerEnabled,
-    isPermissionPrimerLoading,
-    user,
   ]);
 
   useEffect(() => {

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -59,6 +59,7 @@ import { useCheckLocation } from '@dailydotdev/shared/src/hooks/useCheckLocation
 import Seo, { defaultSeo, defaultSeoTitle, robotsProps } from '../next-seo';
 import useWebappVersion from '../hooks/useWebappVersion';
 import { getAppOrigin, getSiteOrigin } from '../lib/seo';
+import { getOnboardingRedirect } from '../lib/onboardingRedirect';
 import { PixelsProvider } from '../context/PixelsContext';
 
 structuredCloneJsonPolyfill();
@@ -100,30 +101,10 @@ const getRedirectUri = () =>
 
 const getPage = () => window.location.pathname;
 
-const onboardingExcludedPaths = [
-  '/onboarding',
-  '/activate',
-  '/recruiter',
-  '/jobs',
-  '/settings',
-];
-// While an auth intent is active, only force the rest of onboarding when the
-// user lands on the main feed.
-const mainFeedPathnames = new Set([
-  '/',
-  '/popular',
-  '/upvoted',
-  '/discussed',
-  '/latest',
-  '/following',
-  '/my-feed',
-]);
 const hotAndColdModalQueryKey = 'openModal';
 const hotAndColdModalQueryValue = 'hottakes';
 const hotAndColdModalLegacyQueryValue = 'hotAndCold';
 const swipeOnboardingPreviewQueryKey = 'swipeOnboardingPreview';
-const isOnboardingExcludedPath = (pathname: string): boolean =>
-  onboardingExcludedPaths.some((path) => pathname.startsWith(path));
 
 const APP_ORIGIN = getAppOrigin();
 const SITE_ORIGIN = getSiteOrigin();
@@ -255,61 +236,29 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
   }, [activeModalType, openModal, router, shouldOpenHotAndColdFromQuery]);
 
   useEffect(() => {
-    // Don't act on the query until it's parsed; `ref=install` is read below and
-    // is undefined on the first render of a hard load.
-    if (!router.isReady) {
+    const redirect = getOnboardingRedirect({
+      pathname: router.pathname,
+      isRouterReady: router.isReady,
+      hasRoutedInstallReferral: installReferralRoutedRef.current,
+      isComingFromInstall,
+      isPermissionPrimerLoading,
+      isPermissionPrimerEnabled,
+      isLoggedIn: !!user,
+      isFunnel,
+      isOnboardingActionsReady,
+      isOnboardingComplete,
+      isSwipeOnboardingPreviewForced,
+    });
+
+    if (!redirect) {
       return;
     }
 
-    // Never redirect away from onboarding-related surfaces (prevents loops).
-    if (isOnboardingExcludedPath(router.pathname)) {
-      return;
-    }
-
-    // Once an install referral has been routed, stop here. The redirect drops
-    // the `ref` query, so a later run on the still-pending `/` flips
-    // `isComingFromInstall` to false and would race a second redirect on top.
-    if (installReferralRoutedRef.current) {
-      return;
-    }
-
-    // Wait for the permission primer experiment to resolve before routing
-    // install referrals.
-    if (isComingFromInstall && isPermissionPrimerLoading) {
-      return;
-    }
-
-    // `MainLayout` defers `?ref=install` referrals to this effect, so route
-    // them here exclusively. Enrolled users get the activation primer (which
-    // takes priority over onboarding completion). Logged-out users who aren't
-    // enrolled still need onboarding — the gate below never fires for them
-    // since their onboarding actions never load while logged out.
-    if (isComingFromInstall && isPermissionPrimerEnabled) {
+    if (redirect.isInstallReferral) {
       installReferralRoutedRef.current = true;
-      router.replace('/activate');
-      return;
     }
 
-    if (isComingFromInstall && !user) {
-      installReferralRoutedRef.current = true;
-      router.replace('/onboarding');
-      return;
-    }
-
-    if (isFunnel || !isOnboardingActionsReady || isOnboardingComplete) {
-      return;
-    }
-
-    // While the auth intent is active, defer the rest of onboarding until they
-    // navigate to the main feed.
-    if (shouldShowLogin && !mainFeedPathnames.has(router.pathname)) {
-      return;
-    }
-
-    const destination = isSwipeOnboardingPreviewForced
-      ? '/onboarding?swipeOnboardingPreview=1'
-      : '/onboarding';
-    router.replace(destination);
+    router.replace(redirect.destination);
     // `router.pathname` is depended on explicitly because the `router` ref is
     // stable across in-app navigations.
   }, [
@@ -319,7 +268,6 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
     router.pathname,
     router.isReady,
     isOnboardingComplete,
-    shouldShowLogin,
     isSwipeOnboardingPreviewForced,
     isComingFromInstall,
     isPermissionPrimerEnabled,

--- a/packages/webapp/pages/activate.tsx
+++ b/packages/webapp/pages/activate.tsx
@@ -16,9 +16,9 @@ const seo: NextSeoProps = {
   noindex: true,
 };
 
-// Whether install referrals reach this page is decided upstream in `_app`
-// via the permission primer flag. Once here, the primer stays put until the
-// user acts on it — no per-user re-evaluation, so it never bounces out.
+// Install referrals (`/?ref=install`) are routed here by `getOnboardingRedirect`
+// in `_app`. Once here, the primer stays put until the user acts on it, then
+// hands off to `/onboarding`.
 function ActivatePage(): ReactElement {
   const router = useRouter();
 


### PR DESCRIPTION
## Changes

Two commits: a bug fix, then the cleanup it exposed. Reviewable separately.

### 1. `fix(webapp): keep users on the page they signed up from`

Signing up from a post page immediately redirects to `/onboarding`, so the user loses the post they were reading.

[#6050](https://github.com/dailydotdev/apps/pull/6050) introduced the rule that onboarding is only *forced* on the main feed, gated on the `inline_login` flag:

```js
if (isInlineLoginEnabled && !mainFeedPathnames.has(router.pathname)) return;
```

`isInlineLoginEnabled` was truthy for the whole session. [#6131](https://github.com/dailydotdev/apps/pull/6131) graduated the experiment to 100% and, while deleting the flag, substituted `shouldShowLogin` for it rather than dropping the condition. `shouldShowLogin` is `loginState !== null`, i.e. true only while the auth modal is open. So:

1. User on `/posts/[id]` opens signup. `shouldShowLogin` true, guard holds.
2. Registration succeeds. `AuthModal` calls `closeLogin()`, `shouldShowLogin` goes false.
3. Boot refetches, onboarding actions resolve as incomplete.
4. Effect re-runs, guard no longer holds, `router.replace('/onboarding')`.

The redirect carries no `after_auth`, so the post is unrecoverable even after finishing onboarding. The comment above the guard still described the intended behavior, so this was a cleanup slip rather than a product decision.

The decision also moves out of the `useEffect` into a pure `getOnboardingRedirect`, because there is no `_app.spec.tsx` and that is why a variable swap survived ~2 months in production.

### 2. `refactor(onboarding): one feed rule, and drop the settled experiments`

**Permission primer.** `onboarding_permission_primer` won, so `?ref=install` now routes to `/activate` unconditionally. Removes the flag, the `useConditionalFeature`, its loading gate, and the separate logged-out branch. Worth knowing: `/activate` had exactly one entry point (this flag), so hardcoding is what keeps the page reachable at all. **The extension is untouched** — it still opens `r.daily.dev/install`, landing on `/?ref=install` as before.

**Swipe onboarding preview.** `/onboarding` reads `swipeOnboardingPreview` itself, so forwarding it through the redirect was dead plumbing, and `_app` had reimplemented `isSwipeOnboardingPreviewQueryForced` inline. QA hits `/onboarding?swipeOnboardingPreview=1` directly.

**Feed pages.** `MainLayout` (logged out) and `getOnboardingRedirect` (signed in) kept separate lists that had drifted apart. Neither was a superset of the other:

| pathname | was: logged-out | was: signed-in | now |
|---|---|---|---|
| `/`, `/popular`, `/upvoted`, `/my-feed` | yes | yes | yes |
| `/discussed`, `/following` | no | yes | **no** |
| `/feeds/[slugOrId]`, `/explore/[tag]` | yes | no | **no** |
| `/search/posts` | intended, never matched (`page` is `search/posts`) | no | no |
| `/latest` | n/a | listed, route doesn't exist | removed |

Both now read `isOnboardingFeedPathname` from `shared/src/lib/onboarding.ts`. `_app` has no access to `useActiveFeedNameContext`, so the predicate is pathname-based.

**Behavior deltas to be aware of:** logged-out visitors on custom feeds and explore tags no longer get pushed into onboarding, and signed-in users with incomplete onboarding are no longer forced from `/discussed` or `/following`.

**Excluded paths** shrink to the two redirect targets; `/recruiter`, `/jobs`, `/settings` were redundant once the rule became feed-pages-only.

`isPageApplicableForOnboarding` fed both the redirect and the hold-paint-until-boot gate. Only the redirect moves to the new predicate; the paint gate keeps the broader set as `isFeedShapedPage`, since narrowing it there would be an unrelated layout change.

Net: `getOnboardingRedirect` goes from 110 lines and 11 params to 73 and 7.

### Not included

`isFunnel` stays. It looks redundant now (`/helloworld` is never a feed pathname), but `isFunnelRef` is captured at `AuthContext` mount and stays true after the funnel navigates to `/`, so dropping it would start redirecting users who bail mid-funnel. That's a product call, not a refactor.

## Events

No new tracking events. `ExtensionPrimerShown` / `ExtensionPrimerCtaClick` are unchanged and still fire, since `/activate` stays.

## Experiment

Removes `onboarding_permission_primer` (concluded, shipped as the winner). Removes the last dependency on auth-modal state left over from the already-graduated `inline_login` rollout. No new experiments.

## Manual Testing

- [x] `pnpm --filter shared test` — 301 suites, 2028 tests
- [x] `pnpm --filter webapp test` — 45 suites, 336 tests
- [x] `pnpm --filter extension test` — 6 suites, 43 tests
- [x] `node ./scripts/typecheck-strict-changed.js`
- [x] eslint clean on all changed files
- [x] `pnpm --filter webapp build:notls`

New coverage: 27 tests on `getOnboardingRedirect` (including the post-page signup regression, which is structurally guarded now that no auth-modal input exists on the params type), and 16 pinning `isOnboardingFeedPathname` so the two call sites can't drift again.

`MainLayout`'s redirect is gated on `!isTesting`, so it can't be exercised in tests. That's why it had no coverage and why the shared predicate is where the contract is pinned.

Worth sanity-checking on the preview: sign up from a post page (stays), sign up from `/popular` (goes to onboarding), and `?ref=install` lands on `/activate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
