### PR TITLE
feat(seo): title tag pages for news queries instead of "posts"

### DIFF
--- a/packages/webapp/__tests__/TagPageStaticProps.spec.ts
+++ b/packages/webapp/__tests__/TagPageStaticProps.spec.ts
@@ -1,0 +1,92 @@
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import type { Keyword } from '@dailydotdev/shared/src/graphql/keywords';
+import { getStaticProps } from '../pages/tags/[tag]';
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => {
+  const actual = jest.requireActual('@dailydotdev/shared/src/graphql/common');
+
+  return {
+    ...actual,
+    gqlClient: {
+      request: jest.fn(),
+    },
+  };
+});
+
+const mockRequest = gqlClient.request as jest.Mock;
+
+const mockTagRequests = (keyword: Keyword): void => {
+  mockRequest
+    .mockResolvedValueOnce({ keyword })
+    .mockResolvedValueOnce({ page: { edges: [] } })
+    .mockResolvedValueOnce({ recommendedTags: { tags: [] } })
+    .mockResolvedValueOnce({ topCreatorsByTag: [] });
+};
+
+describe('tag page static props', () => {
+  beforeEach(() => {
+    mockRequest.mockReset();
+  });
+
+  it('should use the custom tag title in the news SEO title', async () => {
+    mockTagRequests({
+      value: 'javascript',
+      occurrences: 1,
+      status: 'allow',
+      flags: { title: 'JavaScript' },
+    });
+
+    const result = await getStaticProps({
+      params: { tag: 'javascript' },
+    } as never);
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          title: 'JavaScript News & Updates | daily.dev',
+        },
+      },
+    });
+  });
+
+  it('should format a tag slug used in the news SEO title', async () => {
+    mockTagRequests({
+      value: 'machine-learning',
+      occurrences: 1,
+      status: 'allow',
+    });
+
+    const result = await getStaticProps({
+      params: { tag: 'machine-learning' },
+    } as never);
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          title: 'Machine Learning News & Updates | daily.dev',
+        },
+      },
+    });
+  });
+
+  it('should scope company tags to developer news', async () => {
+    mockTagRequests({
+      value: 'google',
+      occurrences: 1,
+      status: 'allow',
+      flags: { title: 'Google' },
+    });
+
+    const result = await getStaticProps({
+      params: { tag: 'google' },
+    } as never);
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          title: 'Google Developer News & Updates | daily.dev',
+        },
+      },
+    });
+  });
+});

--- a/packages/webapp/lib/tagSeoTitle.spec.ts
+++ b/packages/webapp/lib/tagSeoTitle.spec.ts
@@ -1,0 +1,56 @@
+import { getPageSeoTitles } from '../components/layouts/utils';
+import { getTagSeoTitle } from './tagSeoTitle';
+
+describe('getTagSeoTitle', () => {
+  it('should use the news and updates template by default', () => {
+    expect(getTagSeoTitle('javascript', 'JavaScript')).toEqual(
+      'JavaScript News & Updates',
+    );
+  });
+
+  it('should scope company tags to developer news', () => {
+    expect(getTagSeoTitle('google', 'Google')).toEqual(
+      'Google Developer News & Updates',
+    );
+    expect(getTagSeoTitle('nvidia', 'NVIDIA')).toEqual(
+      'NVIDIA Developer News & Updates',
+    );
+  });
+
+  it('should apply variant rules to a mixed case route param', () => {
+    expect(getTagSeoTitle('Google', 'Google')).toEqual(
+      'Google Developer News & Updates',
+    );
+    expect(getTagSeoTitle('Tech-News', 'Tech News')).toEqual(
+      'Tech News: Latest Technology Updates',
+    );
+  });
+
+  it('should use a hand-set title for tech-news', () => {
+    expect(getTagSeoTitle('tech-news', 'Tech News')).toEqual(
+      'Tech News: Latest Technology Updates',
+    );
+  });
+
+  it('should not repeat news when the tag name already contains it', () => {
+    expect(getTagSeoTitle('ai-news', 'AI News')).toEqual(
+      'AI News: Latest Updates & Discussions',
+    );
+  });
+
+  it('should keep the daily.dev suffix for the longest tag names', () => {
+    const longestTitles = [
+      getTagSeoTitle(
+        'internal-developer-platform',
+        'Internal Developer Platform',
+      ),
+      getTagSeoTitle('anthropic', 'Anthropic'),
+      getTagSeoTitle('tech-news', 'Tech News'),
+      getTagSeoTitle('ai-news', 'AI News'),
+    ];
+
+    longestTitles.forEach((title) => {
+      expect(getPageSeoTitles(title).title).toEqual(`${title} | daily.dev`);
+    });
+  });
+});

