### PR TITLE
fix(cards): stop clipping the highlight chip glow on featured-wide heroes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ pnpm --filter <package> test|lint|lint:fix
 
 - Early returns over if-else; handle errors/guards first, happy path last.
 - Comments only explain *why* (constraints, gotchas, trade-offs), never *what*.
+- Don't narrate a change in a comment. Even *why* comments are rare here: no multi-line preamble above a new component, test, or class-name ternary explaining the bug it fixes. That reasoning goes in the commit message and PR description, where it stays accurate as the code moves on.
 - Fail fast on violated invariants with a thrown error; no silent no-op fallbacks.
 - **Always derive types from Zod schemas with `z.infer`**; never hand-write a type that duplicates a schema.
 - **No barrel `index.ts` files.** Import directly from the source file. When you see an existing barrel, delete it and fix imports.

--- a/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement, Ref } from 'react';
 import React, { forwardRef, useMemo } from 'react';
 import classNames from 'classnames';
-import { CardTextContainer } from '../common/Card';
 import { SquadPostCardHeader } from '../common/SquadPostCardHeader';
 import PostTags from '../common/PostTags';
 import PostMetadata from '../common/PostMetadata';
@@ -17,6 +16,7 @@ import { INNER_GRID_COLS } from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
+import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
 
 export const FreeformFeaturedWideGridCard = forwardRef(
   function FreeformFeaturedWideGridCard(
@@ -68,11 +68,7 @@ export const FreeformFeaturedWideGridCard = forwardRef(
           )}
         >
           <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
-            <CardTextContainer
-              className={
-                useGlass ? 'min-h-0 flex-1 overflow-hidden' : undefined
-              }
-            >
+            <FeaturedWideTextContainer useGlass={useGlass}>
               <SquadPostCardHeader
                 post={post}
                 enableSourceHeader={enableSourceHeader}
@@ -103,7 +99,7 @@ export const FreeformFeaturedWideGridCard = forwardRef(
                   {description}
                 </p>
               )}
