### PR TITLE
fix(cards): fetch impressions on feed posts so the flagged stat renders

### DIFF
--- a/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
+++ b/packages/shared/src/components/post/PostUpvotesCommentsCount.tsx
@@ -161,7 +161,11 @@ const PostUpvotesCommentsCountContent = ({
             </span>
           ),
         })}
-      {!impressionsEnabled && showPostAnalytics && (
+      {/* With the flag on, the impressions stat doubles as the analytics link,
+          but it only renders when the post has impression data — keep the
+          button as the fallback entry point so authors/team never lose the
+          direct link to analytics. */}
+      {showPostAnalytics && (!impressionsEnabled || !impressionsLabel) && (
         <Link href={`${webappUrl}posts/${post.id}/analytics`} passHref>
           <Button
             tag="a"

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -272,6 +272,9 @@ export const FEED_POST_INFO_FRAGMENT = gql`
     numUpvotes
     numComments
     numAwards
+    analytics {
+      impressions
+    }
     summary
     yggdrasilId
     creatorTwitter


### PR DESCRIPTION
## Context

Follow-up to #6260 (`card_impressions` experiment) and Ido's Slack report: with the flag on, impressions and the analytics link disappeared from posts ("No direct link to analytics except in the dropdown"). The flag is currently force-enabled for `team: 1` only, which is why only the team sees it.

## Root causes (both client-side — the API is fine)

1. **Feed cards never get the data.** `FEED_POST_INFO_FRAGMENT` didn't request `analytics { impressions }`, so `usePostImpressions` always saw `undefined → 0` on every card variant (standard, v2, glass actions), and the stat is real-data-only by design. Running the app's own composed `SOURCE_FEED_QUERY` against the production API confirmed feed nodes come back with no `analytics` key at all.
2. **The post modal reuses the feed item.** `Feed.tsx` passes `selectedPost` straight into `ArticlePostModal` → `PostFocusCard`/`PostContent` with no `POST_BY_ID` refetch, so the modal had no `analytics` either — while the flag simultaneously hid the old impressions line and the "Post analytics" button. Net effect in the modal flow: nothing at all. Direct `/posts/[id]` loads use `SharedPostInfo` (which does fetch analytics), which is why the full page looked fine (e.g. anonymous prod shows "76 Impressions").

## Fix

- Add `analytics { impressions }` to `FeedPostInfo` — one field feeds every card variant **and** the post modal, since the modal renders the feed item. Impressions are public API data (`PostAnalyticsPublic`), so there's no permission concern; it's a single-row PK left-join the post page already does on every load.
- Keep the "Post analytics" button visible for authors/team whenever the clickable impressions stat has no data to render. Flag off: behaviour unchanged. Flag on: the stat doubles as the analytics link (routes owner/team to `/posts/[id]/analytics`), and the button only appears as a fallback when there's nothing to click — so the analytics entry point can never silently vanish again.

## Validation

- Composed feed query against production now returns impressions (e.g. 205K / 100K / 1.37M on changelog posts).
- `Feed.spec.tsx` 43/43 pass; `SharePostContent.spec.tsx` passes.
- `tsc` on `packages/shared` reports the same 22 pre-existing errors as clean main — none in the touched files.
- Local run with the team's flag state forced (`card_impressions` + `post_redesign` + `feed_card_glass_actions`) renders a clickable "76 Impressions" on the focus-layout post page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-feed-card-impressions-data.preview.app.daily.dev