### PR TITLE
fix: improve link composer commentary input

### DIFF
--- a/packages/shared/src/components/modals/post/SmartComposerModal.spec.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.spec.tsx
@@ -9,6 +9,7 @@ import { usePrompt } from '../../../hooks/usePrompt';
 import { useNotificationToggle } from '../../../hooks/notifications';
 import { useComposerAudience } from '../../post/composer/useComposerAudience';
 import { useComposerSubmit } from '../../post/composer/useComposerSubmit';
+import { LogEvent } from '../../../lib/log';
 import { SmartComposerModal } from './SmartComposerModal';
 
 jest.mock('../../../contexts/AuthContext', () => ({
@@ -201,5 +202,35 @@ describe('SmartComposerModal', () => {
     expect(
       screen.getByRole('textbox', { name: 'Post commentary' }),
     ).toHaveFocus();
+  });
+
+  it('ignores the submit shortcut when submitting is blocked', () => {
+    jest.mocked(useComposerSubmit).mockReturnValue({
+      handleSubmit,
+      isSubmitDisabled: true,
+      isInFlight: false,
+      preview: undefined,
+      isLoadingPreview: true,
+      fetchPreview: jest.fn(),
+      standupErrors: {},
+    });
+
+    renderWithClient(
+      <SmartComposerModal
+        isOpen
+        initialKind="link"
+        onRequestClose={onRequestClose}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Link URL' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(logEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event_name: LogEvent.SubmitSmartComposer }),
+    );
   });
 });

--- a/packages/shared/src/components/modals/post/SmartComposerModal.spec.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useLogContext } from '../../../contexts/LogContext';
@@ -57,10 +57,6 @@ jest.mock('../../post/composer/KindModePicker', () => ({
   KindModePicker: () => null,
 }));
 
-jest.mock('../../post/composer/LinkForm', () => ({
-  LinkForm: () => null,
-}));
-
 jest.mock('../../post/composer/PollForm', () => ({
   PollForm: () => null,
 }));
