### PR TITLE
fix(feed): keep the scroll position when returning from a post on mobile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ The "calling platform" is not just extension vs webapp. Native iOS/Android wrapp
 - Infinite scroll: pass `fetchNextPage`, `canFetchMore` (from `hasNextPage`), and `isFetchingNextPage` as separate props. Never derive `canFetchMore` from callback existence (`!!onScrollEnd`). Gate with `canFetchMore && !isFetchingNextPage` (see `InfiniteScrolling.tsx`).
 - Paginated dropdowns with a pre-selected value not in page one: insert a placeholder entry up front and dedupe by `id` when the real item loads. Never `findIndex(...) || 0` (silently selects the first item); use `?? -1`.
 - Portaled drawers/overlays must `stopPropagation` on the overlay click, otherwise `useOutsideClick` closes the parent modal (see `BaseDrawer`).
+- Next's `experimental.scrollRestoration` is off, so the router resets the scroll to the top in a layout effect on every route change, back/forward included. `useScrollRestoration` restores the position itself, and it has to wait for the feed to reach full height before scrolling: a short budget expires mid-render on a phone and strands the user in the middle of a partially rendered feed.
 - Tooltip requests: wrap the real interactive hover target with the tooltip component. A native `title` attribute is not a substitute.
 - When renaming visible copy, update text-asserting tests (`findByText`) in the same PR.
 - In markdown conversion utilities, never run formatting regexes across already-generated HTML (e.g. image `src` URLs containing `_`). Add regression tests for URL edge cases.

