### PR TITLE
fix(onboarding): device-testing fixes for the post-signup funnel

### DIFF
--- a/packages/shared/src/components/auth/AuthOptionsInner.tsx
+++ b/packages/shared/src/components/auth/AuthOptionsInner.tsx
@@ -775,6 +775,7 @@ function AuthOptionsInner({
             isLoading={isProfileUpdateLoading}
             onUpdateHints={onUpdateHint}
             simplified={simplified}
+            isOnboardingFunnel={isOnboardingFunnel}
             {...(user?.isPlus && {
               title: 'Complete your profile',
             })}

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -4,7 +4,7 @@ import React, { useContext, useEffect, useState } from 'react';
 import type { SocialRegistrationParameters } from '../../lib/auth';
 import { AuthEventNames } from '../../lib/auth';
 import { formToJson } from '../../lib/form';
-import { Button, ButtonVariant } from '../buttons/Button';
+import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import ImageInput from '../fields/ImageInput';
 import { TextField } from '../fields/TextField';
 import { MailIcon, UserIcon, LockIcon, AtIcon } from '../icons';
@@ -27,6 +27,11 @@ import ExperienceLevelDropdown from '../profile/ExperienceLevelDropdown';
 import { Loader } from '../Loader';
 import { labels } from '../../lib';
 import { generateNameFromEmail } from '../../lib/strings';
+import SignupDisclaimer from './SignupDisclaimer';
+import {
+  FunnelGlassBar,
+  funnelGlassBarCta,
+} from '../../features/onboarding/shared/FunnelGlassBar';
 
 export interface SocialRegistrationFormProps extends AuthFormProps {
   className?: string;
@@ -37,6 +42,12 @@ export interface SocialRegistrationFormProps extends AuthFormProps {
   onUpdateHints?: (errors: ProfileFormHint) => void;
   onSignup?: (params: SocialRegistrationParameters) => void;
   isLoading?: boolean;
+  /**
+   * Post-signup onboarding only: the same chrome the email signup takes, so the
+   * two account-details screens are one screen with one extra field. Everywhere
+   * else — the auth modal, the recruiter flows — keeps the modal footer.
+   */
+  isOnboardingFunnel?: boolean;
 }
 
 export type SocialRegistrationFormValues = Omit<
@@ -54,6 +65,7 @@ export const SocialRegistrationForm = ({
   onSignup,
   isLoading,
   simplified,
+  isOnboardingFunnel,
 }: SocialRegistrationFormProps): ReactElement => {
   const { logEvent } = useLogContext();
   const { user } = useContext(AuthContext);
@@ -179,6 +191,146 @@ export const SocialRegistrationForm = ({
     return <></>;
   }
 
+  const submitButton = (
+    <Button
+      form="auth-form"
+      type="submit"
+      className={isOnboardingFunnel ? funnelGlassBarCta : 'w-full'}
+      size={isOnboardingFunnel ? ButtonSize.Medium : undefined}
+      variant={ButtonVariant.Primary}
+      disabled={isLoading}
+    >
+      {user?.isPlus ? 'Continue' : 'Sign up'}
+    </Button>
+  );
+
+  const fields = (
+    <>
+      {isAppleRegistration && currentName && (
+        <input name="name" type="hidden" value={currentName} readOnly />
+      )}
+      {isAppleRegistration && !shouldShowAppleEmail && (
+        <input name="email" type="hidden" value={currentEmail} readOnly />
+      )}
+      {!isAppleRegistration && (
+        <ImageInput
+          className={{ container: 'mb-4' }}
+          initialValue={user?.image}
+          size="medium"
+          viewOnly
+        />
+      )}
+      {(!isAppleRegistration || shouldShowAppleEmail) && (
+        <TextField
+          saveHintSpace
+          className={{ container: 'w-full' }}
+          leftIcon={emailFieldIcon(provider)}
+          name="email"
+          inputId="email"
+          label="Email"
+          type="email"
+          value={currentEmail}
+          readOnly={!isAppleRegistration}
+          rightIcon={!isAppleRegistration ? <LockIcon /> : undefined}
+          onBlur={(e) => setEmail(e.target.value)}
+        />
+      )}
+      {!isAppleRegistration && (
+        <TextField
+          saveHintSpace
+          className={{ container: 'w-full' }}
+          leftIcon={<UserIcon size={IconSize.Small} />}
+          name="name"
+          inputId="name"
+          label="Name"
+          value={currentName}
+          valid={!nameHint && !hints?.name}
+          hint={hints?.name || nameHint}
+          onBlur={(e) => setName(e.target.value)}
+          valueChanged={() => {
+            if (hints?.name) {
+              onUpdateHints?.({ ...hints, name: '' });
+            }
+            if (nameHint) {
+              setNameHint('');
+            }
+          }}
+        />
+      )}
+      <TextField
+        saveHintSpace
+        className={{ container: 'w-full' }}
+        leftIcon={<AtIcon size={IconSize.Small} secondary />}
+        name="username"
+        inputId="username"
+        label="Enter a username"
+        value={username}
+        minLength={1}
+        valid={isLoadingUsername || (!usernameHint && !hints?.username)}
+        hint={
+          isLoadingUsername
+            ? labels.generatingUsername
+            : hints?.username || usernameHint
+        }
+        onBlur={(e) => setUsername(e.target.value)}
+        valueChanged={() =>
+          hints?.[username] && onUpdateHints({ ...hints, username: '' })
+        }
+        rightIcon={isLoadingUsername ? <Loader /> : null}
+      />
+      <ExperienceLevelDropdown
+        className={{ container: 'w-full' }}
+        name="experienceLevel"
+        onChange={() => {
+          if (experienceLevelHint) {
+            setExperienceLevelHint(null);
+          }
+        }}
+        valid={experienceLevelHint === null}
+        hint={experienceLevelHint}
+        saveHintSpace
+      />
+      <Checkbox name="optOutMarketing" className="font-normal">
+        I don’t want to receive updates and promotions via email
+      </Checkbox>
+    </>
+  );
+
+  // Same shell, spacing and docked CTA as the email signup, so the two
+  // account-details screens differ only by the avatar above the fields.
+  if (isOnboardingFunnel) {
+    return (
+      <div className="flex flex-col">
+        <AuthHeader simplified={simplified} onboardingHeadline title={title} />
+        <div className={classNames(!simplified && 'px-4 pb-4 tablet:px-6')}>
+          <AuthForm
+            className={classNames(
+              'mt-10 w-full flex-1 place-items-center gap-2 self-center overflow-y-auto pb-2',
+              className,
+            )}
+            ref={formRef}
+            onSubmit={onSubmit}
+            id="auth-form"
+            data-testid="registration_form"
+          >
+            {fields}
+            <ConditionalWrapper
+              condition={simplified ?? false}
+              wrapper={(component) => (
+                <AuthContainer className="!mt-0 !px-0 pb-1 pt-3">
+                  {component}
+                </AuthContainer>
+              )}
+            >
+              <FunnelGlassBar>{submitButton}</FunnelGlassBar>
+              <SignupDisclaimer className="!text-text-tertiary typo-caption1" />
+            </ConditionalWrapper>
+          </AuthForm>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <>
       <AuthHeader simplified={simplified} title={title} />
@@ -192,93 +344,7 @@ export const SocialRegistrationForm = ({
         id="auth-form"
         data-testid="registration_form"
       >
-        {isAppleRegistration && currentName && (
-          <input name="name" type="hidden" value={currentName} readOnly />
-        )}
-        {isAppleRegistration && !shouldShowAppleEmail && (
-          <input name="email" type="hidden" value={currentEmail} readOnly />
-        )}
-        {!isAppleRegistration && (
-          <ImageInput
-            className={{ container: 'mb-4' }}
-            initialValue={user?.image}
-            size="medium"
-            viewOnly
-          />
-        )}
-        {(!isAppleRegistration || shouldShowAppleEmail) && (
-          <TextField
-            saveHintSpace
-            className={{ container: 'w-full' }}
-            leftIcon={emailFieldIcon(provider)}
-            name="email"
-            inputId="email"
-            label="Email"
-            type="email"
-            value={currentEmail}
-            readOnly={!isAppleRegistration}
-            rightIcon={!isAppleRegistration ? <LockIcon /> : undefined}
-            onBlur={(e) => setEmail(e.target.value)}
-          />
-        )}
-        {!isAppleRegistration && (
-          <TextField
-            saveHintSpace
-            className={{ container: 'w-full' }}
-            leftIcon={<UserIcon size={IconSize.Small} />}
-            name="name"
-            inputId="name"
-            label="Name"
-            value={currentName}
-            valid={!nameHint && !hints?.name}
-            hint={hints?.name || nameHint}
-            onBlur={(e) => setName(e.target.value)}
-            valueChanged={() => {
-              if (hints?.name) {
-                onUpdateHints?.({ ...hints, name: '' });
-              }
-              if (nameHint) {
-                setNameHint('');
-              }
-            }}
-          />
-        )}
-        <TextField
-          saveHintSpace
-          className={{ container: 'w-full' }}
-          leftIcon={<AtIcon size={IconSize.Small} secondary />}
-          name="username"
-          inputId="username"
-          label="Enter a username"
-          value={username}
-          minLength={1}
-          valid={isLoadingUsername || (!usernameHint && !hints?.username)}
-          hint={
-            isLoadingUsername
-              ? labels.generatingUsername
-              : hints?.username || usernameHint
-          }
-          onBlur={(e) => setUsername(e.target.value)}
-          valueChanged={() =>
-            hints?.[username] && onUpdateHints({ ...hints, username: '' })
-          }
-          rightIcon={isLoadingUsername ? <Loader /> : null}
-        />
-        <ExperienceLevelDropdown
-          className={{ container: 'w-full' }}
-          name="experienceLevel"
-          onChange={() => {
-            if (experienceLevelHint) {
-              setExperienceLevelHint(null);
-            }
-          }}
-          valid={experienceLevelHint === null}
-          hint={experienceLevelHint}
-          saveHintSpace
-        />
-        <Checkbox name="optOutMarketing" className="font-normal">
-          I don’t want to receive updates and promotions via email
-        </Checkbox>
+        {fields}
       </AuthForm>
       <ConditionalWrapper
         condition={simplified ?? false}
@@ -286,17 +352,7 @@ export const SocialRegistrationForm = ({
           <AuthContainer className="!mt-0">{component}</AuthContainer>
         )}
       >
-        <Modal.Footer>
-          <Button
-            form="auth-form"
-            type="submit"
-            className="w-full"
-            variant={ButtonVariant.Primary}
-            disabled={isLoading}
-          >
-            {user?.isPlus ? 'Continue' : 'Sign up'}
-          </Button>
-        </Modal.Footer>
+        <Modal.Footer>{submitButton}</Modal.Footer>
       </ConditionalWrapper>
     </>
   );

--- a/packages/shared/src/components/auth/SocialRegistrationForm.tsx
+++ b/packages/shared/src/components/auth/SocialRegistrationForm.tsx
@@ -43,9 +43,8 @@ export interface SocialRegistrationFormProps extends AuthFormProps {
   onSignup?: (params: SocialRegistrationParameters) => void;
   isLoading?: boolean;
   /**
-   * Post-signup onboarding only: the same chrome the email signup takes, so the
-   * two account-details screens are one screen with one extra field. Everywhere
-   * else — the auth modal, the recruiter flows — keeps the modal footer.
+   * Post-signup onboarding only: the chrome the email signup takes, so the two
+   * account-details screens read as one. Everywhere else keeps the modal footer.
    */
   isOnboardingFunnel?: boolean;
 }
@@ -296,8 +295,6 @@ export const SocialRegistrationForm = ({
     </>
   );
 
-  // Same shell, spacing and docked CTA as the email signup, so the two
-  // account-details screens differ only by the avatar above the fields.
   if (isOnboardingFunnel) {
     return (
       <div className="flex flex-col">

--- a/packages/shared/src/components/fields/CodeField.spec.tsx
+++ b/packages/shared/src/components/fields/CodeField.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { CodeField } from './CodeField';
 
 const onSubmit = jest.fn();
@@ -57,6 +57,27 @@ describe('CodeField', () => {
     expect(onSubmit).toHaveBeenCalledWith('725432');
   });
 
+  // A soft keyboard or IME whose keydown cannot be cancelled delivers its
+  // character through `input`, so a write shorter than the code is a keystroke.
+  it('should treat a write shorter than the code as a typed digit', async () => {
+    setup();
+
+    fireEvent.change(boxes()[0], { target: { value: '7' } });
+
+    expect(boxes().map((box) => box.value)).toEqual(['7', '', '', '', '', '']);
+    await waitFor(() => expect(boxes()[1]).toHaveFocus());
+  });
+
+  it('should not spread a second digit written into the same box', () => {
+    setup();
+
+    fireEvent.change(boxes()[0], { target: { value: '7' } });
+    fireEvent.change(boxes()[0], { target: { value: '77' } });
+
+    expect(boxes()[1]).toHaveValue('');
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('should take the digits out of a code pasted with surrounding text', () => {
     setup();
 
@@ -65,6 +86,18 @@ describe('CodeField', () => {
     });
 
     expect(onSubmit).toHaveBeenCalledWith('725432');
+  });
+
+  it('should keep a partial paste in place and focus the next box', async () => {
+    setup();
+
+    fireEvent.paste(boxes()[0], {
+      clipboardData: { getData: () => 'code: 72' },
+    });
+
+    expect(boxes().map((box) => box.value)).toEqual(['7', '2', '', '', '', '']);
+    expect(onSubmit).not.toHaveBeenCalled();
+    await waitFor(() => expect(boxes()[2]).toHaveFocus());
   });
 
   it('should ignore a paste that carries no digits', () => {

--- a/packages/shared/src/components/fields/CodeField.spec.tsx
+++ b/packages/shared/src/components/fields/CodeField.spec.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { CodeField } from './CodeField';
+
+const renderField = (onSubmit = jest.fn()) => {
+  render(<CodeField onSubmit={onSubmit} />);
+
+  return onSubmit;
+};
+
+const boxes = () => screen.getAllByRole('textbox') as HTMLInputElement[];
+
+describe('CodeField', () => {
+  it('should offer the first box to the platform as the code field', () => {
+    renderField();
+
+    const [first, ...rest] = boxes();
+    expect(first).toHaveAttribute('autocomplete', 'one-time-code');
+    expect(first).toHaveAttribute('inputmode', 'numeric');
+    // `tel` would not be the pair Safari's AutoFill is documented against.
+    expect(first).toHaveAttribute('type', 'text');
+    rest.forEach((box) => {
+      expect(box).toHaveAttribute('autocomplete', 'off');
+    });
+  });
+
+  it('should not cap any box, so a whole code written in survives', () => {
+    renderField();
+
+    boxes().forEach((box) => expect(box).not.toHaveAttribute('maxlength'));
+  });
+
+  // iOS AutoFill and Gboard's clipboard chip both write the code straight into
+  // the focused box rather than firing a paste event.
+  it('should spread a code written into the first box and submit it', () => {
+    const onSubmit = renderField();
+
+    fireEvent.change(boxes()[0], { target: { value: '725432' } });
+
+    expect(boxes().map((box) => box.value)).toEqual([
+      '7',
+      '2',
+      '5',
+      '4',
+      '3',
+      '2',
+    ]);
+    expect(onSubmit).toHaveBeenCalledWith('725432');
+  });
+
+  it('should spread a code written into a later box too', () => {
+    const onSubmit = renderField();
+
+    fireEvent.change(boxes()[3], { target: { value: '725432' } });
+
+    expect(onSubmit).toHaveBeenCalledWith('725432');
+  });
+
+  it('should take the digits out of a code pasted with surrounding text', () => {
+    const onSubmit = renderField();
+
+    fireEvent.paste(boxes()[0], {
+      clipboardData: { getData: () => 'Your code is 725432\n' },
+    });
+
+    expect(onSubmit).toHaveBeenCalledWith('725432');
+  });
+
+  it('should ignore a paste that carries no digits', () => {
+    const onSubmit = renderField();
+
+    fireEvent.paste(boxes()[0], {
+      clipboardData: { getData: () => 'no code here' },
+    });
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(boxes()[0]).toHaveValue('');
+  });
+
+  it('should still take one digit per box when typed', () => {
+    renderField();
+
+    fireEvent.keyDown(boxes()[0], { key: '7' });
+    expect(boxes()[0]).toHaveValue('7');
+  });
+});

--- a/packages/shared/src/components/fields/CodeField.spec.tsx
+++ b/packages/shared/src/components/fields/CodeField.spec.tsx
@@ -2,17 +2,18 @@ import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { CodeField } from './CodeField';
 
-const renderField = (onSubmit = jest.fn()) => {
-  render(<CodeField onSubmit={onSubmit} />);
+const onSubmit = jest.fn();
 
-  return onSubmit;
-};
-
+const setup = () => render(<CodeField onSubmit={onSubmit} />);
 const boxes = () => screen.getAllByRole('textbox') as HTMLInputElement[];
 
 describe('CodeField', () => {
+  beforeEach(() => {
+    onSubmit.mockReset();
+  });
+
   it('should offer the first box to the platform as the code field', () => {
-    renderField();
+    setup();
 
     const [first, ...rest] = boxes();
     expect(first).toHaveAttribute('autocomplete', 'one-time-code');
@@ -25,7 +26,7 @@ describe('CodeField', () => {
   });
 
   it('should not cap any box, so a whole code written in survives', () => {
-    renderField();
+    setup();
 
     boxes().forEach((box) => expect(box).not.toHaveAttribute('maxlength'));
   });
@@ -33,7 +34,7 @@ describe('CodeField', () => {
   // iOS AutoFill and Gboard's clipboard chip both write the code straight into
   // the focused box rather than firing a paste event.
   it('should spread a code written into the first box and submit it', () => {
-    const onSubmit = renderField();
+    setup();
 
     fireEvent.change(boxes()[0], { target: { value: '725432' } });
 
@@ -49,7 +50,7 @@ describe('CodeField', () => {
   });
 
   it('should spread a code written into a later box too', () => {
-    const onSubmit = renderField();
+    setup();
 
     fireEvent.change(boxes()[3], { target: { value: '725432' } });
 
@@ -57,7 +58,7 @@ describe('CodeField', () => {
   });
 
   it('should take the digits out of a code pasted with surrounding text', () => {
-    const onSubmit = renderField();
+    setup();
 
     fireEvent.paste(boxes()[0], {
       clipboardData: { getData: () => 'Your code is 725432\n' },
@@ -67,7 +68,7 @@ describe('CodeField', () => {
   });
 
   it('should ignore a paste that carries no digits', () => {
-    const onSubmit = renderField();
+    setup();
 
     fireEvent.paste(boxes()[0], {
       clipboardData: { getData: () => 'no code here' },
@@ -78,7 +79,7 @@ describe('CodeField', () => {
   });
 
   it('should still take one digit per box when typed', () => {
-    renderField();
+    setup();
 
     fireEvent.keyDown(boxes()[0], { key: '7' });
     expect(boxes()[0]).toHaveValue('7');

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -42,8 +42,16 @@ export function CodeField({
     }
   };
 
+  // A code lifted out of an email arrives with whatever the selection handles
+  // caught around it — a trailing newline, a "Your code:" prefix. Take the
+  // digits and ignore the rest rather than rejecting the whole paste.
   const onSlice = (text: string) => {
-    const sliced = text.slice(0, length);
+    const sliced = text.replace(/\D/g, '').slice(0, length);
+
+    if (!sliced) {
+      return;
+    }
+
     setCode(sliced.split(''));
     onChange?.(sliced);
 
@@ -52,8 +60,9 @@ export function CodeField({
     }
   };
 
-  // Typed digits never reach here — `onKeyDown` handles and cancels those — so
-  // this only sees values the platform writes in, which arrive whole.
+  // Typed digits never reach here — `onKeyDown` handles and cancels those. This
+  // is the platform writing a value in: iOS AutoFill, or Gboard's clipboard
+  // chip, which inserts as text and so never fires a paste event.
   const onFill = (value: string, index: number) => {
     const digits = value.replace(/\D/g, '');
 
@@ -66,15 +75,8 @@ export function CodeField({
   };
 
   const onPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
-    const text = e.clipboardData.getData('text');
-    const isNumbersOnly = checkIsNumbersOnly(text);
-
-    if (!isNumbersOnly) {
-      e.preventDefault();
-      return;
-    }
-
-    onSlice(text);
+    e.preventDefault();
+    onSlice(e.clipboardData.getData('text'));
   };
 
   const onKeyDown = async (
@@ -133,9 +135,11 @@ export function CodeField({
     <span className="flex flex-row gap-2">
       {[...Array(length)].map((_, index) => {
         // The platform only offers a code to a field it can see and focus, so
-        // this rides on the first box rather than a hidden mirror of it. It
-        // arrives as the whole code in one write, hence no `maxLength` here —
-        // typed input is still one digit per box, capped in `onKeyDown`.
+        // this rides on the first box rather than a hidden mirror of it.
+        //
+        // No box carries `maxLength`: a whole code written into any of them has
+        // to survive, and typing is already capped to one digit per box in
+        // `onKeyDown`.
         const isAutofillTarget = index === 0;
 
         return (
@@ -151,8 +155,7 @@ export function CodeField({
             label=""
             {...(isAutofillTarget
               ? { autoComplete: 'one-time-code', name: 'code' }
-              : { autoComplete: 'off', maxLength: 1 })}
-            showMaxLength={false}
+              : { autoComplete: 'off' })}
             className={{ baseField: '!h-11 w-11 mobileL:!h-12 mobileL:w-12' }}
             onPaste={onPaste}
             value={code[index] || ''}

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -52,6 +52,19 @@ export function CodeField({
     }
   };
 
+  // Typed digits never reach here — `onKeyDown` handles and cancels those — so
+  // this only sees values the platform writes in, which arrive whole.
+  const onFill = (value: string, index: number) => {
+    const digits = value.replace(/\D/g, '');
+
+    if (digits.length > 1) {
+      onSlice(digits);
+      return;
+    }
+
+    updateCode(digits, index);
+  };
+
   const onPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
     const text = e.clipboardData.getData('text');
     const isNumbersOnly = checkIsNumbersOnly(text);
@@ -118,48 +131,42 @@ export function CodeField({
 
   return (
     <span className="flex flex-row gap-2">
-      <input
-        type="text"
-        id="code"
-        name="code"
-        value={code.join('')}
-        onChange={() => {}} // Controlled by the individual inputs
-        autoComplete="one-time-code"
-        hidden
-        onInput={(e) => {
-          // Handle iOS Safari autofill
-          const { value } = e.target as HTMLInputElement;
-          if (value && value.length === length) {
-            onSlice(value);
-          }
-        }}
-      />
-      {[...Array(length)].map((_, index) => (
-        <TextField
-          // eslint-disable-next-line react/no-array-index-key
-          key={`code-${index}`}
-          type="tel"
-          inputId={`code-${index}`}
-          tabIndex={index + 1}
-          label=""
-          maxLength={1}
-          showMaxLength={false}
-          className={{ baseField: '!h-11 w-11 mobileL:!h-12 mobileL:w-12' }}
-          onPaste={onPaste}
-          value={code[index] || ''}
-          onKeyDown={(e) => onKeyDown(e, index)}
-          disabled={disabled}
-          autoComplete="off"
-          inputMode="numeric"
-          pattern="[0-9]*"
-          autoFocus={index === 0}
-          inputRef={(el) => {
-            if (el) {
-              elementsRef.current[index] = el;
-            }
-          }}
-        />
-      ))}
+      {[...Array(length)].map((_, index) => {
+        // The platform only offers a code to a field it can see and focus, so
+        // this rides on the first box rather than a hidden mirror of it. It
+        // arrives as the whole code in one write, hence no `maxLength` here —
+        // typed input is still one digit per box, capped in `onKeyDown`.
+        const isAutofillTarget = index === 0;
+
+        return (
+          <TextField
+            // eslint-disable-next-line react/no-array-index-key
+            key={`code-${index}`}
+            type="tel"
+            inputId={`code-${index}`}
+            tabIndex={index + 1}
+            label=""
+            {...(isAutofillTarget
+              ? { autoComplete: 'one-time-code', name: 'code' }
+              : { autoComplete: 'off', maxLength: 1 })}
+            showMaxLength={false}
+            className={{ baseField: '!h-11 w-11 mobileL:!h-12 mobileL:w-12' }}
+            onPaste={onPaste}
+            value={code[index] || ''}
+            onChange={(e) => onFill(e.target.value, index)}
+            onKeyDown={(e) => onKeyDown(e, index)}
+            disabled={disabled}
+            inputMode="numeric"
+            pattern="[0-9]*"
+            autoFocus={index === 0}
+            inputRef={(el) => {
+              if (el) {
+                elementsRef.current[index] = el;
+              }
+            }}
+          />
+        );
+      })}
     </span>
   );
 }

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -142,7 +142,10 @@ export function CodeField({
           <TextField
             // eslint-disable-next-line react/no-array-index-key
             key={`code-${index}`}
-            type="tel"
+            // `text` + `inputmode`, not `tel`: the numeric keypad comes from
+            // `inputMode` either way, and this is the pair Safari's one-time-code
+            // AutoFill is documented against. `tel` predates `inputmode`.
+            type="text"
             inputId={`code-${index}`}
             tabIndex={index + 1}
             label=""

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -42,35 +42,55 @@ export function CodeField({
     }
   };
 
-  // A code copied out of an email drags the selection's whitespace and prose
-  // along with it, so take the digits rather than rejecting the whole paste.
-  const onSlice = (text: string) => {
-    const sliced = text.replace(/\D/g, '').slice(0, length);
+  const focusBox = async (index: number) => {
+    const target = elementsRef.current[index];
 
-    if (!sliced) {
+    if (!target) {
       return;
     }
 
-    setCode(sliced.split(''));
-    onChange?.(sliced);
-
-    if (sliced.length === length) {
-      onSubmit(sliced);
-    }
+    await nextTick();
+    target.focus();
   };
 
-  // Only ever sees platform-written values — iOS AutoFill, or Gboard's
-  // clipboard chip, which inserts as text and fires no paste event. Typed
-  // digits are handled and cancelled in `onKeyDown`.
+  // A code copied out of an email drags the selection's whitespace and prose
+  // along with it, so take the digits rather than rejecting the whole paste.
+  const onSlice = (text: string) => {
+    const digits = text.replace(/\D/g, '').slice(0, length);
+
+    if (!digits) {
+      return;
+    }
+
+    setCode(Array.from({ length }, (_, index) => digits[index] ?? ''));
+    onChange?.(digits);
+
+    if (digits.length === length) {
+      onSubmit(digits);
+      return;
+    }
+
+    focusBox(digits.length);
+  };
+
+  // Platform writes land here — iOS AutoFill and Gboard's clipboard chip insert
+  // as text and fire no paste event — but so do keystrokes from IMEs and soft
+  // keyboards whose keydown `onKeyDown` cannot cancel. Only a whole code is a
+  // fill.
   const onFill = (value: string, index: number) => {
     const digits = value.replace(/\D/g, '');
 
-    if (digits.length > 1) {
+    if (digits.length >= length) {
       onSlice(digits);
       return;
     }
 
-    updateCode(digits, index);
+    const typed = digits.slice(-1);
+    updateCode(typed, index);
+
+    if (typed) {
+      focusBox(index + 1);
+    }
   };
 
   const onPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
@@ -105,12 +125,7 @@ export function CodeField({
         return;
       }
 
-      const previous = index - 1;
-
-      if (elementsRef.current[previous]) {
-        await nextTick();
-        elementsRef.current[previous].focus();
-      }
+      await focusBox(index - 1);
     }
 
     if (!isNumbersOnly) {
@@ -119,14 +134,7 @@ export function CodeField({
       e.preventDefault();
       updateCode(key, index);
 
-      if (index < length - 1) {
-        const nextIndex = index + 1;
-
-        if (elementsRef.current[nextIndex]) {
-          await nextTick();
-          elementsRef.current[nextIndex].focus();
-        }
-      }
+      await focusBox(index + 1);
     }
   };
 
@@ -136,7 +144,8 @@ export function CodeField({
           hint rides on the box that takes focus rather than a hidden mirror of
           it, `text` + `inputMode` is the pair Safari documents AutoFill
           against, and no box takes `maxLength` — a whole code written into one
-          would be cut to a digit. */}
+          would be cut to a digit. `name` is part of that hint and nothing
+          reads it: serialising this form would yield a single digit. */}
       {[...Array(length)].map((_, index) => {
         const isAutofillTarget = index === 0;
 

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -42,9 +42,8 @@ export function CodeField({
     }
   };
 
-  // A code lifted out of an email arrives with whatever the selection handles
-  // caught around it — a trailing newline, a "Your code:" prefix. Take the
-  // digits and ignore the rest rather than rejecting the whole paste.
+  // A code copied out of an email drags the selection's whitespace and prose
+  // along with it, so take the digits rather than rejecting the whole paste.
   const onSlice = (text: string) => {
     const sliced = text.replace(/\D/g, '').slice(0, length);
 
@@ -60,9 +59,9 @@ export function CodeField({
     }
   };
 
-  // Typed digits never reach here — `onKeyDown` handles and cancels those. This
-  // is the platform writing a value in: iOS AutoFill, or Gboard's clipboard
-  // chip, which inserts as text and so never fires a paste event.
+  // Only ever sees platform-written values — iOS AutoFill, or Gboard's
+  // clipboard chip, which inserts as text and fires no paste event. Typed
+  // digits are handled and cancelled in `onKeyDown`.
   const onFill = (value: string, index: number) => {
     const digits = value.replace(/\D/g, '');
 
@@ -133,22 +132,18 @@ export function CodeField({
 
   return (
     <span className="flex flex-row gap-2">
+      {/* The platform only offers a code to the field it has focused, so the
+          hint rides on the box that takes focus rather than a hidden mirror of
+          it, `text` + `inputMode` is the pair Safari documents AutoFill
+          against, and no box takes `maxLength` — a whole code written into one
+          would be cut to a digit. */}
       {[...Array(length)].map((_, index) => {
-        // The platform only offers a code to a field it can see and focus, so
-        // this rides on the first box rather than a hidden mirror of it.
-        //
-        // No box carries `maxLength`: a whole code written into any of them has
-        // to survive, and typing is already capped to one digit per box in
-        // `onKeyDown`.
         const isAutofillTarget = index === 0;
 
         return (
           <TextField
             // eslint-disable-next-line react/no-array-index-key
             key={`code-${index}`}
-            // `text` + `inputmode`, not `tel`: the numeric keypad comes from
-            // `inputMode` either way, and this is the pair Safari's one-time-code
-            // AutoFill is documented against. `tel` predates `inputmode`.
             type="text"
             inputId={`code-${index}`}
             tabIndex={index + 1}
@@ -164,7 +159,7 @@ export function CodeField({
             disabled={disabled}
             inputMode="numeric"
             pattern="[0-9]*"
-            autoFocus={index === 0}
+            autoFocus={isAutofillTarget}
             inputRef={(el) => {
               if (el) {
                 elementsRef.current[index] = el;

--- a/packages/shared/src/components/onboarding/OnboardingPWA.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingPWA.tsx
@@ -43,10 +43,9 @@ export const OnboardingPWA = ({
           </OnboardingHeadline>
           <OnboardingSubheadline>{PWA_EXPLAINER}</OnboardingSubheadline>
         </div>
-        {/* In flow rather than an absolute full-screen layer: at `w-full` the
-            footage's own aspect ratio made it tall enough on a wide phone to
-            reach up into the subheadline. Anchored to the bottom because the
-            frame's top third is empty space above the hand. */}
+        {/* In flow, not an absolute full-screen layer: at `w-full` the
+            footage's aspect ratio made it tall enough on a wide phone to reach
+            into the subheadline. Bottom-anchored — its top third is empty. */}
         <video
           {...footage}
           className="max-h-[45dvh] w-full max-w-64 object-cover object-bottom"

--- a/packages/shared/src/components/onboarding/OnboardingPWA.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingPWA.tsx
@@ -1,6 +1,5 @@
 import type { ReactElement } from 'react';
 import React from 'react';
-import classNames from 'classnames';
 import {
   OnboardingHeadline,
   OnboardingSubheadline,
@@ -30,13 +29,44 @@ export const OnboardingPWA = ({
   isOnboarding,
 }: OnboardingPWAProps): ReactElement => {
   const isChrome = checkIsChromeOnly();
+  const footage = {
+    poster: isChrome ? cloudinaryMobilePWAChrome : cloudinaryPWA,
+    src: isChrome ? cloudinaryPWAVideoChrome : cloudinaryPWAVideo,
+  };
+
+  if (isOnboarding) {
+    return (
+      <>
+        <div className="flex flex-col gap-6">
+          <OnboardingHeadline>
+            {headline || DEFAULT_PWA_HEADLINE}
+          </OnboardingHeadline>
+          <OnboardingSubheadline>{PWA_EXPLAINER}</OnboardingSubheadline>
+        </div>
+        {/* In flow rather than an absolute full-screen layer: at `w-full` the
+            footage's own aspect ratio made it tall enough on a wide phone to
+            reach up into the subheadline. Anchored to the bottom because the
+            frame's top third is empty space above the hand. */}
+        <video
+          {...footage}
+          className="max-h-[45dvh] w-full max-w-64 object-cover object-bottom"
+          muted
+          autoPlay
+          loop
+          playsInline
+          disablePictureInPicture
+          controls={false}
+        />
+      </>
+    );
+  }
+
   return (
     <>
       <div className="rounded-lg pointer-events-none absolute top-0 z-2 flex h-screen w-screen flex-col gap-4 p-6 opacity-0 backdrop-blur transition-all duration-200" />
       <video
+        {...footage}
         className="absolute top-0 max-h-screen w-full"
-        poster={isChrome ? cloudinaryMobilePWAChrome : cloudinaryPWA}
-        src={isChrome ? cloudinaryPWAVideoChrome : cloudinaryPWAVideo}
         muted
         autoPlay
         loop
@@ -44,29 +74,13 @@ export const OnboardingPWA = ({
         disablePictureInPicture
         controls={false}
       />
-      <div
-        className={classNames(
-          'z-1 flex flex-col',
-          isOnboarding ? 'gap-6' : 'gap-4',
-        )}
-      >
-        {isOnboarding ? (
-          <>
-            <OnboardingHeadline>
-              {headline || DEFAULT_PWA_HEADLINE}
-            </OnboardingHeadline>
-            <OnboardingSubheadline>{PWA_EXPLAINER}</OnboardingSubheadline>
-          </>
-        ) : (
-          <>
-            <OnboardingTitle className="!px-0">
-              {headline || DEFAULT_PWA_HEADLINE}
-            </OnboardingTitle>
-            <Typography className="text-center text-text-tertiary typo-body">
-              {PWA_EXPLAINER}
-            </Typography>
-          </>
-        )}
+      <div className="z-1 flex flex-col gap-4">
+        <OnboardingTitle className="!px-0">
+          {headline || DEFAULT_PWA_HEADLINE}
+        </OnboardingTitle>
+        <Typography className="text-center text-text-tertiary typo-body">
+          {PWA_EXPLAINER}
+        </Typography>
       </div>
     </>
   );

--- a/packages/shared/src/components/plus/PlusListItem.tsx
+++ b/packages/shared/src/components/plus/PlusListItem.tsx
@@ -40,7 +40,8 @@ export interface PlusItem {
 export interface PlusListItemProps {
   item: PlusItem;
   typographyProps?: TypographyProps<TypographyTag.P>;
-  icon?: FC<IconProps>;
+  /** `null` renders no icon at all; omitting it falls back to the check mark. */
+  icon?: FC<IconProps> | null;
   iconProps?: IconProps;
   badgeProps?: TypographyProps<TypographyTag.Span>;
   onHover?: () => void;

--- a/packages/shared/src/features/onboarding/components/PlusComparingCards.tsx
+++ b/packages/shared/src/features/onboarding/components/PlusComparingCards.tsx
@@ -30,7 +30,7 @@ export enum OnboardingPlans {
 }
 
 interface PlusCardProps {
-  currency: string;
+  currency?: string;
   onClickNext: () => void;
   onClickPlus: () => void;
   productOption?: ProductPricingPreview;
@@ -96,7 +96,9 @@ const PlusCard = ({
     <li
       aria-labelledby={`${id}-heading`}
       className={classNames(
-        'mx-auto w-[21rem] rounded-16 border border-border-subtlest-tertiary p-4',
+        // Capped rather than fixed: at a flat 21rem the card outgrew the
+        // step's gutters on a 360px phone and spilled off the right edge.
+        'mx-auto w-full max-w-[21rem] rounded-16 border border-border-subtlest-tertiary p-4',
         isPaidPlan && 'bg-surface-float',
       )}
     >
@@ -223,10 +225,10 @@ export const PlusComparingCards = ({
   free,
   plus,
 }: PlusComparingCardsProps): ReactElement => {
-  const currency = productOption.currency?.symbol;
+  const currency = productOption?.currency?.symbol;
 
   const productOptions = Object.values(OnboardingPlans).map((plan) => ({
-    key: plan,
+    plan,
     currency,
     productOption: plan === OnboardingPlans.Plus ? productOption : undefined,
     onClickNext,
@@ -237,10 +239,10 @@ export const PlusComparingCards = ({
   return (
     <ul
       aria-label="Pricing plans"
-      className="mx-auto flex grid-cols-1 flex-col-reverse place-content-center items-start gap-6 tablet:grid-cols-2 laptop:grid"
+      className="mx-auto flex w-full grid-cols-1 flex-col-reverse place-content-center items-start gap-6 tablet:grid-cols-2 laptop:grid"
     >
-      {productOptions.map((option) => (
-        <PlusCard key={option.key} {...option} />
+      {productOptions.map(({ plan, ...option }) => (
+        <PlusCard key={plan} {...option} />
       ))}
     </ul>
   );

--- a/packages/shared/src/features/onboarding/components/PlusComparingCards.tsx
+++ b/packages/shared/src/features/onboarding/components/PlusComparingCards.tsx
@@ -96,8 +96,8 @@ const PlusCard = ({
     <li
       aria-labelledby={`${id}-heading`}
       className={classNames(
-        // Capped rather than fixed: at a flat 21rem the card outgrew the
-        // step's gutters on a 360px phone and spilled off the right edge.
+        // Capped, not fixed: a flat 21rem outgrew the step's gutters on a
+        // 360px phone and spilled off the right edge.
         'mx-auto w-full max-w-[21rem] rounded-16 border border-border-subtlest-tertiary p-4',
         isPaidPlan && 'bg-surface-float',
       )}

--- a/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
+++ b/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
@@ -115,16 +115,19 @@ export function FunnelStepCtaWrapper({
     <div className="relative flex flex-1 flex-col gap-4">
       <FunnelStepTopBar skip={skip} />
       <div className={classNames('flex-1', containerClassName)}>{children}</div>
-      <div className="pointer-events-none sticky z-3 bottom-safe-or-2">
+      {/* Flush to the viewport edge, with the safe area taken as padding below:
+          offsetting the rail itself left a strip under it that the scrim could
+          not reach, and content scrolled visibly through it on Chrome iOS. */}
+      <div className="pointer-events-none sticky bottom-0 z-3">
         {/* Scrim so content scrolling past the bar dissolves into the page. */}
         <div
           aria-hidden
-          className="absolute inset-x-0 -bottom-6 -top-2 bg-gradient-to-t from-background-default via-background-default via-65% to-transparent"
+          className="absolute inset-x-0 -top-2 bottom-0 bg-gradient-to-t from-background-default via-background-default via-65% to-transparent"
         />
         <div
           className={classNames(
             funnelStepRail,
-            'relative flex flex-col gap-3 pb-6 pt-6',
+            'relative flex flex-col gap-3 pt-6 pb-safe-or-6',
           )}
         >
           {note}

--- a/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
+++ b/packages/shared/src/features/onboarding/shared/FunnelStepCtaWrapper.tsx
@@ -115,9 +115,9 @@ export function FunnelStepCtaWrapper({
     <div className="relative flex flex-1 flex-col gap-4">
       <FunnelStepTopBar skip={skip} />
       <div className={classNames('flex-1', containerClassName)}>{children}</div>
-      {/* Flush to the viewport edge, with the safe area taken as padding below:
-          offsetting the rail itself left a strip under it that the scrim could
-          not reach, and content scrolled visibly through it on Chrome iOS. */}
+      {/* Flush to the edge with the safe area as padding: offsetting the rail
+          left a strip the scrim could not reach, and content scrolled visibly
+          through it wherever that inset is large — Chrome on iOS. */}
       <div className="pointer-events-none sticky bottom-0 z-3">
         {/* Scrim so content scrolling past the bar dissolves into the page. */}
         <div

--- a/packages/storybook/stories/components/onboarding/SignupAccountDetails.stories.tsx
+++ b/packages/storybook/stories/components/onboarding/SignupAccountDetails.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { PropsWithChildren, ReactElement } from 'react';
+import React from 'react';
+import { fn } from 'storybook/test';
+import RegistrationForm from '@dailydotdev/shared/src/components/auth/RegistrationForm';
+import { SocialRegistrationForm } from '@dailydotdev/shared/src/components/auth/SocialRegistrationForm';
+import { SocialProvider } from '@dailydotdev/shared/src/components/auth/common';
+import { AuthDataProvider } from '@dailydotdev/shared/src/contexts/AuthDataContext';
+import { AuthTriggers } from '@dailydotdev/shared/src/lib/auth';
+import { FunnelStepTopBar } from '@dailydotdev/shared/src/features/onboarding/shared/FunnelStepTopBar';
+import ExtensionProviders from '../../extension/_providers';
+
+/**
+ * The two account-details screens on `/onboarding`. Both render from the page's
+ * `isAuthenticating` branch, before `FunnelStepper` mounts, so they take the
+ * funnel's chrome through an explicit prop rather than context.
+ *
+ * They are meant to be the same screen: the social one differs only by the
+ * avatar above the fields. Compare them side by side after any change to
+ * either.
+ */
+const meta: Meta = {
+  title: 'Components/Onboarding/Signup account details',
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+// The page's own `isAuthenticating` markup, copied so the story shows the
+// screen at the width and offsets production gives it.
+const AuthShell = ({ children }: PropsWithChildren): ReactElement => (
+  <ExtensionProviders>
+    <AuthDataProvider initialEmail="ido@daily.dev">
+      <div className="relative z-3 flex h-full max-h-dvh min-h-dvh w-full flex-1 flex-col items-center overflow-x-hidden">
+        <FunnelStepTopBar />
+        <div className="relative z-2 flex w-full flex-grow flex-col flex-wrap justify-center px-4 pt-3 tablet:flex-row tablet:gap-10 tablet:px-6">
+          <div className="h-full w-full rounded-none tablet:max-w-[30rem]">
+            {children}
+          </div>
+        </div>
+      </div>
+    </AuthDataProvider>
+  </ExtensionProviders>
+);
+
+export const Email: Story = {
+  name: '1. Email signup',
+  render: () => (
+    <AuthShell>
+      <RegistrationForm
+        simplified
+        isOnboardingFunnel
+        showHeadline={false}
+        trigger={AuthTriggers.Onboarding}
+        onSignup={fn()}
+        onUpdateHints={fn()}
+      />
+    </AuthShell>
+  ),
+};
+
+export const Social: Story = {
+  name: '2. Social signup',
+  render: () => (
+    <AuthShell>
+      <SocialRegistrationForm
+        simplified
+        isOnboardingFunnel
+        provider={SocialProvider.Google}
+        hints={{}}
+        onSignup={fn()}
+        onUpdateHints={fn()}
+      />
+    </AuthShell>
+  ),
+};

--- a/packages/storybook/stories/components/onboarding/SignupAccountDetails.stories.tsx
+++ b/packages/storybook/stories/components/onboarding/SignupAccountDetails.stories.tsx
@@ -11,13 +11,9 @@ import { FunnelStepTopBar } from '@dailydotdev/shared/src/features/onboarding/sh
 import ExtensionProviders from '../../extension/_providers';
 
 /**
- * The two account-details screens on `/onboarding`. Both render from the page's
- * `isAuthenticating` branch, before `FunnelStepper` mounts, so they take the
- * funnel's chrome through an explicit prop rather than context.
- *
- * They are meant to be the same screen: the social one differs only by the
- * avatar above the fields. Compare them side by side after any change to
- * either.
+ * The two account-details screens on `/onboarding`, which are meant to be the
+ * same screen — the social one differs only by the avatar above the fields.
+ * Compare them side by side after touching either.
  */
 const meta: Meta = {
   title: 'Components/Onboarding/Signup account details',
@@ -28,7 +24,7 @@ export default meta;
 
 type Story = StoryObj;
 
-// The page's own `isAuthenticating` markup, copied so the story shows the
+// Copied from the page's `isAuthenticating` branch, so the story shows the
 // screen at the width and offsets production gives it.
 const AuthShell = ({ children }: PropsWithChildren): ReactElement => (
   <ExtensionProviders>

--- a/packages/storybook/stories/components/onboarding/SignupAccountDetails.stories.tsx
+++ b/packages/storybook/stories/components/onboarding/SignupAccountDetails.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj;
 // screen at the width and offsets production gives it.
 const AuthShell = ({ children }: PropsWithChildren): ReactElement => (
   <ExtensionProviders>
-    <AuthDataProvider initialEmail="ido@daily.dev">
+    <AuthDataProvider initialEmail="new.user@example.com">
       <div className="relative z-3 flex h-full max-h-dvh min-h-dvh w-full flex-1 flex-col items-center overflow-x-hidden">
         <FunnelStepTopBar />
         <div className="relative z-2 flex w-full flex-grow flex-col flex-wrap justify-center px-4 pt-3 tablet:flex-row tablet:gap-10 tablet:px-6">


### PR DESCRIPTION
Device-testing findings from the merged onboarding funnel (#6391), one commit each so any can be reverted on its own.

**The paid `/helloworld` funnel is unchanged.** Every change here is either gated on `isOnboarding`/`isOnboardingFunnel` or a containment fix that renders identically wherever it already fitted.

---

## Add to Home Screen — the footage covered the text

**iOS, wide phones.** The video was an absolute full-screen layer at `w-full`, so its own aspect ratio decided its height: on a 402px viewport it grew past the subheadline and painted over the last line.

Now in flow below the text, height-capped, anchored to the bottom of its frame — the top third of the footage is empty space above the hand, so cropping there lets the phone render larger in less height.

## Content types — a strip of content under the CTA

**Chrome on iOS.** The sticky rail sat at `bottom-safe-or-2` while its scrim only reached 24px past it. Wherever the bottom safe-area inset exceeds that, the difference is uncovered and the next card scrolls visibly through it.

The rail is pinned to the viewport edge now and takes the safe area as padding, so the scrim always reaches the bottom. Verified: rail bottom and scrim bottom both land exactly on the viewport edge.

## Plus — the plan cards ran off the right edge

**Android, 360px.** `PlusCard` was a flat `w-[21rem]` = 336px. Inside the step's `px-6` gutters the content box is 312px, and `mx-auto` cannot produce a negative margin — so the card kept its 24px left gutter and overflowed 24px to the right.

Capped rather than fixed: it fills the rail when the rail is narrower, and renders at exactly 21rem when it is not. Left and right gutters now measure 24px each at 360px, with no horizontal overflow.

Also clears three pre-existing strict-mode violations the file only surfaced once it entered the changed-file guard. One of them widens `PlusListItem`'s `icon` prop to `FC<IconProps> | null` — the component already handles `null` (the Free card passes it to render no check mark); only the type disallowed it.

## Social signup — a different screen from the email one

After a Google sign-in the account-details screen kept the auth modal's markup: its own `px-6 tablet:px-[3.75rem]` on top of the page's padding, `mt-6` instead of `mt-10`, and a bare full-width button in a `Modal.Footer` instead of the docked glass bar.

Same shell, spacing, rail and CTA as the email signup now. The avatar above the fields is the only difference. Gated on `isOnboardingFunnel`, so the auth modal and the recruiter flows keep the modal footer.

Adds **Components/Onboarding/Signup account details** to Storybook, rendering both screens so they can be compared directly.

## Verify email — the code was never offered

`autocomplete="one-time-code"` was on a *hidden* mirror input, which iOS never autofills, while all six visible boxes carried `autocomplete="off"`. The suggestion above the keyboard could not appear under any circumstances.

The hint is on the first visible box now and accepts the whole code in one write. Typed input is unaffected — `onKeyDown` still handles and cancels every digit, so the new `onChange` only ever sees values the platform writes in.

The boxes also move from `type="tel"` to `type="text"` + `inputmode="numeric"` — the same numeric keypad, but the pair Safari's AutoFill is documented against. `tel` predates `inputmode` and was only ever a way to force digits.

**On iOS 26 this covers Gmail too.** Autofill of codes from third-party mail and messaging apps shipped in iOS 26; iOS 17–18 read only Apple Mail and Messages, and an account added under Settings → Mail counts there even if it is read in the Gmail app.

**Android has no OS-level autofill for an emailed code** — WebOTP and Chrome's incoming code autofill are both SMS-only, and SMS needs an origin-bound message we do not send. Paste is the whole path there, and two things were breaking it:

- `onPaste` rejected anything that was not purely digits, so a code lifted out of an email with a trailing newline or a "Your code:" prefix pasted *nothing*. It takes the digits now and ignores the rest.
- Every box but the first carried `maxLength=1`. Gboard's clipboard chip inserts as text rather than firing a paste event, so a code offered while focus sat on a later box was truncated to one digit. Typing is capped in `onKeyDown` already, so the attribute only ever cost us.

A third break came out of review: the "more than one digit means the platform wrote it" rule rested on `onKeyDown` cancelling every typed digit, which does not hold where the keydown is uncancellable or reports `Unidentified` — composing IMEs, dictation, some Android keyboards. There the character arrives through `input`, and a second digit in the same box was read as a code and spread from box 0. A write is only a fill now if it carries the whole code, and the single-digit path advances focus the way `onKeyDown` does.

`CodeField` had no spec; it has one now — 10 tests covering all of the above plus the AutoFill contract.

Reading the code ourselves is not possible from the client, and is not needed: once the suggestion is tapped the six digits arrive in one write, and `CodeField` already submits on the sixth. One tap verifies, with no press on Verify.

---

## Not doing — the App Store on the PWA step

Parked at Tsahi's request; recorded here so the ground covered is not re-litigated.

**The share sheet cannot be opened programmatically.**

`navigator.share()` opens the Web Share sheet — share *targets* only, no "Add to Home Screen". That entry exists solely in Safari's own share menu, and no API reaches it. `beforeinstallprompt`/`prompt()` is Chromium-only and never fires in iOS Safari.

**Linking to the App Store does work**, and `appStoreUrl` already exists in `constants.ts`. One tap opens the App Store app on our product page — the install itself is still the user's tap there; no web API installs an iOS app.

If we take it, the step stops being "Add to Home Screen" and becomes "Get the app": new headline, new subcopy, and the current footage demonstrates a technique we would no longer be teaching. Worth deciding whether the store CTA **replaces** the A2HS step or sits under it as a secondary route.

## Tests

`shared` 321 suites / 2,123 tests, `webapp` 45 / 336, `extension` 6 / 43 — all green, strict typecheck and lint clean.


### Preview domain
https://claude-onboarding-funnel-followu.preview.app.daily.dev
