### PR TITLE
fix: recover reader permission flow when the extension bridge is unreachable

### DIFF
--- a/packages/shared/src/components/modals/ReaderInstallPromptModal.spec.tsx
+++ b/packages/shared/src/components/modals/ReaderInstallPromptModal.spec.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import ReactModal from 'react-modal';
+import ReaderInstallPromptModal from './ReaderInstallPromptModal';
+import { LazyModal } from './common/types';
+import type { Post } from '../../graphql/posts';
+import type { PagePermissionBridgeResult } from '../../features/extensionEmbed/pagePermissionBridge';
+
+const mockOpenModal = jest.fn();
+const mockCloseModal = jest.fn();
+const mockUpdateFlag = jest.fn();
+const mockIsMarkerPresent = jest.fn<boolean, []>();
+const mockRequestPermission = jest.fn<
+  Promise<PagePermissionBridgeResult>,
+  []
+>();
+
+jest.mock('../../hooks/useLazyModal', () => ({
+  useLazyModal: () => ({
+    openModal: mockOpenModal,
+    closeModal: mockCloseModal,
+  }),
+}));
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+jest.mock('../../contexts/SettingsContext', () => ({
+  useSettingsContext: () => ({ updateFlag: mockUpdateFlag }),
+}));
+
+jest.mock('../post/reader/hooks/useLegacyPostLayoutOptOut', () => ({
+  useLegacyPostLayoutOptOut: () => ({ optOut: jest.fn() }),
+}));
+
+jest.mock(
+  '../../features/extensionEmbed/useIsBrowserExtensionInstalled',
+  () => ({
+    useIsBrowserExtensionInstalled: () => ({
+      isInstalled: true,
+      isChecking: false,
+    }),
+    isBrowserExtensionInstalled: () => mockIsMarkerPresent(),
+    detectBrowserExtensionInstalled: jest.fn().mockResolvedValue(false),
+  }),
+);
+
+jest.mock('../../features/extensionEmbed/getBrowserExtensionInstallId', () => ({
+  getBrowserExtensionInstallId: () => 'test-extension-id',
+}));
+
+jest.mock('../../features/extensionEmbed/pagePermissionBridge', () => ({
+  ...jest.requireActual('../../features/extensionEmbed/pagePermissionBridge'),
+  requestFrameEmbeddingPermissionFromPage: () => mockRequestPermission(),
+}));
+
+jest.mock('../../features/extensionEmbed/ExtensionSiteEmbed', () => ({
+  ExtensionSiteEmbed: () => null,
+}));
+
+const post = {
+  id: 'p1',
+  permalink: 'https://example.com/article',
+  domain: 'example.com',
+} as Post;
+
+const renderComponent = () =>
+  render(
+    <ReaderInstallPromptModal post={post} isOpen onRequestClose={jest.fn()} />,
+  );
+
+const clickEnableButton = () => {
+  fireEvent.click(
+    screen.getByRole('button', { name: 'Enable permissions & read inside' }),
+  );
+};
+
+describe('ReaderInstallPromptModal permission flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = '<div id="__next"></div>';
+    ReactModal.setAppElement('#__next');
+    mockIsMarkerPresent.mockReturnValue(true);
+  });
+
+  it('skips the bridge and opens the reader preview when the content script never ran in this tab', () => {
+    // Install detected via the resource probe only (e.g. tab opened before
+    // install, or the extension new-tab surface) — the bridge request event
+    // would go unanswered, so the click must not wait on it.
+    mockIsMarkerPresent.mockReturnValue(false);
+
+    renderComponent();
+    clickEnableButton();
+
+    expect(mockRequestPermission).not.toHaveBeenCalled();
+    expect(mockCloseModal).toHaveBeenCalled();
+    expect(mockOpenModal).toHaveBeenCalledWith(
+      expect.objectContaining({ type: LazyModal.ReaderPreview }),
+    );
+  });
+
+  it('falls back to the reader preview when the bridge fails instead of resetting silently', async () => {
+    mockRequestPermission.mockResolvedValue({
+      granted: false,
+      error: 'timeout',
+    });
+
+    renderComponent();
+    clickEnableButton();
+
+    await waitFor(() =>
+      expect(mockOpenModal).toHaveBeenCalledWith(
+        expect.objectContaining({ type: LazyModal.ReaderPreview }),
+      ),
+    );
+    expect(mockUpdateFlag).not.toHaveBeenCalled();
+  });
+
+  it('persists acknowledgement and prepares the reader once permission is granted', async () => {
+    mockRequestPermission.mockResolvedValue({ granted: true });
+
+    renderComponent();
+    clickEnableButton();
+
+    await waitFor(() =>
+      expect(mockUpdateFlag).toHaveBeenCalledWith(
+        'readerInstallPromptAcknowledged',
+        true,
+      ),
+    );
+    expect(mockOpenModal).not.toHaveBeenCalled();
+  });
+
+  it('stays on the prompt when the user declines the browser permission prompt', async () => {
+    mockRequestPermission.mockResolvedValue({ granted: false });
+
+    renderComponent();
+    clickEnableButton();
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: 'Enable permissions & read inside',
+        }),
+      ).toBeEnabled(),
+    );
+    expect(mockOpenModal).not.toHaveBeenCalled();
+    expect(mockUpdateFlag).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/components/modals/ReaderInstallPromptModal.tsx
+++ b/packages/shared/src/components/modals/ReaderInstallPromptModal.tsx
@@ -376,7 +376,16 @@ function ReaderInstallPromptModal({
     // Targets the extension can't embed (non-http(s)) or surfaces without a
     // resolvable extension id skip the inline permission step — the reader
     // modal falls back to its own classic flow.
-    if (!canRequestPermissions) {
+    //
+    // The bridge additionally needs the extension's content script listening
+    // in this exact tab. The install marker is stamped by that same script,
+    // so a missing marker — install detected via the resource probe only:
+    // tab opened before the extension was installed, or the extension's own
+    // new-tab surface where content scripts never run — means the request
+    // event would go unanswered and the button would spin until the bridge
+    // timeout. The reader preview owns an in-iframe permission screen that
+    // talks to the extension directly, so route there instead.
+    if (!canRequestPermissions || !isBrowserExtensionInstalled()) {
       openReaderPreview();
       return;
     }
@@ -389,16 +398,27 @@ function ReaderInstallPromptModal({
     setIsRequestingPermission(true);
     const permissionPromise = requestFrameEmbeddingPermissionFromPage();
 
-    permissionPromise.then(({ granted }) => {
+    permissionPromise.then(({ granted, error }) => {
       setIsRequestingPermission(false);
-      if (!granted) {
+      if (granted) {
+        // Persist enablement only once permission is actually granted.
+        // Setting it optimistically would leave the reader "enabled" after a
+        // denied OS prompt, so every later read would re-trigger the
+        // permission request.
+        updateFlag('readerInstallPromptAcknowledged', true);
+        setIsPreparingReader(true);
         return;
       }
-      // Persist enablement only once permission is actually granted. Setting
-      // it optimistically would leave the reader "enabled" after a denied OS
-      // prompt, so every later read would re-trigger the permission request.
-      updateFlag('readerInstallPromptAcknowledged', true);
-      setIsPreparingReader(true);
+      // `error` set means the bridge broke — orphaned content script after
+      // the post-grant runtime.reload, extension builds that stamp the
+      // marker but predate the bridge listener, or a timeout — rather than
+      // the user declining the browser prompt. Recover into the reader
+      // preview and let its in-iframe permission screen take over instead
+      // of silently resetting the button. A clean denial (no error) keeps
+      // the prompt so the user can pick the new-tab path instead.
+      if (error) {
+        openReaderPreview();
+      }
     });
   };
 

--- a/packages/shared/src/components/post/reader/hooks/useEnableReaderInside.ts
+++ b/packages/shared/src/components/post/reader/hooks/useEnableReaderInside.ts
@@ -7,6 +7,7 @@ import { LazyModal } from '../../../modals/common/types';
 import { LogEvent, TargetId } from '../../../../lib/log';
 import { isBrowserExtensionInstalled } from '../../../../features/extensionEmbed/useIsBrowserExtensionInstalled';
 import { requestFrameEmbeddingPermissionFromPage } from '../../../../features/extensionEmbed/pagePermissionBridge';
+import { useToastNotification } from '../../../../hooks/useToastNotification';
 
 /**
  * Drives the "turn the reader on" flow from a user gesture (e.g. the settings
@@ -22,6 +23,7 @@ export function useEnableReaderInside(): { enable: () => void } {
   const { flags, setSettings } = useSettingsContext();
   const { logEvent } = useLogContext();
   const { openModal } = useLazyModal();
+  const { displayToast } = useToastNotification();
 
   const enable = useCallback(() => {
     if (!isBrowserExtensionInstalled()) {
@@ -32,8 +34,18 @@ export function useEnableReaderInside(): { enable: () => void } {
     // Must run synchronously within the click so the content-script bridge
     // still has the click's transient user activation when it forwards the
     // permission request to the background.
-    requestFrameEmbeddingPermissionFromPage().then(({ granted }) => {
+    requestFrameEmbeddingPermissionFromPage().then(({ granted, error }) => {
       if (!granted) {
+        // A bridge failure (orphaned content script after an extension
+        // reload, older builds without the bridge listener) would otherwise
+        // read as "the toggle does nothing" — tell the user how to recover.
+        // A clean denial needs no messaging; the browser prompt was the
+        // interaction.
+        if (error) {
+          displayToast(
+            'Could not enable the reader. Refresh the page and try again.',
+          );
+        }
         return;
       }
       // Write both flags in one update — setSettings merges atomically, so
@@ -52,7 +64,7 @@ export function useEnableReaderInside(): { enable: () => void } {
         target_id: TargetId.On,
       });
     });
-  }, [flags, logEvent, openModal, setSettings]);
+  }, [displayToast, flags, logEvent, openModal, setSettings]);
 
   return { enable };
 }

--- a/packages/shared/src/features/extensionEmbed/pagePermissionBridge.spec.ts
+++ b/packages/shared/src/features/extensionEmbed/pagePermissionBridge.spec.ts
@@ -1,0 +1,69 @@
+import {
+  pagePermissionBridgeRequestEvent,
+  pagePermissionBridgeResultEvent,
+  requestFrameEmbeddingPermissionFromPage,
+} from './pagePermissionBridge';
+import type { PagePermissionBridgeResult } from './pagePermissionBridge';
+
+const dispatchResult = (detail: PagePermissionBridgeResult): void => {
+  window.dispatchEvent(
+    new CustomEvent<PagePermissionBridgeResult>(
+      pagePermissionBridgeResultEvent,
+      { detail },
+    ),
+  );
+};
+
+describe('requestFrameEmbeddingPermissionFromPage', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('dispatches the request event synchronously to preserve user activation', () => {
+    const onRequest = jest.fn();
+    window.addEventListener(pagePermissionBridgeRequestEvent, onRequest);
+
+    requestFrameEmbeddingPermissionFromPage();
+
+    expect(onRequest).toHaveBeenCalledTimes(1);
+    window.removeEventListener(pagePermissionBridgeRequestEvent, onRequest);
+  });
+
+  it('resolves with the granted result from the content script', async () => {
+    const promise = requestFrameEmbeddingPermissionFromPage();
+
+    dispatchResult({ granted: true });
+
+    await expect(promise).resolves.toEqual({
+      granted: true,
+      error: undefined,
+    });
+  });
+
+  it('resolves with a timeout error when no content script answers', async () => {
+    const promise = requestFrameEmbeddingPermissionFromPage();
+
+    jest.runAllTimers();
+
+    await expect(promise).resolves.toEqual({
+      granted: false,
+      error: 'timeout',
+    });
+  });
+
+  it('ignores late results after the timeout already settled the promise', async () => {
+    const promise = requestFrameEmbeddingPermissionFromPage();
+
+    jest.runAllTimers();
+    dispatchResult({ granted: true });
+
+    await expect(promise).resolves.toEqual({
+      granted: false,
+      error: 'timeout',
+    });
+  });
+});

--- a/packages/shared/src/features/extensionEmbed/pagePermissionBridge.ts
+++ b/packages/shared/src/features/extensionEmbed/pagePermissionBridge.ts
@@ -46,7 +46,12 @@ export const frameEmbeddingPermissionBridgeTiming = {
   pingMaxAttempts: 25,
 } as const;
 
-const PAGE_HELPER_TIMEOUT_MS = 60_000;
+// Long enough for the user to answer the browser's permission prompt plus
+// the post-grant reload poll (~6s worst case), but short enough that a dead
+// bridge — extension builds that stamp the install marker but predate the
+// bridge listener — resolves into the caller's error fallback without the
+// UI feeling hung.
+const PAGE_HELPER_TIMEOUT_MS = 20_000;
 
 // Drives chrome.permissions.request through the installed extension's
 // content script. Must be invoked synchronously from a user-input handler


### PR DESCRIPTION
## Changes

The "Enable permissions & read inside" button in the reader install prompt drives `chrome.permissions.request` through a CustomEvent round-trip to the extension's `ping` content script. Reported via user feedback: pressing the button repeatedly just leaves it stuck on the spinner (Chrome).

The round-trip goes dead whenever the content script isn't actually listening in that tab, and every failure path was silently swallowed (`if (!granted) return;`), so the user saw a 60-second spinner that quietly reset with no feedback:

- **Tab opened before the extension was installed** — content scripts don't inject into already-open tabs, but the install-detection fallback probe (web-accessible resource preload) succeeds anyway, so the modal offered the bridge flow in a tab with no listener. This is the *happy install path*: install from the modal in a new tab → return → click → dead air.
- **The extension's own new-tab surface** — content scripts never run on `chrome-extension://` pages, so the bridge was unreachable there, always.
- **Orphaned content script** — the post-grant `runtime.reload()` invalidates the content-script context in every open daily.dev tab; later clicks fail with "Extension context invalidated".
- **Version skew** — the `ping` script shipped in #5854 but the bridge listener only in #6070, so those builds stamp the install marker yet never answer.

### Fix (webapp-only, works with all shipped extension builds)

- Gate the bridge on the install marker at click time — the marker is stamped by the same content script that owns the bridge listener, so no marker ⇒ no listener. Route straight to the reader preview instead, whose in-iframe permission screen (`frame.html`) talks to the extension directly.
- On bridge errors/timeouts, recover into the reader preview instead of silently resetting the button. A clean user denial (no error) still keeps the prompt.
- Cut the bridge timeout 60s → 20s so residual dead-bridge cases resolve into the fallback quickly.
- The settings reader toggle (`useEnableReaderInside`) now shows a recovery toast on bridge failure instead of doing nothing.

## Tests

- New: `ReaderInstallPromptModal.spec.tsx` (click routing: marker gate, error fallback, grant, denial) and `pagePermissionBridge.spec.ts` (sync dispatch, result, timeout, late-result dedupe).
- `shared` + `webapp` suites green (only pre-existing, unrelated `numberFormat.spec.ts` locale failures on local Node), strict typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-reader-permission-bridge-fal.preview.app.daily.dev