--- a/packages/webapp/lib/tagSeoTitle.ts
+++ b/packages/webapp/lib/tagSeoTitle.ts
@@ -1,0 +1,46 @@
+// Generic "{Company} News" SERPs are consumer-news territory and collide with
+// real products (Google News, Apple News), so company tags target the
+// dev-scoped query instead.
+const COMPANY_TAGS = new Set([
+  'google',
+  'microsoft',
+  'apple',
+  'amazon',
+  'openai',
+  'nvidia',
+  'intel',
+  'anthropic',
+  'samsung',
+  'netflix',
+  'tesla',
+]);
+
+// Wins over a backend-set keyword title on purpose: "Tech News" is the highest
+// impressions tag page and the default template would stutter into
+// "Tech News News & Updates".
+const HAND_SET_TITLES: Record<string, string> = {
+  'tech-news': 'Tech News: Latest Technology Updates',
+};
+
+// Variant rules match the slug rather than the display title, since the display
+// title comes from backend-editable keyword flags. The stutter check is the
+// exception: it guards the rendered string.
+export const getTagSeoTitle = (tag: string, tagTitle: string): string => {
+  // Tag slugs are lowercase, but the route param keeps the casing of the URL.
+  const slug = tag.toLowerCase();
+
+  const handSet = HAND_SET_TITLES[slug];
+  if (handSet) {
+    return handSet;
+  }
+
+  if (/\bnews\b/i.test(tagTitle)) {
+    return `${tagTitle}: Latest Updates & Discussions`;
+  }
+
+  if (COMPANY_TAGS.has(slug)) {
+    return `${tagTitle} Developer News & Updates`;
+  }
+
+  return `${tagTitle} News & Updates`;
+};

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -19,6 +19,7 @@ import { GET_RECOMMENDED_TAGS_QUERY } from '@dailydotdev/shared/src/graphql/feed
 import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import { TOP_CREATORS_BY_TAG_QUERY } from '@dailydotdev/shared/src/graphql/users';
 import type { UserShortProfile } from '@dailydotdev/shared/src/lib/user';
+import { formatKeyword } from '@dailydotdev/shared/src/lib/strings';
 import { TagTopicPage } from '@dailydotdev/shared/src/components/tags/TagTopicPage';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 import { getLayout } from '../../components/layouts/FeedLayout';
@@ -26,6 +27,7 @@ import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
 import type { DynamicSeoProps } from '../../components/common';
 import { defaultOpenGraph, defaultSeo } from '../../next-seo';
 import { getAppOrigin } from '../../lib/seo';
+import { getTagSeoTitle } from '../../lib/tagSeoTitle';
 
 const appOrigin = getAppOrigin();
 