-            </CardTextContainer>
+            </FeaturedWideTextContainer>
             <FeaturedWideActions
               post={post}
               useGlass={useGlass}

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
@@ -115,6 +115,9 @@ const renderGlassHero = (postOverride: Partial<Post>): RenderResult => {
   const gb = new GrowthBook();
   gb.setFeatures({
     [featureFeedCardGlassActions.id]: { defaultValue: true },
+    [featureHeroCards.id]: {
+      defaultValue: { ...featureHeroCards.defaultValue, enabled: true },
+    },
   });
   return render(
     <TestBootProvider client={new QueryClient()} gb={gb}>
@@ -145,4 +148,20 @@ it('keeps the full-size glass hero title (typo-title1) when there is no TLDR', (
   const heading = screen.getByRole('heading', { level: 3 });
   expect(heading).toHaveClass('typo-title1');
   expect(heading).toHaveClass('line-clamp-3');
+});
+
+// The chip's glow is a sibling layer that paints a few pixels outside the chip's
+// own box. The glass text column clips its content (so the title + TLDR can't
+// spill behind the floating pill), so its horizontal inset has to be padding
+// inside the clip box: with margin, the clip edge sat exactly where the chip
+// starts and the glow's left bleed was cut off.
+it('insets the clipped glass text column with padding so the chip glow is not clipped', () => {
+  renderGlassHero({ hero: makeHero('major') });
+
+  const chip = screen.getByText('Major').parentElement!;
+  expect(chip.firstElementChild).toHaveClass('breaking-news-chip-glow');
+
+  const textColumn = chip.closest('.overflow-hidden.flex-1');
+  expect(textColumn).toHaveClass('px-4');
+  expect(textColumn).not.toHaveClass('mx-4');
 });

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
@@ -150,11 +150,6 @@ it('keeps the full-size glass hero title (typo-title1) when there is no TLDR', (
   expect(heading).toHaveClass('line-clamp-3');
 });
 
-// The chip's glow is a sibling layer that paints a few pixels outside the chip's
-// own box. The glass text column clips its content (so the title + TLDR can't
-// spill behind the floating pill), so its horizontal inset has to be padding
-// inside the clip box: with margin, the clip edge sat exactly where the chip
-// starts and the glow's left bleed was cut off.
 it('insets the clipped glass text column with padding so the chip glow is not clipped', () => {
   renderGlassHero({ hero: makeHero('major') });
 

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
@@ -3,7 +3,6 @@ import React, { forwardRef, useMemo } from 'react';
 import classNames from 'classnames';
 import { usePostFeedback } from '../../../hooks/usePostFeedback';
 import { isVideoPost, PostType } from '../../../graphql/posts';
-import { CardTextContainer } from '../common/Card';
 import { Origin } from '../../../lib/log';
 import { PostCardHeader } from '../common/PostCardHeader';
 import PostTags from '../common/PostTags';
@@ -21,6 +20,7 @@ import { INNER_GRID_COLS } from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
+import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
 
 export const ArticleFeaturedWideGridCard = forwardRef(
   function ArticleFeaturedWideGridCard(
@@ -112,9 +112,7 @@ export const ArticleFeaturedWideGridCard = forwardRef(
 
     const standardContent = (
       <>
-        <CardTextContainer
-          className={useGlass ? 'min-h-0 flex-1 overflow-hidden' : undefined}
-        >
+        <FeaturedWideTextContainer useGlass={useGlass}>
           <PostCardHeader
             post={post}
             className="flex"
@@ -157,7 +155,7 @@ export const ArticleFeaturedWideGridCard = forwardRef(
               {description}
             </p>
           )}
-        </CardTextContainer>
+        </FeaturedWideTextContainer>
         <FeaturedWideActions
           post={post}
           useGlass={useGlass}

--- a/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
@@ -3,7 +3,6 @@ import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { isPostUpdated } from '../../../graphql/posts';
 import { TimeFormatType } from '../../../lib/dateFormat';
-import { CardTextContainer } from '../common/Card';
 import PostTags from '../common/PostTags';
 import PostMetadata from '../common/PostMetadata';
 import { ClickbaitShield } from '../common/ClickbaitShield';
@@ -18,6 +17,7 @@ import { INNER_GRID_COLS } from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
+import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
 
 export const CollectionFeaturedWideGridCard = forwardRef(
   function CollectionFeaturedWideGridCard(
@@ -65,11 +65,7 @@ export const CollectionFeaturedWideGridCard = forwardRef(
           )}
         >
           <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
-            <CardTextContainer
-              className={
-                useGlass ? 'min-h-0 flex-1 overflow-hidden' : undefined
-              }
-            >
+            <FeaturedWideTextContainer useGlass={useGlass}>
               <CollectionCardHeader post={post} />
               <h3
                 className={classNames(
@@ -101,7 +97,7 @@ export const CollectionFeaturedWideGridCard = forwardRef(
                   {post.summary}
                 </p>
               )}
-            </CardTextContainer>
+            </FeaturedWideTextContainer>
             <FeaturedWideActions
               post={post}
               useGlass={useGlass}

--- a/packages/shared/src/components/cards/common/FeaturedWideTextContainer.tsx
+++ b/packages/shared/src/components/cards/common/FeaturedWideTextContainer.tsx
@@ -2,13 +2,6 @@ import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 
-// The glass variant clips this column so the line-clamped title + TLDR can't
-// spill behind the floating action pill. That clip is load-bearing, so the 16px
-// inset has to be padding *inside* the clipping box instead of margin on it:
-// with margin the clip edge lands exactly where the first child starts, and the
-// HighlightChip's blurred glow layer - which paints outside the chip's own box -
-// gets cut off. Emit exactly one of `mx-4`/`px-4`; classNames has no
-// tailwind-merge, so stacking both would leave the winner to CSS source order.
 export const FeaturedWideTextContainer = ({
   useGlass,
   children,

--- a/packages/shared/src/components/cards/common/FeaturedWideTextContainer.tsx
+++ b/packages/shared/src/components/cards/common/FeaturedWideTextContainer.tsx
@@ -1,0 +1,27 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+
+// The glass variant clips this column so the line-clamped title + TLDR can't
+// spill behind the floating action pill. That clip is load-bearing, so the 16px
+// inset has to be padding *inside* the clipping box instead of margin on it:
+// with margin the clip edge lands exactly where the first child starts, and the
+// HighlightChip's blurred glow layer - which paints outside the chip's own box -
+// gets cut off. Emit exactly one of `mx-4`/`px-4`; classNames has no
+// tailwind-merge, so stacking both would leave the winner to CSS source order.
+export const FeaturedWideTextContainer = ({
+  useGlass,
+  children,
+}: {
+  useGlass?: boolean;
+  children: ReactNode;
+}): ReactElement => (
+  <div
+    className={classNames(
+      'flex flex-col',
+      useGlass ? 'min-h-0 flex-1 overflow-hidden px-4' : 'mx-4',
+    )}
+  >
+    {children}
+  </div>
+);

--- a/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
@@ -2,7 +2,6 @@ import type { ReactElement, Ref } from 'react';
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
 import { isSocialTwitterPost, isVideoPost } from '../../../graphql/posts';
-import { CardTextContainer } from '../common/Card';
 import { PostCardHeader } from '../common/PostCardHeader';
 import PostTags from '../common/PostTags';
 import PostMetadata from '../common/PostMetadata';
@@ -22,6 +21,7 @@ import { INNER_GRID_COLS } from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
+import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
 
 export const ShareFeaturedWideGridCard = forwardRef(
   function ShareFeaturedWideGridCard(
@@ -81,11 +81,7 @@ export const ShareFeaturedWideGridCard = forwardRef(
           )}
         >
           <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
-            <CardTextContainer
-              className={
-                useGlass ? 'min-h-0 flex-1 overflow-hidden' : undefined
-              }
-            >
+            <FeaturedWideTextContainer useGlass={useGlass}>
               <PostCardHeader
                 post={post}
                 className="flex"
@@ -145,7 +141,7 @@ export const ShareFeaturedWideGridCard = forwardRef(
                   )}
                 </>
               )}
-            </CardTextContainer>
+            </FeaturedWideTextContainer>
             <FeaturedWideActions
               post={post}
               useGlass={useGlass}


### PR DESCRIPTION
## What was wrong

The highlight chip's glow is a blurred sibling layer (`-inset-0.5` + `blur-[2px]`) that deliberately paints a few pixels **outside** the chip's own box. In glass mode the featured-wide text column clips its content and carried its 16px inset as `mx-4`, so the clip edge landed exactly where the chip starts — the glow's left bleed was cut, a hard one-pixel step on the left while the other three sides faded normally over ~7px.

## The fix

Move the inset *inside* the clipping box (`px-4`) so the box spans the full content column. Same content width, same vertical clipping, but the halo now lands well inside the clip rect. The expression all four featured-wide cards duplicated is now a shared `FeaturedWideTextContainer`.

## Key decisions

- **Kept `overflow-hidden`.** It is load-bearing — it keeps the line-clamped title + TLDR from spilling behind the floating glass pill (the case `HeroGlassOverlap` was built for). Removing it would have been the easy fix and a regression.
- **No theme-conditional patch.** The clip exists in both themes; it was only *visible* in light mode because a missing red bloom disappears against the dark surface. A light-mode-only class would have hidden the real cause.
- **Left the shared `CardTextContainer` alone.** It backs every other card variant (grid, list, collection); converting it globally would ripple invisibly until something else regressed.
- **Exactly one of `mx-4`/`px-4` is emitted.** `classNames` has no tailwind-merge here, so stacking both would leave the winner to CSS source order.

## Expected side effect

Dark mode also regains the full left bloom (it was clipped there too). Barely perceptible, but a real visual delta.

## Verification

- Measured in a browser against the real card: pre-fix the glow's left edge sat **2px outside** the clip rect; post-fix it sits **14px inside**. Identical in light and dark, confirming the clip was never theme-specific.
- Vertical clipping is unchanged — across all 29 glass hero columns in the three `HeroGlassOverlap` stories, column height, content width, `scrollHeight - clientHeight` and last-child overflow are identical to pre-fix.
- Added one integration test asserting the clipped glass column carries the padding inset rather than the margin, and that the chip's glow layer still renders.
- shared (cards + `Feed`), webapp and extension suites pass; lint, prettier and the changed-file strict typecheck are clean.

## Out of scope

- The glow's *strength* (`opacity-40` + `blur-[2px]`) still reads weakly over a near-white surface even un-clipped. Happy to retune if design wants it.
- The visible string "Must-read" comes from the remote `hero_cards.chipLabels` config, not from code — relabelling is a GrowthBook change.

Closes ENG-1918

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1918-light-mode-must-read-gl.preview.app.daily.dev