@@ -71,6 +67,14 @@ jest.mock('../../post/composer/TextForm', () => ({
 
 jest.mock('../../tooltip/Tooltip', () => ({
   Tooltip: ({ children }: React.PropsWithChildren) => children,
+}));
+
+jest.mock('../../post/write/WriteLinkPreview', () => ({
+  WriteLinkPreview: () => null,
+}));
+
+jest.mock('../../post/write/WritePreviewSkeleton', () => ({
+  WritePreviewSkeleton: () => null,
 }));
 
 jest.mock('../common/Modal', () => ({
@@ -91,9 +95,13 @@ describe('SmartComposerModal', () => {
   const showPrompt = jest.fn();
   const onSubmitted = jest.fn();
   const onRequestClose = jest.fn();
+  let handleSubmit: jest.Mock;
 
   beforeEach(() => {
     jest.clearAllMocks();
+    handleSubmit = jest.fn((event?: React.FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+    });
 
     jest.mocked(useAuthContext).mockReturnValue({
       user: null,
@@ -131,7 +139,7 @@ describe('SmartComposerModal', () => {
       userAudienceId: 'user-1',
     } as unknown as ReturnType<typeof useComposerAudience>);
     jest.mocked(useComposerSubmit).mockReturnValue({
-      handleSubmit: jest.fn(),
+      handleSubmit,
       isSubmitDisabled: false,
       isInFlight: false,
       preview: { url: 'https://daily.dev', title: 'daily.dev' },
@@ -174,5 +182,24 @@ describe('SmartComposerModal', () => {
 
     expect(onSubmitted).toHaveBeenCalledTimes(1);
     expect(onRequestClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps Enter in the link URL field from submitting the composer', () => {
+    renderWithClient(
+      <SmartComposerModal
+        isOpen
+        initialKind="link"
+        onRequestClose={onRequestClose}
+      />,
+    );
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Link URL' }), {
+      key: 'Enter',
+    });
+
+    expect(handleSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole('textbox', { name: 'Post commentary' }),
+    ).toHaveFocus();
   });
 });

--- a/packages/shared/src/components/modals/post/SmartComposerModal.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.tsx
@@ -404,18 +404,26 @@ export function SmartComposerModal({
     />
   );
 
+  const isCoverUploading = !!cover?.isUploading;
+  const isSubmitBlocked =
+    isSubmitDisabled || isCoverUploading || (isEditing && !isDirty);
+
   const onFormSubmit = useCallback(
     (event: React.FormEvent<HTMLFormElement>) => {
+      if (isSubmitBlocked) {
+        event.preventDefault();
+        return undefined;
+      }
+
       logEvent({
         event_name: LogEvent.SubmitSmartComposer,
         extra: JSON.stringify({ kind, audiences: selectedIds.length }),
       });
       return handleSubmit(event);
     },
-    [handleSubmit, kind, logEvent, selectedIds.length],
+    [handleSubmit, isSubmitBlocked, kind, logEvent, selectedIds.length],
   );
 
-  const isCoverUploading = !!cover?.isUploading;
   const scheduleButtonNode = canSchedule ? (
     <SchedulePostButton
       isScheduled={schedule.isScheduled}
@@ -435,7 +443,7 @@ export function SmartComposerModal({
       type="submit"
       variant={ButtonVariant.Primary}
       size={ButtonSize.Small}
-      disabled={isSubmitDisabled || isCoverUploading || (isEditing && !isDirty)}
+      disabled={isSubmitBlocked}
       loading={isInFlight || isCoverUploading}
       className="px-5"
     >

--- a/packages/shared/src/components/post/composer/LinkForm.spec.tsx
+++ b/packages/shared/src/components/post/composer/LinkForm.spec.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LinkForm } from './LinkForm';
+import { DEFAULT_LINK, TITLE_MAX_LENGTH, type LinkFormState } from './types';
+
+jest.mock('../../../hooks/input', () => ({
+  useDebouncedUrl: (
+    callback: (value?: string) => void,
+    onValidate: (value?: string) => boolean,
+  ) => [
+    (value?: string) => {
+      if (value && onValidate(value)) {
+        callback(value);
+      }
+    },
+    jest.fn(),
+  ],
+}));
+
+jest.mock('../write/WriteLinkPreview', () => ({
+  WriteLinkPreview: () => null,
+}));
+
+jest.mock('../write/WritePreviewSkeleton', () => ({
+  WritePreviewSkeleton: () => null,
+}));
+
+const renderLinkForm = ({
+  initialValue = DEFAULT_LINK,
+  onSubmit = jest.fn(),
+}: {
+  initialValue?: LinkFormState;
+  onSubmit?: jest.Mock;
+} = {}) => {
+  const fetchPreview = jest.fn();
+
+  const FormHarness = (): React.ReactElement => {
+    const [value, setValue] = useState<LinkFormState>(initialValue);
+
+    return (
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          onSubmit();
+        }}
+      >
+        <LinkForm
+          value={value}
+          onChange={setValue}
+          fetchPreview={fetchPreview}
+        />
+        <button type="submit">Post</button>
+      </form>
+    );
+  };
+
+  render(<FormHarness />);
+
+  return { fetchPreview, onSubmit };
+};
+
+describe('LinkForm', () => {
+  it('collapses pasted commentary newlines into spaces', () => {
+    renderLinkForm();
+
+    const commentary = screen.getByRole('textbox', {
+      name: 'Post commentary',
+    });
+
+    fireEvent.change(commentary, {
+      target: { value: 'First line\n  second line\r\n\nthird line' },
+    });
+
+    expect(commentary).toHaveValue('First line second line third line');
+  });
+
+  it('moves focus to commentary instead of submitting when Enter is pressed in the URL field', () => {
+    const { onSubmit } = renderLinkForm();
+
+    const urlInput = screen.getByRole('textbox', { name: 'Link URL' });
+    const commentary = screen.getByRole('textbox', {
+      name: 'Post commentary',
+    });
+
+    fireEvent.keyDown(urlInput, { key: 'Enter' });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(commentary).toHaveFocus();
+  });
+
+  it('submits when Ctrl+Enter is pressed in the URL field', () => {
+    const { onSubmit } = renderLinkForm();
+
+    fireEvent.keyDown(screen.getByRole('textbox', { name: 'Link URL' }), {
+      key: 'Enter',
+      ctrlKey: true,
+    });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('submits when Ctrl+Enter is pressed in the commentary field', () => {
+    const { onSubmit } = renderLinkForm();
+
+    fireEvent.keyDown(
+      screen.getByRole('textbox', {
+        name: 'Post commentary',
+      }),
+      {
+        key: 'Enter',
+        ctrlKey: true,
+      },
+    );
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps commentary capped to the composer title length', () => {
+    renderLinkForm();
+
+    expect(
+      screen.getByRole('textbox', {
+        name: 'Post commentary',
+      }),
+    ).toHaveAttribute('maxlength', `${TITLE_MAX_LENGTH}`);
+  });
+});

--- a/packages/shared/src/components/post/composer/LinkForm.spec.tsx
+++ b/packages/shared/src/components/post/composer/LinkForm.spec.tsx
@@ -56,7 +56,7 @@ const renderLinkForm = ({
 
   render(<FormHarness />);
 
-  return { fetchPreview, onSubmit };
+  return { onSubmit };
 };
 
 describe('LinkForm', () => {

--- a/packages/shared/src/components/post/composer/LinkForm.spec.tsx
+++ b/packages/shared/src/components/post/composer/LinkForm.spec.tsx
@@ -124,4 +124,16 @@ describe('LinkForm', () => {
       }),
     ).toHaveAttribute('maxlength', `${TITLE_MAX_LENGTH}`);
   });
+
+  it('keeps plain Enter in the commentary from adding a line', () => {
+    const { onSubmit } = renderLinkForm();
+
+    const commentary = screen.getByRole('textbox', {
+      name: 'Post commentary',
+    });
+    const notPrevented = fireEvent.keyDown(commentary, { key: 'Enter' });
+
+    expect(notPrevented).toBe(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
 });

--- a/packages/shared/src/components/post/composer/LinkForm.tsx
+++ b/packages/shared/src/components/post/composer/LinkForm.tsx
@@ -25,8 +25,6 @@ interface LinkFormProps {
   initialUrl?: string;
 }
 
-const COMMENTARY_MAX_HEIGHT = 144;
-
 export const LinkForm = ({
   value,
   onChange,
@@ -76,10 +74,10 @@ export const LinkForm = ({
     isPreviewForComposerUrl(preview, value.url) && !isDismissedForCurrentUrl;
   const showSkeleton = isLoadingPreview && !isDismissedForCurrentUrl;
 
-  useAutoResizeTextarea(commentaryRef, value.commentary, COMMENTARY_MAX_HEIGHT);
+  useAutoResizeTextarea(commentaryRef, value.commentary);
 
-  const onUrlKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
+  const onEnterKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       if (event.nativeEvent.isComposing || event.key !== 'Enter') {
         return;
       }
@@ -91,22 +89,6 @@ export const LinkForm = ({
       }
 
       commentaryRef.current?.focus();
-    },
-    [],
-  );
-
-  const onCommentaryKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (
-        event.nativeEvent.isComposing ||
-        event.key !== 'Enter' ||
-        (!event.ctrlKey && !event.metaKey)
-      ) {
-        return;
-      }
-
-      event.preventDefault();
-      event.currentTarget.form?.requestSubmit();
     },
     [],
   );
@@ -135,7 +117,7 @@ export const LinkForm = ({
         onInput={(event) => {
           onUrlChange(event.currentTarget.value);
         }}
-        onKeyDown={onUrlKeyDown}
+        onKeyDown={onEnterKeyDown}
         aria-label="Link URL"
         className="w-full bg-transparent font-bold leading-tight text-text-primary outline-none typo-title2 placeholder:text-text-quaternary"
       />
@@ -154,9 +136,9 @@ export const LinkForm = ({
             ),
           })
         }
-        onKeyDown={onCommentaryKeyDown}
+        onKeyDown={onEnterKeyDown}
         aria-label="Post commentary"
-        className="w-full resize-none overflow-hidden break-words bg-transparent text-text-primary outline-none typo-callout placeholder:text-text-quaternary"
+        className="max-h-36 w-full resize-none overflow-y-auto break-words bg-transparent text-text-primary outline-none typo-callout placeholder:text-text-quaternary"
       />
       {(showSkeleton || (preview && showPreview)) && (
         <div className="relative flex flex-col gap-3">

--- a/packages/shared/src/components/post/composer/LinkForm.tsx
+++ b/packages/shared/src/components/post/composer/LinkForm.tsx
@@ -76,9 +76,7 @@ export const LinkForm = ({
     isPreviewForComposerUrl(preview, value.url) && !isDismissedForCurrentUrl;
   const showSkeleton = isLoadingPreview && !isDismissedForCurrentUrl;
 
-  useAutoResizeTextarea(commentaryRef, value.commentary, {
-    maxHeight: COMMENTARY_MAX_HEIGHT,
-  });
+  useAutoResizeTextarea(commentaryRef, value.commentary, COMMENTARY_MAX_HEIGHT);
 
   const onUrlKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/shared/src/components/post/composer/LinkForm.tsx
+++ b/packages/shared/src/components/post/composer/LinkForm.tsx
@@ -7,8 +7,13 @@ import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
 import { MiniCloseIcon } from '../../icons';
 import { Tooltip } from '../../tooltip/Tooltip';
 import type { ExternalLinkPreview } from '../../../graphql/posts';
+import { useAutoResizeTextarea } from '../../../hooks/utils/useAutoResizeTextarea';
 import { TITLE_MAX_LENGTH, type LinkFormState } from './types';
-import { isPreviewForComposerUrl, normalizeComposerUrl } from './utils';
+import {
+  isPreviewForComposerUrl,
+  normalizeComposerUrl,
+  normalizeSingleLineComposerText,
+} from './utils';
 
 interface LinkFormProps {
   value: LinkFormState;
@@ -20,6 +25,8 @@ interface LinkFormProps {
   initialUrl?: string;
 }
 
+const COMMENTARY_MAX_HEIGHT = 144;
+
 export const LinkForm = ({
   value,
   onChange,
@@ -30,6 +37,7 @@ export const LinkForm = ({
   initialUrl,
 }: LinkFormProps): ReactElement => {
   const urlRef = useRef<HTMLInputElement>(null);
+  const commentaryRef = useRef<HTMLTextAreaElement>(null);
   const [dismissedUrl, setDismissedUrl] = useState<string | null>(null);
 
   useEffect(() => {
@@ -68,6 +76,43 @@ export const LinkForm = ({
     isPreviewForComposerUrl(preview, value.url) && !isDismissedForCurrentUrl;
   const showSkeleton = isLoadingPreview && !isDismissedForCurrentUrl;
 
+  useAutoResizeTextarea(commentaryRef, value.commentary, {
+    maxHeight: COMMENTARY_MAX_HEIGHT,
+  });
+
+  const onUrlKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      if (event.nativeEvent.isComposing || event.key !== 'Enter') {
+        return;
+      }
+
+      event.preventDefault();
+      if (event.ctrlKey || event.metaKey) {
+        event.currentTarget.form?.requestSubmit();
+        return;
+      }
+
+      commentaryRef.current?.focus();
+    },
+    [],
+  );
+
+  const onCommentaryKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (
+        event.nativeEvent.isComposing ||
+        event.key !== 'Enter' ||
+        (!event.ctrlKey && !event.metaKey)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.currentTarget.form?.requestSubmit();
+    },
+    [],
+  );
+
   useEffect(() => {
     if (!initialUrl) {
       return;
@@ -92,10 +137,12 @@ export const LinkForm = ({
         onInput={(event) => {
           onUrlChange(event.currentTarget.value);
         }}
+        onKeyDown={onUrlKeyDown}
         aria-label="Link URL"
         className="w-full bg-transparent font-bold leading-tight text-text-primary outline-none typo-title2 placeholder:text-text-quaternary"
       />
       <textarea
+        ref={commentaryRef}
         name="commentary"
         placeholder="Add a comment (optional)"
         maxLength={TITLE_MAX_LENGTH}
@@ -104,9 +151,12 @@ export const LinkForm = ({
         onChange={(event) =>
           onChange({
             ...value,
-            commentary: event.currentTarget.value.replace(/\n/g, ''),
+            commentary: normalizeSingleLineComposerText(
+              event.currentTarget.value,
+            ),
           })
         }
+        onKeyDown={onCommentaryKeyDown}
         aria-label="Post commentary"
         className="w-full resize-none overflow-hidden break-words bg-transparent text-text-primary outline-none typo-callout placeholder:text-text-quaternary"
       />

--- a/packages/shared/src/components/post/composer/TextForm.tsx
+++ b/packages/shared/src/components/post/composer/TextForm.tsx
@@ -4,7 +4,6 @@ import React, {
   useCallback,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useRef,
 } from 'react';
 import classNames from 'classnames';
@@ -21,7 +20,9 @@ import {
   ACCEPTED_TYPES,
   imageSizeLimitMB,
 } from '../../../graphql/posts';
+import { useAutoResizeTextarea } from '../../../hooks/utils/useAutoResizeTextarea';
 import { TITLE_MAX_LENGTH, type TextFormState } from './types';
+import { normalizeSingleLineComposerText } from './utils';
 
 export interface TextFormCover {
   preview: string;
@@ -80,14 +81,7 @@ export const TextForm = forwardRef<TextFormHandle, TextFormProps>(
       titleEl.setSelectionRange(end, end);
     }, []);
 
-    useLayoutEffect(() => {
-      const titleEl = titleRef.current;
-      if (!titleEl) {
-        return;
-      }
-      titleEl.style.height = 'auto';
-      titleEl.style.height = `${titleEl.scrollHeight}px`;
-    }, [value.title]);
+    useAutoResizeTextarea(titleRef, value.title);
 
     const onTitleKeyDown = useCallback(
       (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -152,7 +146,7 @@ export const TextForm = forwardRef<TextFormHandle, TextFormProps>(
             onChange={(e) =>
               onChange({
                 ...value,
-                title: e.currentTarget.value.replace(/\n/g, ''),
+                title: normalizeSingleLineComposerText(e.currentTarget.value),
               })
             }
             onKeyDown={onTitleKeyDown}

--- a/packages/shared/src/components/post/composer/utils.spec.ts
+++ b/packages/shared/src/components/post/composer/utils.spec.ts
@@ -1,4 +1,8 @@
-import { isPreviewForComposerUrl, normalizeComposerUrl } from './utils';
+import {
+  isPreviewForComposerUrl,
+  normalizeComposerUrl,
+  normalizeSingleLineComposerText,
+} from './utils';
 
 describe('composer utils', () => {
   it('normalizes URLs without a protocol', () => {
@@ -19,5 +23,11 @@ describe('composer utils', () => {
 
     expect(isPreviewForComposerUrl(preview, 'daily.dev')).toBe(true);
     expect(isPreviewForComposerUrl(preview, 'https://example.com')).toBe(false);
+  });
+
+  it('collapses newlines in single-line composer text into spaces', () => {
+    expect(
+      normalizeSingleLineComposerText('First line\n  second line\r\n\nthird'),
+    ).toBe('First line second line third');
   });
 });

--- a/packages/shared/src/components/post/composer/utils.ts
+++ b/packages/shared/src/components/post/composer/utils.ts
@@ -6,6 +6,9 @@ export const normalizeComposerUrl = (value: string): string => {
   return result.success ? result.data : '';
 };
 
+export const normalizeSingleLineComposerText = (value: string): string =>
+  value.replace(/\s*[\r\n]+\s*/g, ' ');
+
 export const isPreviewForComposerUrl = (
   preview: ExternalLinkPreview | undefined,
   value: string,

--- a/packages/shared/src/hooks/utils/useAutoResizeTextarea.spec.tsx
+++ b/packages/shared/src/hooks/utils/useAutoResizeTextarea.spec.tsx
@@ -1,19 +1,11 @@
 import React, { useRef } from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { useAutoResizeTextarea } from './useAutoResizeTextarea';
 
-interface TestTextareaProps {
-  value: string;
-  maxHeight?: number;
-}
-
-const TestTextarea = ({
-  value,
-  maxHeight,
-}: TestTextareaProps): React.ReactElement => {
+const TestTextarea = ({ value }: { value: string }): React.ReactElement => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useAutoResizeTextarea(textareaRef, value, maxHeight);
+  useAutoResizeTextarea(textareaRef, value);
 
   return (
     <textarea
@@ -26,14 +18,36 @@ const TestTextarea = ({
 };
 
 describe('useAutoResizeTextarea', () => {
+  const nativeResizeObserver = global.ResizeObserver;
   let scrollHeight = 64;
+  let clientWidth = 400;
+  let triggerResize: () => void = () => undefined;
 
   beforeEach(() => {
     scrollHeight = 64;
+    clientWidth = 400;
     Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
       configurable: true,
       get: () => scrollHeight,
     });
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'clientWidth', {
+      configurable: true,
+      get: () => clientWidth,
+    });
+    global.ResizeObserver = jest.fn((callback: ResizeObserverCallback) => {
+      const observer = {
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      } as unknown as ResizeObserver;
+      triggerResize = () => callback([], observer);
+
+      return observer;
+    }) as unknown as typeof ResizeObserver;
+  });
+
+  afterEach(() => {
+    global.ResizeObserver = nativeResizeObserver;
   });
 
   it('resizes the textarea to its scroll height', () => {
@@ -48,15 +62,14 @@ describe('useAutoResizeTextarea', () => {
     expect(textarea).toHaveStyle({ height: '96px' });
   });
 
-  it('caps the textarea height and enables vertical scrolling', () => {
-    scrollHeight = 200;
+  it('resizes when the textarea width changes', () => {
+    render(<TestTextarea value="Long commentary" />);
+    const textarea = screen.getByRole('textbox', { name: 'Composer text' });
 
-    render(<TestTextarea value="Long commentary" maxHeight={144} />);
+    scrollHeight = 144;
+    clientWidth = 200;
+    act(() => triggerResize());
 
-    expect(screen.getByRole('textbox', { name: 'Composer text' })).toHaveStyle({
-      height: '144px',
-      maxHeight: '144px',
-      overflowY: 'auto',
-    });
+    expect(textarea).toHaveStyle({ height: '144px' });
   });
 });

--- a/packages/shared/src/hooks/utils/useAutoResizeTextarea.spec.tsx
+++ b/packages/shared/src/hooks/utils/useAutoResizeTextarea.spec.tsx
@@ -13,7 +13,7 @@ const TestTextarea = ({
 }: TestTextareaProps): React.ReactElement => {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-  useAutoResizeTextarea(textareaRef, value, { maxHeight });
+  useAutoResizeTextarea(textareaRef, value, maxHeight);
 
   return (
     <textarea

--- a/packages/shared/src/hooks/utils/useAutoResizeTextarea.spec.tsx
+++ b/packages/shared/src/hooks/utils/useAutoResizeTextarea.spec.tsx
@@ -1,0 +1,62 @@
+import React, { useRef } from 'react';
+import { render, screen } from '@testing-library/react';
+import { useAutoResizeTextarea } from './useAutoResizeTextarea';
+
+interface TestTextareaProps {
+  value: string;
+  maxHeight?: number;
+}
+
+const TestTextarea = ({
+  value,
+  maxHeight,
+}: TestTextareaProps): React.ReactElement => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useAutoResizeTextarea(textareaRef, value, { maxHeight });
+
+  return (
+    <textarea
+      ref={textareaRef}
+      aria-label="Composer text"
+      value={value}
+      readOnly
+    />
+  );
+};
+
+describe('useAutoResizeTextarea', () => {
+  let scrollHeight = 64;
+
+  beforeEach(() => {
+    scrollHeight = 64;
+    Object.defineProperty(HTMLTextAreaElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get: () => scrollHeight,
+    });
+  });
+
+  it('resizes the textarea to its scroll height', () => {
+    const { rerender } = render(<TestTextarea value="Short title" />);
+    const textarea = screen.getByRole('textbox', { name: 'Composer text' });
+
+    expect(textarea).toHaveStyle({ height: '64px' });
+
+    scrollHeight = 96;
+    rerender(<TestTextarea value="Longer title" />);
+
+    expect(textarea).toHaveStyle({ height: '96px' });
+  });
+
+  it('caps the textarea height and enables vertical scrolling', () => {
+    scrollHeight = 200;
+
+    render(<TestTextarea value="Long commentary" maxHeight={144} />);
+
+    expect(screen.getByRole('textbox', { name: 'Composer text' })).toHaveStyle({
+      height: '144px',
+      maxHeight: '144px',
+      overflowY: 'auto',
+    });
+  });
+});

--- a/packages/shared/src/hooks/utils/useAutoResizeTextarea.ts
+++ b/packages/shared/src/hooks/utils/useAutoResizeTextarea.ts
@@ -1,14 +1,10 @@
 import type { RefObject } from 'react';
 import { useLayoutEffect } from 'react';
 
-interface UseAutoResizeTextareaOptions {
-  maxHeight?: number;
-}
-
 export const useAutoResizeTextarea = (
   textareaRef: RefObject<HTMLTextAreaElement>,
   value: string,
-  { maxHeight }: UseAutoResizeTextareaOptions = {},
+  maxHeight?: number,
 ): void => {
   useLayoutEffect(() => {
     const textarea = textareaRef.current;

--- a/packages/shared/src/hooks/utils/useAutoResizeTextarea.ts
+++ b/packages/shared/src/hooks/utils/useAutoResizeTextarea.ts
@@ -1,34 +1,39 @@
 import type { RefObject } from 'react';
-import { useLayoutEffect } from 'react';
+import { useCallback, useLayoutEffect } from 'react';
 
 export const useAutoResizeTextarea = (
   textareaRef: RefObject<HTMLTextAreaElement>,
   value: string,
-  maxHeight?: number,
 ): void => {
-  useLayoutEffect(() => {
+  const resize = useCallback(() => {
     const textarea = textareaRef.current;
     if (!textarea) {
       return;
     }
-
     textarea.style.height = 'auto';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [textareaRef]);
 
-    const { scrollHeight } = textarea;
-    const nextHeight =
-      typeof maxHeight === 'number'
-        ? Math.min(scrollHeight, maxHeight)
-        : scrollHeight;
+  useLayoutEffect(() => {
+    resize();
+  }, [resize, value]);
 
-    textarea.style.height = `${nextHeight}px`;
-
-    if (typeof maxHeight !== 'number') {
-      textarea.style.removeProperty('max-height');
-      textarea.style.removeProperty('overflow-y');
-      return;
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return undefined;
     }
 
-    textarea.style.maxHeight = `${maxHeight}px`;
-    textarea.style.overflowY = scrollHeight > maxHeight ? 'auto' : 'hidden';
-  }, [maxHeight, textareaRef, value]);
+    let width = textarea.clientWidth;
+    const observer = new ResizeObserver(() => {
+      if (textarea.clientWidth === width) {
+        return;
+      }
+      width = textarea.clientWidth;
+      resize();
+    });
+    observer.observe(textarea);
+
+    return () => observer.disconnect();
+  }, [resize, textareaRef]);
 };

--- a/packages/shared/src/hooks/utils/useAutoResizeTextarea.ts
+++ b/packages/shared/src/hooks/utils/useAutoResizeTextarea.ts
@@ -1,0 +1,38 @@
+import type { RefObject } from 'react';
+import { useLayoutEffect } from 'react';
+
+interface UseAutoResizeTextareaOptions {
+  maxHeight?: number;
+}
+
+export const useAutoResizeTextarea = (
+  textareaRef: RefObject<HTMLTextAreaElement>,
+  value: string,
+  { maxHeight }: UseAutoResizeTextareaOptions = {},
+): void => {
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+    if (!textarea) {
+      return;
+    }
+
+    textarea.style.height = 'auto';
+
+    const { scrollHeight } = textarea;
+    const nextHeight =
+      typeof maxHeight === 'number'
+        ? Math.min(scrollHeight, maxHeight)
+        : scrollHeight;
+
+    textarea.style.height = `${nextHeight}px`;
+
+    if (typeof maxHeight !== 'number') {
+      textarea.style.removeProperty('max-height');
+      textarea.style.removeProperty('overflow-y');
+      return;
+    }
+
+    textarea.style.maxHeight = `${maxHeight}px`;
+    textarea.style.overflowY = scrollHeight > maxHeight ? 'auto' : 'hidden';
+  }, [maxHeight, textareaRef, value]);
+};


### PR DESCRIPTION
## Summary
- Add a shared auto-resize hook for composer textareas and use it in the text and link composer fields.
- Normalize pasted newlines in single-line composer text to spaces so words stay readable without changing stored post semantics.
- Prevent plain Enter in the link URL field from accidentally submitting; focus moves to commentary instead, while Ctrl/Cmd+Enter still submits.

## Verification
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/post/composer/LinkForm.spec.tsx src/components/modals/post/SmartComposerModal.spec.tsx src/hooks/utils/useAutoResizeTextarea.spec.tsx src/components/post/composer/utils.spec.ts --runInBand`
- `pnpm --filter @dailydotdev/shared exec eslint src/components/post/composer/LinkForm.tsx src/components/post/composer/TextForm.tsx src/components/post/composer/utils.ts src/components/post/composer/LinkForm.spec.tsx src/components/post/composer/utils.spec.ts src/components/modals/post/SmartComposerModal.spec.tsx src/hooks/utils/useAutoResizeTextarea.ts src/hooks/utils/useAutoResizeTextarea.spec.tsx --max-warnings 0`
- `node ./scripts/typecheck-strict-changed.js`
- `git diff --check origin/main...HEAD`

Closes ENG-1908

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1908-feedback-bug-report-lin.preview.app.daily.dev