@@ -47,7 +49,7 @@ const getTagPageJsonLd = ({
   topPosts: TopPost[];
 }): string => {
   const encodedTag = encodeURIComponent(tag);
-  const tagTitle = initialData.flags?.title || tag;
+  const tagTitle = initialData.flags?.title || formatKeyword(tag);
   const tagDescription =
     initialData.flags?.description ||
     `Find all the recent posts, videos, updates and discussions about ${tagTitle}`;
@@ -60,7 +62,7 @@ const getTagPageJsonLd = ({
         '@type': 'CollectionPage',
         '@id': `${tagUrl}#page`,
         url: tagUrl,
-        name: `${tagTitle} posts on daily.dev`,
+        name: getTagSeoTitle(tag, tagTitle),
         description: tagDescription,
         isPartOf: { '@type': 'WebSite', url: appOrigin },
       },
@@ -142,10 +144,11 @@ interface TagPageParams extends ParsedUrlQuery {
 }
 
 const getSeoData = (
+  tag: string,
   title: string,
   description = `Find all the recent posts, videos, updates and discussions about ${title}`,
 ): NextSeoProps => {
-  const seoTitles = getPageSeoTitles(`${title} posts`);
+  const seoTitles = getPageSeoTitles(getTagSeoTitle(tag, title));
 
   return {
     ...defaultSeo,
@@ -176,7 +179,7 @@ export async function getStaticProps({
       topPosts: [],
       recommendedTags: [],
       topContributors: [],
-      seo: getSeoData(tag),
+      seo: getSeoData(tag, formatKeyword(tag)),
     },
   };
 
@@ -225,7 +228,8 @@ export async function getStaticProps({
     const recommendedTags = recommendedTagsResult?.recommendedTags?.tags ?? [];
     const topContributors = topContributorsResult?.topCreatorsByTag ?? [];
     const seo = getSeoData(
-      initialData.flags?.title || tag,
+      tag,
+      initialData.flags?.title || formatKeyword(tag),
       initialData.flags?.description,
     );
 


### PR DESCRIPTION
## Summary

Retitles all ~1,005 tag pages from `{Tag} posts | daily.dev` to `{Tag} News & Updates | daily.dev`. Every ranking a tag page holds today is a `<tag> news` query (spring boot news today, llm updates today, visual studio code news, angular news, go programming news), and the two strategic targets (javascript news, frontend news) are the same shape. The title is the strongest relevance signal these pages have, and it was spending it on "posts" — a word with no search demand.

Two variant rules, in `packages/webapp/lib/tagSeoTitle.ts`:

- **Tags whose name already says "News"** get `{Tag}: Latest Updates & Discussions` instead of stuttering into "Tech News News & Updates". `tech-news` — the highest-impressions tag page — gets a hand-set `Tech News: Latest Technology Updates`.
- **11 company tags** (Google, Microsoft, Apple, Amazon, OpenAI, NVIDIA, Intel, Anthropic, Samsung, Netflix, Tesla) get `{Tag} Developer News & Updates`. Google and Apple both ship products called "{Name} News", and the generic `{Company} News` SERP is consumer-news territory we can't win; dev-scoped dodges the collision and describes the content more honestly.

Rules match the slug, not the display title, since the display title comes from backend-editable keyword flags. The JSON-LD `CollectionPage.name` now reuses the same helper so structured data and `<title>` agree, which required formatting its title source (`flags.title || formatKeyword(tag)`, previously the raw slug).

Unrelated pre-existing bug found while verifying this on the preview: the tag `CollectionPage`/`ItemList`/`BreadcrumbList` JSON-LD never reaches the HTML, on this preview and on production alike (`initialData` arrives fine, so the `<script type="application/ld+json">` inside `next/head` is being dropped). The `name` change above is therefore inert until that is fixed separately — worth its own issue, since it means the tag structured data has never shipped.

Length is safe: the longest tag name (Internal Developer Platform) lands at 54 characters with the suffix, so no page trips the 60-character cutoff in `getTemplatedTitle` that silently drops `| daily.dev`.

Risk is low — these pages currently get approximately zero search traffic (one tag page in the GSC top 1,000), so the downside is about as small as title experiments get, against the upside of every `<tag> news` query where we're sitting at positions 12-27.

Scope: title tag only. The visible H1 stays the bare tag name, and meta descriptions and the sr-only SEO block are separate changes.

## Test plan

- [x] `pnpm --filter webapp test -- Tag utils.spec` (30 tests: new `tagSeoTitle.spec.ts` covers all four rules, mixed-case route params, and asserts the brand suffix survives for the longest names; `TagPageStaticProps.spec.ts` covers the default, slug-formatted, and company-tag titles through `getStaticProps`)
- [x] `pnpm --filter webapp lint`
- [x] `node ./scripts/typecheck-strict-changed.js`
- [x] Verify a rendered title on preview: `/tags/javascript`, `/tags/google`, `/tags/tech-news`

Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-tag-page-news-title.preview.app.daily.dev
