### PR TITLE
fix(webapp): serve the service worker script with no-cache

### DIFF
--- a/packages/webapp/app/serwist/[path]/route.ts
+++ b/packages/webapp/app/serwist/[path]/route.ts
@@ -1,7 +1,23 @@
 import { createSerwistRoute } from '@serwist/turbopack';
 
-export const { dynamic, dynamicParams, revalidate, generateStaticParams, GET } =
-  createSerwistRoute({
-    swSrc: 'app/sw.ts',
-    useNativeEsbuild: true,
-  });
+const route = createSerwistRoute({
+  swSrc: 'app/sw.ts',
+  useNativeEsbuild: true,
+});
+
+export const { dynamic, dynamicParams, revalidate, generateStaticParams } =
+  route;
+
+// Browsers only pick up a new deployment once they re-fetch the service
+// worker script, and that fetch honors HTTP caching. Without an explicit
+// header this route is served with a multi-hour TTL, which pins logged-in
+// users (the only ones with the SW registered) to the previous build's
+// precache long after a deploy. `no-cache` keeps the response cacheable but
+// forces revalidation on every SW update check.
+export const GET = async (
+  ...args: Parameters<typeof route.GET>
+): Promise<Response> => {
+  const response = await route.GET(...args);
+  response.headers.set('Cache-Control', 'no-cache, must-revalidate');
+  return response;
+};

--- a/packages/webapp/next.config.ts
+++ b/packages/webapp/next.config.ts
@@ -356,6 +356,16 @@ const nextConfig: NextConfig = {
           ],
         },
         {
+          // The service worker script must revalidate on every update check,
+          // otherwise logged-in clients stay pinned to the previous build's
+          // precache until the TTL lapses (see app/serwist/[path]/route.ts,
+          // which sets the same header at the handler level).
+          source: '/serwist/:path*',
+          headers: [
+            { key: 'Cache-Control', value: 'no-cache, must-revalidate' },
+          ],
+        },
+        {
           // Static page (headers can't come from the page itself); framing is
           // limited to our own origin and our extensions. This CSP takes
           // precedence over the global X-Frame-Options in modern browsers.


### PR DESCRIPTION
## The problem

After #6400 deployed, production still showed the broken wide cards for logged-in users — while every logged-out check (and the preview deployment) looked fixed.

Cause: the webapp registers its Serwist service worker **only for logged-in users** (`register={!!user}` in `_app.tsx`), and the SW precaches the app shell. Clients only pick up a new deployment when they re-fetch `/serwist/sw.js` (it has `skipWaiting: true`, so a fresh script activates immediately) — but that fetch honors HTTP caching, and production served the script with `cache-control: public, max-age=14400`. Net effect: every deploy takes up to **4+ hours** to reach logged-in users, our whole active audience.

The route (`app/serwist/[path]/route.ts`, a `force-static` handler from `@serwist/turbopack`) sets `Content-Type` and `Service-Worker-Allowed` but no `Cache-Control`, so it fell through to default static caching.

## The fix

Serve the SW script with `Cache-Control: no-cache, must-revalidate` so every SW update check revalidates (ETag makes the common case a cheap 304):

- Wrap the route handler's `GET` to set the header — it's stored in the prerender (`sw.js.meta` now records `cache-control: no-cache, must-revalidate`).
- Mirror the rule in `next.config.ts` `headers()` for `/serwist/:path*` as a routing-layer backstop.

## Testing

- `pnpm --filter webapp build` passes; the prerendered `/serwist/sw.js` response metadata contains the new header.
- Lint + strict typecheck guard pass.
- Please verify on this PR's preview: `curl -sI https://<preview>/serwist/sw.js | grep -i cache-control` should show `no-cache, must-revalidate`.

Note: if Cloudflare in front of production has a "Browser Cache TTL" override or cache rule matching `*.js`, it may still rewrite this header — worth checking the zone config after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-sw-no-cache.preview.app.daily.dev