### PR TITLE
fix(squads): say whether each posting gate reviews posts

### DIFF
--- a/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.spec.tsx
+++ b/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.spec.tsx
@@ -22,6 +22,30 @@ const getGate = (label: string) =>
   screen.getByLabelText(label) as HTMLInputElement;
 
 describe('SquadModerationSettingsSection', () => {
+  it('spells out whether each gate reviews posts', () => {
+    renderComponent();
+
+    expect(screen.getByText('All members can post. No review.')).toBeVisible();
+    expect(
+      screen.getByText('All members can post. Every post is reviewed.'),
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        'Only members with enough reputation can post. No review.',
+      ),
+    ).toBeVisible();
+  });
+
+  it('says posts skip review under the reputation gate', () => {
+    renderComponent({ initialPostingMinReputation: 100 });
+
+    expect(
+      screen.getByText(
+        'Members below this reputation cannot post at all. Everyone else posts without review.',
+      ),
+    ).toBeVisible();
+  });
+
   it('selects the open gate when nothing is configured', () => {
     renderComponent();
 

--- a/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.spec.tsx
+++ b/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.spec.tsx
@@ -36,16 +36,6 @@ describe('SquadModerationSettingsSection', () => {
     ).toBeVisible();
   });
 
-  it('says posts skip review under the reputation gate', () => {
-    renderComponent({ initialPostingMinReputation: 100 });
-
-    expect(
-      screen.getByText(
-        'Members below this reputation cannot post at all. Everyone else posts without review.',
-      ),
-    ).toBeVisible();
-  });
-
   it('selects the open gate when nothing is configured', () => {
     renderComponent();
 

--- a/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.tsx
+++ b/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.tsx
@@ -6,6 +6,11 @@ import { SourceMemberRole } from '../../../graphql/sources';
 import { TextField } from '../../fields/TextField';
 import { WidgetCard } from '../../widgets/WidgetCard';
 import { Tooltip } from '../../tooltip/Tooltip';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../typography/Typography';
 
 export enum SquadPostingGate {
   None = 'none',
@@ -33,19 +38,43 @@ const memberRoleOptions = [
   },
 ];
 
+// Each option spells out both halves of the outcome, since "who can post" and
+// "does anyone review it" are easy to conflate once a threshold is involved.
+const gateOption = (
+  value: SquadPostingGate,
+  label: string,
+  description: string,
+) => ({
+  value,
+  label,
+  className: { wrapper: 'mb-1' },
+  afterElement: (
+    <Typography
+      className="ml-8"
+      type={TypographyType.Footnote}
+      color={TypographyColor.Tertiary}
+    >
+      {description}
+    </Typography>
+  ),
+});
+
 const postingGateOptions = [
-  {
-    label: 'Anyone can post',
-    value: SquadPostingGate.None,
-  },
-  {
-    label: 'Require post approval',
-    value: SquadPostingGate.Moderation,
-  },
-  {
-    label: 'Require a minimum reputation',
-    value: SquadPostingGate.Reputation,
-  },
+  gateOption(
+    SquadPostingGate.None,
+    'Anyone can post',
+    'All members can post. No review.',
+  ),
+  gateOption(
+    SquadPostingGate.Moderation,
+    'Require post approval',
+    'All members can post. Every post is reviewed.',
+  ),
+  gateOption(
+    SquadPostingGate.Reputation,
+    'Require a minimum reputation',
+    'Only members with enough reputation can post. No review.',
+  ),
 ];
 
 const getInitialGate = (
@@ -106,7 +135,7 @@ export function SquadModerationSettingsSection({
         </SquadSettingsSection>
         <SquadSettingsSection
           title="Posting requirements"
-          description="Choose what members need to clear before their posts go live."
+          description="Choose who can post and whether their posts are reviewed first."
         >
           <Tooltip
             side="top"
@@ -136,7 +165,7 @@ export function SquadModerationSettingsSection({
               defaultValue={`${
                 initialPostingMinReputation ?? DEFAULT_POSTING_MIN_REPUTATION
               }`}
-              hint="Members below this reputation will not be able to post."
+              hint="Members below this reputation cannot post at all. Everyone else posts without review."
             />
           )}
         </SquadSettingsSection>

--- a/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.tsx
+++ b/packages/shared/src/components/squads/settings/SquadModerationSettingsSection.tsx
@@ -165,7 +165,6 @@ export function SquadModerationSettingsSection({
               defaultValue={`${
                 initialPostingMinReputation ?? DEFAULT_POSTING_MIN_REPUTATION
               }`}
-              hint="Members below this reputation cannot post at all. Everyone else posts without review."
             />
           )}
         </SquadSettingsSection>


### PR DESCRIPTION
Follow-up to #6408. The reputation option did not make clear whether posts from members *above* the threshold still need approval, or publish straight away.

Each option now states both halves of the outcome (who can post, and whether anyone reviews it), rendered as a muted line under the label via `RadioItem`'s `afterElement` slot:

| Option | Description |
| --- | --- |
| Anyone can post | All members can post. No review. |
| Require post approval | All members can post. Every post is reviewed. |
| Require a minimum reputation | Only members with enough reputation can post. No review. |

Read as a set, the axis is now obvious: the first two differ on review, the third differs on who can post, and only the middle one ever puts something in the queue.

The section description also becomes "Choose who can post and whether their posts are reviewed first."

The threshold field carries no hint: the option description plus the "Minimum reputation" label already say everything a hint would, so one was added and then dropped as redundant.

## Verification

- `SquadModerationSettingsSection.spec.tsx` gains a case asserting the review/no-review wording on every option. 7/7 pass.
- Lint and the strict-changed guard are clean.

https://claude.ai/code/session_01YDfs5kxvMN3i7WRp1y3mmm

### Preview domain
https://fix-squad-posting-gate-copy.preview.app.daily.dev