### PR TITLE
fix(auth): make the verification code field iOS AutoFill-friendly

### DIFF
--- a/packages/shared/src/components/auth/EmailCodeVerification.spec.tsx
+++ b/packages/shared/src/components/auth/EmailCodeVerification.spec.tsx
@@ -96,6 +96,18 @@ describe('EmailCodeVerification', () => {
     expect(screen.queryByText('Invalid code')).not.toBeInTheDocument();
   });
 
+  it('should ask for the full code instead of verifying a partial one', async () => {
+    await renderComponent();
+
+    await act(async () => {
+      await userEvent.type(getInput(), '725');
+      await userEvent.click(screen.getByRole('button', { name: 'Verify' }));
+    });
+
+    expect(screen.getByText('Enter the 6-digit code')).toBeInTheDocument();
+    expect(onVerifyCode).not.toHaveBeenCalled();
+  });
+
   it('should render the funnel glass bar CTA in the onboarding funnel', async () => {
     await renderComponent({ isOnboardingFunnel: true });
 

--- a/packages/shared/src/components/auth/EmailCodeVerification.spec.tsx
+++ b/packages/shared/src/components/auth/EmailCodeVerification.spec.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EmailCodeVerification from './EmailCodeVerification';
+import { funnelGlassBarCta } from '../../features/onboarding/shared/FunnelGlassBar';
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+jest.mock('../../contexts/AuthDataContext', () => ({
+  useAuthData: () => ({ email: 'ada@daily.dev' }),
+}));
+
+const onVerifyCode = jest.fn();
+const onSubmit = jest.fn();
+
+const renderComponent = async (props = {}) => {
+  await act(async () => {
+    render(
+      <EmailCodeVerification
+        onVerifyCode={onVerifyCode}
+        onSubmit={onSubmit}
+        {...props}
+      />,
+    );
+  });
+};
+
+const getInput = () => screen.getByRole('textbox') as HTMLInputElement;
+
+describe('EmailCodeVerification', () => {
+  beforeEach(() => {
+    onVerifyCode.mockReset().mockResolvedValue(undefined);
+    onSubmit.mockReset();
+  });
+
+  it('should verify a code carried in by the email link without interaction', async () => {
+    await renderComponent({ code: '725432' });
+
+    expect(getInput()).toHaveValue('725432');
+    expect(onVerifyCode).toHaveBeenCalledTimes(1);
+    expect(onVerifyCode).toHaveBeenCalledWith('725432');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not verify a partial code carried in by the email link', async () => {
+    await renderComponent({ code: '725' });
+
+    expect(getInput()).toHaveValue('725');
+    expect(onVerifyCode).not.toHaveBeenCalled();
+  });
+
+  it('should wait for the reader when no code was linked', async () => {
+    await renderComponent();
+
+    expect(getInput()).toHaveValue('');
+    expect(onVerifyCode).not.toHaveBeenCalled();
+  });
+
+  it('should keep the Verify button as the fallback when a linked code fails', async () => {
+    onVerifyCode.mockRejectedValueOnce(new Error('Invalid code'));
+    await renderComponent({ code: '725432' });
+
+    expect(screen.getByText('Invalid code')).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: 'Verify' }));
+    });
+
+    expect(onVerifyCode).toHaveBeenCalledTimes(2);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should verify the code the reader typed', async () => {
+    await renderComponent();
+
+    await act(async () => {
+      await userEvent.type(getInput(), '725432');
+    });
+
+    expect(onVerifyCode).toHaveBeenCalledWith('725432');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should clear a failed attempt hint as soon as the code is edited', async () => {
+    onVerifyCode.mockRejectedValueOnce(new Error('Invalid code'));
+    await renderComponent({ code: '725432' });
+
+    expect(screen.getByText('Invalid code')).toBeInTheDocument();
+
+    await act(async () => {
+      await userEvent.type(getInput(), '{backspace}');
+    });
+
+    expect(screen.queryByText('Invalid code')).not.toBeInTheDocument();
+  });
+
+  it('should render the funnel glass bar CTA in the onboarding funnel', async () => {
+    await renderComponent({ isOnboardingFunnel: true });
+
+    expect(screen.getByRole('button', { name: 'Verify' })).toHaveClass(
+      ...funnelGlassBarCta.split(' '),
+    );
+  });
+});

