### PR TITLE
fix(onboarding): scale the install-PWA footage up to fill its area

### DIFF
--- a/packages/shared/src/components/onboarding/OnboardingPWA.tsx
+++ b/packages/shared/src/components/onboarding/OnboardingPWA.tsx
@@ -48,11 +48,13 @@ export const OnboardingPWA = ({
             translucent glass bar. An explicit height, not `bottom`: a replaced
             element's intrinsic ratio wins over an inset pair. The 7rem must
             stay below the bar rail's minimum height — past the page bottom it
-            would make the step scroll. */}
+            would make the step scroll. `cover` + `object-bottom` scales the
+            footage up to fill the whole area; the overflow it sheds at the top
+            is the frame's own blank third. */}
         <div className="relative w-full flex-1">
           <video
             {...footage}
-            className="pointer-events-none absolute inset-x-0 top-0 h-[calc(100%+7rem)] w-full object-contain object-top"
+            className="pointer-events-none absolute inset-x-0 top-0 h-[calc(100%+7rem)] w-full object-cover object-bottom"
             muted
             autoPlay
             loop


### PR DESCRIPTION
## Changes

Follow-up to #6421's install-PWA layout fix. `object-contain` kept the whole frame visible but left the footage's own blank top third on screen as a dead gap under the subheadline. Switching to `object-cover object-bottom` scales the footage up until it fills the whole area (still starting below the subheadline, still bleeding behind the glass bar, still no scroll):

- On modern iPhone heights (812pt+), the crop sheds only the frame's blank top region — the phone-in-hand content is fully visible and noticeably larger.
- The step is iOS-only, so the sole degraded case is the discontinued SE height (667pt), where the crop reaches into the in-video browser chrome; bottom-anchoring keeps the share-sheet instructions in view there.

Verified in the `InstallPwa` story at 375×812 and 375×667: no page scroll (`scrollHeight` equals the viewport), video box extends 88px behind the glass bar.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

- [x] Sanity checks in the webapp (Storybook story at both iPhone heights)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-pwa-footage-scale-up.preview.app.daily.dev