### PR TITLE
fix(settings): stop long feedback URLs scrolling the page sideways on mobile

### DIFF
--- a/packages/shared/src/components/feedback/FeedbackCard.spec.tsx
+++ b/packages/shared/src/components/feedback/FeedbackCard.spec.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { FeedbackCard } from './FeedbackCard';
+import type { FeedbackItem } from '../../graphql/feedback';
+import { FeedbackCategory, FeedbackStatus } from '../../graphql/feedback';
+
+const longUrl =
+  'https://app.daily.dev/posts/a-very-long-post-slug?utm_source=feedback&utm_campaign=bug';
+
+const item: FeedbackItem = {
+  id: 'f1',
+  category: FeedbackCategory.BugReport,
+  description: `The app is broken on ${longUrl}`,
+  status: FeedbackStatus.Pending,
+  createdAt: '2026-08-02T10:00:00.000Z',
+  updatedAt: '2026-08-02T10:00:00.000Z',
+  replies: [
+    {
+      id: 'r1',
+      body: `Tracked here: ${longUrl}`,
+      authorName: 'Chris',
+      createdAt: '2026-08-02T11:00:00.000Z',
+    },
+  ],
+};
+
+describe('FeedbackCard', () => {
+  // An unbreakable URL widens the card's min-content, which grows the column
+  // rendering it and scrolls the whole page sideways on mobile.
+  it('should let long URLs wrap mid-token', () => {
+    render(<FeedbackCard item={item} isExpanded onToggleExpand={jest.fn()} />);
+
+    expect(screen.getByText(item.description)).toHaveClass('break-words');
+    expect(screen.getByText(item.replies[0].body)).toHaveClass('break-words');
+  });
+});

--- a/packages/shared/src/components/feedback/FeedbackCard.tsx
+++ b/packages/shared/src/components/feedback/FeedbackCard.tsx
@@ -54,9 +54,12 @@ export const FeedbackCard = ({
         </Typography>
       </div>
 
+      {/* Feedback bodies routinely contain long URLs. Without `break-words` an
+          unbreakable run widens the card's min-content, growing whichever column
+          renders it and scrolling the page sideways on narrow screens. */}
       <Typography
         type={TypographyType.Body}
-        className="mt-3 whitespace-pre-wrap"
+        className="mt-3 whitespace-pre-wrap break-words"
       >
         {description}
         {isLongDescription && !isExpanded ? '...' : ''}
@@ -122,7 +125,7 @@ export const FeedbackCard = ({
                 </Typography>
                 <Typography
                   type={TypographyType.Callout}
-                  className="mt-1 whitespace-pre-wrap"
+                  className="mt-1 whitespace-pre-wrap break-words"
                 >
                   {reply.body}
                 </Typography>

--- a/packages/webapp/components/layouts/SettingsLayout/common.tsx
+++ b/packages/webapp/components/layouts/SettingsLayout/common.tsx
@@ -26,9 +26,12 @@ export enum AccountSecurityDisplay {
   ConnectEmail = 'connect_email',
 }
 
+// Without `min-w-0` the section's `overflow-x-hidden` below is inert: a `flex-1`
+// item defaults to `min-width: auto`, so wide content grows this column past the
+// viewport and scrolls the page sideways instead of being clipped.
 export const AccountPageContent = classed(
   'main',
-  'flex flex-col tablet:border border-border-subtlest-tertiary flex-1 rounded-16 h-fit',
+  'flex min-w-0 flex-col tablet:border border-border-subtlest-tertiary flex-1 rounded-16 h-fit',
 );
 export const AccountPageSection = classed(
   'section',


### PR DESCRIPTION
## Changes

Feedback bodies render with `whitespace-pre-wrap` and no wrapping override, so a long unbreakable run (typically a URL) sets a min-content width wider than the viewport. `AccountPageContent` is a `flex-1` item with the default `min-width: auto`, so it grows to that min-content instead of shrinking, and `AccountPageSection`'s existing `overflow-x-hidden` never gets a chance to clip — the whole page ends up wider than the screen and slides sideways.

- `FeedbackCard`: add `break-words` to the description and reply bodies so long URLs wrap. This is the root-cause fix, and it also covers the two internal `/team/feedback` pages that share the card.
- `SettingsLayout/common.tsx`: add `min-w-0` to `AccountPageContent` so the column can actually shrink and the existing `overflow-x-hidden` becomes effective.
- Add `FeedbackCard.spec.tsx` as a regression guard.

### Key decisions

- **`min-w-0` reaches slightly past the reported screen.** `AccountPageContent` backs every `/settings/*` page, not just feedback. `break-words` alone fixes Chrome, but Safari does not shrink min-content for `overflow-wrap: break-word`, so without `min-w-0` the fix likely would not hold on iOS. The class is inert when content fits, and no settings page relies on a horizontally scrollable region.
- **The spec asserts a class name, not geometry.** jsdom cannot measure layout, so it verifies `break-words` is present — it fails if the class is removed. The layout proof is the measurement below, which CI does not reproduce.

### Verification

Measured in headless Chromium against the repo's compiled Tailwind CSS at 360/384/420/501/655/1024px. `document.scrollWidth` vs a 384px viewport (Galaxy S23+ CSS width):

| content | before | after |
| -- | -- | -- |
| long URL | 459px (overflows) | 384px |
| 400-char token | 4249px (overflows) | 384px |
| prose only | 384px | 384px (unchanged) |

Suites pass: shared 312 suites / 2084 tests, webapp 45 / 336. ESLint and `typecheck-strict-changed` clean.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Verified by headless-browser measurement at MobileL (420px), Tablet (656px) and Laptop (1020px), plus 360/384/501px — see the table above. Not tested on physical iOS or Android devices. Extension and companion are unaffected: neither consumes `FeedbackCard` or `AccountPageContent`.

Closes ENG-1860

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1860-feedback-bug-report-the.preview.app.daily.dev