--- a/packages/shared/src/components/auth/EmailCodeVerification.tsx
+++ b/packages/shared/src/components/auth/EmailCodeVerification.tsx
@@ -93,7 +93,7 @@ function EmailCodeVerification({
       target_type: TargetType.VerifyEmail,
     });
     setHint('');
-    if (!code) {
+    if (code.length !== CODE_LENGTH) {
       setHint('Enter the 6-digit code');
       return;
     }

--- a/packages/shared/src/components/auth/EmailCodeVerification.tsx
+++ b/packages/shared/src/components/auth/EmailCodeVerification.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import ConditionalWrapper from '../ConditionalWrapper';
@@ -32,6 +32,8 @@ interface EmailCodeVerificationProps extends AuthFormProps {
 
 const noop = (): void => undefined;
 
+const CODE_LENGTH = 6;
+
 function EmailCodeVerification({
   code: codeProp,
   onSubmit,
@@ -43,7 +45,8 @@ function EmailCodeVerification({
   const { email } = useAuthData();
   const { logEvent } = useLogContext();
   const [hint, setHint] = useState('');
-  const [code, setCode] = useState(codeProp ?? '');
+  const linkedCode = (codeProp ?? '').replace(/\D/g, '').slice(0, CODE_LENGTH);
+  const [code, setCode] = useState(linkedCode);
   const [isVerifying, setIsVerifying] = useState(false);
   const verifyingRef = useRef(false);
   const { timer, setTimer, runTimer } = useTimer(noop, 60);
@@ -74,6 +77,15 @@ function EmailCodeVerification({
     }
   };
 
+  useEffect(() => {
+    if (linkedCode.length !== CODE_LENGTH) {
+      return;
+    }
+
+    handleVerify(linkedCode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [linkedCode]);
+
   const onCodeVerification = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     logEvent({
@@ -101,13 +113,15 @@ function EmailCodeVerification({
   };
 
   const onCodeSubmit = async (newCode: string) => {
-    if (newCode.length === 6) {
+    if (newCode.length === CODE_LENGTH) {
       setCode(newCode);
       await handleVerify(newCode);
     }
   };
 
-  const onCodeChange = async () => {
+  const onCodeChange = (newCode: string) => {
+    setCode(newCode);
+
     if (hint?.length > 0) {
       setHint('');
     }
@@ -149,6 +163,7 @@ function EmailCodeVerification({
           readOnly
         />
         <CodeField
+          defaultValue={linkedCode}
           onSubmit={onCodeSubmit}
           onChange={onCodeChange}
           disabled={isVerifying}

--- a/packages/shared/src/components/fields/CodeField.spec.tsx
+++ b/packages/shared/src/components/fields/CodeField.spec.tsx
@@ -129,6 +129,30 @@ describe('CodeField', () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it('should snap a collapsed mid-string caret back to the end', async () => {
+    setup();
+
+    const input = getInput();
+    await userEvent.type(input, '123');
+    input.setSelectionRange(1, 1);
+    fireEvent.select(input);
+
+    expect(input.selectionStart).toBe(3);
+    expect(input.selectionEnd).toBe(3);
+  });
+
+  it('should leave a range selection alone', async () => {
+    setup();
+
+    const input = getInput();
+    await userEvent.type(input, '123');
+    input.setSelectionRange(0, 3);
+    fireEvent.select(input);
+
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(3);
+  });
+
   it('should take no input while disabled', async () => {
     setup({ disabled: true });
 

--- a/packages/shared/src/components/fields/CodeField.spec.tsx
+++ b/packages/shared/src/components/fields/CodeField.spec.tsx
@@ -1,120 +1,142 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CodeField } from './CodeField';
 
 const onSubmit = jest.fn();
+const onChange = jest.fn();
 
-const setup = () => render(<CodeField onSubmit={onSubmit} />);
-const boxes = () => screen.getAllByRole('textbox') as HTMLInputElement[];
+const setup = (props: { disabled?: boolean; defaultValue?: string } = {}) =>
+  render(<CodeField onSubmit={onSubmit} onChange={onChange} {...props} />);
+
+const getInput = () => screen.getByRole('textbox') as HTMLInputElement;
+
+const getBoxes = () =>
+  Array.from(document.querySelectorAll('[aria-hidden="true"]')).map(
+    (box) => box.textContent,
+  );
 
 describe('CodeField', () => {
   beforeEach(() => {
     onSubmit.mockReset();
+    onChange.mockReset();
   });
 
-  it('should offer the first box to the platform as the code field', () => {
+  it('should offer the whole code to the platform through one field', () => {
     setup();
 
-    const [first, ...rest] = boxes();
-    expect(first).toHaveAttribute('autocomplete', 'one-time-code');
-    expect(first).toHaveAttribute('inputmode', 'numeric');
-    // `tel` would not be the pair Safari's AutoFill is documented against.
-    expect(first).toHaveAttribute('type', 'text');
-    rest.forEach((box) => {
-      expect(box).toHaveAttribute('autocomplete', 'off');
-    });
+    const input = getInput();
+    expect(screen.getAllByRole('textbox')).toHaveLength(1);
+    expect(input).toHaveAttribute('autocomplete', 'one-time-code');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+    expect(input).toHaveAttribute('pattern', '[0-9]*');
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('name', 'code');
+    expect(input).toHaveAccessibleName('Verification code');
   });
 
-  it('should not cap any box, so a whole code written in survives', () => {
+  it('should keep the field fillable rather than hiding it', () => {
     setup();
 
-    boxes().forEach((box) => expect(box).not.toHaveAttribute('maxlength'));
+    const input = getInput();
+    expect(input).not.toHaveAttribute('hidden');
+    expect(input.className).not.toMatch(/(^|\s)(hidden|invisible)(\s|$)/);
+    expect(input).not.toHaveAttribute('tabindex');
   });
 
-  // iOS AutoFill and Gboard's clipboard chip both write the code straight into
-  // the focused box rather than firing a paste event.
-  it('should spread a code written into the first box and submit it', () => {
+  it('should not cap length so a prose paste survives until it is sanitized', () => {
     setup();
 
-    fireEvent.change(boxes()[0], { target: { value: '725432' } });
-
-    expect(boxes().map((box) => box.value)).toEqual([
-      '7',
-      '2',
-      '5',
-      '4',
-      '3',
-      '2',
-    ]);
-    expect(onSubmit).toHaveBeenCalledWith('725432');
+    expect(getInput()).not.toHaveAttribute('maxlength');
   });
 
-  it('should spread a code written into a later box too', () => {
+  it('should render the digits in presentational boxes', () => {
     setup();
 
-    fireEvent.change(boxes()[3], { target: { value: '725432' } });
-
-    expect(onSubmit).toHaveBeenCalledWith('725432');
+    expect(getBoxes()).toEqual(['', '', '', '', '', '']);
   });
 
-  // A soft keyboard or IME whose keydown cannot be cancelled delivers its
-  // character through `input`, so a write shorter than the code is a keystroke.
-  it('should treat a write shorter than the code as a typed digit', async () => {
+  it('should fill the boxes left to right and drop anything but digits', async () => {
     setup();
 
-    fireEvent.change(boxes()[0], { target: { value: '7' } });
+    await userEvent.type(getInput(), '12a3');
 
-    expect(boxes().map((box) => box.value)).toEqual(['7', '', '', '', '', '']);
-    await waitFor(() => expect(boxes()[1]).toHaveFocus());
-  });
-
-  it('should not spread a second digit written into the same box', () => {
-    setup();
-
-    fireEvent.change(boxes()[0], { target: { value: '7' } });
-    fireEvent.change(boxes()[0], { target: { value: '77' } });
-
-    expect(boxes()[1]).toHaveValue('');
+    expect(getBoxes()).toEqual(['1', '2', '3', '', '', '']);
+    expect(onChange).toHaveBeenLastCalledWith('123');
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should remove the last digit on backspace', async () => {
+    setup();
+
+    await userEvent.type(getInput(), '123{backspace}');
+
+    expect(getBoxes()).toEqual(['1', '2', '', '', '', '']);
+  });
+
+  it('should submit a whole code written in at once', () => {
+    setup();
+
+    fireEvent.change(getInput(), { target: { value: '725432' } });
+
+    expect(getBoxes()).toEqual(['7', '2', '5', '4', '3', '2']);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith('725432');
+  });
+
+  it('should submit once when one insertion arrives as two events', () => {
+    setup();
+
+    fireEvent.change(getInput(), { target: { value: '725432' } });
+    fireEvent.change(getInput(), { target: { value: '725432' } });
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   it('should take the digits out of a code pasted with surrounding text', () => {
     setup();
 
-    fireEvent.paste(boxes()[0], {
-      clipboardData: { getData: () => 'Your code is 725432\n' },
+    fireEvent.change(getInput(), {
+      target: { value: 'Your code is 725 432!' },
     });
 
+    expect(getBoxes()).toEqual(['7', '2', '5', '4', '3', '2']);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith('725432');
   });
 
-  it('should keep a partial paste in place and focus the next box', async () => {
+  it('should ignore a write that carries no digits', () => {
     setup();
 
-    fireEvent.paste(boxes()[0], {
-      clipboardData: { getData: () => 'code: 72' },
-    });
+    fireEvent.change(getInput(), { target: { value: 'no code here' } });
 
-    expect(boxes().map((box) => box.value)).toEqual(['7', '2', '', '', '', '']);
+    expect(getBoxes()).toEqual(['', '', '', '', '', '']);
     expect(onSubmit).not.toHaveBeenCalled();
-    await waitFor(() => expect(boxes()[2]).toHaveFocus());
   });
 
-  it('should ignore a paste that carries no digits', () => {
-    setup();
+  it('should render a complete default value without submitting it', () => {
+    setup({ defaultValue: '725432' });
 
-    fireEvent.paste(boxes()[0], {
-      clipboardData: { getData: () => 'no code here' },
-    });
-
+    expect(getBoxes()).toEqual(['7', '2', '5', '4', '3', '2']);
+    expect(getInput()).toHaveValue('725432');
     expect(onSubmit).not.toHaveBeenCalled();
-    expect(boxes()[0]).toHaveValue('');
   });
 
-  it('should still take one digit per box when typed', () => {
-    setup();
+  it('should render a partial default value without submitting it', () => {
+    setup({ defaultValue: '725' });
 
-    fireEvent.keyDown(boxes()[0], { key: '7' });
-    expect(boxes()[0]).toHaveValue('7');
+    expect(getBoxes()).toEqual(['7', '2', '5', '', '', '']);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('should take no input while disabled', async () => {
+    setup({ disabled: true });
+
+    expect(getInput()).toBeDisabled();
+
+    await userEvent.type(getInput(), '725432');
+
+    expect(getBoxes()).toEqual(['', '', '', '', '', '']);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -47,12 +47,17 @@ export function CodeField({
     onSubmit(digits);
   };
 
-  // A caret left mid-string would scramble the order of the digits after it.
+  // A collapsed caret parked mid-string would scramble the order of the digits
+  // after it; a deliberate range selection (select-all, drag) stays native.
   const keepCaretAtEnd = (e: SyntheticEvent<HTMLInputElement>) => {
     const input = e.currentTarget;
     const end = input.value.length;
 
-    if (input.selectionStart === end && input.selectionEnd === end) {
+    if (input.selectionStart !== input.selectionEnd) {
+      return;
+    }
+
+    if (input.selectionStart === end) {
       return;
     }
 
@@ -84,7 +89,7 @@ export function CodeField({
         autoFocus
         aria-label="Verification code"
         autoComplete="one-time-code"
-        className="absolute inset-0 z-1 h-full w-full bg-transparent text-transparent caret-transparent typo-body focus:outline-none"
+        className="absolute inset-0 z-1 h-full w-full bg-transparent text-transparent caret-transparent typo-body [forced-color-adjust:none] focus:outline-none"
         disabled={disabled}
         id="code"
         inputMode="numeric"

--- a/packages/shared/src/components/fields/CodeField.tsx
+++ b/packages/shared/src/components/fields/CodeField.tsx
@@ -1,182 +1,105 @@
-import type { ReactElement, ClipboardEventHandler, KeyboardEvent } from 'react';
+import type { ChangeEvent, ReactElement, SyntheticEvent } from 'react';
 import React, { useRef, useState } from 'react';
-import { TextField } from './TextField';
-import { ArrowKey, KeyboardCommand } from '../../lib/element';
-import { checkIsNumbersOnly } from '../../lib';
-import { nextTick } from '../../lib/func';
+import classNames from 'classnames';
+import { BaseField } from './common';
 
 interface CodeFieldProps {
   onChange?: (code: string) => void;
   onSubmit: (code: string) => void;
   length?: number;
   disabled?: boolean;
-  hint?: string;
+  defaultValue?: string;
 }
 
 const DEFAULT_LENGTH = 6;
-const INVALID_KEYS = [ArrowKey.Up, ArrowKey.Down, '.'];
+
+const toDigits = (value: string, length: number): string =>
+  value.replace(/\D/g, '').slice(0, length);
 
 export function CodeField({
   disabled,
   onChange,
   onSubmit,
+  defaultValue = '',
   length = DEFAULT_LENGTH,
 }: CodeFieldProps): ReactElement {
-  const elementsRef = useRef<HTMLInputElement[]>(
-    Array(Math.max(0, length)).fill(null),
-  );
-  const [code, setCode] = useState<string[]>(
-    Array(Math.max(0, length)).fill(''),
-  );
+  const submittedRef = useRef<string | null>(null);
+  const [code, setCode] = useState(() => toDigits(defaultValue, length));
+  const [isFocused, setIsFocused] = useState(false);
+  const caretIndex = Math.min(code.length, length - 1);
 
-  const updateCode = (value: string, index: number) => {
-    const newCode = [...code];
-    newCode[index] = value;
-    setCode(newCode);
-    onChange?.(newCode.join(''));
-
-    const finalCode = newCode.join('');
-
-    if (finalCode.length === length && index === length - 1) {
-      onSubmit(finalCode);
-    }
-  };
-
-  const focusBox = async (index: number) => {
-    const target = elementsRef.current[index];
-
-    if (!target) {
-      return;
-    }
-
-    await nextTick();
-    target.focus();
-  };
-
-  // A code copied out of an email drags the selection's whitespace and prose
-  // along with it, so take the digits rather than rejecting the whole paste.
-  const onSlice = (text: string) => {
-    const digits = text.replace(/\D/g, '').slice(0, length);
-
-    if (!digits) {
-      return;
-    }
-
-    setCode(Array.from({ length }, (_, index) => digits[index] ?? ''));
+  const onInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const digits = toDigits(e.target.value, length);
+    setCode(digits);
     onChange?.(digits);
 
-    if (digits.length === length) {
-      onSubmit(digits);
+    if (digits.length < length) {
+      submittedRef.current = null;
       return;
     }
 
-    focusBox(digits.length);
+    // AutoFill can deliver a single insertion as two change events.
+    if (submittedRef.current === digits) {
+      return;
+    }
+
+    submittedRef.current = digits;
+    onSubmit(digits);
   };
 
-  // Platform writes land here — iOS AutoFill and Gboard's clipboard chip insert
-  // as text and fire no paste event — but so do keystrokes from IMEs and soft
-  // keyboards whose keydown `onKeyDown` cannot cancel. Only a whole code is a
-  // fill.
-  const onFill = (value: string, index: number) => {
-    const digits = value.replace(/\D/g, '');
+  // A caret left mid-string would scramble the order of the digits after it.
+  const keepCaretAtEnd = (e: SyntheticEvent<HTMLInputElement>) => {
+    const input = e.currentTarget;
+    const end = input.value.length;
 
-    if (digits.length >= length) {
-      onSlice(digits);
+    if (input.selectionStart === end && input.selectionEnd === end) {
       return;
     }
 
-    const typed = digits.slice(-1);
-    updateCode(typed, index);
-
-    if (typed) {
-      focusBox(index + 1);
-    }
-  };
-
-  const onPaste: ClipboardEventHandler<HTMLInputElement> = (e) => {
-    e.preventDefault();
-    onSlice(e.clipboardData.getData('text'));
-  };
-
-  const onKeyDown = async (
-    e: KeyboardEvent<HTMLInputElement>,
-    index: number,
-  ) => {
-    const { key } = e;
-    const isNumbersOnly = checkIsNumbersOnly(key);
-
-    if ((e.ctrlKey || e.metaKey) && key === 'v') {
-      return;
-    }
-
-    if (key === KeyboardCommand.Enter) {
-      onSubmit(code.join(''));
-      return;
-    }
-
-    if (INVALID_KEYS.includes(key)) {
-      e.preventDefault();
-    }
-
-    if (key === KeyboardCommand.Backspace) {
-      updateCode('', index);
-
-      if (index <= 0) {
-        return;
-      }
-
-      await focusBox(index - 1);
-    }
-
-    if (!isNumbersOnly) {
-      e.preventDefault();
-    } else if (key.length === 1) {
-      e.preventDefault();
-      updateCode(key, index);
-
-      await focusBox(index + 1);
-    }
+    input.setSelectionRange(end, end);
   };
 
   return (
-    <span className="flex flex-row gap-2">
-      {/* The platform only offers a code to the field it has focused, so the
-          hint rides on the box that takes focus rather than a hidden mirror of
-          it, `text` + `inputMode` is the pair Safari documents AutoFill
-          against, and no box takes `maxLength` — a whole code written into one
-          would be cut to a digit. `name` is part of that hint and nothing
-          reads it: serialising this form would yield a single digit. */}
-      {[...Array(length)].map((_, index) => {
-        const isAutofillTarget = index === 0;
-
-        return (
-          <TextField
-            // eslint-disable-next-line react/no-array-index-key
-            key={`code-${index}`}
-            type="text"
-            inputId={`code-${index}`}
-            tabIndex={index + 1}
-            label=""
-            {...(isAutofillTarget
-              ? { autoComplete: 'one-time-code', name: 'code' }
-              : { autoComplete: 'off' })}
-            className={{ baseField: '!h-11 w-11 mobileL:!h-12 mobileL:w-12' }}
-            onPaste={onPaste}
-            value={code[index] || ''}
-            onChange={(e) => onFill(e.target.value, index)}
-            onKeyDown={(e) => onKeyDown(e, index)}
-            disabled={disabled}
-            inputMode="numeric"
-            pattern="[0-9]*"
-            autoFocus={isAutofillTarget}
-            inputRef={(el) => {
-              if (el) {
-                elementsRef.current[index] = el;
-              }
-            }}
-          />
-        );
-      })}
-    </span>
+    <div className="relative flex flex-row gap-2">
+      {Array.from({ length }, (_, index) => (
+        <BaseField
+          aria-hidden
+          // eslint-disable-next-line react/no-array-index-key
+          key={`code-${index}`}
+          className={classNames(
+            'h-11 w-11 items-center justify-center rounded-14 !px-0 text-text-primary typo-body mobileL:h-12 mobileL:w-12',
+            disabled && 'opacity-32',
+            isFocused && index === caretIndex && 'focused',
+          )}
+        >
+          {code[index] ?? ''}
+        </BaseField>
+      ))}
+      {/* iOS only offers a code to the focused field carrying the hint, refuses
+          to fill hidden fields, and zooms on fonts under 16px; browsers cut a
+          paste to `maxLength` before the digits could be sliced out — hence one
+          visible-but-transparent input over the whole row, with no cap. */}
+      <input
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus
+        aria-label="Verification code"
+        autoComplete="one-time-code"
+        className="absolute inset-0 z-1 h-full w-full bg-transparent text-transparent caret-transparent typo-body focus:outline-none"
+        disabled={disabled}
+        id="code"
+        inputMode="numeric"
+        name="code"
+        onBlur={() => setIsFocused(false)}
+        onChange={onInputChange}
+        onFocus={(e) => {
+          setIsFocused(true);
+          keepCaretAtEnd(e);
+        }}
+        onSelect={keepCaretAtEnd}
+        pattern="[0-9]*"
+        type="text"
+        value={code}
+      />
+    </div>
   );
 }

--- a/packages/shared/src/components/onboarding/OnboardingPWA.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingPWA.tsx
@@ -43,19 +43,24 @@ export const OnboardingPWA = ({
           </OnboardingHeadline>
           <OnboardingSubheadline>{PWA_EXPLAINER}</OnboardingSubheadline>
         </div>
-        {/* In flow, not an absolute full-screen layer: at `w-full` the
-            footage's aspect ratio made it tall enough on a wide phone to reach
-            into the subheadline. Bottom-anchored — its top third is empty. */}
-        <video
-          {...footage}
-          className="max-h-[45dvh] w-full max-w-64 object-cover object-bottom"
-          muted
-          autoPlay
-          loop
-          playsInline
-          disablePictureInPicture
-          controls={false}
-        />
+        {/* The area's top edge is in flow so the footage can never reach the
+            subheadline, while the height overshoot lets it run on under the
+            translucent glass bar. An explicit height, not `bottom`: a replaced
+            element's intrinsic ratio wins over an inset pair. The 7rem must
+            stay below the bar rail's minimum height — past the page bottom it
+            would make the step scroll. */}
+        <div className="relative w-full flex-1">
+          <video
+            {...footage}
+            className="pointer-events-none absolute inset-x-0 top-0 h-[calc(100%+7rem)] w-full object-contain object-top"
+            muted
+            autoPlay
+            loop
+            playsInline
+            disablePictureInPicture
+            controls={false}
+          />
+        </div>
       </>
     );
   }

--- a/packages/shared/src/features/onboarding/steps/FunnelInstallPwa.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelInstallPwa.tsx
@@ -20,6 +20,7 @@ function FunnelInstallPwaComponent({
     <FunnelStepCtaWrapper
       isGlass
       cta={{ label: cta }}
+      containerClassName={isOnboarding ? 'flex' : undefined}
       onClick={() => onTransition({ type: FunnelStepTransitionType.Complete })}
     >
       <div
@@ -27,7 +28,7 @@ function FunnelInstallPwaComponent({
           isOnboarding
             ? classNames(
                 funnelStepRail,
-                'flex flex-col items-center gap-6 py-6 pt-3',
+                'flex flex-1 flex-col items-center gap-6 py-6 pt-3',
               )
             : 'flex flex-col items-center gap-6 p-6 pt-4 mobileL:pt-10 tablet:max-w-96'
         }

--- a/packages/shared/src/lib/numberFormat.ts
+++ b/packages/shared/src/lib/numberFormat.ts
@@ -52,9 +52,6 @@ export const getPrice = (item: PaddleProductLineItem): number => {
   return priceAmount / 100;
 };
 
-export const checkIsNumbersOnly = (value: string): boolean =>
-  /^\d+$/.test(value);
-
 export const formatDataTileValue = (value: number): string => {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return '0';


### PR DESCRIPTION
## Changes

- Rewrite `CodeField` from six separate inputs into a **single real input** (`autocomplete="one-time-code"`, `inputmode="numeric"`) stretched invisibly over six presentational boxes, so iOS offers the emailed code above the keyboard and one tap fills all digits.
  - Root cause of the missing suggestion: iOS only offers the code to the *focused* field carrying the `one-time-code` hint; the old layout had the hint on box 1 only and `autocomplete="off"` on the rest, so tapping any other box (or typing one digit, which moved focus) suppressed it. WebKit also distrusts clusters of one-character inputs with scripted focus-hopping.
  - The input is visible-but-transparent (iOS refuses to fill hidden fields), keeps a 17px font (no focus zoom), forces the caret to the end (mid-row taps can't scramble digit order), and deliberately has **no `maxLength`** — browsers truncate a paste to fit it, which would cut "Your code is 123 456!" to `Your c` before the digits could be extracted. Length is enforced in the value sanitizer instead.
  - Paste, backspace, and selection are now native; a ref guard keeps AutoFill's occasional double change event from submitting twice.
- Wire the `/verification?email=…&code=…` deep link: the code now pre-fills the boxes and auto-verifies on mount (it was silently dropped before).
- Rewrite `CodeField.spec.tsx` (12 tests, incl. an attribute regression test for the AutoFill contract) and add a new `EmailCodeVerification.spec.tsx` (7 tests).
- Delete `checkIsNumbersOnly` from `numberFormat.ts` — its only consumer was the old CodeField.

- Address review findings: exact-length guard before Verify (partial codes get the hint, not an API call), range selections stay native (only a collapsed mid-string caret snaps to the end), and `forced-color-adjust: none` so forced-colors mode doesn't double the digits.
- Fix the install-PWA step's footage (reported from device testing): it was top-cropped by `object-cover object-bottom`; now top-aligned `object-contain` in an area that starts below the subheadline and bleeds behind the glass bar, without making the step scroll.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

Verified live on `/verification`: click-anywhere focuses the code input, typing/paste-with-prose/backspace behave, a simulated AutoFill insertion fills all boxes and fires the verify mutation exactly once, deep-link prefill auto-verifies, and errors surface as the hint. All shared + webapp suites, strict typecheck, and lint pass.

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

On-device note for QA: iOS only harvests codes from the built-in Apple Mail app (iOS 17+) and Messages — testing with the Gmail app will never show the QuickType chip; that path uses Gmail's copy chip + paste, which this field also handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-autofill-onboarding-code.preview.app.daily.dev
