### PR TITLE
feat(seo): dynamize tag and source section titles with entity names

### DIFF
--- a/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
+++ b/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
@@ -6,18 +6,13 @@ import { Button } from '../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../buttons/common';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { ArrowIcon } from '../icons';
-import {
-  Typography,
-  TypographyTag,
-  TypographyType,
-} from '../typography/Typography';
+import { Typography, TypographyType } from '../typography/Typography';
 
 export interface HorizontalScrollTitleProps {
   copy: string;
   id?: string;
   icon?: ReactNode;
   type?: TypographyType;
-  tag?: TypographyTag;
 }
 
 export interface HorizontalScrollHeaderProps {
@@ -38,17 +33,21 @@ export const HorizontalScrollTitle = ({
   copy,
   icon,
   type = TypographyType.Title2,
-  tag = TypographyTag.P,
 }: HorizontalScrollTitleProps): ReactElement => {
   return (
     <span className="flex flex-row items-center">
       {icon}
-      <Typography tag={tag} type={type} id={id} bold>
+      <Typography type={type} id={id} bold>
         {copy}
       </Typography>
     </span>
   );
 };
+
+const isScrollTitleProps = (
+  value: HorizontalScrollHeaderProps['title'],
+): value is HorizontalScrollTitleProps =>
+  !!value && typeof value === 'object' && 'copy' in value;
 
 export function HorizontalScrollHeader({
   title,
@@ -62,12 +61,10 @@ export function HorizontalScrollHeader({
   className,
   buttonSize = ButtonSize.Medium,
 }: HorizontalScrollHeaderProps): ReactElement {
-  const isCopyTitle = !!title && typeof title === 'object' && 'copy' in title;
-  const isCustomTitle = !!title && typeof title === 'object' && !isCopyTitle;
-  const hasTitle =
-    isCustomTitle ||
-    (isCopyTitle && !!(title as HorizontalScrollTitleProps).copy);
+  const hasTitle = isScrollTitleProps(title) ? !!title.copy : !!title;
 
+  // Rails that render their own heading above the scroll container pass no
+  // title, so without scroll controls there is nothing left to show.
   if (!hasTitle && !canScroll) {
     return <></>;
   }
@@ -75,17 +72,12 @@ export function HorizontalScrollHeader({
   return (
     <div
       className={classNames(
-        'mx-4 flex w-auto flex-row items-center justify-between laptop:mx-0 laptop:w-full',
-        hasTitle || canScroll ? 'min-h-10' : '',
-        !hasTitle && canScroll && 'hidden tablet:flex',
+        'mx-4 flex min-h-10 w-auto flex-row items-center justify-between laptop:mx-0 laptop:w-full',
+        !hasTitle && 'hidden tablet:flex',
         className,
       )}
     >
-      {isCustomTitle
-        ? title
-        : hasTitle && (
-            <HorizontalScrollTitle {...(title as HorizontalScrollTitleProps)} />
-          )}
+      {isScrollTitleProps(title) ? <HorizontalScrollTitle {...title} /> : title}
       {canScroll && (
         <div
           className={classNames(

--- a/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
+++ b/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
@@ -6,13 +6,18 @@ import { Button } from '../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../buttons/common';
 import ConditionalWrapper from '../ConditionalWrapper';
 import { ArrowIcon } from '../icons';
-import { Typography, TypographyType } from '../typography/Typography';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
 
 export interface HorizontalScrollTitleProps {
   copy: string;
   id?: string;
   icon?: ReactNode;
   type?: TypographyType;
+  tag?: TypographyTag;
 }
 
 export interface HorizontalScrollHeaderProps {
@@ -33,11 +38,12 @@ export const HorizontalScrollTitle = ({
   copy,
   icon,
   type = TypographyType.Title2,
+  tag = TypographyTag.P,
 }: HorizontalScrollTitleProps): ReactElement => {
   return (
     <span className="flex flex-row items-center">
       {icon}
-      <Typography type={type} id={id} bold>
+      <Typography tag={tag} type={type} id={id} bold>
         {copy}
       </Typography>
     </span>

--- a/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
+++ b/packages/shared/src/components/HorizontalScroll/HorizontalScrollHeader.tsx
@@ -62,24 +62,37 @@ export function HorizontalScrollHeader({
   className,
   buttonSize = ButtonSize.Medium,
 }: HorizontalScrollHeaderProps): ReactElement {
-  // Check if title is props object or custom ReactNode
-  const isCustomTitle =
-    title && typeof title === 'object' && !('copy' in title);
+  const isCopyTitle = !!title && typeof title === 'object' && 'copy' in title;
+  const isCustomTitle = !!title && typeof title === 'object' && !isCopyTitle;
+  const hasTitle =
+    isCustomTitle ||
+    (isCopyTitle && !!(title as HorizontalScrollTitleProps).copy);
+
+  if (!hasTitle && !canScroll) {
+    return <></>;
+  }
 
   return (
     <div
       className={classNames(
-        'mx-4 flex min-h-10 w-auto flex-row items-center justify-between laptop:mx-0 laptop:w-full',
+        'mx-4 flex w-auto flex-row items-center justify-between laptop:mx-0 laptop:w-full',
+        hasTitle || canScroll ? 'min-h-10' : '',
+        !hasTitle && canScroll && 'hidden tablet:flex',
         className,
       )}
     >
       {isCustomTitle
         ? title
-        : title && (
+        : hasTitle && (
             <HorizontalScrollTitle {...(title as HorizontalScrollTitleProps)} />
           )}
       {canScroll && (
-        <div className="hidden flex-row items-center gap-3 tablet:flex">
+        <div
+          className={classNames(
+            'flex-row items-center gap-3',
+            hasTitle ? 'hidden tablet:flex' : 'flex',
+          )}
+        >
           <Button
             variant={ButtonVariant.Tertiary}
             icon={<ArrowIcon className="-rotate-90" />}

--- a/packages/shared/src/components/HorizontalScroll/useHorizontalScrollHeader.tsx
+++ b/packages/shared/src/components/HorizontalScroll/useHorizontalScrollHeader.tsx
@@ -70,21 +70,20 @@ export const useHorizontalScrollHeader = <
     }
   }, [element, numCards, scrollableElementWidth, onScroll]);
 
-  const header =
-    title || isOverflowing ? (
-      <HorizontalScrollHeader
-        title={title}
-        isAtEnd={isAtEnd}
-        isAtStart={isAtStart}
-        canScroll={isOverflowing}
-        onClickNext={onClickNext}
-        onClickPrevious={onClickPrevious}
-        onClickSeeAll={onClickSeeAll}
-        linkToSeeAll={linkToSeeAll}
-        className={className}
-        buttonSize={buttonSize}
-      />
-    ) : null;
+  const header = (
+    <HorizontalScrollHeader
+      title={title}
+      isAtEnd={isAtEnd}
+      isAtStart={isAtStart}
+      canScroll={isOverflowing}
+      onClickNext={onClickNext}
+      onClickPrevious={onClickPrevious}
+      onClickSeeAll={onClickSeeAll}
+      linkToSeeAll={linkToSeeAll}
+      className={className}
+      buttonSize={buttonSize}
+    />
+  );
 
   return {
     header,

--- a/packages/shared/src/components/HorizontalScroll/useHorizontalScrollHeader.tsx
+++ b/packages/shared/src/components/HorizontalScroll/useHorizontalScrollHeader.tsx
@@ -70,20 +70,21 @@ export const useHorizontalScrollHeader = <
     }
   }, [element, numCards, scrollableElementWidth, onScroll]);
 
-  const header = (
-    <HorizontalScrollHeader
-      title={title}
-      isAtEnd={isAtEnd}
-      isAtStart={isAtStart}
-      canScroll={isOverflowing}
-      onClickNext={onClickNext}
-      onClickPrevious={onClickPrevious}
-      onClickSeeAll={onClickSeeAll}
-      linkToSeeAll={linkToSeeAll}
-      className={className}
-      buttonSize={buttonSize}
-    />
-  );
+  const header =
+    title || isOverflowing ? (
+      <HorizontalScrollHeader
+        title={title}
+        isAtEnd={isAtEnd}
+        isAtStart={isAtStart}
+        canScroll={isOverflowing}
+        onClickNext={onClickNext}
+        onClickPrevious={onClickPrevious}
+        onClickSeeAll={onClickSeeAll}
+        linkToSeeAll={linkToSeeAll}
+        className={className}
+        buttonSize={buttonSize}
+      />
+    ) : null;
 
   return {
     header,

--- a/packages/shared/src/components/RelatedEntities.tsx
+++ b/packages/shared/src/components/RelatedEntities.tsx
@@ -45,7 +45,7 @@ export const RelatedEntities = ({
 
   return (
     <div className={classNames('mb-10 w-auto', className)}>
-      <p className="mb-3 h-10 font-bold typo-body">{title}</p>
+      <h2 className="mb-3 h-10 font-bold typo-body">{title}</h2>
       <div className="no-scrollbar flex gap-2 overflow-x-auto">
         {items.map((item) => {
           return (

--- a/packages/shared/src/components/RelatedEntities.tsx
+++ b/packages/shared/src/components/RelatedEntities.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { ElementPlaceholder } from './ElementPlaceholder';
 import Link from './utilities/Link';
+import { EntitySectionHeading } from './entity/EntitySectionHeading';
 
 export interface RelatedEntity {
   id?: string;
@@ -45,7 +46,7 @@ export const RelatedEntities = ({
 
   return (
     <div className={classNames('mb-10 w-auto', className)}>
-      <h2 className="mb-3 h-10 font-bold typo-body">{title}</h2>
+      <EntitySectionHeading className="mb-3">{title}</EntitySectionHeading>
       <div className="no-scrollbar flex gap-2 overflow-x-auto">
         {items.map((item) => {
           return (

--- a/packages/shared/src/components/archive/ArchiveEntryCard.tsx
+++ b/packages/shared/src/components/archive/ArchiveEntryCard.tsx
@@ -18,6 +18,7 @@ import { RequestKey, StaleTime } from '../../lib/query';
 import Link from '../utilities/Link';
 import { ArrowIcon } from '../icons';
 import { IconSize } from '../Icon';
+import { EntitySectionHeading } from '../entity/EntitySectionHeading';
 
 interface ArchiveEntryCardProps {
   scopeType: ArchiveScopeType.Tag | ArchiveScopeType.Source;
@@ -57,8 +58,10 @@ export function ArchiveEntryCard({
 
   return (
     <section className={classNames('flex flex-col gap-3', className)}>
-      <div className="flex items-center justify-between">
-        <h2 className="font-bold typo-body">Best of {scopeName}</h2>
+      <div className="mb-3 flex items-center justify-between">
+        <EntitySectionHeading className="mb-0 mt-0">
+          Best of {scopeName}
+        </EntitySectionHeading>
         <Link href={indexUrl} prefetch={false}>
           <a className="group flex items-center gap-1 text-text-tertiary transition-colors typo-footnote hover:text-text-primary">
             All archives

--- a/packages/shared/src/components/entity/EntityRailWithFade.tsx
+++ b/packages/shared/src/components/entity/EntityRailWithFade.tsx
@@ -1,0 +1,16 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+
+export const EntityRailWithFade = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement => (
+  <div className="relative mb-10">
+    {children}
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-r from-transparent to-background-default"
+    />
+  </div>
+);

--- a/packages/shared/src/components/entity/EntitySectionHeading.tsx
+++ b/packages/shared/src/components/entity/EntitySectionHeading.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+
+interface EntitySectionHeadingProps {
+  children: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+}
+
+export const EntitySectionHeading = ({
+  children,
+  icon,
+  className,
+}: EntitySectionHeadingProps): ReactElement => (
+  <Typography
+    tag={TypographyTag.H2}
+    type={TypographyType.Title3}
+    color={TypographyColor.Primary}
+    bold
+    className={classNames('mb-4 mt-2', className)}
+  >
+    {icon ? (
+      <span className="inline-flex flex-wrap items-center gap-x-1.5">
+        {icon}
+        <span>{children}</span>
+      </span>
+    ) : (
+      children
+    )}
+  </Typography>
+);

--- a/packages/shared/src/components/feeds/HorizontalFeed.tsx
+++ b/packages/shared/src/components/feeds/HorizontalFeed.tsx
@@ -13,7 +13,7 @@ interface HorizontalFeedProps<T> {
   feedQueryKey: unknown[];
   query: string;
   variables: T;
-  title: HorizontalScrollTitleProps;
+  title?: HorizontalScrollTitleProps;
   emptyScreen: ReactElement;
   className?: string;
 }
@@ -24,7 +24,7 @@ export default function HorizontalFeed<T>({
   ...props
 }: HorizontalFeedProps<T>): ReactElement {
   const { ref, header } = useHorizontalScrollHeader({
-    title: { ...title, type: TypographyType.Body },
+    title: title ? { type: TypographyType.Body, ...title } : undefined,
   });
   const { isListMode } = useFeedLayout();
 

--- a/packages/shared/src/components/tags/TagTopicPage.tsx
+++ b/packages/shared/src/components/tags/TagTopicPage.tsx
@@ -541,11 +541,7 @@ export const TagTopicPage = ({
             </RailWithFade>
           </ActiveFeedNameContext.Provider>
 
-          <WhoToFollow
-            tag={tag}
-            title={title}
-            initialUsers={topContributors}
-          />
+          <WhoToFollow tag={tag} title={title} initialUsers={topContributors} />
           <TagTopSources tag={tag} title={title} />
 
           <ActiveFeedNameContext.Provider

--- a/packages/shared/src/components/tags/TagTopicPage.tsx
+++ b/packages/shared/src/components/tags/TagTopicPage.tsx
@@ -88,8 +88,10 @@ export interface TagTopicPageProps {
 
 const SectionHeading = ({
   children,
+  icon,
 }: {
   children: ReactNode;
+  icon?: ReactNode;
 }): ReactElement => (
   <Typography
     tag={TypographyTag.H2}
@@ -98,7 +100,14 @@ const SectionHeading = ({
     bold
     className="mb-4 mt-2"
   >
-    {children}
+    {icon ? (
+      <span className="inline-flex flex-wrap items-center gap-x-1.5">
+        {icon}
+        <span>{children}</span>
+      </span>
+    ) : (
+      children
+    )}
   </Typography>
 );
 
@@ -109,7 +118,7 @@ const RailWithFade = ({ children }: { children: ReactNode }): ReactElement => (
     {children}
     <div
       aria-hidden
-      className="pointer-events-none absolute bottom-0 right-0 top-11 w-12 bg-gradient-to-r from-transparent to-background-default"
+      className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-r from-transparent to-background-default"
     />
   </div>
 );
@@ -521,6 +530,7 @@ export const TagTopicPage = ({
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsTopPosts }}
           >
+            <SectionHeading>Recommended {title} stories</SectionHeading>
             <RailWithFade>
               <HorizontalFeed
                 feedName={OtherFeedPage.TagsTopPosts}
@@ -531,10 +541,6 @@ export const TagTopicPage = ({
                 ]}
                 query={TAG_FEED_QUERY}
                 variables={topPostsQueryVariables}
-                title={{
-                  copy: `Recommended ${title} stories`,
-                  tag: TypographyTag.H2,
-                }}
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />
@@ -547,6 +553,11 @@ export const TagTopicPage = ({
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsMostUpvoted }}
           >
+            <SectionHeading
+              icon={<UpvoteIcon size={IconSize.Medium} className="shrink-0" />}
+            >
+              Most upvoted {title} posts
+            </SectionHeading>
             <RailWithFade>
               <HorizontalFeed
                 feedName={OtherFeedPage.TagsMostUpvoted}
@@ -557,13 +568,6 @@ export const TagTopicPage = ({
                 ]}
                 query={MOST_UPVOTED_FEED_QUERY}
                 variables={mostUpvotedQueryVariables}
-                title={{
-                  copy: `Most upvoted ${title} posts`,
-                  tag: TypographyTag.H2,
-                  icon: (
-                    <UpvoteIcon size={IconSize.Medium} className="mr-1.5" />
-                  ),
-                }}
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />
@@ -572,6 +576,11 @@ export const TagTopicPage = ({
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsBestDiscussed }}
           >
+            <SectionHeading
+              icon={<DiscussIcon size={IconSize.Medium} className="shrink-0" />}
+            >
+              Best discussed {title} posts
+            </SectionHeading>
             <RailWithFade>
               <HorizontalFeed
                 feedName={OtherFeedPage.TagsBestDiscussed}
@@ -582,13 +591,6 @@ export const TagTopicPage = ({
                 ]}
                 query={MOST_DISCUSSED_FEED_QUERY}
                 variables={bestDiscussedQueryVariables}
-                title={{
-                  copy: `Best discussed ${title} posts`,
-                  tag: TypographyTag.H2,
-                  icon: (
-                    <DiscussIcon size={IconSize.Medium} className="mr-1.5" />
-                  ),
-                }}
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />

--- a/packages/shared/src/components/tags/TagTopicPage.tsx
+++ b/packages/shared/src/components/tags/TagTopicPage.tsx
@@ -148,7 +148,13 @@ const EntityGridSkeleton = (): ReactElement => (
   </EntityFeedGrid>
 );
 
-const TagTopSources = ({ tag }: { tag: string }): ReactElement | null => {
+const TagTopSources = ({
+  tag,
+  title,
+}: {
+  tag: string;
+  title: string;
+}): ReactElement | null => {
   const { data: topSources, isPending } = useQuery({
     queryKey: [RequestKey.SourceByTag, null, tag],
     queryFn: async () =>
@@ -168,7 +174,7 @@ const TagTopSources = ({ tag }: { tag: string }): ReactElement | null => {
 
   return (
     <section className="mb-10">
-      <SectionHeading>Top sources covering it</SectionHeading>
+      <SectionHeading>Top sources covering {title}</SectionHeading>
       {isPending ? (
         <EntityGridSkeleton />
       ) : (
@@ -188,9 +194,11 @@ const TagTopSources = ({ tag }: { tag: string }): ReactElement | null => {
 
 const WhoToFollow = ({
   tag,
+  title,
   initialUsers = [],
 }: {
   tag: string;
+  title: string;
   initialUsers?: UserShortProfile[];
 }): ReactElement | null => {
   const { data: topContributors, isPending } = useQuery({
@@ -213,7 +221,7 @@ const WhoToFollow = ({
 
   return (
     <section className="mb-10">
-      <SectionHeading>Who to follow</SectionHeading>
+      <SectionHeading>Who to follow for {title}</SectionHeading>
       {isLoading ? (
         <EntityGridSkeleton />
       ) : (
@@ -510,7 +518,6 @@ export const TagTopicPage = ({
             </section>
           )}
 
-          {/* Recommended stories */}
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsTopPosts }}
           >
@@ -524,15 +531,22 @@ export const TagTopicPage = ({
                 ]}
                 query={TAG_FEED_QUERY}
                 variables={topPostsQueryVariables}
-                title={{ copy: 'Recommended stories' }}
+                title={{
+                  copy: `Recommended ${title} stories`,
+                  tag: TypographyTag.H2,
+                }}
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />
             </RailWithFade>
           </ActiveFeedNameContext.Provider>
 
-          <WhoToFollow tag={tag} initialUsers={topContributors} />
-          <TagTopSources tag={tag} />
+          <WhoToFollow
+            tag={tag}
+            title={title}
+            initialUsers={topContributors}
+          />
+          <TagTopSources tag={tag} title={title} />
 
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsMostUpvoted }}
@@ -548,7 +562,8 @@ export const TagTopicPage = ({
                 query={MOST_UPVOTED_FEED_QUERY}
                 variables={mostUpvotedQueryVariables}
                 title={{
-                  copy: 'Most upvoted posts',
+                  copy: `Most upvoted ${title} posts`,
+                  tag: TypographyTag.H2,
                   icon: (
                     <UpvoteIcon size={IconSize.Medium} className="mr-1.5" />
                   ),
@@ -572,7 +587,8 @@ export const TagTopicPage = ({
                 query={MOST_DISCUSSED_FEED_QUERY}
                 variables={bestDiscussedQueryVariables}
                 title={{
-                  copy: 'Best discussed posts',
+                  copy: `Best discussed ${title} posts`,
+                  tag: TypographyTag.H2,
                   icon: (
                     <DiscussIcon size={IconSize.Medium} className="mr-1.5" />
                   ),

--- a/packages/shared/src/components/tags/TagTopicPage.tsx
+++ b/packages/shared/src/components/tags/TagTopicPage.tsx
@@ -57,6 +57,8 @@ import { EngagementPlacement } from '../../lib/engagementAds';
 import UserEntityCard from '../cards/entity/UserEntityCard';
 import SourceEntityCard from '../cards/entity/SourceEntityCard';
 import EntityCardSkeleton from '../cards/entity/EntityCardSkeleton';
+import { EntitySectionHeading } from '../entity/EntitySectionHeading';
+import { EntityRailWithFade } from '../entity/EntityRailWithFade';
 import { TagPageNavbar } from './TagPageNavbar';
 import { PublicPageSignupBanner } from '../auth/PublicPageSignupBanner';
 import { largeNumberFormat } from '../../lib/numberFormat';
@@ -85,43 +87,6 @@ export interface TagTopicPageProps {
   topContributors: UserShortProfile[];
   jsonLd?: string | null;
 }
-
-const SectionHeading = ({
-  children,
-  icon,
-}: {
-  children: ReactNode;
-  icon?: ReactNode;
-}): ReactElement => (
-  <Typography
-    tag={TypographyTag.H2}
-    type={TypographyType.Title3}
-    color={TypographyColor.Primary}
-    bold
-    className="mb-4 mt-2"
-  >
-    {icon ? (
-      <span className="inline-flex flex-wrap items-center gap-x-1.5">
-        {icon}
-        <span>{children}</span>
-      </span>
-    ) : (
-      children
-    )}
-  </Typography>
-);
-
-// Wraps a horizontal post rail with a right-edge gradient so the last card
-// blends into the background instead of being hard-cut by the scroll overflow.
-const RailWithFade = ({ children }: { children: ReactNode }): ReactElement => (
-  <div className="relative mb-10">
-    {children}
-    <div
-      aria-hidden
-      className="pointer-events-none absolute inset-y-0 right-0 w-12 bg-gradient-to-r from-transparent to-background-default"
-    />
-  </div>
-);
 
 // Render the user/source cards in the same grid the post feed uses (same
 // column count + card width) so every card on the page lines up identically.
@@ -183,7 +148,7 @@ const TagTopSources = ({
 
   return (
     <section className="mb-10">
-      <SectionHeading>Top sources covering {title}</SectionHeading>
+      <EntitySectionHeading>Top sources covering {title}</EntitySectionHeading>
       {isPending ? (
         <EntityGridSkeleton />
       ) : (
@@ -230,7 +195,7 @@ const WhoToFollow = ({
 
   return (
     <section className="mb-10">
-      <SectionHeading>Who to follow for {title}</SectionHeading>
+      <EntitySectionHeading>Who to follow for {title}</EntitySectionHeading>
       {isLoading ? (
         <EntityGridSkeleton />
       ) : (
@@ -497,7 +462,7 @@ export const TagTopicPage = ({
 
           {showRoadmap && initialData?.flags?.roadmap && (
             <section className="mb-10">
-              <SectionHeading>Roadmaps</SectionHeading>
+              <EntitySectionHeading>Roadmaps</EntitySectionHeading>
               <Link href={initialData.flags.roadmap} passHref prefetch={false}>
                 <a
                   target="_blank"
@@ -530,8 +495,10 @@ export const TagTopicPage = ({
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsTopPosts }}
           >
-            <SectionHeading>Recommended {title} stories</SectionHeading>
-            <RailWithFade>
+            <EntitySectionHeading>
+              Recommended {title} stories
+            </EntitySectionHeading>
+            <EntityRailWithFade>
               <HorizontalFeed
                 feedName={OtherFeedPage.TagsTopPosts}
                 feedQueryKey={[
@@ -544,7 +511,7 @@ export const TagTopicPage = ({
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />
-            </RailWithFade>
+            </EntityRailWithFade>
           </ActiveFeedNameContext.Provider>
 
           <WhoToFollow tag={tag} title={title} initialUsers={topContributors} />
@@ -553,12 +520,12 @@ export const TagTopicPage = ({
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsMostUpvoted }}
           >
-            <SectionHeading
+            <EntitySectionHeading
               icon={<UpvoteIcon size={IconSize.Medium} className="shrink-0" />}
             >
               Most upvoted {title} posts
-            </SectionHeading>
-            <RailWithFade>
+            </EntitySectionHeading>
+            <EntityRailWithFade>
               <HorizontalFeed
                 feedName={OtherFeedPage.TagsMostUpvoted}
                 feedQueryKey={[
@@ -571,17 +538,17 @@ export const TagTopicPage = ({
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />
-            </RailWithFade>
+            </EntityRailWithFade>
           </ActiveFeedNameContext.Provider>
           <ActiveFeedNameContext.Provider
             value={{ feedName: OtherFeedPage.TagsBestDiscussed }}
           >
-            <SectionHeading
+            <EntitySectionHeading
               icon={<DiscussIcon size={IconSize.Medium} className="shrink-0" />}
             >
               Best discussed {title} posts
-            </SectionHeading>
-            <RailWithFade>
+            </EntitySectionHeading>
+            <EntityRailWithFade>
               <HorizontalFeed
                 feedName={OtherFeedPage.TagsBestDiscussed}
                 feedQueryKey={[
@@ -594,7 +561,7 @@ export const TagTopicPage = ({
                 className="!mx-0 !mb-0"
                 emptyScreen={<></>}
               />
-            </RailWithFade>
+            </EntityRailWithFade>
           </ActiveFeedNameContext.Provider>
           <ArchiveEntryCard
             scopeType={ArchiveScopeType.Tag}
@@ -605,7 +572,7 @@ export const TagTopicPage = ({
 
           <div className="my-2 h-px w-full bg-border-subtlest-tertiary" />
 
-          <SectionHeading>All posts about {title}</SectionHeading>
+          <EntitySectionHeading>All posts about {title}</EntitySectionHeading>
           <Feed
             feedName={OtherFeedPage.Tag}
             feedQueryKey={['tagFeed', user?.id ?? 'anonymous', tag]}

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -178,6 +178,8 @@ const renderComponent = (
     optOutQuestSystem: false,
     optOutAchievements: false,
     isGamificationEnabled: true,
+    isQuestExperienceEnabled: true,
+    toggleQuestExperience: jest.fn().mockResolvedValue(undefined),
     toggleOptOutAchievements: jest.fn().mockResolvedValue(undefined),
     toggleAllGamification: jest.fn().mockResolvedValue(undefined),
     optOutCompanion: false,
@@ -319,7 +321,15 @@ it('should show login popup when logged-out on follow click', async () => {
 it('should render who to follow section from static props', async () => {
   renderComponent(undefined, defaultUser, initialDataObj, [topContributor]);
 
-  expect(await screen.findByText('Who to follow')).toBeInTheDocument();
+  expect(
+    await screen.findByRole('heading', {
+      level: 2,
+      name: 'Who to follow for React',
+    }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('heading', { level: 2, name: 'All posts about React' }),
+  ).toBeInTheDocument();
   expect(screen.getByText('Ido').closest('a')).toHaveAttribute(
     'href',
     '/idoshamun',
@@ -467,20 +477,37 @@ it('should unblock tag', async () => {
 });
 
 it('should load title and description for tag', async () => {
-  renderComponent([createFeedMock(), createTagsSettingsMock()], defaultUser, {
-    ...initialDataObj,
-    flags: {
-      title: 'React custom title',
-      description: 'React is an amazing framework',
+  renderComponent(
+    [createFeedMock(), createTagsSettingsMock()],
+    defaultUser,
+    {
+      ...initialDataObj,
+      flags: {
+        title: 'React custom title',
+        description: 'React is an amazing framework',
+      },
     },
-  });
+    [topContributor],
+  );
 
   await waitFor(() => {
     expect(
-      screen.getByRole('heading', { name: 'React custom title' }),
+      screen.getByRole('heading', { level: 1, name: 'React custom title' }),
     ).toBeInTheDocument();
     expect(
       screen.getByText('React is an amazing framework'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'Who to follow for React custom title',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', {
+        level: 2,
+        name: 'All posts about React custom title',
+      }),
     ).toBeInTheDocument();
   });
 });

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -328,6 +328,12 @@ it('should render who to follow section from static props', async () => {
     }),
   ).toBeInTheDocument();
   expect(
+    screen.getByRole('heading', {
+      level: 2,
+      name: 'Recommended React stories',
+    }),
+  ).toBeInTheDocument();
+  expect(
     screen.getByRole('heading', { level: 2, name: 'All posts about React' }),
   ).toBeInTheDocument();
   expect(screen.getByText('Ido').closest('a')).toHaveAttribute(

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -68,6 +68,11 @@ import { ArchiveBreadcrumbs } from '@dailydotdev/shared/src/components/archive/A
 import { PageHeader } from '@dailydotdev/shared/src/components/layout/PageHeader';
 import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
 import { ArchiveScopeType } from '@dailydotdev/shared/src/graphql/archive';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
 import Custom404 from '../404';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -117,7 +122,10 @@ const SourceRelatedTags = ({
   );
 };
 
-const SimilarSources = ({ sourceId }: SourceIdProps) => {
+const SimilarSources = ({
+  sourceId,
+  sourceName,
+}: SourceIdProps & { sourceName: string }) => {
   const { data: similarSources, isPending } = useQuery({
     queryKey: [RequestKey.SimilarSources, null, sourceId],
 
@@ -148,7 +156,7 @@ const SimilarSources = ({ sourceId }: SourceIdProps) => {
         name: source.name,
         permalink: source.permalink,
       }))}
-      title="Similar sources"
+      title={`Sources similar to ${sourceName}`}
       className={pageSectionClassName}
     />
   );
@@ -298,7 +306,7 @@ const SourcePage = ({
           )}
           <SourceRelatedTags sourceId={source.id} initialTags={relatedTags} />
         </PageInfoHeader>
-        <SimilarSources sourceId={source.id} />
+        <SimilarSources sourceId={source.id} sourceName={source.name} />
         {relatedTags.length > 0 && (
           <div className="sr-only">
             {relatedTags
@@ -337,7 +345,8 @@ const SourcePage = ({
             query={MOST_UPVOTED_FEED_QUERY}
             variables={mostUpvotedQueryVariables}
             title={{
-              copy: 'Most upvoted posts',
+              copy: `Most upvoted posts from ${source.name}`,
+              tag: TypographyTag.H2,
               icon: <UpvoteIcon size={IconSize.Medium} className="mr-1.5" />,
             }}
             className={horizontalFeedClassName}
@@ -357,7 +366,8 @@ const SourcePage = ({
             query={MOST_DISCUSSED_FEED_QUERY}
             variables={bestDiscussedQueryVariables}
             title={{
-              copy: 'Best discussed posts',
+              copy: `Best discussed posts from ${source.name}`,
+              tag: TypographyTag.H2,
               icon: <DiscussIcon size={IconSize.Medium} className="mr-1.5" />,
             }}
             className={horizontalFeedClassName}
@@ -373,9 +383,14 @@ const SourcePage = ({
         <div
           className={`${pageSectionClassName} mb-5 flex w-auto items-center`}
         >
-          <p className="flex items-center font-bold typo-body">
+          <Typography
+            tag={TypographyTag.H2}
+            type={TypographyType.Body}
+            bold
+            className="flex items-center"
+          >
             All posts from {source.name}
-          </p>
+          </Typography>
         </div>
         <Feed
           feedName={OtherFeedPage.Squad}

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -68,11 +68,8 @@ import { ArchiveBreadcrumbs } from '@dailydotdev/shared/src/components/archive/A
 import { PageHeader } from '@dailydotdev/shared/src/components/layout/PageHeader';
 import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
 import { ArchiveScopeType } from '@dailydotdev/shared/src/graphql/archive';
-import {
-  Typography,
-  TypographyTag,
-  TypographyType,
-} from '@dailydotdev/shared/src/components/typography/Typography';
+import { EntitySectionHeading } from '@dailydotdev/shared/src/components/entity/EntitySectionHeading';
+import { EntityRailWithFade } from '@dailydotdev/shared/src/components/entity/EntityRailWithFade';
 import Custom404 from '../404';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -86,7 +83,7 @@ const appOrigin = getAppOrigin();
 const pageSectionClassName = 'mx-4';
 const pageSectionAutoWidthClassName = `${pageSectionClassName} !w-auto`;
 const pageFeedClassName = '!mx-4 !w-auto';
-const horizontalFeedClassName = 'laptop:!mx-4';
+const horizontalRailClassName = '!mx-0 !mb-0';
 
 interface SourcePageProps extends DynamicSeoProps {
   source?: Source;
@@ -335,44 +332,56 @@ const SourcePage = ({
         <ActiveFeedNameContext.Provider
           value={{ feedName: OtherFeedPage.SourceMostUpvoted }}
         >
-          <HorizontalFeed
-            feedName={OtherFeedPage.SourceMostUpvoted}
-            feedQueryKey={[
-              'sourceMostUpvoted',
-              user?.id ?? 'anonymous',
-              Object.values(mostUpvotedQueryVariables),
-            ]}
-            query={MOST_UPVOTED_FEED_QUERY}
-            variables={mostUpvotedQueryVariables}
-            title={{
-              copy: `Most upvoted posts from ${source.name}`,
-              tag: TypographyTag.H2,
-              icon: <UpvoteIcon size={IconSize.Medium} className="mr-1.5" />,
-            }}
-            className={horizontalFeedClassName}
-            emptyScreen={<></>}
-          />
+          <div className={pageSectionClassName}>
+            <EntitySectionHeading
+              icon={
+                <UpvoteIcon size={IconSize.Medium} className="shrink-0" />
+              }
+            >
+              Most upvoted posts from {source.name}
+            </EntitySectionHeading>
+            <EntityRailWithFade>
+              <HorizontalFeed
+                feedName={OtherFeedPage.SourceMostUpvoted}
+                feedQueryKey={[
+                  'sourceMostUpvoted',
+                  user?.id ?? 'anonymous',
+                  Object.values(mostUpvotedQueryVariables),
+                ]}
+                query={MOST_UPVOTED_FEED_QUERY}
+                variables={mostUpvotedQueryVariables}
+                className={horizontalRailClassName}
+                emptyScreen={<></>}
+              />
+            </EntityRailWithFade>
+          </div>
         </ActiveFeedNameContext.Provider>
         <ActiveFeedNameContext.Provider
           value={{ feedName: OtherFeedPage.SourceBestDiscussed }}
         >
-          <HorizontalFeed
-            feedName={OtherFeedPage.SourceBestDiscussed}
-            feedQueryKey={[
-              'sourceBestDiscussed',
-              user?.id ?? 'anonymous',
-              Object.values(bestDiscussedQueryVariables),
-            ]}
-            query={MOST_DISCUSSED_FEED_QUERY}
-            variables={bestDiscussedQueryVariables}
-            title={{
-              copy: `Best discussed posts from ${source.name}`,
-              tag: TypographyTag.H2,
-              icon: <DiscussIcon size={IconSize.Medium} className="mr-1.5" />,
-            }}
-            className={horizontalFeedClassName}
-            emptyScreen={<></>}
-          />
+          <div className={pageSectionClassName}>
+            <EntitySectionHeading
+              icon={
+                <DiscussIcon size={IconSize.Medium} className="shrink-0" />
+              }
+            >
+              Best discussed posts from {source.name}
+            </EntitySectionHeading>
+            <EntityRailWithFade>
+              <HorizontalFeed
+                feedName={OtherFeedPage.SourceBestDiscussed}
+                feedQueryKey={[
+                  'sourceBestDiscussed',
+                  user?.id ?? 'anonymous',
+                  Object.values(bestDiscussedQueryVariables),
+                ]}
+                query={MOST_DISCUSSED_FEED_QUERY}
+                variables={bestDiscussedQueryVariables}
+                className={horizontalRailClassName}
+                emptyScreen={<></>}
+              />
+            </EntityRailWithFade>
+          </div>
         </ActiveFeedNameContext.Provider>
         <ArchiveEntryCard
           scopeType={ArchiveScopeType.Source}
@@ -380,29 +389,22 @@ const SourcePage = ({
           scopeName={source.name}
           className={`${pageSectionClassName} mb-6`}
         />
-        <div
-          className={`${pageSectionClassName} mb-5 flex w-auto items-center`}
-        >
-          <Typography
-            tag={TypographyTag.H2}
-            type={TypographyType.Body}
-            bold
-            className="flex items-center"
-          >
+        <div className={pageSectionClassName}>
+          <EntitySectionHeading>
             All posts from {source.name}
-          </Typography>
+          </EntitySectionHeading>
+          <Feed
+            feedName={OtherFeedPage.Squad}
+            feedQueryKey={[
+              'sourceFeed',
+              user?.id ?? 'anonymous',
+              Object.values(queryVariables),
+            ]}
+            query={SOURCE_FEED_QUERY}
+            variables={queryVariables}
+            className={pageFeedClassName}
+          />
         </div>
-        <Feed
-          feedName={OtherFeedPage.Squad}
-          feedQueryKey={[
-            'sourceFeed',
-            user?.id ?? 'anonymous',
-            Object.values(queryVariables),
-          ]}
-          query={SOURCE_FEED_QUERY}
-          variables={queryVariables}
-          className={pageFeedClassName}
-        />
         {shouldShowAuthBanner && isLaptop && <AuthenticationBanner />}
       </FeedPageLayoutComponent>
     </>

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -334,9 +334,7 @@ const SourcePage = ({
         >
           <div className={pageSectionClassName}>
             <EntitySectionHeading
-              icon={
-                <UpvoteIcon size={IconSize.Medium} className="shrink-0" />
-              }
+              icon={<UpvoteIcon size={IconSize.Medium} className="shrink-0" />}
             >
               Most upvoted posts from {source.name}
             </EntitySectionHeading>
@@ -361,9 +359,7 @@ const SourcePage = ({
         >
           <div className={pageSectionClassName}>
             <EntitySectionHeading
-              icon={
-                <DiscussIcon size={IconSize.Medium} className="shrink-0" />
-              }
+              icon={<DiscussIcon size={IconSize.Medium} className="shrink-0" />}
             >
               Best discussed posts from {source.name}
             </EntitySectionHeading>


### PR DESCRIPTION
## Summary
- Dynamize tag and source page section titles with the entity display name (e.g. "Most upvoted React posts", "Sources similar to React").
- Promote horizontal rail and related-entity section titles to real H2s so the new keywords count as semantic headings for SEO.
- Update TagPage tests to assert H2 roles and custom `flags.title` usage in section copy.

## Test plan
- [x] `node ./scripts/typecheck-strict-changed.js`
- [x] `NODE_ENV=test pnpm --filter webapp exec jest __tests__/TagPage.tsx`
- [ ] Spot-check `/tags/react` and a source page for updated section titles and unchanged visual styling
- [ ] Confirm heading outline: one H1, section rails as H2s


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-entity-section-seo-titles.preview.app.daily.dev