### PR TITLE
fix(tags): render keyword titles instead of derived casing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ The "calling platform" is not just extension vs webapp. Native iOS/Android wrapp
 - On search pages, `MainFeedLayout` renders page `children` AFTER the `<Feed>`. Content above feed results goes through the `searchChildren` prop (via `layoutProps`).
 - Feed promos between nav and feed belong in the content flow (pushing content down), not absolutely positioned on sticky nav, unless overlay behavior is explicitly requested.
 - Match existing horizontal gaps on both sides when adding buttons near search fields or other controls.
+- Tag *labels* render the backend `flags.title` or the raw value (`#react`, like post pages) — never a casing derived in the client. The API exposes titles only on `Keyword`, so surfaces holding bare tag strings (profile top tags, tag navbar) read them from `tagTitlesQueryOptions`. A keyword's own *page title* (tag page H1, `<title>`, JSON-LD) is the exception: it keeps the `formatKeyword(tag)` fallback that #6414 added for SEO.
 
 ## Forms and Interaction Lessons
 

--- a/packages/shared/src/components/recruiter/UserEngagementSections.tsx
+++ b/packages/shared/src/components/recruiter/UserEngagementSections.tsx
@@ -7,7 +7,6 @@ import { Chip } from '../cards/common/PostTags';
 import { MedalBadgeIcon } from '../icons';
 import { IconSize } from '../Icon';
 import { formatMonthYearOnly } from '../../lib/dateFormat';
-import { formatKeyword } from '../../lib/strings';
 import { Image, ImageType } from '../image/Image';
 import type { Squad } from '../../graphql/sources';
 import type { TopReader } from '../badges/TopReaderBadge';
