### PR TITLE
feat: enforce iubenda CMP by TCF region, remove iubenda_cmp flag

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -241,7 +241,9 @@ function renderComponent(
   const resolvedUser = arguments.length < 2 ? defaultUser : user;
 
   mocks.forEach(mockGraphQL);
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
   const settingsContext: SettingsContextData = {
     ...baseSettingsContext,
     setTheme: jest.fn(),
@@ -1860,9 +1862,11 @@ const renderWithHighlightLayout = ({
   mockGraphQL(createFeedMock(buildFeedPage(posts)));
   // First ad page uses active=false, subsequent pages use active=true. Mock
   // both up to a handful of refills so multi-ad scenarios don't run dry.
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
   nock('http://localhost:3000')
-    .get('/v1/a?active=true')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=true&gdpr=0')
     .times(10)
     .reply(200, [ad]);
 

--- a/packages/shared/src/contexts/AuthContext.tsx
+++ b/packages/shared/src/contexts/AuthContext.tsx
@@ -18,7 +18,7 @@ import type { Squad } from '../graphql/sources';
 import type { Feed } from '../graphql/feed';
 import { checkIsExtension, isIOSNative, isNullOrUndefined } from '../lib/func';
 import { AFTER_AUTH_PARAM } from '../components/auth/common';
-import { Continent, outsideGdpr } from '../lib/geo';
+import { Continent, outsideGdpr, tcfRegions } from '../lib/geo';
 import {
   invalidPlusRegions,
   onboardingUrl,
@@ -77,6 +77,7 @@ export interface AuthContextData {
   geo?: Boot['geo'];
   isAndroidApp?: boolean;
   isGdprCovered?: boolean;
+  isTcfCovered?: boolean;
   isValidRegion?: boolean;
   isFunnel?: boolean;
   feeds?: Feed[];
@@ -122,6 +123,11 @@ export function checkIfGdprCovered(geo?: Boot['geo']): boolean {
     !outsideGdpr.includes(geo?.region) ||
     isIOSNative()
   );
+}
+
+// Strictly geographic (no iOS special-case): gates the iubenda CMP only.
+export function checkIfTcfCovered(geo?: Boot['geo']): boolean {
+  return tcfRegions.includes(geo?.region ?? '');
 }
 
 export type AuthContextProviderProps = {
@@ -237,6 +243,7 @@ export const AuthContextProvider = ({
       setDaily,
       isValidRegion,
       isGdprCovered: checkIfGdprCovered(geo),
+      isTcfCovered: checkIfTcfCovered(geo),
     }),
     [
       firstLoad,

--- a/packages/shared/src/features/monetization/useAdQuery.ts
+++ b/packages/shared/src/features/monetization/useAdQuery.ts
@@ -5,10 +5,7 @@ import { useFeature } from '../../components/GrowthBookProvider';
 import type { Ad } from '../../graphql/posts';
 import { fetchAdByPlacement, resolveAdFetchOptions } from '../../lib/ads';
 import type { FetchAdByPlacementOptions } from '../../lib/ads';
-import {
-  featureIubendaCmp,
-  featurePostBoostAds,
-} from '../../lib/featureManagement';
+import { featurePostBoostAds } from '../../lib/featureManagement';
 import { useAdMacroContext } from './useAdMacroContext';
 
 interface UseAdQueryOptions {
@@ -27,11 +24,7 @@ export const useAdQuery = ({
   active,
 }: UseAdQueryOptions) => {
   const boostsEnabled = useFeature(featurePostBoostAds);
-  const cmpEnabled = useFeature(featureIubendaCmp);
-  const macroContext = useAdMacroContext(enabled);
-  // consent params ride on ad requests only for CMP users; with the flag off
-  // the request is byte-identical to the pre-CMP one
-  const consent = cmpEnabled ? macroContext ?? undefined : undefined;
+  const consent = useAdMacroContext(enabled) ?? undefined;
   const fetchOptions = useMemo(
     () =>
       resolveAdFetchOptions({

--- a/packages/shared/src/features/monetization/useFetchAd.ts
+++ b/packages/shared/src/features/monetization/useFetchAd.ts
@@ -6,10 +6,7 @@ import {
   fetchAdByPlacement,
   resolveAdFetchOptions,
 } from '../../lib/ads';
-import {
-  featureIubendaCmp,
-  featurePostBoostAds,
-} from '../../lib/featureManagement';
+import { featurePostBoostAds } from '../../lib/featureManagement';
 import { useAdMacroContext } from './useAdMacroContext';
 
 interface UseFetchAds {
@@ -21,11 +18,7 @@ interface UseFetchAds {
 
 export const useFetchAd = (): UseFetchAds => {
   const boostsEnabled = useFeature(featurePostBoostAds);
-  const cmpEnabled = useFeature(featureIubendaCmp);
-  const macroContext = useAdMacroContext(true);
-  // consent params ride on ad requests only for CMP users; with the flag off
-  // the request is byte-identical to the pre-CMP one
-  const consent = cmpEnabled ? macroContext ?? undefined : undefined;
+  const consent = useAdMacroContext(true) ?? undefined;
 
   const fetchAdQuery: UseFetchAds['fetchAd'] = useCallback(
     ({ active, placement = AdPlacement.Feed }) => {

--- a/packages/shared/src/hooks/useCookieBanner.spec.tsx
+++ b/packages/shared/src/hooks/useCookieBanner.spec.tsx
@@ -8,7 +8,6 @@ import { useConsentCookie } from './useCookieConsent';
 import { useAuthContext } from '../contexts/AuthContext';
 import { getIubendaConsent } from '../lib/iubenda';
 import { isIOSNative } from '../lib/func';
-import { useFeature } from '../components/GrowthBookProvider';
 
 jest.mock('./useCookieConsent', () => ({
   useConsentCookie: jest.fn(),
@@ -27,10 +26,6 @@ jest.mock('../lib/func', () => ({
   isIOSNative: jest.fn(),
 }));
 
-jest.mock('../components/GrowthBookProvider', () => ({
-  useFeature: jest.fn(),
-}));
-
 const mockUseConsentCookie = useConsentCookie as jest.MockedFunction<
   typeof useConsentCookie
 >;
@@ -41,18 +36,19 @@ const mockGetIubendaConsent = getIubendaConsent as jest.MockedFunction<
   typeof getIubendaConsent
 >;
 const mockIsIOSNative = isIOSNative as jest.MockedFunction<typeof isIOSNative>;
-const mockUseFeature = useFeature as jest.MockedFunction<typeof useFeature>;
 
 const saveCookies = jest.fn();
 
 const setup = ({
   hasAccepted = false,
   isGdprCovered = true,
+  isTcfCovered = false,
   user = null,
   isAuthReady = true,
 }: {
   hasAccepted?: boolean;
   isGdprCovered?: boolean;
+  isTcfCovered?: boolean;
   user?: unknown;
   isAuthReady?: boolean;
 } = {}) => {
@@ -64,6 +60,7 @@ const setup = ({
     isAuthReady,
     user,
     isGdprCovered,
+    isTcfCovered,
   } as never);
 };
 
@@ -71,7 +68,6 @@ describe('useCookieBanner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockIsIOSNative.mockReturnValue(false);
-    mockUseFeature.mockReturnValue(false);
     localStorage.clear();
   });
 
@@ -141,9 +137,8 @@ describe('useCookieBanner', () => {
     expect(localStorage.getItem('cookie_acknowledged')).toBe('true');
   });
 
-  it('suppresses the homegrown banner for GDPR users when the iubenda CMP is on', () => {
-    setup({ isGdprCovered: true, user: null });
-    mockUseFeature.mockReturnValue(true);
+  it('suppresses the homegrown banner in TCF regions', () => {
+    setup({ isGdprCovered: true, isTcfCovered: true, user: null });
     mockGetIubendaConsent.mockReturnValue(undefined);
 
     const { result } = renderHook(() => useCookieBanner());
@@ -152,9 +147,8 @@ describe('useCookieBanner', () => {
     expect(result.current.showBanner).toBe(false);
   });
 
-  it('keeps the homegrown banner for non-GDPR users when the iubenda CMP is on', () => {
-    setup({ isGdprCovered: false, user: null });
-    mockUseFeature.mockReturnValue(true);
+  it('keeps the homegrown banner outside TCF regions', () => {
+    setup({ isGdprCovered: false, isTcfCovered: false, user: null });
     mockGetIubendaConsent.mockReturnValue(undefined);
 
     const { result } = renderHook(() => useCookieBanner());

--- a/packages/shared/src/hooks/useCookieBanner.ts
+++ b/packages/shared/src/hooks/useCookieBanner.ts
@@ -4,8 +4,6 @@ import type { AcceptCookiesCallback } from './useCookieConsent';
 import { useConsentCookie } from './useCookieConsent';
 import { isIOSNative } from '../lib/func';
 import { getIubendaConsent } from '../lib/iubenda';
-import { useFeature } from '../components/GrowthBookProvider';
-import { featureIubendaCmp } from '../lib/featureManagement';
 
 export const cookieAcknowledgedKey = 'cookie_acknowledged';
 
@@ -43,8 +41,7 @@ interface UseCookieBanner {
 }
 
 export function useCookieBanner(): UseCookieBanner {
-  const { isAuthReady, user, isGdprCovered } = useAuthContext();
-  const iubendaCmp = useFeature(featureIubendaCmp);
+  const { isAuthReady, user, isGdprCovered, isTcfCovered } = useAuthContext();
   const isInitializedRef = useRef(false);
   const [isOpen, setIsOpen] = useState(false);
   const { saveCookies, cookieExists: hasAccepted } = useConsentCookie(
@@ -76,9 +73,9 @@ export function useCookieBanner(): UseCookieBanner {
       }
     }
 
-    // iubenda owns the banner for GDPR-covered users when the CMP is on; its
-    // consent is mirrored into our cookies by the Iubenda component.
-    if (iubendaCmp && isGdprCovered) {
+    // iubenda owns the banner in TCF regions; its consent is mirrored into
+    // our cookies by the Iubenda component.
+    if (isTcfCovered) {
       return;
     }
 
@@ -121,7 +118,7 @@ export function useCookieBanner(): UseCookieBanner {
     user,
     hasAccepted,
     isGdprCovered,
-    iubendaCmp,
+    isTcfCovered,
   ]);
 
   return {

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -121,10 +121,6 @@ export const featureStreakFreeze = new Feature('streak_freeze', isDevelopment);
 // does not necessarily mean they can't boost a post if they have access to cores
 export const featurePostBoostAds = new Feature('post_boost_ads', isDevelopment);
 
-// iubenda CMP (TCF banner) for GDPR-covered users; when on, iubenda owns the
-// cookie banner and the homegrown one is suppressed for those users
-export const featureIubendaCmp = new Feature('iubenda_cmp', false);
-
 export const briefCardFeedFeature = new Feature(
   'brief_card_feed',
   isDevelopment,

--- a/packages/shared/src/lib/geo.ts
+++ b/packages/shared/src/lib/geo.ts
@@ -45,3 +45,41 @@ export enum Continent {
 }
 
 export const outsideGdpr = ['US', 'IL'];
+
+// IAB TCF scope: EU-27 + EEA (IS/LI/NO) + UK + CH. Gates the iubenda CMP
+// (TCF banner) only — broader GDPR-style gating (pixels, homegrown banner)
+// stays on `outsideGdpr`.
+export const tcfRegions = [
+  'AT',
+  'BE',
+  'BG',
+  'HR',
+  'CY',
+  'CZ',
+  'DK',
+  'EE',
+  'FI',
+  'FR',
+  'DE',
+  'GR',
+  'HU',
+  'IE',
+  'IT',
+  'LV',
+  'LT',
+  'LU',
+  'MT',
+  'NL',
+  'PL',
+  'PT',
+  'RO',
+  'SK',
+  'SI',
+  'ES',
+  'SE',
+  'IS',
+  'LI',
+  'NO',
+  'GB',
+  'CH',
+];

--- a/packages/webapp/__tests__/BookmarksPage.tsx
+++ b/packages/webapp/__tests__/BookmarksPage.tsx
@@ -75,7 +75,9 @@ function renderComponent(
   client = new QueryClient();
 
   mocks.forEach(mockGraphQL);
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
 
   return render(
     <TestBootProvider client={client} auth={{ user: resolvedUser }}>

--- a/packages/webapp/__tests__/MyFeedPage.tsx
+++ b/packages/webapp/__tests__/MyFeedPage.tsx
@@ -97,7 +97,9 @@ function renderComponent(
   client = new QueryClient();
 
   mocks.forEach(mockGraphQL);
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
   return render(
     <TestBootProvider
       client={client}

--- a/packages/webapp/__tests__/SourcePage.tsx
+++ b/packages/webapp/__tests__/SourcePage.tsx
@@ -129,7 +129,9 @@ const renderComponent = (
   client = new QueryClient();
 
   mocks.forEach(mockGraphQL);
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
   const settingsContext: SettingsContextData = {
     spaciness: 'eco',
     openNewTab: true,

--- a/packages/webapp/__tests__/SquadFeedPage.tsx
+++ b/packages/webapp/__tests__/SquadFeedPage.tsx
@@ -241,7 +241,9 @@ const renderComponent = (
   client = new QueryClient();
 
   mocks.forEach(mockGraphQL);
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
 
   return render(
     <TestBootProvider

--- a/packages/webapp/__tests__/TagPage.tsx
+++ b/packages/webapp/__tests__/TagPage.tsx
@@ -155,7 +155,9 @@ const renderComponent = (
 
   (mocks ?? [createFeedMock(), createTagsSettingsMock()]).forEach(mockGraphQL);
   mockGraphQL(createArchiveIndexMock());
-  nock('http://localhost:3000').get('/v1/a?active=false').reply(200, [ad]);
+  nock('http://localhost:3000')
+    .get('/v1/a?active=false&gdpr=0')
+    .reply(200, [ad]);
   const settingsContext: SettingsContextData = {
     spaciness: 'eco',
     openNewTab: true,

--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -2,8 +2,6 @@
 import type { ReactElement } from 'react';
 import { useEffect, useRef } from 'react';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { featureIubendaCmp } from '@dailydotdev/shared/src/lib/featureManagement';
 import {
   cookieAcknowledgedKey,
   GdprConsentKey,
@@ -49,8 +47,7 @@ export const openIubendaPreferences = (): boolean => {
 };
 
 export const Iubenda = (): ReactElement | null => {
-  const { isAuthReady, isGdprCovered, isFunnel } = useAuthContext();
-  const cmpEnabled = useFeature(featureIubendaCmp);
+  const { isAuthReady, isTcfCovered, isFunnel } = useAuthContext();
   const { saveCookies } = useConsentCookie(GdprConsentKey.Necessary);
   const injectedRef = useRef(false);
 
@@ -65,8 +62,7 @@ export const Iubenda = (): ReactElement | null => {
     globalThis?.localStorage?.setItem(cookieAcknowledgedKey, 'true');
   };
 
-  const enabled =
-    isAuthReady && isGdprCovered && cmpEnabled && !isFunnel && !isIOSNative();
+  const enabled = isAuthReady && isTcfCovered && !isFunnel && !isIOSNative();
 
   useEffect(() => {
     if (!enabled || injectedRef.current) {

--- a/packages/webapp/pages/settings/privacy.tsx
+++ b/packages/webapp/pages/settings/privacy.tsx
@@ -17,8 +17,6 @@ import {
 import { GdprConsentKey } from '@dailydotdev/shared/src/hooks/useCookieBanner';
 import { CookieConsentItem } from '@dailydotdev/shared/src/components/modals/user/CookieConsentItem';
 import { useConsentCookie } from '@dailydotdev/shared/src/hooks/useCookieConsent';
-import { useFeature } from '@dailydotdev/shared/src/components/GrowthBookProvider';
-import { featureIubendaCmp } from '@dailydotdev/shared/src/lib/featureManagement';
 import { Button } from '@dailydotdev/shared/src/components/buttons/Button';
 import { ButtonVariant } from '@dailydotdev/shared/src/components/buttons/common';
 import { openIubendaPreferences } from '../../components/Iubenda';
@@ -37,8 +35,7 @@ const seo: NextSeoProps = {
 const AccountInvitePage = (): ReactElement | null => {
   const router = useRouter();
   const { saveCookies } = useConsentCookie(GdprConsentKey.Marketing);
-  const { user, isAuthReady, isGdprCovered } = useAuthContext();
-  const iubendaCmp = useFeature(featureIubendaCmp);
+  const { user, isAuthReady, isGdprCovered, isTcfCovered } = useAuthContext();
 
   useEffect(() => {
     if (!isAuthReady) {
@@ -96,7 +93,7 @@ const AccountInvitePage = (): ReactElement | null => {
           >
             Cookie Policy →
           </Typography>
-          {iubendaCmp ? (
+          {isTcfCovered ? (
             // the custom toggles can't regenerate a TCF consent string, so
             // consent edits must go through the CMP's own preferences UI
             <Button


### PR DESCRIPTION
## Changes

Follow-up to #6382 — replaces GrowthBook gating with code-enforced geo targeting, per the decision that deploy-speed rollback is acceptable.

- **New `tcfRegions` include list** in `lib/geo.ts` (EU-27 + EEA IS/LI/NO + UK + CH — the IAB TCF scope) exposed as `isTcfCovered` on `AuthContext` (works for anonymous users too, since it derives from boot geo — no GB attribute dependency).
- **CMP surfaces now gate on `isTcfCovered`**: the iubenda loader, homegrown-banner suppression, and the settings-page iubenda preferences entry. `iubenda_cmp` feature flag deleted.
- **Deliberately untouched**: the broad `isGdprCovered` (everyone except US/IL) still gates pixels, the homegrown banner, and ad-macro fallback semantics — so LGPD-style regions (e.g. Brazil) keep their current privacy posture; tightening that is a separate legal decision.
- **Ad-request consent params are now always on** (previously flag-gated): non-TCF users send `gdpr=0`/`gdpr=1` per the legacy resolver, matching what their tracker macros already emit; TCF users send the full consent string after consenting.

## What users see after this deploys

- EEA/UK/CH webapp users (logged-in **and** anonymous): iubenda TCF banner (one-time re-prompt for legacy consenters), TCF consent on ads.
- Everyone else, extension, iOS, funnel: unchanged.

Rollback = revert + redeploy (accepted trade-off; no runtime kill switch).

## Events

None.

## Cleanup still pending (post-stabilization)

Port consumers to CMP state, then delete the `ilikecookies*` mirror, `hasMarketingConsent()`, and the homegrown banner for TCF regions.

### Preview domain
https://feat-iubenda-cmp-code-enforced-e.preview.app.daily.dev