### PR TITLE
feat(posts): allow deleting scheduled posts

### DIFF
--- a/packages/shared/src/components/post/schedule/ScheduledPostItem.spec.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostItem.spec.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+import type { InfiniteData } from '@tanstack/react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import nock from 'nock';
+import { ScheduledPostItem } from './ScheduledPostItem';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { usePrompt } from '../../../hooks/usePrompt';
+import { useToastNotification } from '../../../hooks/useToastNotification';
+import type { Connection } from '../../../graphql/common';
+import type { ScheduledPost } from '../../../graphql/posts';
+import { DELETE_POST_MUTATION } from '../../../graphql/posts';
+import { generateQueryKey, RequestKey } from '../../../lib/query';
+import { mockGraphQL } from '../../../../__tests__/helpers/graphql';
+import { defaultQueryClientTestingConfig } from '../../../../__tests__/helpers/tanstack-query';
+
+jest.mock('../../../contexts/AuthContext', () => ({
+  ...jest.requireActual('../../../contexts/AuthContext'),
+  useAuthContext: jest.fn(),
+}));
+
+jest.mock('../../../hooks/usePrompt', () => ({
+  usePrompt: jest.fn(),
+}));
+
+jest.mock('../../../hooks/useToastNotification', () => ({
+  useToastNotification: jest.fn(),
+}));
+
+jest.mock('../../tooltip/Tooltip', () => ({
+  Tooltip: ({ children }: React.PropsWithChildren) => children,
+}));
+
+const user = { id: 'user-1', timezone: 'UTC' };
+
+const post = {
+  id: 'post-1',
+  title: 'Scheduled title',
+  flags: { scheduledAt: '2026-08-10T10:00:00.000Z' },
+  source: { id: 'source-1', handle: 'squad', name: 'My Squad', image: '' },
+} as ScheduledPost;
+
+const scheduledPostsKey = generateQueryKey(RequestKey.ScheduledPosts, user);
+
+const showPrompt = jest.fn();
+const displayToast = jest.fn();
+
+const setupItem = () => {
+  const client = new QueryClient(defaultQueryClientTestingConfig);
+  client.setQueryData<InfiniteData<Connection<ScheduledPost>>>(
+    scheduledPostsKey,
+    {
+      pages: [
+        {
+          edges: [{ node: post }],
+          pageInfo: { endCursor: '', hasNextPage: false },
+        },
+      ],
+      pageParams: [''],
+    },
+  );
+
+  render(
+    <QueryClientProvider client={client}>
+      <ScheduledPostItem post={post} />
+    </QueryClientProvider>,
+  );
+
+  return client;
+};
+
+const getCachedIds = (client: QueryClient) => {
+  const data =
+    client.getQueryData<InfiniteData<Connection<ScheduledPost>>>(
+      scheduledPostsKey,
+    );
+
+  if (!data) {
+    throw new Error('scheduled posts cache is missing');
+  }
+
+  return data.pages.flatMap((page) => page.edges.map((edge) => edge.node.id));
+};
+
+describe('ScheduledPostItem', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    nock.cleanAll();
+    jest.mocked(useAuthContext).mockReturnValue({
+      user,
+    } as ReturnType<typeof useAuthContext>);
+    jest.mocked(usePrompt).mockReturnValue({
+      showPrompt,
+      prompt: null,
+    });
+    jest.mocked(useToastNotification).mockReturnValue({
+      displayToast,
+      dismissToast: jest.fn(),
+      subject: null,
+    } as unknown as ReturnType<typeof useToastNotification>);
+  });
+
+  it('deletes the post and drops it from the list once confirmed', async () => {
+    showPrompt.mockResolvedValue(true);
+    let requested = false;
+    mockGraphQL({
+      request: { query: DELETE_POST_MUTATION, variables: { id: post.id } },
+      result: () => {
+        requested = true;
+        return { data: { deletePost: { _: true } } };
+      },
+    });
+
+    const client = setupItem();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete scheduled post' }),
+    );
+
+    await waitFor(() => expect(requested).toBe(true));
+    await waitFor(() => expect(getCachedIds(client)).toEqual([]));
+    expect(displayToast).toHaveBeenCalledWith('Scheduled post deleted');
+  });
+
+  it('keeps the post when the confirmation is dismissed', async () => {
+    showPrompt.mockResolvedValue(false);
+
+    const client = setupItem();
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Delete scheduled post' }),
+    );
+
+    await waitFor(() => expect(showPrompt).toHaveBeenCalled());
+    expect(getCachedIds(client)).toEqual([post.id]);
+    expect(displayToast).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/components/post/schedule/ScheduledPostItem.spec.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostItem.spec.tsx
@@ -96,20 +96,14 @@ describe('ScheduledPostItem', () => {
     });
     jest.mocked(useToastNotification).mockReturnValue({
       displayToast,
-      dismissToast: jest.fn(),
-      subject: null,
     } as unknown as ReturnType<typeof useToastNotification>);
   });
 
   it('deletes the post and drops it from the list once confirmed', async () => {
     showPrompt.mockResolvedValue(true);
-    let requested = false;
     mockGraphQL({
       request: { query: DELETE_POST_MUTATION, variables: { id: post.id } },
-      result: () => {
-        requested = true;
-        return { data: { deletePost: { _: true } } };
-      },
+      result: () => ({ data: { deletePost: { _: true } } }),
     });
 
     const client = setupItem();
@@ -117,7 +111,6 @@ describe('ScheduledPostItem', () => {
       screen.getByRole('button', { name: 'Delete scheduled post' }),
     );
 
-    await waitFor(() => expect(requested).toBe(true));
     await waitFor(() => expect(getCachedIds(client)).toEqual([]));
     expect(displayToast).toHaveBeenCalledWith('Scheduled post deleted');
   });

--- a/packages/shared/src/components/post/schedule/ScheduledPostItem.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostItem.tsx
@@ -8,11 +8,15 @@ import {
   TypographyColor,
   TypographyType,
 } from '../../typography/Typography';
+import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
+import { TrashIcon } from '../../icons';
+import { Tooltip } from '../../tooltip/Tooltip';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import type { ScheduledPost } from '../../../graphql/posts';
 import { webappUrl } from '../../../lib/constants';
 import { formatScheduleDelta } from '../../../lib/scheduledPost';
 import { dateFormatInTimezone } from '../../../lib/timezones';
+import { useDeleteScheduledPost } from './useDeleteScheduledPost';
 
 interface ScheduledPostItemProps {
   post: ScheduledPost;
@@ -22,6 +26,7 @@ export function ScheduledPostItem({
   post,
 }: ScheduledPostItemProps): ReactElement | null {
   const { user } = useAuthContext();
+  const { deleteScheduledPost, isDeleting } = useDeleteScheduledPost();
   const scheduledAt = post.flags?.scheduledAt;
 
   if (!scheduledAt) {
@@ -37,39 +42,52 @@ export function ScheduledPostItem({
   const delta = formatScheduleDelta(scheduledDate);
 
   return (
-    <Link href={`${webappUrl}posts/${post.id}/edit`} passHref>
-      <a className="flex items-center gap-3 border-b border-border-subtlest-tertiary px-4 py-3 hover:bg-surface-hover">
-        <SourceAvatar
-          source={post.source}
-          size={ProfileImageSize.Medium}
-          className="!mr-0"
+    <div className="flex items-center border-b border-border-subtlest-tertiary pr-4 hover:bg-surface-hover">
+      <Link href={`${webappUrl}posts/${post.id}/edit`} passHref>
+        <a className="flex min-w-0 flex-1 items-center gap-3 px-4 py-3">
+          <SourceAvatar
+            source={post.source}
+            size={ProfileImageSize.Medium}
+            className="!mr-0"
+          />
+          <div className="flex min-w-0 flex-1 flex-col">
+            <Typography type={TypographyType.Body} bold truncate>
+              {post.title || 'Untitled post'}
+            </Typography>
+            {post.source?.name && (
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Tertiary}
+                truncate
+              >
+                {post.source.name}
+              </Typography>
+            )}
+          </div>
+          <div className="flex shrink-0 flex-col items-end text-text-tertiary">
+            <Typography type={TypographyType.Caption1}>{absolute}</Typography>
+            {delta && (
+              <Typography
+                type={TypographyType.Caption2}
+                color={TypographyColor.Tertiary}
+              >
+                {delta}
+              </Typography>
+            )}
+          </div>
+        </a>
+      </Link>
+      <Tooltip content="Delete scheduled post">
+        <Button
+          type="button"
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+          icon={<TrashIcon />}
+          onClick={() => deleteScheduledPost(post.id)}
+          disabled={isDeleting}
+          aria-label="Delete scheduled post"
         />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <Typography type={TypographyType.Body} bold truncate>
-            {post.title || 'Untitled post'}
-          </Typography>
-          {post.source?.name && (
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Tertiary}
-              truncate
-            >
-              {post.source.name}
-            </Typography>
-          )}
-        </div>
-        <div className="flex shrink-0 flex-col items-end text-text-tertiary">
-          <Typography type={TypographyType.Caption1}>{absolute}</Typography>
-          {delta && (
-            <Typography
-              type={TypographyType.Caption2}
-              color={TypographyColor.Tertiary}
-            >
-              {delta}
-            </Typography>
-          )}
-        </div>
-      </a>
-    </Link>
+      </Tooltip>
+    </div>
   );
 }

--- a/packages/shared/src/components/post/schedule/ScheduledPostList.tsx
+++ b/packages/shared/src/components/post/schedule/ScheduledPostList.tsx
@@ -54,7 +54,8 @@ export function ScheduledPostList(): ReactElement {
           type={TypographyType.Callout}
           color={TypographyColor.Tertiary}
         >
-          Posts waiting to go live. Select one to edit or reschedule it.
+          Posts waiting to go live. Select one to edit or reschedule it, or
+          delete it before it goes live.
         </Typography>
       </div>
       <InfiniteScrolling

--- a/packages/shared/src/components/post/schedule/useDeleteScheduledPost.ts
+++ b/packages/shared/src/components/post/schedule/useDeleteScheduledPost.ts
@@ -35,7 +35,7 @@ export const useDeleteScheduledPost = (): UseDeleteScheduledPost => {
   const { displayToast } = useToastNotification();
 
   const { mutate, isPending } = useMutation({
-    mutationFn: (id: string) => deletePost(id),
+    mutationFn: deletePost,
     onSuccess: (_, id) => {
       client.setQueryData<InfiniteData<Connection<ScheduledPost>>>(
         generateQueryKey(RequestKey.ScheduledPosts, user),

--- a/packages/shared/src/components/post/schedule/useDeleteScheduledPost.ts
+++ b/packages/shared/src/components/post/schedule/useDeleteScheduledPost.ts
@@ -1,0 +1,73 @@
+import { useCallback } from 'react';
+import type { InfiniteData } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { Connection } from '../../../graphql/common';
+import type { ScheduledPost } from '../../../graphql/posts';
+import { deletePost } from '../../../graphql/posts';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import type { PromptOptions } from '../../../hooks/usePrompt';
+import { usePrompt } from '../../../hooks/usePrompt';
+import { useToastNotification } from '../../../hooks/useToastNotification';
+import { generateQueryKey, RequestKey } from '../../../lib/query';
+import { labels } from '../../../lib/labels';
+import { ButtonColor, ButtonVariant } from '../../buttons/Button';
+
+const deletePromptOptions: PromptOptions = {
+  title: 'Delete scheduled post?',
+  description:
+    'Are you sure you want to delete this scheduled post? It will never go live and this action cannot be undone.',
+  okButton: {
+    title: 'Delete',
+    variant: ButtonVariant.Primary,
+    color: ButtonColor.Cabbage,
+  },
+};
+
+export interface UseDeleteScheduledPost {
+  deleteScheduledPost: (id: string) => Promise<void>;
+  isDeleting: boolean;
+}
+
+export const useDeleteScheduledPost = (): UseDeleteScheduledPost => {
+  const client = useQueryClient();
+  const { user } = useAuthContext();
+  const { showPrompt } = usePrompt();
+  const { displayToast } = useToastNotification();
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (id: string) => deletePost(id),
+    onSuccess: (_, id) => {
+      client.setQueryData<InfiniteData<Connection<ScheduledPost>>>(
+        generateQueryKey(RequestKey.ScheduledPosts, user),
+        (data) => {
+          if (!data) {
+            return data;
+          }
+
+          return {
+            ...data,
+            pages: data.pages.map((page) => ({
+              ...page,
+              edges: page.edges.filter(({ node }) => node.id !== id),
+            })),
+          };
+        },
+      );
+      displayToast('Scheduled post deleted');
+    },
+    onError: () => displayToast(labels.error.generic),
+  });
+
+  const deleteScheduledPost = useCallback(
+    async (id: string) => {
+      if (!(await showPrompt(deletePromptOptions))) {
+        return;
+      }
+
+      mutate(id);
+    },
+    [mutate, showPrompt],
+  );
+
+  return { deleteScheduledPost, isDeleting: isPending };
+};


### PR DESCRIPTION
The scheduled posts list only allowed editing or rescheduling. Each row now has a delete action.

## Changes

- `useDeleteScheduledPost` — confirms via the shared prompt, calls the existing `deletePost` mutation, drops the post from the cached `ScheduledPosts` list, and toasts on success/failure.
- `ScheduledPostItem` — adds a trash button to each row.
- `ScheduledPostList` — subtitle now mentions deleting.
- Spec covering the confirmed and dismissed paths.

## Key decisions

- Reuses the existing `deletePost` mutation rather than adding a scheduled-specific one. Note this assumes daily-api lets an author delete their own not-yet-published post — worth a sanity check before merge.
- The delete button is a **sibling** of the row link, not nested inside the `<a>`, so the DOM stays valid and clicking delete never navigates to the edit page.
- The button is always visible rather than revealed on hover, so it works on touch.
- Removes the post from the query cache on success for instant feedback instead of invalidating and refetching.
- No new permission gate: `scheduledPosts` takes no author filter and only ever returns the caller's own posts, so the viewer is always the author. Backend access control remains the real gate.

## Verification

`eslint`, `prettier`, and `typecheck-strict-changed` clean on the changed files; `jest src/components/post` (11 suites) and the full `webapp` suite (45 suites / 336 tests) pass.

Closes ENG-1914

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1914-make-scheduled-posts-de.preview.app.daily.dev