@@ -47,7 +46,7 @@ export const UserEngagementSections = ({
           {recentlyRead.map((badge) => (
             <Chip key={badge.keyword.value} className="!my-0 gap-1.5">
               <MedalBadgeIcon size={IconSize.XSmall} secondary />
-              <span>{formatKeyword(badge.keyword.value)}</span>
+              <span>{badge.keyword.flags?.title || badge.keyword.value}</span>
               <span className="text-text-quaternary">·</span>
               <span className="text-text-quaternary">
                 {formatMonthYearOnly(new Date(badge.issuedAt))}

--- a/packages/shared/src/components/tags/TagDirectoryListItem.tsx
+++ b/packages/shared/src/components/tags/TagDirectoryListItem.tsx
@@ -6,7 +6,6 @@ import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { PlusIcon, VIcon } from '../icons';
 import { Tooltip } from '../tooltip/Tooltip';
 import { getTagPageLink } from '../../lib/links';
-import { formatKeyword } from '../../lib/strings';
 import {
   Typography,
   TypographyColor,
@@ -39,7 +38,7 @@ export function TagDirectoryListItem({
           color={TypographyColor.Secondary}
           className="block min-w-0 flex-1 cursor-pointer truncate px-2 py-1 no-underline transition-colors hover:text-text-primary"
         >
-          {title || formatKeyword(tag)}
+          {title || tag}
         </Typography>
       </Link>
       <Tooltip content={isFollowed ? `Following #${tag}` : `Follow #${tag}`}>

--- a/packages/shared/src/components/tags/TagPageNavbar.tsx
+++ b/packages/shared/src/components/tags/TagPageNavbar.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { ButtonSize } from '../buttons/Button';
 import { pageHeaderClassName } from '../layout/PageHeader';
@@ -8,8 +9,8 @@ import {
   SquadDirectoryNavbarItem,
 } from '../squads/layout/SquadDirectoryNavbar';
 import { getTagPageLink } from '../../lib/links';
-import { formatKeyword } from '../../lib/strings';
 import { webappUrl } from '../../lib/constants';
+import { tagTitlesQueryOptions } from '../../graphql/keywords';
 
 interface TagPageNavbarProps {
   // The tag currently being viewed; rendered as the active tab.
@@ -33,6 +34,7 @@ export function TagPageNavbar({
   recommendedTags = [],
   className,
 }: TagPageNavbarProps): ReactElement {
+  const { data: tagTitles = {} } = useQuery(tagTitlesQueryOptions());
   const tags = useMemo(() => {
     const rec = recommendedTags.filter((tag) => tag && tag !== activeTag);
     const ordered = activeTag ? [activeTag, ...rec] : rec;
@@ -59,9 +61,9 @@ export function TagPageNavbar({
             key={tag}
             buttonSize={ButtonSize.Small}
             isActive={tag === activeTag}
-            label={formatKeyword(tag)}
+            label={tagTitles[tag] || tag}
             path={getTagPageLink(tag)}
-            ariaLabel={formatKeyword(tag)}
+            ariaLabel={tagTitles[tag] || tag}
           />
         ))}
       </SquadDirectoryNavbar>

--- a/packages/shared/src/features/opportunity/graphql.ts
+++ b/packages/shared/src/features/opportunity/graphql.ts
@@ -295,6 +295,9 @@ export const OPPORTUNITY_MATCHES_QUERY = gql`
             recentlyRead {
               keyword {
                 value
+                flags {
+                  title
+                }
               }
               issuedAt
             }
@@ -671,6 +674,9 @@ export const OPPORTUNITY_PREVIEW = gql`
           recentlyRead {
             keyword {
               value
+              flags {
+                title
+              }
             }
             issuedAt
           }

--- a/packages/shared/src/features/profile/components/ProfileWidgets/ReadingOverview.spec.tsx
+++ b/packages/shared/src/features/profile/components/ProfileWidgets/ReadingOverview.spec.tsx
@@ -8,6 +8,8 @@ import type {
 } from '../../../../graphql/users';
 import { ReadingOverview } from './ReadingOverview';
 import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
+import { mockGraphQL } from '../../../../../__tests__/helpers/graphql';
+import { TAG_TITLES_QUERY } from '../../../../graphql/keywords';
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -101,10 +103,30 @@ describe('ReadingOverview component', () => {
       screen.getByText('Posts read in the last months (16)'),
     ).toBeInTheDocument();
     expect(screen.getByText('Top tags by reading days')).toBeInTheDocument();
-    expect(screen.getByText('Javascript')).toBeInTheDocument();
-    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('javascript')).toBeInTheDocument();
+    expect(screen.getByText('react')).toBeInTheDocument();
     expect(screen.getByText('+60%')).toBeInTheDocument(); // javascript percentage
     expect(screen.getByText('+40%')).toBeInTheDocument(); // react percentage
+  });
+
+  it('should render the keyword title once it is available', async () => {
+    mockGraphQL({
+      request: { query: TAG_TITLES_QUERY },
+      result: {
+        data: {
+          tags: [
+            { value: 'javascript', flags: { title: 'JavaScript' } },
+            { value: 'react', flags: null },
+          ],
+        },
+      },
+    });
+
+    renderComponent();
+
+    expect(await screen.findByText('JavaScript')).toBeInTheDocument();
+    // No title on the keyword: keep the raw value rather than invent a casing.
+    expect(screen.getByText('react')).toBeInTheDocument();
   });
 
   it('should render streaks section when streak data is available', () => {

--- a/packages/shared/src/features/profile/components/ProfileWidgets/ReadingOverviewComponents.tsx
+++ b/packages/shared/src/features/profile/components/ProfileWidgets/ReadingOverviewComponents.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import type { UserStreak, MostReadTag } from '../../../../graphql/users';
 import { largeNumberFormat, getTagPageLink } from '../../../../lib';
 import Link from '../../../../components/utilities/Link';
@@ -11,7 +12,8 @@ import {
   TypographyType,
 } from '../../../../components/typography/Typography';
 import { SummaryCard } from './BadgesAndAwardsComponents';
-import { anchorDefaultRel, capitalize } from '../../../../lib/strings';
+import { anchorDefaultRel } from '../../../../lib/strings';
+import { tagTitlesQueryOptions } from '../../../../graphql/keywords';
 import { ActivityContainer } from '../../../../components/profile/ActivitySection';
 import { ClickableText } from '../../../../components/buttons/ClickableText';
 import { ElementPlaceholder } from '../../../../components/ElementPlaceholder';
@@ -20,10 +22,12 @@ import { migrateUserToStreaks } from '../../../../lib/constants';
 // ReadingTagProgress component
 interface ReadingTagProgressProps {
   tag: MostReadTag;
+  title?: string;
 }
 
 export const ReadingTagProgress = ({
   tag: { value: tag, count, percentage, total },
+  title,
 }: ReadingTagProgressProps): ReactElement => {
   const value = `+${(percentage * 100).toFixed(0)}%`;
 
@@ -38,7 +42,7 @@ export const ReadingTagProgress = ({
             color={TypographyColor.Primary}
             truncate
           >
-            {capitalize(tag)}
+            {title || tag}
           </Typography>
         </Link>
         <Typography
@@ -86,23 +90,31 @@ interface ReadingTagsSectionProps {
 
 export const ReadingTagsSection = ({
   mostReadTags,
-}: ReadingTagsSectionProps): ReactElement => (
-  <>
-    <Typography
-      tag={TypographyTag.H3}
-      type={TypographyType.Subhead}
-      color={TypographyColor.Tertiary}
-      className="my-1"
-    >
-      Top tags by reading days
-    </Typography>
-    <div className="my-3 grid max-w-full grid-cols-2 gap-2">
-      {mostReadTags?.map((tag) => (
-        <ReadingTagProgress key={tag.value} tag={tag} />
-      ))}
-    </div>
-  </>
-);
+}: ReadingTagsSectionProps): ReactElement => {
+  const { data: tagTitles = {} } = useQuery(tagTitlesQueryOptions());
+
+  return (
+    <>
+      <Typography
+        tag={TypographyTag.H3}
+        type={TypographyType.Subhead}
+        color={TypographyColor.Tertiary}
+        className="my-1"
+      >
+        Top tags by reading days
+      </Typography>
+      <div className="my-3 grid max-w-full grid-cols-2 gap-2">
+        {mostReadTags?.map((tag) => (
+          <ReadingTagProgress
+            key={tag.value}
+            tag={tag}
+            title={tagTitles[tag.value]}
+          />
+        ))}
+      </div>
+    </>
+  );
+};
 
 // HeatmapLegend component
 export const HeatmapLegend = (): ReactElement => (

--- a/packages/shared/src/graphql/keywords.ts
+++ b/packages/shared/src/graphql/keywords.ts
@@ -1,4 +1,6 @@
 import { gql } from 'graphql-request';
+import { gqlClient } from './common';
+import { generateQueryKey, RequestKey, StaleTime } from '../lib/query';
 
 export type KeywordStatus = 'pending' | 'allow' | 'deny' | 'synonym';
 
@@ -86,6 +88,36 @@ export const KEYWORD_QUERY = gql`
     }
   }
 `;
+
+export const TAG_TITLES_QUERY = gql`
+  query TagTitles {
+    tags {
+      value
+      flags {
+        title
+      }
+    }
+  }
+`;
+
+// Keyword titles ("Machine Learning", "DevOps") are only exposed on `Keyword`,
+// so surfaces holding nothing but raw tag values share one lookup of the whole
+// directory. Callers fall back to the raw value, never to an invented casing.
+export const tagTitlesQueryOptions = () => ({
+  queryKey: generateQueryKey(RequestKey.TagTitles),
+  queryFn: async (): Promise<Record<string, string>> => {
+    const { tags } = await gqlClient.request<{ tags: Keyword[] }>(
+      TAG_TITLES_QUERY,
+    );
+
+    return Object.fromEntries(
+      tags.flatMap(({ value, flags }) =>
+        flags?.title ? [[value, flags.title]] : [],
+      ),
+    );
+  },
+  staleTime: StaleTime.OneDay,
+});
 
 export const TAG_DIRECTORY_QUERY = gql`
   query TagDirectory {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -148,6 +148,7 @@ export enum RequestKey {
   PersonalizedDigest = 'personalizedDigest',
   Changelog = 'changelog',
   Tags = 'tags',
+  TagTitles = 'tag_titles',
   FeedPreview = 'feedPreview',
   FeedPreviewCustom = 'feedPreviewCustom',
   DailyFeed = 'dailyFeed',

--- a/packages/shared/src/lib/strings.ts
+++ b/packages/shared/src/lib/strings.ts
@@ -22,8 +22,9 @@ export const capitalize = (value: string): string =>
   (value && value[0].toUpperCase() + value.slice(1)) || '';
 
 /**
- * Formats a keyword/tag value to be human-readable by removing hyphens
- * and capitalizing each word. For example: "machine-learning" -> "Machine Learning"
+ * Formats a keyword/tag value into a human-readable page title, e.g.
+ * "machine-learning" -> "Machine Learning". Only for titles and SEO metadata of
+ * a keyword's own page; tag labels render the keyword title or the raw value.
  * @param value - The keyword/tag value to format
  * @returns The formatted string
  */

--- a/packages/webapp/__tests__/ProfileIndexPage.tsx
+++ b/packages/webapp/__tests__/ProfileIndexPage.tsx
@@ -121,10 +121,10 @@ it('should show the top reading tags of the user', async () => {
   renderComponent();
   await waitForNock();
   await screen.findByText('Top tags by reading days');
-  // Tags are rendered capitalized without the # prefix
-  await screen.findByText('Javascript');
-  await screen.findByText('Golang');
-  await screen.findByText('C#');
+  // No keyword title available: the raw tag value is rendered as-is
+  await screen.findByText('javascript');
+  await screen.findByText('golang');
+  await screen.findByText('c#');
 });
 
 it('should show the about me section with readme of the user', async () => {


### PR DESCRIPTION
## Summary

Profile top tags were rendered with `capitalize()`, so a slug came out as "Machine-learning" or "Devops". Tag labels now show the backend keyword title (`flags.title`) and fall back to the raw value, matching how post pages render tags.

Surfaces changed:

- **Profile → Reading Overview → "Top tags by reading days"** — the reported bug (`capitalize(tag)`).
- **Tag page navbar tabs** and **tags directory rows** — previously `formatKeyword`, which invents a casing.
- **Recruiter top reader badges** — now use `flags.title` like every other top reader surface; the two opportunity queries request that field.

## Key decisions

**Where the titles come from.** `MostReadTag` doesn't expose `flags`, and `recommendedTags` returns only a name — the API exposes titles solely on `Keyword`. So `tagTitlesQueryOptions` (in `graphql/keywords.ts`) loads the public tag directory once as a `value → title` map and shares it. It's ~1,000 keywords, all titled, ~10KB gzipped, cached a day. Written as an options creator rather than a hook, per `packages/shared/src/hooks/AGENTS.md`.

**Keyword page titles keep `formatKeyword`.** The tag page H1, `<title>`, and JSON-LD are untouched. [#6414](https://github.com/dailydotdev/apps/pull/6414) formatted that title source two days ago on purpose ("which required formatting its title source (`flags.title || formatKeyword(tag)`, previously the raw slug)"), so a tag without a backend title still gets a readable SEO title. The "no client-derived casing" rule is scoped to tag *labels*; `formatKeyword`'s doc comment and `AGENTS.md` now record that split.

**Trade-off worth a look:** `TagPageNavbar` now issues the directory query on statically-generated tag pages, so its tab labels hydrate from the raw slug to the title. Dropping the lookup there is a one-line change if you'd rather keep those pages request-free — the raw slug is still a valid representation.

## Test plan

- [x] `pnpm --filter @dailydotdev/shared test` — 327 suites / 2168 tests
- [x] `pnpm --filter webapp test` — 50 suites / 361 tests
- [x] `pnpm --filter extension test` — 6 suites / 43 tests
- [x] `pnpm --filter webapp build` — passes, incl. `/tags` and `/tags/[tag]`
- [x] `node ./scripts/typecheck-strict-changed.js` — only pre-existing errors (blamed to #5005, #3270, #2480)
- [x] New `ReadingOverview` case: the title wins when present, a title-less keyword keeps its raw value

Closes ENG-1922

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1922-fix-tags-presentation-o.preview.app.daily.dev