### PR TITLE
fix(webapp): stretch the source page feed sections so rail cards keep their width

### DIFF
--- a/packages/shared/src/components/entity/EntityRailWithFade.tsx
+++ b/packages/shared/src/components/entity/EntityRailWithFade.tsx
@@ -6,7 +6,11 @@ export const EntityRailWithFade = ({
 }: {
   children: ReactNode;
 }): ReactElement => (
-  <div className="relative mb-10">
+  // w-full matters: inside a `flex-col items-start` page (BaseFeedPage) a
+  // width-less wrapper shrinks to its content, so the horizontal feed grid
+  // resolves its percentage-based auto-columns against its own intrinsic
+  // width and the cards blow up to ~2x size.
+  <div className="relative mb-10 w-full">
     {children}
     <div
       aria-hidden

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -82,6 +82,12 @@ import { getAppOrigin } from '../../lib/seo';
 const appOrigin = getAppOrigin();
 const pageSectionClassName = 'mx-4';
 const pageSectionAutoWidthClassName = `${pageSectionClassName} !w-auto`;
+// Feed sections must stretch: the page main (BaseFeedPage) is a
+// `flex-col items-start`, so a width-less margined wrapper shrinks to its
+// content and the horizontal rails size their percentage-based grid columns
+// against their own intrinsic width, blowing the cards up to ~2x.
+// `self-stretch` (not `w-full`) accounts for the mx-4 margins.
+const pageFeedSectionClassName = `${pageSectionClassName} self-stretch`;
 const pageFeedClassName = '!mx-4 !w-auto';
 const horizontalRailClassName = '!mx-0 !mb-0';
 
@@ -332,7 +338,7 @@ const SourcePage = ({
         <ActiveFeedNameContext.Provider
           value={{ feedName: OtherFeedPage.SourceMostUpvoted }}
         >
-          <div className={pageSectionClassName}>
+          <div className={pageFeedSectionClassName}>
             <EntitySectionHeading
               icon={<UpvoteIcon size={IconSize.Medium} className="shrink-0" />}
             >
@@ -357,7 +363,7 @@ const SourcePage = ({
         <ActiveFeedNameContext.Provider
           value={{ feedName: OtherFeedPage.SourceBestDiscussed }}
         >
-          <div className={pageSectionClassName}>
+          <div className={pageFeedSectionClassName}>
             <EntitySectionHeading
               icon={<DiscussIcon size={IconSize.Medium} className="shrink-0" />}
             >
@@ -385,7 +391,7 @@ const SourcePage = ({
           scopeName={source.name}
           className={`${pageSectionClassName} mb-6`}
         />
-        <div className={pageSectionClassName}>
+        <div className={pageFeedSectionClassName}>
           <EntitySectionHeading>
             All posts from {source.name}
           </EntitySectionHeading>


### PR DESCRIPTION
## The bug (the real one behind the "cards are too wide" reports)

Since #6396, the horizontal "Most upvoted" / "Best discussed" rails on source pages (e.g. `/sources/trends`) render giant cards — ~550-730px instead of ~290px, with widths varying per strip.

#6396 wrapped the rails in two width-less divs (`EntityRailWithFade`'s `relative mb-10` plus a `mx-4` section wrapper). The page `main` (`BaseFeedPage`) is a `flex-col` with **`items-start`**, so those wrappers shrink to fit their content. The rail grid then resolves its percentage-based `auto-cols-[calc((100%/var(--num-cards))-…)]` against its own intrinsic width (~2900px, content-dependent) instead of the ~1500px content area — every card blows up ~2x, and each strip differently.

Reproduced anonymously with no flags at 1722px viewport: grid widths 2892px/3195px, cards 553px/613px. (Tag pages are unaffected — `TagTopicPage`'s section container is a default *stretch* flex-col.)

## The fix

- `EntityRailWithFade`: add `w-full` (it has no horizontal margins).
- Source page feed section wrappers (two rails + "All posts"): new `pageFeedSectionClassName` = `mx-4 self-stretch`. `self-stretch`, not `w-full`, because stretch accounts for the `mx-4` margins (100% width would overflow the main by 32px).

This restores exactly the width behavior the feeds had before #6396, when `FeedContainer` (which carries its own `w-full`) was the direct flex item.

## Verification

Playwright against the local app (prod API), measuring the rail grids:

| scenario | before | after |
|---|---|---|
| source page, grid mode | grids 2892/3195px, cards 553/613px | grids 1566px, cards 288px |
| source page, list mode | 308px (unaffected) | 308px |
| source page, layout v2 | broken same way | grid 1610px, cards 287px |
| tag page (3 rails) | unaffected | grids 1550px, cards 284px |

`pnpm --filter webapp test` (45 suites, 336 tests) passes, lint + strict typecheck guard pass.

Related: matches the existing AGENTS.md lesson — in `flex-col` non-stretch layouts, width-capped/margined children need an explicit width/stretch or they shrink to content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-horizontal-rail-width.preview.app.daily.dev