--- a/packages/shared/src/hooks/useScrollRestoration.spec.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.spec.ts
@@ -1,0 +1,187 @@
+import { act, renderHook } from '@testing-library/react';
+import { useScrollRestoration } from './useScrollRestoration';
+
+const mockRouter = { asPath: '/' };
+
+jest.mock('next/router', () => ({
+  useRouter: () => mockRouter,
+}));
+
+const FEED_PATH = '/';
+const VIEWPORT_HEIGHT = 780;
+const SAVED_POSITION = 5000;
+const FEED_HEIGHT = 20000;
+
+let scrollTo: jest.Mock;
+let pageHeight: number;
+// The hook keys positions by history entry, so a fresh key per test keeps its
+// module-level map from leaking between them.
+let historyKey: string;
+let historyKeyCount = 0;
+
+const setPageHeight = (height: number) => {
+  pageHeight = height;
+};
+
+const setScrollY = (position: number) => {
+  Object.defineProperty(window, 'scrollY', {
+    configurable: true,
+    value: position,
+  });
+};
+
+const scrollUserTo = (position: number) => {
+  setScrollY(position);
+  window.dispatchEvent(new Event('scroll'));
+};
+
+// One rAF tick, driven by the fake timers backing requestAnimationFrame.
+const advanceFrames = (count = 1) =>
+  act(() => {
+    jest.advanceTimersByTime(16 * count);
+  });
+
+const renderScrollRestoration = () => renderHook(() => useScrollRestoration());
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  window.sessionStorage.clear();
+
+  historyKeyCount += 1;
+  historyKey = `feed-entry-${historyKeyCount}`;
+  window.history.replaceState({ key: historyKey }, '', FEED_PATH);
+  mockRouter.asPath = FEED_PATH;
+
+  scrollTo = jest.fn((_left: number, top: number) => setScrollY(top));
+  Object.defineProperty(window, 'scrollTo', {
+    configurable: true,
+    value: scrollTo,
+  });
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    value: VIEWPORT_HEIGHT,
+  });
+  Object.defineProperty(document.documentElement, 'scrollHeight', {
+    configurable: true,
+    get: () => pageHeight,
+  });
+
+  setScrollY(0);
+  setPageHeight(VIEWPORT_HEIGHT);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// The mobile flow: scroll the feed, open a post, then come back to a feed that
+// only reaches its full height once the cached pages have reconciled.
+const saveFeedPosition = () => {
+  setPageHeight(FEED_HEIGHT);
+  const { unmount } = renderScrollRestoration();
+
+  scrollUserTo(SAVED_POSITION);
+  advanceFrames();
+
+  unmount();
+
+  // Next.js resets the scroll to the top when the next route commits.
+  setScrollY(0);
+  setPageHeight(VIEWPORT_HEIGHT);
+};
+
+describe('useScrollRestoration', () => {
+  it('waits for the feed to render before restoring the saved position', () => {
+    saveFeedPosition();
+
+    renderScrollRestoration();
+
+    // The previous 1s budget expired here and dropped the user at the bottom of
+    // the partially rendered feed.
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(scrollTo).not.toHaveBeenCalled();
+
+    setPageHeight(FEED_HEIGHT);
+    advanceFrames();
+
+    expect(scrollTo).toHaveBeenCalledWith(0, SAVED_POSITION);
+  });
+
+  it('leaves the user at the top when the page never grows tall enough', () => {
+    saveFeedPosition();
+
+    renderScrollRestoration();
+
+    act(() => {
+      jest.advanceTimersByTime(15000);
+    });
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(window.scrollY).toBe(0);
+  });
+
+  it('keeps the saved position when the router resets the scroll to the top', () => {
+    saveFeedPosition();
+
+    renderScrollRestoration();
+
+    scrollUserTo(0);
+    advanceFrames(2);
+
+    setPageHeight(FEED_HEIGHT);
+    advanceFrames();
+
+    expect(scrollTo).toHaveBeenCalledWith(0, SAVED_POSITION);
+  });
+
+  it('stops restoring once the user takes over the scroll', () => {
+    saveFeedPosition();
+
+    renderScrollRestoration();
+
+    act(() => {
+      window.dispatchEvent(new Event('touchmove'));
+    });
+
+    setPageHeight(FEED_HEIGHT);
+    advanceFrames(2);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+
+  it('persists the position so a reloaded tab can still restore it', () => {
+    saveFeedPosition();
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    expect(
+      JSON.parse(window.sessionStorage.getItem('scrollPositions') ?? '{}'),
+    ).toHaveProperty(`${FEED_PATH}:${historyKey}`, SAVED_POSITION);
+  });
+
+  it('restores a position left in storage by a previous page load', () => {
+    window.sessionStorage.setItem(
+      'scrollPositions',
+      JSON.stringify({ [`${FEED_PATH}:${historyKey}`]: SAVED_POSITION }),
+    );
+    setPageHeight(FEED_HEIGHT);
+
+    renderScrollRestoration();
+    advanceFrames();
+
+    expect(scrollTo).toHaveBeenCalledWith(0, SAVED_POSITION);
+  });
+
+  it('does not restore when the user never scrolled the page', () => {
+    setPageHeight(FEED_HEIGHT);
+
+    renderScrollRestoration();
+    advanceFrames(2);
+
+    expect(scrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/hooks/useScrollRestoration.spec.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.spec.ts
@@ -96,7 +96,7 @@ describe('useScrollRestoration', () => {
     // The previous 1s budget expired here and dropped the user at the bottom of
     // the partially rendered feed.
     act(() => {
-      jest.advanceTimersByTime(2000);
+      jest.advanceTimersByTime(1500);
     });
     expect(scrollTo).not.toHaveBeenCalled();
 

--- a/packages/shared/src/hooks/useScrollRestoration.spec.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.spec.ts
@@ -45,7 +45,6 @@ const renderScrollRestoration = () => renderHook(() => useScrollRestoration());
 
 beforeEach(() => {
   jest.useFakeTimers();
-  window.sessionStorage.clear();
 
   historyKeyCount += 1;
   historyKey = `feed-entry-${historyKeyCount}`;
@@ -81,8 +80,6 @@ const saveFeedPosition = () => {
   const { unmount } = renderScrollRestoration();
 
   scrollUserTo(SAVED_POSITION);
-  advanceFrames();
-
   unmount();
 
   // Next.js resets the scroll to the top when the next route commits.
@@ -125,11 +122,23 @@ describe('useScrollRestoration', () => {
   it('keeps the saved position when the router resets the scroll to the top', () => {
     saveFeedPosition();
 
-    renderScrollRestoration();
+    const { unmount } = renderScrollRestoration();
 
+    // Next's reset-to-top lands while we are still waiting for the feed height.
     scrollUserTo(0);
-    advanceFrames(2);
+    advanceFrames();
 
+    setPageHeight(FEED_HEIGHT);
+    advanceFrames();
+    expect(scrollTo).toHaveBeenCalledWith(0, SAVED_POSITION);
+
+    // The reset must not have overwritten the entry for the next visit back.
+    unmount();
+    scrollTo.mockClear();
+    setScrollY(0);
+    setPageHeight(VIEWPORT_HEIGHT);
+
+    renderScrollRestoration();
     setPageHeight(FEED_HEIGHT);
     advanceFrames();
 
@@ -151,29 +160,25 @@ describe('useScrollRestoration', () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
-  it('persists the position so a reloaded tab can still restore it', () => {
+  it('records the position again once the user takes over', () => {
     saveFeedPosition();
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
-
-    expect(
-      JSON.parse(window.sessionStorage.getItem('scrollPositions') ?? '{}'),
-    ).toHaveProperty(`${FEED_PATH}:${historyKey}`, SAVED_POSITION);
-  });
-
-  it('restores a position left in storage by a previous page load', () => {
-    window.sessionStorage.setItem(
-      'scrollPositions',
-      JSON.stringify({ [`${FEED_PATH}:${historyKey}`]: SAVED_POSITION }),
-    );
-    setPageHeight(FEED_HEIGHT);
-
     renderScrollRestoration();
+
+    act(() => {
+      window.dispatchEvent(new Event('touchmove'));
+    });
+    setPageHeight(FEED_HEIGHT);
+    scrollUserTo(1200);
+
+    // Remounting is the next back navigation to the same history entry.
+    setPageHeight(VIEWPORT_HEIGHT);
+    setScrollY(0);
+    renderScrollRestoration();
+    setPageHeight(FEED_HEIGHT);
     advanceFrames();
 
-    expect(scrollTo).toHaveBeenCalledWith(0, SAVED_POSITION);
+    expect(scrollTo).toHaveBeenCalledWith(0, 1200);
   });
 
   it('does not restore when the user never scrolled the page', () => {

--- a/packages/shared/src/hooks/useScrollRestoration.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.ts
@@ -3,9 +3,9 @@ import { useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 
 const scrollPositions: Record<string, number> = {};
-// A feed restored from cache needs several seconds to reconcile on a mid-range
-// phone. A shorter budget expires mid-render, which is exactly when the page is
-// still too short to hold the saved position.
+// A feed restored from cache needs longer than a second to reconcile on a
+// mid-range phone. A shorter budget expires mid-render, which is exactly when
+// the page is still too short to hold the saved position.
 const RESTORE_TIMEOUT_MS = 2000;
 
 const getScrollKey = (asPath: string): string => {

--- a/packages/shared/src/hooks/useScrollRestoration.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.ts
@@ -1,9 +1,95 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { useRouter } from 'next/router';
 
-const scrollPositions: Record<string, number> = {};
-const RESTORE_TIMEOUT_MS = 1000;
+const SESSION_STORAGE_KEY = 'scrollPositions';
+// Long sessions accumulate one entry per history entry, so keep the map bounded.
+const MAX_STORED_POSITIONS = 50;
+const PERSIST_DEBOUNCE_MS = 500;
+// A feed restored from cache needs several seconds to reconcile on a mid-range
+// phone. A shorter budget expires mid-render, which is exactly when the page is
+// still too short to hold the saved position.
+const RESTORE_TIMEOUT_MS = 10000;
+const SCROLL_TOLERANCE_PX = 2;
+
+type ScrollPositions = Record<string, number>;
+
+// Positions recorded during this page load. Persisting them is debounced, so
+// this also serves the reads that happen before the next flush.
+const pendingPositions: ScrollPositions = {};
+let persistTimeout: number | null = null;
+
+// Dropping the least recently written entries keeps the payload small.
+const capPositions = (positions: ScrollPositions): ScrollPositions =>
+  Object.fromEntries(Object.entries(positions).slice(-MAX_STORED_POSITIONS));
+
+const getStorage = (): Storage | null => {
+  try {
+    return globalThis.window?.sessionStorage ?? null;
+  } catch {
+    // Reading storage throws outright when the browser blocks it.
+    return null;
+  }
+};
+
+// sessionStorage is per-tab and survives a reload, which is how a discarded
+// mobile tab still comes back to the position the user left off at.
+const readStoredPositions = (): ScrollPositions => {
+  const storage = getStorage();
+
+  if (!storage) {
+    return {};
+  }
+
+  try {
+    const stored: unknown = JSON.parse(
+      storage.getItem(SESSION_STORAGE_KEY) ?? '{}',
+    );
+
+    return stored && typeof stored === 'object'
+      ? (stored as ScrollPositions)
+      : {};
+  } catch {
+    return {};
+  }
+};
+
+const persistPositions = (): void => {
+  if (persistTimeout) {
+    window.clearTimeout(persistTimeout);
+    persistTimeout = null;
+  }
+
+  const storage = getStorage();
+
+  if (!storage) {
+    return;
+  }
+
+  try {
+    storage.setItem(
+      SESSION_STORAGE_KEY,
+      JSON.stringify(
+        capPositions({ ...readStoredPositions(), ...pendingPositions }),
+      ),
+    );
+  } catch {
+    // Hitting the quota must not break navigation, the in-memory map still works.
+  }
+};
+
+// Writing on every scroll frame would stringify the whole map dozens of times a
+// second, which is exactly the jank the phones in the report can't afford.
+const schedulePersist = (): void => {
+  if (persistTimeout) {
+    return;
+  }
+
+  persistTimeout = window.setTimeout(() => {
+    persistTimeout = null;
+    persistPositions();
+  }, PERSIST_DEBOUNCE_MS);
+};
 
 const getScrollKey = (asPath: string): string => {
   if (typeof window === 'undefined') {
@@ -13,47 +99,113 @@ const getScrollKey = (asPath: string): string => {
   return historyKey ? `${asPath}:${historyKey}` : asPath;
 };
 
+const readPosition = (key: string): number => {
+  const position = pendingPositions[key] ?? readStoredPositions()[key];
+
+  return typeof position === 'number' ? position : 0;
+};
+
+const writePosition = (key: string, position: number): void => {
+  // Re-inserting keeps insertion order aligned with recency so the cap drops
+  // the entries the user is least likely to navigate back to.
+  delete pendingPositions[key];
+  pendingPositions[key] = position;
+
+  Object.keys(pendingPositions)
+    .slice(0, -MAX_STORED_POSITIONS)
+    .forEach((staleKey) => delete pendingPositions[staleKey]);
+
+  schedulePersist();
+};
+
 export const useScrollRestoration = (): void => {
   const { asPath } = useRouter();
+  const isRestoringRef = useRef(false);
 
   useEffect(() => {
+    let frame = 0;
+
     const handleScroll = () => {
-      scrollPositions[getScrollKey(asPath)] = window.scrollY;
+      // Both our restore pass and Next's own reset-to-top on navigation emit
+      // scroll events. Recording those would overwrite the user's position.
+      if (isRestoringRef.current || frame) {
+        return;
+      }
+
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        writePosition(getScrollKey(asPath), window.scrollY);
+      });
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('pagehide', persistPositions);
+    document.addEventListener('visibilitychange', persistPositions);
 
     return () => {
       window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('pagehide', persistPositions);
+      document.removeEventListener('visibilitychange', persistPositions);
+      cancelAnimationFrame(frame);
+      persistPositions();
     };
   }, [asPath]);
 
   useEffect(() => {
-    const target = scrollPositions[getScrollKey(asPath)] ?? 0;
-    if (target === 0) {
+    const target = readPosition(getScrollKey(asPath));
+
+    if (!target) {
       return undefined;
     }
 
-    // Wait until the page is tall enough before scrolling, so we don't clamp
-    // to the bottom while feed content is still hydrating.
+    isRestoringRef.current = true;
     const deadline = performance.now() + RESTORE_TIMEOUT_MS;
     let frame = 0;
+
+    const stop = () => {
+      isRestoringRef.current = false;
+      cancelAnimationFrame(frame);
+      window.removeEventListener('wheel', stop);
+      window.removeEventListener('touchmove', stop);
+      window.removeEventListener('keydown', stop);
+      window.removeEventListener('mousedown', stop);
+    };
 
     const tick = () => {
       const maxScroll =
         document.documentElement.scrollHeight - window.innerHeight;
 
-      if (maxScroll >= target || performance.now() >= deadline) {
-        window.scrollTo(0, Math.min(target, Math.max(0, maxScroll)));
+      // Scrolling before the page is tall enough clamps to the bottom of what
+      // has rendered so far, so wait instead of settling for a wrong position.
+      if (maxScroll >= target) {
+        window.scrollTo(0, target);
+
+        // Next resets the scroll to the top in a layout effect of the same
+        // commit that mounts us, so keep re-applying until the position sticks.
+        if (Math.abs(window.scrollY - target) <= SCROLL_TOLERANCE_PX) {
+          stop();
+          return;
+        }
+      }
+
+      if (performance.now() >= deadline) {
+        stop();
         return;
       }
 
       frame = requestAnimationFrame(tick);
     };
 
+    // Restoring must never fight the user, any real input ends the attempt.
+    // `mousedown` covers scrollbar drags, which emit no wheel event.
+    window.addEventListener('wheel', stop, { passive: true });
+    window.addEventListener('touchmove', stop, { passive: true });
+    window.addEventListener('keydown', stop);
+    window.addEventListener('mousedown', stop);
+
     frame = requestAnimationFrame(tick);
 
-    return () => cancelAnimationFrame(frame);
+    return stop;
   }, [asPath]);
 };
 

--- a/packages/shared/src/hooks/useScrollRestoration.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.ts
@@ -6,7 +6,7 @@ const scrollPositions: Record<string, number> = {};
 // A feed restored from cache needs several seconds to reconcile on a mid-range
 // phone. A shorter budget expires mid-render, which is exactly when the page is
 // still too short to hold the saved position.
-const RESTORE_TIMEOUT_MS = 10000;
+const RESTORE_TIMEOUT_MS = 2000;
 
 const getScrollKey = (asPath: string): string => {
   if (typeof window === 'undefined') {

--- a/packages/shared/src/hooks/useScrollRestoration.ts
+++ b/packages/shared/src/hooks/useScrollRestoration.ts
@@ -2,94 +2,11 @@ import { useEffect, useRef } from 'react';
 
 import { useRouter } from 'next/router';
 
-const SESSION_STORAGE_KEY = 'scrollPositions';
-// Long sessions accumulate one entry per history entry, so keep the map bounded.
-const MAX_STORED_POSITIONS = 50;
-const PERSIST_DEBOUNCE_MS = 500;
+const scrollPositions: Record<string, number> = {};
 // A feed restored from cache needs several seconds to reconcile on a mid-range
 // phone. A shorter budget expires mid-render, which is exactly when the page is
 // still too short to hold the saved position.
 const RESTORE_TIMEOUT_MS = 10000;
-const SCROLL_TOLERANCE_PX = 2;
-
-type ScrollPositions = Record<string, number>;
-
-// Positions recorded during this page load. Persisting them is debounced, so
-// this also serves the reads that happen before the next flush.
-const pendingPositions: ScrollPositions = {};
-let persistTimeout: number | null = null;
-
-// Dropping the least recently written entries keeps the payload small.
-const capPositions = (positions: ScrollPositions): ScrollPositions =>
-  Object.fromEntries(Object.entries(positions).slice(-MAX_STORED_POSITIONS));
-
-const getStorage = (): Storage | null => {
-  try {
-    return globalThis.window?.sessionStorage ?? null;
-  } catch {
-    // Reading storage throws outright when the browser blocks it.
-    return null;
-  }
-};
-
-// sessionStorage is per-tab and survives a reload, which is how a discarded
-// mobile tab still comes back to the position the user left off at.
-const readStoredPositions = (): ScrollPositions => {
-  const storage = getStorage();
-
-  if (!storage) {
-    return {};
-  }
-
-  try {
-    const stored: unknown = JSON.parse(
-      storage.getItem(SESSION_STORAGE_KEY) ?? '{}',
-    );
-
-    return stored && typeof stored === 'object'
-      ? (stored as ScrollPositions)
-      : {};
-  } catch {
-    return {};
-  }
-};
-
-const persistPositions = (): void => {
-  if (persistTimeout) {
-    window.clearTimeout(persistTimeout);
-    persistTimeout = null;
-  }
-
-  const storage = getStorage();
-
-  if (!storage) {
-    return;
-  }
-
-  try {
-    storage.setItem(
-      SESSION_STORAGE_KEY,
-      JSON.stringify(
-        capPositions({ ...readStoredPositions(), ...pendingPositions }),
-      ),
-    );
-  } catch {
-    // Hitting the quota must not break navigation, the in-memory map still works.
-  }
-};
-
-// Writing on every scroll frame would stringify the whole map dozens of times a
-// second, which is exactly the jank the phones in the report can't afford.
-const schedulePersist = (): void => {
-  if (persistTimeout) {
-    return;
-  }
-
-  persistTimeout = window.setTimeout(() => {
-    persistTimeout = null;
-    persistPositions();
-  }, PERSIST_DEBOUNCE_MS);
-};
 
 const getScrollKey = (asPath: string): string => {
   if (typeof window === 'undefined') {
@@ -99,60 +16,30 @@ const getScrollKey = (asPath: string): string => {
   return historyKey ? `${asPath}:${historyKey}` : asPath;
 };
 
-const readPosition = (key: string): number => {
-  const position = pendingPositions[key] ?? readStoredPositions()[key];
-
-  return typeof position === 'number' ? position : 0;
-};
-
-const writePosition = (key: string, position: number): void => {
-  // Re-inserting keeps insertion order aligned with recency so the cap drops
-  // the entries the user is least likely to navigate back to.
-  delete pendingPositions[key];
-  pendingPositions[key] = position;
-
-  Object.keys(pendingPositions)
-    .slice(0, -MAX_STORED_POSITIONS)
-    .forEach((staleKey) => delete pendingPositions[staleKey]);
-
-  schedulePersist();
-};
-
 export const useScrollRestoration = (): void => {
   const { asPath } = useRouter();
   const isRestoringRef = useRef(false);
 
   useEffect(() => {
-    let frame = 0;
-
     const handleScroll = () => {
-      // Both our restore pass and Next's own reset-to-top on navigation emit
-      // scroll events. Recording those would overwrite the user's position.
-      if (isRestoringRef.current || frame) {
+      // Our own restore pass and Next's reset-to-top on navigation both emit
+      // scroll events, and neither is where the user actually was.
+      if (isRestoringRef.current) {
         return;
       }
 
-      frame = requestAnimationFrame(() => {
-        frame = 0;
-        writePosition(getScrollKey(asPath), window.scrollY);
-      });
+      scrollPositions[getScrollKey(asPath)] = window.scrollY;
     };
 
     window.addEventListener('scroll', handleScroll, { passive: true });
-    window.addEventListener('pagehide', persistPositions);
-    document.addEventListener('visibilitychange', persistPositions);
 
     return () => {
       window.removeEventListener('scroll', handleScroll);
-      window.removeEventListener('pagehide', persistPositions);
-      document.removeEventListener('visibilitychange', persistPositions);
-      cancelAnimationFrame(frame);
-      persistPositions();
     };
   }, [asPath]);
 
   useEffect(() => {
-    const target = readPosition(getScrollKey(asPath));
+    const target = scrollPositions[getScrollKey(asPath)] ?? 0;
 
     if (!target) {
       return undefined;
@@ -176,18 +63,14 @@ export const useScrollRestoration = (): void => {
         document.documentElement.scrollHeight - window.innerHeight;
 
       // Scrolling before the page is tall enough clamps to the bottom of what
-      // has rendered so far, so wait instead of settling for a wrong position.
+      // has rendered so far, so wait rather than settle for a wrong position.
       if (maxScroll >= target) {
         window.scrollTo(0, target);
-
-        // Next resets the scroll to the top in a layout effect of the same
-        // commit that mounts us, so keep re-applying until the position sticks.
-        if (Math.abs(window.scrollY - target) <= SCROLL_TOLERANCE_PX) {
-          stop();
-          return;
-        }
+        stop();
+        return;
       }
 
+      // Out of budget: the feed never got there, so leave the user at the top.
       if (performance.now() >= deadline) {
         stop();
         return;


### PR DESCRIPTION
## Changes

Coming back to the feed from a discussion dropped mobile users at the top, so they had to scroll all the way down again to reach where they were.

Scroll restoration already existed (`useScrollRestoration`, used by `MainFeedLayout`), but it gave the page **one second** to reach the saved height and then scrolled to `min(target, maxScroll)` regardless. On a phone rendering a long cached feed that budget expires mid-render, so the "restore" clamped the user to the bottom of the handful of cards that had rendered — indistinguishable from not remembering at all. Desktop renders fast enough to slip under the deadline, which is why this reads as a mobile bug.

- Wait up to 2s for the page to actually reach the target height
- On timeout, leave the user at the top instead of settling for a clamped position
- Abort on `wheel`/`touchmove`/`keydown`/`mousedown` so restoring never fights the user
- Ignore the scroll events our own restore and the router's reset-to-top emit — those were overwriting the stored position for the next visit

## Key decisions

- **`experimental.scrollRestoration` is off**, so Next does no restoration of its own and resets scroll to `(0,0)` on every route change, back/forward included, from a layout effect in the commit that mounts the feed. That reset is what the new guard filters out. Recorded as a lesson in `AGENTS.md`.
- **No sessionStorage persistence.** An earlier iteration persisted positions across reloads; it was dropped. There is no query persister configured, so after a reload the feed cache is empty and anything below the first page is unreachable anyway — it bought little for ~70 lines, and it grew the hook a second concern against `packages/shared/src/hooks/AGENTS.md` ("Keep hooks single-responsibility").
- Net diff against the previous implementation is small: a longer budget (1s to 2s), no clamping, user-input abort, and one ref guard.

## Testing

New spec `packages/shared/src/hooks/useScrollRestoration.spec.ts` (6 tests). 4 of the 6 fail against `main`, so they pin the regression rather than just the new code.

CI gates run locally, all green: shared lint (`--max-warnings 0`), `typecheck:strict:changed`, shared jest (2089), webapp jest (336), extension jest (43), and `build_extension` (Rspack, 0 errors). Also ran the full webapp `tsc` that `packages/webapp/AGENTS.md` asks for after shared changes.

> [!NOTE]
> Verified through unit tests and source analysis, not on a physical device — the claim that Next's reset lands before our first rAF is read from `next/dist/client/index.js`, not observed live. Worth a sanity check on a real Android/iOS device before merge, especially given the unresolved iOS-specific report on #4632.

Closes ENG-1698

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1698-feedback-ux-issue-the-m.preview.app.daily.dev
