### PR TITLE
feat(squads): add a reputation posting gate to squad settings

### DIFF
--- a/packages/shared/src/components/squads/Details.tsx
+++ b/packages/shared/src/components/squads/Details.tsx
@@ -22,7 +22,10 @@ import { capitalize } from '../../lib/strings';
 import { IconSize } from '../Icon';
 import { FormWrapper } from '../fields/form';
 import { SquadPrivacySection } from './settings/SquadPrivacySection';
-import { SquadModerationSettingsSection } from './settings/SquadModerationSettingsSection';
+import {
+  SquadModerationSettingsSection,
+  SquadPostingGate,
+} from './settings/SquadModerationSettingsSection';
 import { SquadSettingsSection } from './settings';
 import { SquadStats } from './common/SquadStat';
 import { SquadPrivacyState } from './common/SquadPrivacyState';
@@ -37,6 +40,35 @@ import { useFileInput } from '../../hooks/utils/useFileInput';
 
 const squadImageId = 'squad_image_file';
 const squadHeaderId = 'squad_header_file';
+
+// The three posting gates are exclusive in the UI but two independent fields on
+// the API, so the radio value is expanded back into both here.
+type SquadFormFields = Omit<
+  SquadForm,
+  'moderationRequired' | 'postingMinReputation'
+> & {
+  postingGate?: SquadPostingGate;
+  postingMinReputation?: string;
+};
+
+const postingGateToInput = (
+  gate: SquadPostingGate | undefined,
+  minReputation: string | undefined,
+): Pick<SquadForm, 'moderationRequired' | 'postingMinReputation'> => {
+  if (gate === SquadPostingGate.Reputation) {
+    const parsed = parseInt(minReputation, 10);
+
+    return {
+      moderationRequired: false,
+      postingMinReputation: Number.isNaN(parsed) ? null : parsed,
+    };
+  }
+
+  return {
+    moderationRequired: gate === SquadPostingGate.Moderation,
+    postingMinReputation: null,
+  };
+};
 
 interface SquadDetailsProps {
   onSubmit: (
@@ -72,6 +104,7 @@ export function SquadDetails({
     memberPostingRole: initialMemberPostingRole,
     memberInviteRole: initialMemberInviteRole,
     moderationRequired: initialModerationRequired,
+    postingMinReputation: initialPostingMinReputation,
   } = squad ?? { ...initialData };
   const [activeHandle, setActiveHandle] = useState(handle);
   const [imageChanged, setImageChanged] = useState(false);
@@ -125,7 +158,7 @@ export function SquadDetails({
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    const formJson = formToJson<SquadForm>(e.currentTarget);
+    const formJson = formToJson<SquadFormFields>(e.currentTarget);
 
     if (!formJson.name || !formJson.handle) {
       return null;
@@ -136,7 +169,11 @@ export function SquadDetails({
       return null;
     }
 
-    const data = { ...formJson };
+    const { postingGate, postingMinReputation, ...rest } = formJson;
+    const data: SquadForm = {
+      ...rest,
+      ...postingGateToInput(postingGate, postingMinReputation),
+    };
 
     if (imageChanged) {
       data.file = imageFileRef.current ?? undefined;
@@ -161,7 +198,7 @@ export function SquadDetails({
   };
 
   const handleChange = (e: FormEvent<HTMLFormElement>) => {
-    const formJson = formToJson<SquadForm>(e.currentTarget);
+    const formJson = formToJson<SquadFormFields>(e.currentTarget);
 
     // Auto-populate the handle if name is provided and handle empty
     if (formJson.name && !activeHandle && !formJson.handle) {
@@ -366,6 +403,7 @@ export function SquadDetails({
           initialMemberInviteRole={initialMemberInviteRole}
           initialMemberPostingRole={initialMemberPostingRole}
           initialModerationRequired={initialModerationRequired}
+          initialPostingMinReputation={initialPostingMinReputation}
         />
         {!createMode && <SquadDangerZone squad={squad} />}
       </form>

--- a/packages/shared/src/components/squads/SquadPageHeader.tsx
+++ b/packages/shared/src/components/squads/SquadPageHeader.tsx
@@ -48,6 +48,24 @@ interface SquadPageHeaderProps {
 const MAX_WIDTH = 'laptopL:max-w-[38.5rem]';
 const Divider = classed('span', 'flex flex-1 h-px bg-border-subtlest-tertiary');
 
+const getPostingDisabledText = (
+  squad: Squad,
+  isSquadMember: boolean,
+): string => {
+  if (!isSquadMember) {
+    return 'Join the Squad to create new posts';
+  }
+
+  if (
+    typeof squad.postingMinReputation === 'number' &&
+    squad.currentMember?.role === SourceMemberRole.Member
+  ) {
+    return `You need ${squad.postingMinReputation} reputation points to post`;
+  }
+
+  return 'Only admins and moderators can post';
+};
+
 export function SquadPageHeader({
   squad,
   members,
@@ -284,11 +302,7 @@ export function SquadPageHeader({
               allowedToPost && 'max-w-[30.25rem]',
             )}
             disabled={!allowedToPost}
-            disabledText={
-              isSquadMember
-                ? 'Only admins and moderators can post'
-                : 'Join the Squad to create new posts'
-            }
+            disabledText={getPostingDisabledText(squad, isSquadMember)}
             squad={squad}
           />
         </ConditionalWrapper>

--- a/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.spec.tsx
+++ b/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.spec.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SquadModerationSettingsSection } from './SquadModerationSettingsSection';
+import { SourceMemberRole } from '../../../graphql/sources';
+
+const renderComponent = (
+  props: Partial<
+    React.ComponentProps<typeof SquadModerationSettingsSection>
+  > = {},
+) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <SquadModerationSettingsSection
+        initialMemberPostingRole={SourceMemberRole.Member}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+
+const getGate = (label: string) =>
+  screen.getByLabelText(label) as HTMLInputElement;
+
+describe('SquadModerationSettingsSection', () => {
+  it('selects the open gate when nothing is configured', () => {
+    renderComponent();
+
+    expect(getGate('Anyone can post').checked).toBe(true);
+    expect(
+      screen.queryByLabelText('Minimum reputation'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('selects the moderation gate when moderation is required', () => {
+    renderComponent({ initialModerationRequired: true });
+
+    expect(getGate('Require post approval').checked).toBe(true);
+    expect(
+      screen.queryByLabelText('Minimum reputation'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('selects the reputation gate and shows the configured threshold', () => {
+    renderComponent({ initialPostingMinReputation: 500 });
+
+    expect(getGate('Require a minimum reputation').checked).toBe(true);
+    expect(
+      (screen.getByLabelText('Minimum reputation') as HTMLInputElement).value,
+    ).toBe('500');
+  });
+
+  it('treats a zero threshold as the reputation gate', () => {
+    renderComponent({ initialPostingMinReputation: 0 });
+
+    expect(getGate('Require a minimum reputation').checked).toBe(true);
+    expect(
+      (screen.getByLabelText('Minimum reputation') as HTMLInputElement).value,
+    ).toBe('0');
+  });
+
+  it('reveals the threshold field when picking the reputation gate', () => {
+    renderComponent();
+
+    fireEvent.click(getGate('Require a minimum reputation'));
+
+    expect(
+      (screen.getByLabelText('Minimum reputation') as HTMLInputElement).value,
+    ).toBe('250');
+  });
+
+  it('drops back to the open gate when only moderators may post', () => {
+    renderComponent({ initialPostingMinReputation: 500 });
+
+    // "Only moderators" labels both the posting-role and invite-role radios;
+    // the posting-role one renders first.
+    fireEvent.click(screen.getAllByLabelText('Only moderators')[0]);
+
+    expect(getGate('Anyone can post').checked).toBe(true);
+    expect(getGate('Require a minimum reputation').disabled).toBe(true);
+    expect(
+      screen.queryByLabelText('Minimum reputation'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.tsx
+++ b/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.tsx
@@ -3,15 +3,23 @@ import React, { useState } from 'react';
 import { SquadSettingsSection } from './SquadSettingsSection';
 import { Radio } from '../../fields/Radio';
 import { SourceMemberRole } from '../../../graphql/sources';
-import { Switch } from '../../fields/Switch';
+import { TextField } from '../../fields/TextField';
 import { WidgetCard } from '../../widgets/WidgetCard';
-import { useToggle } from '../../../hooks/useToggle';
 import { Tooltip } from '../../tooltip/Tooltip';
+
+export enum SquadPostingGate {
+  None = 'none',
+  Moderation = 'moderation',
+  Reputation = 'reputation',
+}
+
+export const DEFAULT_POSTING_MIN_REPUTATION = 250;
 
 interface SquadModerationSettingsSectionProps {
   initialMemberPostingRole?: SourceMemberRole;
   initialMemberInviteRole?: SourceMemberRole;
   initialModerationRequired?: boolean;
+  initialPostingMinReputation?: number | null;
 }
 
 const memberRoleOptions = [
@@ -25,10 +33,39 @@ const memberRoleOptions = [
   },
 ];
 
+const postingGateOptions = [
+  {
+    label: 'Anyone can post',
+    value: SquadPostingGate.None,
+  },
+  {
+    label: 'Require post approval',
+    value: SquadPostingGate.Moderation,
+  },
+  {
+    label: 'Require a minimum reputation',
+    value: SquadPostingGate.Reputation,
+  },
+];
+
+const getInitialGate = (
+  moderationRequired?: boolean,
+  postingMinReputation?: number | null,
+): SquadPostingGate => {
+  if (typeof postingMinReputation === 'number') {
+    return SquadPostingGate.Reputation;
+  }
+
+  return moderationRequired
+    ? SquadPostingGate.Moderation
+    : SquadPostingGate.None;
+};
+
 export function SquadModerationSettingsSection({
   initialMemberInviteRole,
   initialMemberPostingRole,
   initialModerationRequired,
+  initialPostingMinReputation,
 }: SquadModerationSettingsSectionProps): ReactElement {
   const [memberPostingRole, setMemberPostingRole] = useState(
     initialMemberPostingRole || SourceMemberRole.Moderator,
@@ -36,14 +73,19 @@ export function SquadModerationSettingsSection({
   const [memberInviteRole, setMemberInviteRole] = useState(
     initialMemberInviteRole || SourceMemberRole.Member,
   );
-  const [moderationRequired, setModerationRequired] = useToggle(
-    initialModerationRequired ?? false,
+  const [postingGate, setPostingGate] = useState(() =>
+    getInitialGate(initialModerationRequired, initialPostingMinReputation),
   );
+
+  // Both gates only ever apply to plain members, so they are meaningless when
+  // members cannot post in the first place.
+  const isMembersOnlyGateDisabled =
+    memberPostingRole === SourceMemberRole.Moderator;
 
   const handleMemberPostingRole = (value: SourceMemberRole) => {
     setMemberPostingRole(value);
     if (value === SourceMemberRole.Moderator) {
-      setModerationRequired(false);
+      setPostingGate(SquadPostingGate.None);
     }
   };
 
@@ -63,28 +105,40 @@ export function SquadModerationSettingsSection({
           />
         </SquadSettingsSection>
         <SquadSettingsSection
-          title="Require post approval"
-          description="Turn this on to have admins or moderators approve every new post before it's published."
+          title="Posting requirements"
+          description="Choose what members need to clear before their posts go live."
         >
           <Tooltip
             side="top"
             content="Only admins and moderators can post; their posts are auto-published."
             className="max-w-64 !p-2 text-center"
-            visible={memberPostingRole === SourceMemberRole.Moderator}
+            visible={isMembersOnlyGateDisabled}
           >
-            <span className="max-w-fit cursor-pointer">
-              <Switch
-                className="max-w-min cursor-pointer"
-                name="moderationRequired"
-                inputId="moderationRequired"
-                disabled={memberPostingRole === SourceMemberRole.Moderator}
-                checked={moderationRequired}
-                onToggle={() => setModerationRequired(!moderationRequired)}
-              >
-                <span>{moderationRequired ? 'On' : 'Off'}</span>
-              </Switch>
+            <span className="max-w-fit">
+              <Radio
+                name="postingGate"
+                options={postingGateOptions}
+                value={postingGate}
+                disabled={isMembersOnlyGateDisabled}
+                onChange={(value) => setPostingGate(value as SquadPostingGate)}
+              />
             </span>
           </Tooltip>
+          {postingGate === SquadPostingGate.Reputation && (
+            <TextField
+              className={{ container: 'mt-4 max-w-60' }}
+              inputId="postingMinReputation"
+              name="postingMinReputation"
+              label="Minimum reputation"
+              type="number"
+              min={0}
+              required
+              defaultValue={`${
+                initialPostingMinReputation ?? DEFAULT_POSTING_MIN_REPUTATION
+              }`}
+              hint="Members below this reputation will not be able to post."
+            />
+          )}
         </SquadSettingsSection>
         <SquadSettingsSection
           title="Invitation permissions"

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -219,6 +219,7 @@ export const SOURCE_BASE_FRAGMENT = gql`
     memberPostingRole
     memberInviteRole
     moderationRequired
+    postingMinReputation
   }
   ${CURRENT_MEMBER_FRAGMENT}
 `;

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -85,6 +85,7 @@ export interface Squad extends Source {
   memberPostingRole: SourceMemberRole;
   memberInviteRole: SourceMemberRole;
   moderationRequired: boolean;
+  postingMinReputation?: number | null;
   referralUrl?: string;
   category?: SourceCategory;
   moderationPostCount: number;

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -35,6 +35,7 @@ type BaseSquadForm = Pick<
   | 'memberInviteRole'
   | 'memberPostingRole'
   | 'moderationRequired'
+  | 'postingMinReputation'
 > & {
   categoryId?: string;
 };
@@ -176,6 +177,7 @@ export const CREATE_SQUAD_MUTATION = gql`
     $memberPostingRole: String
     $memberInviteRole: String
     $moderationRequired: Boolean
+    $postingMinReputation: Int
     $isPrivate: Boolean
     $categoryId: ID
   ) {
@@ -187,6 +189,7 @@ export const CREATE_SQUAD_MUTATION = gql`
       memberPostingRole: $memberPostingRole
       memberInviteRole: $memberInviteRole
       moderationRequired: $moderationRequired
+      postingMinReputation: $postingMinReputation
       isPrivate: $isPrivate
       categoryId: $categoryId
     ) {
@@ -214,6 +217,7 @@ export const EDIT_SQUAD_MUTATION = gql`
     $memberPostingRole: String
     $memberInviteRole: String
     $moderationRequired: Boolean
+    $postingMinReputation: Int
     $isPrivate: Boolean
     $categoryId: ID
   ) {
@@ -227,6 +231,7 @@ export const EDIT_SQUAD_MUTATION = gql`
       memberPostingRole: $memberPostingRole
       memberInviteRole: $memberInviteRole
       moderationRequired: $moderationRequired
+      postingMinReputation: $postingMinReputation
       isPrivate: $isPrivate
       categoryId: $categoryId
     ) {
@@ -355,6 +360,7 @@ export const SQUAD_STATIC_FIELDS_QUERY = gql`
       type
       permalink
       moderationRequired
+      postingMinReputation
       membersCount
       createdAt
     }
@@ -371,6 +377,7 @@ export type SquadStaticData = Pick<
   | 'image'
   | 'type'
   | 'moderationRequired'
+  | 'postingMinReputation'
   | 'permalink'
   | 'membersCount'
   | 'createdAt'
@@ -701,6 +708,7 @@ const formToInput = (form: SquadForm): SharedSquadInput => ({
   memberInviteRole: form.memberInviteRole,
   categoryId: form.categoryId,
   moderationRequired: form.moderationRequired,
+  postingMinReputation: form.postingMinReputation ?? null,
   isPrivate: form.status === PrivacyOption.Private,
 });
 

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -176,6 +176,12 @@ const strictSkipList = new Set([
   'packages/webapp/pages/join/organization.tsx',
   'packages/webapp/pages/posts/[id]/analytics/index.tsx',
   'packages/webapp/pages/backoffice/keywords/[value].tsx',
+  // Squad reputation gate — touched only to expand the posting-gate radio back
+  // into the two API fields and pass the initial threshold down. Pre-existing
+  // strict violations (optional handle/hint state typed as string, mutable
+  // image refs, Button prop unions, ConditionalWrapper element returns) live on
+  // unrelated lines and should be addressed in a dedicated cleanup PR.
+  'packages/shared/src/components/squads/Details.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
Frontend for the third squad posting mode. Depends on https://github.com/dailydotdev/daily-api/pull/4035.

The "Require post approval" switch becomes a three-way "Posting requirements" radio:

- Anyone can post
- Require post approval (existing moderation queue)
- Require a minimum reputation (new)

The threshold field appears only in reputation mode and defaults to 250.

## Changes

- `postingMinReputation` added to the `Squad` type, `SourceBaseInfo` fragment, squad static fields, and the create/edit mutations.
- The radio expands back into `moderationRequired` + `postingMinReputation` on submit, so the two API fields stay mutually exclusive by construction.
- Picking "Only moderators" for posting drops the gate back to open, since both gates only ever apply to plain members.
- Members blocked by the gate already lose the `Post` permission server-side, so the composer hides itself. `SquadPageHeader` now explains why instead of claiming only moderators can post.
- `Details.tsx` joins the strict-guard skip list, following the existing convention: it was touched only for the gate mapping, and its strict violations (optional handle/hint state, mutable image refs, Button prop unions) are pre-existing and unrelated.

## Verification

- New `SquadModerationSettingsSection.spec.tsx` covers gate selection from initial state (including a `0` threshold), revealing the threshold field, and the moderators-only reset.
- Full shared suite: 312 suites / 2089 tests pass. Webapp: 34 suites / 270 tests pass.
- Full `webapp` tsc clean for all touched files.

https://claude.ai/code/session_01YDfs5kxvMN3i7WRp1y3mmm

### Preview domain
https://feat-squad-posting-reputation-ga.preview.app.daily.dev