### PR TITLE
feat(world): let a reader name, dress and hide their own world

### DIFF
--- a/packages/shared/src/components/fields/Slider.tsx
+++ b/packages/shared/src/components/fields/Slider.tsx
@@ -2,22 +2,48 @@ import * as React from 'react';
 import * as SliderPrimitive from '@radix-ui/react-slider';
 import classNames from 'classnames';
 
-const Slider = ({
-  className,
-  ...props
-}: React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root>) => {
+interface SliderProps
+  extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+  /**
+   * Names the handle for assistive tech. It goes on the THUMB rather than the
+   * root, because the thumb is what carries `role="slider"` — an `aria-label`
+   * on the root reaches nothing, so a screen would otherwise read a bench of
+   * these as a row of identical unnamed sliders.
+   */
+  thumbLabel?: string;
+  /**
+   * For a bench of several sliders in a narrow column, where the default's
+   * 28px handle and 192px floor add up to a wall. One slider you are deciding
+   * something with wants the big handle; seven you are nudging do not.
+   */
+  compact?: boolean;
+}
+
+const Slider = ({ className, thumbLabel, compact, ...props }: SliderProps) => {
   return (
     <SliderPrimitive.Root
       {...props}
       className={classNames(
-        'relative flex h-5 min-w-48 touch-none select-none items-center',
+        'relative flex touch-none select-none items-center',
+        compact ? 'h-4 min-w-0' : 'h-5 min-w-48',
         className,
       )}
     >
-      <SliderPrimitive.Track className="relative h-2 flex-1 rounded-max bg-surface-disabled">
+      <SliderPrimitive.Track
+        className={classNames(
+          'relative flex-1 rounded-max bg-surface-disabled',
+          compact ? 'h-1' : 'h-2',
+        )}
+      >
         <SliderPrimitive.Range className="absolute h-full rounded-max bg-brand-default" />
       </SliderPrimitive.Track>
-      <SliderPrimitive.Thumb className="block h-7 w-7 rounded-max border-4 border-accent-cabbage-default bg-accent-cabbage-subtlest" />
+      <SliderPrimitive.Thumb
+        aria-label={thumbLabel}
+        className={classNames(
+          'block rounded-max border-accent-cabbage-default bg-accent-cabbage-subtlest',
+          compact ? 'h-3.5 w-3.5 border-2' : 'h-7 w-7 border-4',
+        )}
+      />
     </SliderPrimitive.Root>
   );
 };

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -292,6 +292,8 @@ export enum RequestKey {
   LeaderboardPosition = 'leaderboard_position',
   UserWorld = 'user_world',
   UserWorldTimeline = 'user_world_timeline',
+  UserWorldSettings = 'user_world_settings',
+  UserWorldEntitlements = 'user_world_entitlements',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -292,7 +292,6 @@ export enum RequestKey {
   LeaderboardPosition = 'leaderboard_position',
   UserWorld = 'user_world',
   UserWorldTimeline = 'user_world_timeline',
-  UserWorldSettings = 'user_world_settings',
   UserWorldEntitlements = 'user_world_entitlements',
 }
 

--- a/packages/webapp/__tests__/WorldCustomize.spec.tsx
+++ b/packages/webapp/__tests__/WorldCustomize.spec.tsx
@@ -1,0 +1,208 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { WorldDistrict, WorldEntitlement } from '../graphql/world';
+// The sheet is the bench plus its shell, so this covers the footer too.
+import { WorldCustomizeSheet } from '../components/world/WorldCustomize';
+import type {
+  WorldDraft,
+  WorldDraftSettings,
+} from '../components/world/useWorldDraft';
+
+const mockEntitlements = jest.fn<
+  { entitlements?: WorldEntitlement[]; isPending: boolean },
+  []
+>();
+
+/* The bench asks the API what this world has earned. What it is allowed to
+   OFFER, given an answer, is what this file is about. */
+jest.mock('../components/world/useWorldSettings', () => ({
+  ...jest.requireActual('../components/world/useWorldSettings'),
+  useWorldEntitlements: () => mockEntitlements(),
+}));
+
+const EMPTY: WorldDraftSettings = {
+  name: null,
+  sky: null,
+  crest: null,
+  look: null,
+  private: false,
+};
+
+const district = (reads: number): WorldDistrict => ({
+  niche: { slug: 'ai_llm' },
+  reads,
+  firstReadAt: '2024-01-01',
+  lastReadAt: '2026-01-01',
+  activeDays: 12,
+});
+
+const openBench = (
+  settings: WorldDraftSettings = EMPTY,
+  districts: WorldDistrict[] = [district(40)],
+): WorldDraft => {
+  const draft: WorldDraft = {
+    isOpen: true,
+    settings,
+    setSettings: jest.fn(),
+    open: jest.fn(),
+    cancel: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
+    isSaving: false,
+    applied: null,
+  };
+
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <WorldCustomizeSheet
+        userId="u1"
+        draft={draft}
+        districts={districts}
+        settings={settings}
+      />
+    </QueryClientProvider>,
+  );
+
+  return draft;
+};
+
+beforeEach(() => {
+  mockEntitlements.mockReturnValue({
+    entitlements: [
+      { kind: 'charge', id: 'obelisk', source: 'niche:ai_llm' },
+      { kind: 'tincture', id: '#d97efe', source: 'niche:ai_llm' },
+      { kind: 'tincture', id: '#887bf8', source: 'niche:ai_llm' },
+    ],
+    isPending: false,
+  });
+});
+
+describe('WorldCustomize', () => {
+  it('offers only the charges this world has actually raised', () => {
+    openBench();
+
+    expect(screen.getByRole('button', { name: /Obelisk/ })).toBeInTheDocument();
+    // Somebody else's monument, and never on this shield.
+    expect(
+      screen.queryByRole('button', { name: /Anvil/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/1 of 26 charges earned/)).toBeInTheDocument();
+  });
+
+  /* Decided off the districts, so it needs no round trip — which is what stops
+     the section growing from one line into a crest under the reader's cursor. */
+  it('says a world has raised nothing without waiting for the catalogue', () => {
+    mockEntitlements.mockReturnValue({
+      entitlements: undefined,
+      isPending: true,
+    });
+    openBench(EMPTY, [district(2)]);
+
+    expect(
+      screen.getByText(/becomes a charge you can fly/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('img', { name: 'Your standard' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('draws its full height while the catalogue is still on the wire', () => {
+    mockEntitlements.mockReturnValue({
+      entitlements: undefined,
+      isPending: true,
+    });
+    openBench();
+
+    // The shield, both row labels and every division are in hand already; only
+    // the two rows that ARE the catalogue are placeheld.
+    expect(
+      screen.getByRole('img', { name: 'Your standard' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Per pale/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /Obelisk/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('lets the catalogue overrule the derivation when it grants nothing', () => {
+    mockEntitlements.mockReturnValue({ entitlements: [], isPending: false });
+    openBench();
+
+    expect(
+      screen.getByText(/becomes a charge you can fly/),
+    ).toBeInTheDocument();
+  });
+
+  it('suggests a name off the reading rather than leaving the field blank', () => {
+    openBench();
+
+    expect(screen.getByPlaceholderText(/Arcane Swarm/)).toBeInTheDocument();
+  });
+
+  it('commits a suggestion as a name the reader chose', () => {
+    const draft = openBench();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Another suggestion' }));
+
+    expect(draft.setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: expect.stringContaining('Arcane Swarm'),
+      }),
+    );
+  });
+
+  it('offers eight palettes and five hours over the same world', () => {
+    const draft = openBench();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Slate' }));
+    expect(draft.setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ sky: { pal: 'slate', hour: 'day' } }),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Night' }));
+    expect(draft.setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ sky: { pal: 'brand', hour: 'night' } }),
+    );
+  });
+
+  it('hides the world behind one switch', () => {
+    const draft = openBench();
+
+    fireEvent.click(screen.getByText('Private'));
+
+    expect(draft.setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ private: true }),
+    );
+  });
+
+  it('leaves the world the way it was found on cancel, and writes on save', () => {
+    const draft = openBench();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(draft.cancel).toHaveBeenCalled();
+    expect(draft.save).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+    expect(draft.save).toHaveBeenCalled();
+  });
+
+  it('forks the preset into a look of your own the moment a knob moves', () => {
+    const draft = openBench();
+
+    fireEvent.keyDown(screen.getByRole('slider', { name: 'Outline' }), {
+      key: 'ArrowRight',
+    });
+
+    expect(draft.setSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        look: expect.objectContaining({
+          id: 'mine',
+          base: 'diorama',
+          mine: true,
+        }),
+      }),
+    );
+  });
+});

--- a/packages/webapp/__tests__/useUserWorld.spec.tsx
+++ b/packages/webapp/__tests__/useUserWorld.spec.tsx
@@ -71,13 +71,33 @@ describe('useUserWorld', () => {
     expect(result.current.districts).toBeUndefined();
   });
 
-  it('still reports a real failure as one', async () => {
+  it('still reports a real failure as one, after retrying it', async () => {
+    jest.useFakeTimers();
     request.mockRejectedValue(new Error('network down'));
 
     const { result } = renderHook(() => useUserWorld('u1'), { wrapper });
 
-    await waitFor(() => expect(result.current.error).toBeDefined());
+    try {
+      await waitFor(() => expect(result.current.error).toBeDefined(), {
+        // Three retries on the default backoff before the failure is believed.
+        timeout: 10000,
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+    expect(request).toHaveBeenCalledTimes(4);
     expect(result.current.isPrivate).toBe(false);
+  });
+
+  it('does not retry a refused world', async () => {
+    request.mockRejectedValue({
+      response: { errors: [{ extensions: { code: 'FORBIDDEN' } }] },
+    });
+
+    const { result } = renderHook(() => useUserWorld('u1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isPrivate).toBe(true));
+    expect(request).toHaveBeenCalledTimes(1);
   });
 
   it('asks for nothing without a reader', () => {

--- a/packages/webapp/__tests__/useUserWorld.spec.tsx
+++ b/packages/webapp/__tests__/useUserWorld.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { useUserWorld } from '../components/world/useUserWorld';
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/graphql/common'),
+  gqlClient: { request: jest.fn() },
+}));
+
+const request = gqlClient.request as jest.Mock;
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+);
+
+beforeEach(() => {
+  request.mockReset();
+});
+
+describe('useUserWorld', () => {
+  it('raises the world and its dressing off one round trip', async () => {
+    const districts = [
+      {
+        niche: { slug: 'ai_llm' },
+        reads: 40,
+        firstReadAt: '2024-01-01',
+        lastReadAt: '2026-01-01',
+        activeDays: 12,
+      },
+    ];
+    const settings = {
+      name: 'The quiet scholar',
+      sky: null,
+      crest: null,
+      look: null,
+      private: false,
+    };
+    request.mockResolvedValue({
+      userWorld: districts,
+      userWorldSettings: settings,
+      // The timeline is a second query; this stub answers both.
+      userWorldTimeline: [],
+    });
+
+    const { result } = renderHook(() => useUserWorld('u1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.districts).toEqual(districts);
+    expect(result.current.settings).toEqual(settings);
+    expect(result.current.isPrivate).toBe(false);
+  });
+
+  it('reads a refused world as private rather than as broken', async () => {
+    request.mockRejectedValue({
+      response: { errors: [{ extensions: { code: 'FORBIDDEN' } }] },
+    });
+
+    const { result } = renderHook(() => useUserWorld('u1'), { wrapper });
+
+    await waitFor(() => expect(result.current.isPrivate).toBe(true));
+    // A hidden world is not a failed one: "could not be loaded" would be a lie
+    // about a decision somebody made deliberately.
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.districts).toBeUndefined();
+  });
+
+  it('still reports a real failure as one', async () => {
+    request.mockRejectedValue(new Error('network down'));
+
+    const { result } = renderHook(() => useUserWorld('u1'), { wrapper });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.isPrivate).toBe(false);
+  });
+
+  it('asks for nothing without a reader', () => {
+    renderHook(() => useUserWorld(undefined), { wrapper });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/__tests__/worldCustomization.spec.ts
+++ b/packages/webapp/__tests__/worldCustomization.spec.ts
@@ -1,0 +1,220 @@
+import type { WorldDistrict, WorldSettings } from '../graphql/world';
+import {
+  isWorldCustomised,
+  resolveCrest,
+  resolveLook,
+  resolveSky,
+  suggestedCrest,
+  WORLD_NAME_MAX_LENGTH,
+  worldSuggestions,
+} from '../components/world/worldCustomization';
+import { REALMS } from '../components/world/engine/taxonomy';
+import { worldSettingsPatch } from '../components/world/useWorldDraft';
+
+const district = (slug: string, reads: number): WorldDistrict => ({
+  niche: { slug },
+  reads,
+  firstReadAt: '2024-01-01',
+  lastReadAt: '2026-01-01',
+  activeDays: 10,
+});
+
+describe('worldSuggestions', () => {
+  it('names a world after the realm it read most', () => {
+    const [first] = worldSuggestions([
+      district('ai_llm', 400),
+      district('k8s', 12),
+    ]);
+
+    expect(first).toContain('Arcane Swarm');
+  });
+
+  it('offers several distinct shapes, so ✦ can be walked round', () => {
+    const suggestions = worldSuggestions([district('ai_llm', 400)]);
+
+    expect(suggestions.length).toBeGreaterThan(1);
+    expect(new Set(suggestions).size).toBe(suggestions.length);
+  });
+
+  /* ✦ COMMITS what it shows, and the API rejects a name over the limit — so a
+     suggestion that does not fit is a save that fails. Exhaustive rather than
+     spot-checked, because the overflow depends on which realm, role and epithet
+     happen to collide, and the longest realm name only meets the longest role in
+     one corner of the space. */
+  it('never suggests a name the field cannot hold', () => {
+    // Every realm, against every breadth (which picks the role) and every
+    // volume (which picks the epithet).
+    const breadths = REALMS.map((_, index) => index + 1);
+    const volumes = [1, 4, 40, 400, 4000, 40000];
+    const cases = REALMS.flatMap((realm) =>
+      breadths.flatMap((breadth) =>
+        volumes.map((reads) => {
+          // The realm under test reads most, so it is the one that gets named.
+          const districts = REALMS.slice(0, breadth).map((other) =>
+            district(other.niches[0].id, 1),
+          );
+          districts.push(district(realm.niches[0].id, reads * 2));
+
+          return worldSuggestions(districts);
+        }),
+      ),
+    );
+
+    cases.forEach((suggestions) => {
+      expect(suggestions.length).toBeGreaterThan(0);
+      suggestions.forEach((name) =>
+        expect(name.length).toBeLessThanOrEqual(WORLD_NAME_MAX_LENGTH),
+      );
+    });
+  });
+
+  it('still has something to call a world with nothing in it', () => {
+    expect(worldSuggestions([])).toEqual(['My world']);
+    expect(worldSuggestions(undefined)).toEqual(['My world']);
+  });
+
+  it('ignores a niche the taxonomy cannot place', () => {
+    expect(worldSuggestions([district('not_a_real_niche', 900)])).toEqual([
+      'My world',
+    ]);
+  });
+});
+
+describe('suggestedCrest', () => {
+  it('takes the charge from the largest district and the tinctures from the top two', () => {
+    const crest = suggestedCrest('u1', [
+      district('ai_llm', 40),
+      district('k8s', 12),
+    ]);
+
+    // `ai_llm` raises the obelisk; the taxonomy owns both accents.
+    expect(crest?.charge).toBe('obelisk');
+    expect(crest?.a).not.toBe(crest?.b);
+  });
+
+  it('has no mark at all until something has been raised', () => {
+    expect(suggestedCrest('u1', [district('ai_llm', 2)])).toBeNull();
+    expect(suggestedCrest('u1', [])).toBeNull();
+  });
+
+  it('picks the same division for the same reader every time', () => {
+    const districts = [district('ai_llm', 40)];
+
+    expect(suggestedCrest('u1', districts)?.div).toBe(
+      suggestedCrest('u1', districts)?.div,
+    );
+  });
+});
+
+describe('resolving what a world is drawn with', () => {
+  const stored = {
+    charge: 'anvilyard',
+    div: 'bend',
+    a: 0x111111,
+    b: 0x222222,
+  };
+
+  it('prefers what the owner chose over the suggestion', () => {
+    const settings = { crest: stored } as WorldSettings;
+
+    expect(resolveCrest(settings, 'u1', [district('ai_llm', 40)])).toBe(stored);
+  });
+
+  it('falls back to the suggestion when the owner never dressed it', () => {
+    expect(resolveCrest(null, 'u1', [district('ai_llm', 40)])?.charge).toBe(
+      'obelisk',
+    );
+  });
+
+  it('photographs an untouched world through DIORAMA', () => {
+    expect(resolveLook(null).id).toBe('diorama');
+    expect(resolveLook(undefined).mine).toBe(false);
+  });
+
+  it('hangs the file’s own sky over an untouched world', () => {
+    expect(resolveSky(null)).toEqual({ pal: 'brand', hour: 'day' });
+  });
+
+  it('shows a visitor the sky its owner picked, not a default', () => {
+    const sky = { pal: 'slate', hour: 'night' };
+
+    expect(resolveSky({ sky } as WorldSettings)).toBe(sky);
+  });
+});
+
+describe('isWorldCustomised', () => {
+  it('is false for a world nobody has made anything of', () => {
+    expect(isWorldCustomised(null)).toBe(false);
+    expect(
+      isWorldCustomised({
+        name: null,
+        sky: null,
+        crest: null,
+        look: null,
+        private: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('does not count hiding a world as making it yours', () => {
+    expect(
+      isWorldCustomised({
+        name: null,
+        sky: null,
+        crest: null,
+        look: null,
+        private: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('is true the moment it has a name', () => {
+    expect(
+      isWorldCustomised({
+        name: 'The quiet scholar',
+        sky: null,
+        crest: null,
+        look: null,
+        private: false,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('worldSettingsPatch', () => {
+  const saved: WorldSettings = {
+    name: 'Old name',
+    sky: null,
+    crest: null,
+    look: null,
+    private: false,
+  };
+
+  it('sends only what changed, so a rename does not pin the crest', () => {
+    const patch = worldSettingsPatch({ ...saved, name: 'New name' }, saved);
+
+    expect(patch).toEqual({ name: 'New name' });
+  });
+
+  it('clears a name back to the suggestion with an explicit null', () => {
+    expect(worldSettingsPatch({ ...saved, name: '  ' }, saved)).toEqual({
+      name: null,
+    });
+  });
+
+  it('is empty when the bench was opened and closed again', () => {
+    expect(worldSettingsPatch(saved, saved)).toEqual({});
+  });
+
+  it('treats a world with no stored settings as untouched', () => {
+    const draft = {
+      name: null,
+      sky: null,
+      crest: null,
+      look: null,
+      private: true,
+    };
+
+    expect(worldSettingsPatch(draft, null)).toEqual({ private: true });
+  });
+});

--- a/packages/webapp/components/world/WorldCustomize.tsx
+++ b/packages/webapp/components/world/WorldCustomize.tsx
@@ -1,0 +1,821 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useMemo, useState } from 'react';
+import classNames from 'classnames';
+import {
+  Button,
+  ButtonColor,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { TextField } from '@dailydotdev/shared/src/components/fields/TextField';
+import { Switch } from '@dailydotdev/shared/src/components/fields/Switch';
+import { Slider } from '@dailydotdev/shared/src/components/fields/Slider';
+import { MagicIcon } from '@dailydotdev/shared/src/components/icons';
+import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
+import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import type {
+  WorldCrest,
+  WorldDistrict,
+  WorldLook,
+  WorldLookKnob,
+  WorldSky,
+} from '../../graphql/world';
+import { CHARGES, crestDataUrl, DIVISIONS, hexs } from './engine/crest';
+import {
+  fmtKnob,
+  forkLook,
+  LOOK_DEFS,
+  LOOK_KNOBS,
+  lookFromPreset,
+} from './engine/look';
+import { useWorldEntitlements } from './useWorldSettings';
+import type { WorldDraft, WorldDraftSettings } from './useWorldDraft';
+import { SKY_HOUR, SKY_PAL } from './engine/sky';
+import {
+  resolveLook,
+  resolveSky,
+  suggestedCrest,
+  WORLD_NAME_MAX_LENGTH,
+  worldSuggestions,
+} from './worldCustomization';
+
+/* The crest tables and the look bench are the renderer's, and it is JavaScript
+   on purpose — ported near-verbatim from devcraft so every future diff against
+   the source stays readable. These are the shapes this file reads out of them. */
+const CHARGE_OF = CHARGES as Record<string, { n: string; d: string }>;
+const KNOBS = LOOK_KNOBS as {
+  k: WorldLookKnob;
+  n: string;
+  min: number;
+  max: number;
+  step: number;
+}[];
+/* The two swatch colours are the sky's own zenith and horizon, so a palette
+   chip is a thumbnail of the sky rather than a label for one. */
+const PALETTES = SKY_PAL as { id: string; n: string; a: number; b: number }[];
+const HOURS = SKY_HOUR as { id: string; n: string }[];
+
+/* What the crest rows stand in as while the entitlements are on the wire.
+   Everything else in that section is known on the first frame — the shield, the
+   two row labels and all six divisions — so only the two rows that ARE the
+   answer are placeheld, and the panel never changes height under the cursor.
+   Eight is the count a founded world usually has; the widths are varied so the
+   charge row reads as chips rather than as a progress bar. */
+const SWATCH_SKELETON = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+const CHARGE_SKELETON = [
+  { key: 'c1', width: 'w-24' },
+  { key: 'c2', width: 'w-20' },
+  { key: 'c3', width: 'w-28' },
+  { key: 'c4', width: 'w-20' },
+  { key: 'c5', width: 'w-24' },
+  { key: 'c6', width: 'w-16' },
+];
+
+/* No hint slot. Every one this panel had was its own heading in more words, and
+   the two that survived a first cut ("everyone who visits sees your world
+   through it", "private hides the world") were saying what the control they sat
+   under already says the moment you use it. */
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}): ReactElement => (
+  <section className="flex flex-col gap-2">
+    <Typography
+      tag={TypographyTag.H2}
+      type={TypographyType.Footnote}
+      color={TypographyColor.Tertiary}
+      bold
+    >
+      {title}
+    </Typography>
+    {children}
+  </section>
+);
+
+/**
+ * A labelled row of controls inside a section.
+ *
+ * Every chip row needs one. A section heading says what you are dressing; it
+ * cannot also say which axis a given row is, and a bare row of PLAIN / PER PALE
+ * / PER FESS is six words with nothing telling you what they are six of.
+ */
+const Row = ({
+  label,
+  children,
+}: {
+  label: string;
+  children: ReactNode;
+}): ReactElement => (
+  <div className="flex flex-col gap-1">
+    <Typography
+      type={TypographyType.Caption2}
+      color={TypographyColor.Quaternary}
+    >
+      {label}
+    </Typography>
+    {children}
+  </div>
+);
+
+/* The engine's tables are SHOUTED, because the lab they came from was a lab.
+   Converted here rather than in the tables themselves: they are ported
+   near-verbatim so future diffs against devcraft stay readable, and how a name
+   is CASED is this side's business anyway. */
+const sentence = (value: string) =>
+  value.charAt(0) + value.slice(1).toLowerCase();
+
+interface ChipProps {
+  selected: boolean;
+  label: string;
+  onClick: () => void;
+  icon?: ReactElement;
+  /** Rendered by the chip, so the trigger the tooltip clones is the Button. */
+  tooltip?: string;
+  className?: string;
+}
+
+/**
+ * One chip for palettes, hours, presets, divisions and charges.
+ *
+ * The same shared Button in the same two states the tag pickers use — cabbage
+ * primary when it is chosen, float when it is not. There is nothing special
+ * about a chip on this panel, so it should not be a component that says there
+ * is: five near-copies of a selected state is five places for it to drift out
+ * of the design system.
+ */
+const Chip = ({
+  selected,
+  label,
+  onClick,
+  icon,
+  tooltip,
+  className,
+}: ChipProps): ReactElement => {
+  const shared = {
+    type: 'button' as const,
+    size: ButtonSize.XSmall,
+    icon,
+    pressed: selected,
+    onClick,
+    className,
+  };
+  /* Two branches rather than one with a conditional `color`, because Button's
+     props are a union that takes colour and variant together or neither — the
+     same shape `TagElement` picks a selected tag with. */
+  const button = selected ? (
+    <Button
+      {...shared}
+      variant={ButtonVariant.Primary}
+      color={ButtonColor.Cabbage}
+    >
+      {sentence(label)}
+    </Button>
+  ) : (
+    <Button {...shared} variant={ButtonVariant.Float}>
+      {sentence(label)}
+    </Button>
+  );
+
+  if (!tooltip) {
+    return button;
+  }
+
+  return <Tooltip content={tooltip}>{button}</Tooltip>;
+};
+
+/** A colour a chip carries: the two ends of a sky, or a look's two inks. */
+const ChipSwatch = ({
+  from,
+  to,
+}: {
+  from: number;
+  to: number;
+}): ReactElement => (
+  <i
+    className="h-3 w-3 flex-none rounded-4"
+    style={{
+      background: `linear-gradient(135deg, ${hexs(from)}, ${hexs(to)})`,
+    }}
+  />
+);
+
+/**
+ * A tincture to pick. Bespoke on purpose and the only thing here that is: it is
+ * a swatch of one specific colour, which is the one control the design system
+ * has no token for — the colour IS the value.
+ */
+const Swatch = ({
+  colour,
+  selected,
+  onClick,
+  label,
+}: {
+  colour: number;
+  selected: boolean;
+  onClick: () => void;
+  /** Which row this is, for a screen reader. The tooltip shows only the hex —
+      the row is already labelled right above it for anyone who can see it. */
+  label: string;
+}): ReactElement => (
+  <Tooltip content={hexs(colour)}>
+    <button
+      type="button"
+      aria-label={`${label} ${hexs(colour)}`}
+      aria-pressed={selected}
+      onClick={onClick}
+      style={{ background: hexs(colour) }}
+      className={classNames(
+        'h-6 w-6 flex-none rounded-8 border-2',
+        selected ? 'border-text-primary' : 'border-transparent',
+      )}
+    />
+  </Tooltip>
+);
+
+const CrestGlyph = ({ charge }: { charge: string }): ReactElement => (
+  <svg viewBox="-52 -52 104 104" aria-hidden className="h-4 w-4 flex-none">
+    <path
+      d={(CHARGE_OF[charge] ?? CHARGE_OF.obelisk).d}
+      fill="currentColor"
+      fillRule="evenodd"
+    />
+  </svg>
+);
+
+/**
+ * The mark, drawn by the same emitter that paints the banner flying over the
+ * world. A second SVG copy for the DOM would be the same shield drawn twice and
+ * drifting apart by the second change.
+ */
+const CrestPreview = ({ crest }: { crest: WorldCrest }): ReactElement => {
+  const url = useMemo(() => crestDataUrl(crest), [crest]);
+
+  return (
+    <div
+      role="img"
+      aria-label="Your standard"
+      /* The shield's own 176:208, so the drawing is never squeezed. */
+      className="aspect-[176/208] w-18 flex-none bg-contain bg-center bg-no-repeat"
+      style={{ backgroundImage: url ? `url(${url})` : undefined }}
+    />
+  );
+};
+
+interface CrestBenchProps {
+  userId: string;
+  crest: WorldCrest | null;
+  /**
+   * What is flying over the world right now, for a reader who has never touched
+   * the crest. Derived by the caller from the same districts the renderer used,
+   * so opening the bench shows the mark they can already see rather than a
+   * second, differently-derived one.
+   */
+  suggestion: WorldCrest | null;
+  onChange: (crest: WorldCrest) => void;
+}
+
+/**
+ * The standard: a charge out of the monuments you have raised, tinctures out of
+ * the districts you founded, and a division that is free because a division
+ * encodes nothing. You cannot build one that lies.
+ *
+ * Committing writes the WHOLE crest rather than the one field that changed:
+ * until somebody touches it there is no stored crest at all, so patching a
+ * single key onto nothing would save a division with no charge under it.
+ *
+ * It draws its full height on the FIRST frame. Only the catalogue needs the
+ * network — what the shield currently looks like, what the rows are called and
+ * which divisions exist are all in hand — so the entitlements land into two rows
+ * of placeholders rather than into a one-line "loading" that then grows into a
+ * section and shoves the sky, the look and the Save button down the panel.
+ */
+const CrestBench = ({
+  userId,
+  crest,
+  suggestion,
+  onChange,
+}: CrestBenchProps): ReactElement => {
+  const { entitlements, isPending } = useWorldEntitlements(userId, true);
+  const charges = useMemo(
+    () =>
+      (entitlements ?? [])
+        .filter(({ kind }) => kind === 'charge')
+        .map(({ id }) => id),
+    [entitlements],
+  );
+  const tinctures = useMemo(
+    () =>
+      (entitlements ?? [])
+        .filter(({ kind }) => kind === 'tincture')
+        .map(({ id }) => parseInt(id.replace('#', ''), 16)),
+    [entitlements],
+  );
+
+  /* Eligibility is having built something, and it is answered WITHOUT the query:
+     `suggestion` is derived from the same districts the renderer used and by the
+     same rule the API applies, so a world with nothing raised says so on the
+     first frame instead of after a round trip that could only agree. A stored
+     crest is proof on its own — you cannot un-earn a charge. */
+  /* The second term is the API having the last word: if it grants nothing after
+     all, its answer wins over the derivation. That path does shift the panel,
+     and it should — the two disagreeing is a real event, not a loading state. */
+  if ((!crest && !suggestion) || (!isPending && !charges.length)) {
+    return (
+      <Typography
+        type={TypographyType.Caption1}
+        color={TypographyColor.Quaternary}
+      >
+        Read a topic three times and its monument becomes a charge you can fly.
+      </Typography>
+    );
+  }
+
+  /* The stored crest, then the one already flying, and only then a first-of-each
+     assembly — which is reachable when the API has granted something the
+     renderer's own derivation did not pick. */
+  const current: WorldCrest = crest ??
+    suggestion ?? {
+      charge: charges[0],
+      div: DIVISIONS[0].id,
+      a: tinctures[0],
+      b: tinctures[1] ?? tinctures[0],
+    };
+  const set = (patch: Partial<WorldCrest>) =>
+    onChange({ ...current, ...patch });
+  const total = Object.keys(CHARGES).length;
+
+  return (
+    <>
+      <div className="flex items-start gap-3">
+        <CrestPreview crest={current} />
+        <div className="flex min-w-0 flex-1 flex-col gap-2">
+          <Row label="Field">
+            <div className="flex flex-wrap gap-1">
+              {isPending
+                ? SWATCH_SKELETON.map((key) => (
+                    <ElementPlaceholder
+                      key={`a-${key}`}
+                      className="h-6 w-6 rounded-8"
+                    />
+                  ))
+                : tinctures.map((colour) => (
+                    <Swatch
+                      key={`a-${colour}`}
+                      colour={colour}
+                      selected={colour === current.a}
+                      onClick={() => set({ a: colour })}
+                      label="Field"
+                    />
+                  ))}
+            </div>
+          </Row>
+          <Row label="Second tincture">
+            <div className="flex flex-wrap gap-1">
+              {isPending
+                ? SWATCH_SKELETON.map((key) => (
+                    <ElementPlaceholder
+                      key={`b-${key}`}
+                      className="h-6 w-6 rounded-8"
+                    />
+                  ))
+                : tinctures.map((colour) => (
+                    <Swatch
+                      key={`b-${colour}`}
+                      colour={colour}
+                      selected={colour === current.b}
+                      onClick={() => set({ b: colour })}
+                      label="Second tincture"
+                    />
+                  ))}
+            </div>
+          </Row>
+        </div>
+      </div>
+
+      <Row label="Pattern">
+        <div className="flex flex-wrap gap-1">
+          {DIVISIONS.map((division) => (
+            <Chip
+              key={division.id}
+              label={division.n}
+              selected={division.id === current.div}
+              onClick={() => set({ div: division.id })}
+            />
+          ))}
+        </div>
+      </Row>
+
+      <Row label="Charge">
+        <div className="flex flex-wrap gap-1">
+          {isPending
+            ? CHARGE_SKELETON.map(({ key, width }) => (
+                <ElementPlaceholder
+                  key={key}
+                  className={classNames('h-6 rounded-8', width)}
+                />
+              ))
+            : charges.map((charge) => (
+                <Chip
+                  key={charge}
+                  label={(CHARGE_OF[charge] ?? CHARGE_OF.obelisk).n}
+                  selected={charge === current.charge}
+                  icon={<CrestGlyph charge={charge} />}
+                  onClick={() => set({ charge })}
+                />
+              ))}
+        </div>
+      </Row>
+
+      {/* Real work, this line: it is where a reader finds out the catalogue IS
+          the portrait. Without it the charge row reads as a short list of icons
+          rather than as the list of things they have built. */}
+      <Typography
+        type={TypographyType.Caption1}
+        color={TypographyColor.Quaternary}
+      >
+        {isPending ? (
+          <ElementPlaceholder className="inline-block h-3 w-32 rounded-4 align-middle" />
+        ) : (
+          `${charges.length} of ${total} charges earned`
+        )}
+      </Typography>
+    </>
+  );
+};
+
+interface SkyBenchProps {
+  sky: WorldSky;
+  onChange: (sky: WorldSky) => void;
+}
+
+/**
+ * Eight palettes and five hours: forty skies.
+ *
+ * Two axes rather than one list of forty, because two axes is what makes a sky
+ * feel FOUND instead of picked — you arrive at a combination nobody put in a
+ * menu. Both are free because neither carries a fact: the sky used to report
+ * whichever realm you had been reading lately, and losing that readout is
+ * exactly what let it be handed over. Which quarters of the map are large says
+ * the same thing, permanently and unfakeably.
+ */
+const SkyBench = ({ sky, onChange }: SkyBenchProps): ReactElement => (
+  <>
+    <Row label="Palette">
+      <div className="flex flex-wrap gap-1">
+        {PALETTES.map((palette) => (
+          <Chip
+            key={palette.id}
+            label={palette.n}
+            selected={palette.id === sky.pal}
+            icon={<ChipSwatch from={palette.a} to={palette.b} />}
+            onClick={() => onChange({ ...sky, pal: palette.id })}
+          />
+        ))}
+      </div>
+    </Row>
+    <Row label="Hour">
+      <div className="flex flex-wrap gap-1">
+        {HOURS.map((hour) => (
+          <Chip
+            key={hour.id}
+            label={hour.n}
+            selected={hour.id === sky.hour}
+            onClick={() => onChange({ ...sky, hour: hour.id })}
+          />
+        ))}
+      </div>
+    </Row>
+  </>
+);
+
+interface LookBenchProps {
+  look: WorldLook;
+  onChange: (look: WorldLook) => void;
+}
+
+/**
+ * Six starting points and the seven knobs that fork one.
+ *
+ * The knobs are on screen rather than behind a disclosure, which is how the lab
+ * had them and the reason is the same: a preset is a starting point, and the
+ * whole claim of this section is that your taste gets the last word. Folded away
+ * they read as an advanced mode nobody is expected to open, which is the
+ * opposite of the offer.
+ *
+ * Moving one deselects the presets and that is the entire ceremony. A look of
+ * your own does not have to be named, saved or confirmed — it is just what the
+ * knobs are set to, and clicking any preset is how you leave it again.
+ *
+ * Called a LOOK everywhere in the code and "Vibes" on the panel. The API field,
+ * the engine's uniforms and devcraft all say `look`, so renaming the code to
+ * follow one label would put a translation layer between this file and the three
+ * things it talks to.
+ */
+const LookBench = ({ look, onChange }: LookBenchProps): ReactElement => {
+  return (
+    <>
+      <Row label="Preset">
+        <div className="flex flex-wrap gap-1">
+          {LOOK_DEFS.map((preset) => (
+            <Chip
+              key={preset.id}
+              label={preset.n}
+              tooltip={preset.d}
+              /* Picking a preset throws the fork away, which is the honest
+                 reading of the gesture — you clicked a different look. */
+              selected={!look.mine && preset.id === look.id}
+              icon={<ChipSwatch from={preset.sw[0]} to={preset.sw[1]} />}
+              onClick={() => onChange(lookFromPreset(preset.id))}
+            />
+          ))}
+        </div>
+      </Row>
+
+      <Row label="Fine-tune">
+        <div className="flex flex-col gap-3">
+          {/* One row per knob: name, track, number. Stacked label-over-slider is
+              twice the height for seven of them, and the rail has a crest and a
+              preset row above it and a Save under it. */}
+          {KNOBS.map(({ k, n, min, max, step }) => (
+            <div key={k} className="flex items-center gap-2">
+              <Typography
+                type={TypographyType.Caption1}
+                color={TypographyColor.Tertiary}
+                className="w-14 flex-none"
+                truncate
+              >
+                {n}
+              </Typography>
+              <Slider
+                compact
+                thumbLabel={n}
+                className="flex-1"
+                min={min}
+                max={max}
+                step={step}
+                value={[look[k]]}
+                /* Any knob turns the preset into a look of your own. It is not
+                   a mode you enter, it is what happens the moment you disagree
+                   with one. */
+                onValueChange={([value]) =>
+                  onChange(forkLook(look, { [k]: value }))
+                }
+              />
+              <Typography
+                type={TypographyType.Caption1}
+                color={TypographyColor.Quaternary}
+                className="w-8 flex-none text-right tabular-nums"
+              >
+                {fmtKnob(k, look[k])}
+              </Typography>
+            </div>
+          ))}
+        </div>
+      </Row>
+    </>
+  );
+};
+
+/**
+ * The bench's own title bar. It replaces the rail's "Back to profile" rather
+ * than sitting under it: while the bench is open the way out is out of the
+ * bench, and two back affordances one above the other is a reader guessing
+ * which one loses their edits.
+ */
+function WorldCustomizeHeader({
+  onCancel,
+}: {
+  onCancel: () => void;
+}): ReactElement {
+  return (
+    <header className="flex items-center justify-between gap-2">
+      <Typography type={TypographyType.Body} bold>
+        Make it yours
+      </Typography>
+      <CloseButton
+        type="button"
+        size={ButtonSize.Small}
+        aria-label="Close customisation"
+        onClick={onCancel}
+      />
+    </header>
+  );
+}
+
+interface WorldCustomizeProps {
+  userId: string;
+  draft: WorldDraft;
+  districts?: WorldDistrict[];
+  settings: WorldDraftSettings;
+}
+
+/**
+ * What the gear opens: the one place a world can be made somebody's own.
+ *
+ * Every edit lands on the world behind the panel immediately — this is a bench
+ * over a live frame, not a form with a preview pane — and Save is what makes it
+ * survive a reload. Cancel puts the world back the way it was found.
+ *
+ * Land, level, density and monuments are not in here and never will be. Those
+ * are the portrait: the reading writes them, and nothing on this panel can make
+ * a world claim to be bigger than it was read into being.
+ */
+function WorldCustomize({
+  userId,
+  draft,
+  districts,
+  settings,
+}: WorldCustomizeProps): ReactElement {
+  const { setSettings, error } = draft;
+  const [suggestion, setSuggestion] = useState(0);
+  const suggestions = useMemo(() => worldSuggestions(districts), [districts]);
+  const patch = (next: Partial<WorldDraftSettings>) =>
+    setSettings({ ...settings, ...next });
+
+  return (
+    <div className="flex flex-col gap-5">
+      {/* One label, not two. The heading names the field, so the field's own
+          label is there for a screen reader and nowhere else. */}
+      <Section title="Name">
+        <TextField
+          inputId="world-name"
+          name="worldName"
+          label="World name"
+          fieldType="secondary"
+          className={{ outerLabel: 'sr-only' }}
+          maxLength={WORLD_NAME_MAX_LENGTH}
+          value={settings.name ?? ''}
+          placeholder={suggestions[0]}
+          valueChanged={(name) => patch({ name })}
+          actionButton={
+            <Tooltip content="Another suggestion">
+              <Button
+                type="button"
+                aria-label="Another suggestion"
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={<MagicIcon />}
+                /* ✦ does not reroll. It walks a fixed list of shapes built from
+                   the same facts, so pressing it four times and landing back on
+                   the first one is possible. A suggestion you accept is still a
+                   name you chose, so it commits. */
+                onClick={() => {
+                  const next = (suggestion + 1) % suggestions.length;
+                  setSuggestion(next);
+                  patch({ name: suggestions[next] });
+                }}
+              />
+            </Tooltip>
+          }
+        />
+      </Section>
+
+      <Section title="Crest">
+        <CrestBench
+          userId={userId}
+          crest={settings.crest}
+          suggestion={suggestedCrest(userId, districts)}
+          onChange={(crest) => patch({ crest })}
+        />
+      </Section>
+
+      <Section title="Sky">
+        <SkyBench
+          sky={resolveSky(settings)}
+          onChange={(sky) => patch({ sky })}
+        />
+      </Section>
+
+      <Section title="Vibes">
+        <LookBench
+          look={resolveLook(settings)}
+          onChange={(look) => patch({ look })}
+        />
+      </Section>
+
+      <Section title="Who can see it">
+        <Switch
+          inputId="world-private"
+          name="worldPrivate"
+          checked={settings.private}
+          onToggle={() => patch({ private: !settings.private })}
+        >
+          Private
+        </Switch>
+      </Section>
+
+      {!!error && (
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.StatusError}
+        >
+          {error}
+        </Typography>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The bench's own shell: a scrolling column with a bar bolted to the bottom.
+ *
+ * The bar is OUTSIDE the scroller rather than sticky inside it. Sticky only
+ * pins an element once the content is long enough to push it off — so on a
+ * short bench it comes to rest wherever the sections happen to end, floating in
+ * the middle of the rail. A footer that is sometimes at the bottom is worse
+ * than one that never is.
+ */
+function WorldBench({
+  draft,
+  children,
+  className,
+}: {
+  draft: WorldDraft;
+  children: ReactNode;
+  className?: string;
+}): ReactElement {
+  const { cancel, save, isSaving } = draft;
+
+  return (
+    <div
+      data-world-overlay
+      className={classNames(
+        'pointer-events-auto z-3 flex flex-col bg-background-default',
+        className,
+      )}
+    >
+      <div className="flex flex-1 flex-col gap-4 overflow-y-auto p-4">
+        <WorldCustomizeHeader onCancel={cancel} />
+        {children}
+      </div>
+      <div className="flex flex-none gap-2 border-t border-border-subtlest-tertiary p-4">
+        <Button
+          type="button"
+          variant={ButtonVariant.Float}
+          size={ButtonSize.Small}
+          onClick={cancel}
+          disabled={isSaving}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="button"
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Small}
+          className="flex-1"
+          onClick={save}
+          loading={isSaving}
+        >
+          Save
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/** The bench in the rail it replaces, on laptop and up. */
+export function WorldCustomizeRail({
+  draft,
+  ...props
+}: WorldCustomizeProps): ReactElement {
+  return (
+    <WorldBench
+      draft={draft}
+      className="absolute inset-y-0 left-0 z-1 w-80 border-r border-border-subtlest-tertiary"
+    >
+      <WorldCustomize draft={draft} {...props} />
+    </WorldBench>
+  );
+}
+
+/**
+ * The same bench below laptop, where there is no rail for it to replace.
+ *
+ * It takes the whole screen rather than opening as a drawer over the map: every
+ * control in here changes what the world looks like, and a sheet covering the
+ * bottom half of a phone leaves a strip of world too small to judge a grade by.
+ * The world is still live underneath — closing it is one tap away.
+ */
+export function WorldCustomizeSheet({
+  draft,
+  ...props
+}: WorldCustomizeProps): ReactElement {
+  return (
+    <WorldBench
+      draft={draft}
+      className="absolute inset-3 overflow-hidden rounded-16 border border-border-subtlest-tertiary"
+    >
+      <WorldCustomize draft={draft} {...props} />
+    </WorldBench>
+  );
+}

--- a/packages/webapp/components/world/WorldCustomize.tsx
+++ b/packages/webapp/components/world/WorldCustomize.tsx
@@ -394,16 +394,17 @@ const CrestBench = ({
         </div>
       </Row>
 
-      <Typography
-        type={TypographyType.Caption1}
-        color={TypographyColor.Quaternary}
-      >
-        {isPending ? (
-          <ElementPlaceholder className="inline-block h-3 w-32 rounded-4 align-middle" />
-        ) : (
-          `${charges.length} of ${total} charges earned`
-        )}
-      </Typography>
+      {/* The placeholder div may not nest in Typography's p. */}
+      {isPending ? (
+        <ElementPlaceholder className="h-4 w-32 rounded-4" />
+      ) : (
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Quaternary}
+        >
+          {`${charges.length} of ${total} charges earned`}
+        </Typography>
+      )}
     </>
   );
 };

--- a/packages/webapp/components/world/WorldCustomize.tsx
+++ b/packages/webapp/components/world/WorldCustomize.tsx
@@ -46,9 +46,7 @@ import {
   worldSuggestions,
 } from './worldCustomization';
 
-/* The crest tables and the look bench are the renderer's, and it is JavaScript
-   on purpose — ported near-verbatim from devcraft so every future diff against
-   the source stays readable. These are the shapes this file reads out of them. */
+/* Ported near-verbatim from devcraft's JS renderer so future diffs against the source stay readable. */
 const CHARGE_OF = CHARGES as Record<string, { n: string; d: string }>;
 const KNOBS = LOOK_KNOBS as {
   k: WorldLookKnob;
@@ -57,17 +55,11 @@ const KNOBS = LOOK_KNOBS as {
   max: number;
   step: number;
 }[];
-/* The two swatch colours are the sky's own zenith and horizon, so a palette
-   chip is a thumbnail of the sky rather than a label for one. */
+/* palette.a/b are the sky's own zenith and horizon colours, used as the chip swatch. */
 const PALETTES = SKY_PAL as { id: string; n: string; a: number; b: number }[];
 const HOURS = SKY_HOUR as { id: string; n: string }[];
 
-/* What the crest rows stand in as while the entitlements are on the wire.
-   Everything else in that section is known on the first frame — the shield, the
-   two row labels and all six divisions — so only the two rows that ARE the
-   answer are placeheld, and the panel never changes height under the cursor.
-   Eight is the count a founded world usually has; the widths are varied so the
-   charge row reads as chips rather than as a progress bar. */
+/* Only the tincture/charge rows need the network, so only they get skeletons — keeps panel height stable while entitlements load. */
 const SWATCH_SKELETON = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
 const CHARGE_SKELETON = [
   { key: 'c1', width: 'w-24' },
@@ -78,10 +70,6 @@ const CHARGE_SKELETON = [
   { key: 'c6', width: 'w-16' },
 ];
 
-/* No hint slot. Every one this panel had was its own heading in more words, and
-   the two that survived a first cut ("everyone who visits sees your world
-   through it", "private hides the world") were saying what the control they sat
-   under already says the moment you use it. */
 const Section = ({
   title,
   children,
@@ -102,13 +90,6 @@ const Section = ({
   </section>
 );
 
-/**
- * A labelled row of controls inside a section.
- *
- * Every chip row needs one. A section heading says what you are dressing; it
- * cannot also say which axis a given row is, and a bare row of PLAIN / PER PALE
- * / PER FESS is six words with nothing telling you what they are six of.
- */
 const Row = ({
   label,
   children,
@@ -127,10 +108,7 @@ const Row = ({
   </div>
 );
 
-/* The engine's tables are SHOUTED, because the lab they came from was a lab.
-   Converted here rather than in the tables themselves: they are ported
-   near-verbatim so future diffs against devcraft stay readable, and how a name
-   is CASED is this side's business anyway. */
+/* Converted here rather than in the source tables, since they're ported near-verbatim to keep diffs against devcraft readable. */
 const sentence = (value: string) =>
   value.charAt(0) + value.slice(1).toLowerCase();
 
@@ -144,15 +122,7 @@ interface ChipProps {
   className?: string;
 }
 
-/**
- * One chip for palettes, hours, presets, divisions and charges.
- *
- * The same shared Button in the same two states the tag pickers use — cabbage
- * primary when it is chosen, float when it is not. There is nothing special
- * about a chip on this panel, so it should not be a component that says there
- * is: five near-copies of a selected state is five places for it to drift out
- * of the design system.
- */
+/** Shared chip for palettes, hours, presets, divisions and charges — reuses Button's selected state rather than five near-copies. */
 const Chip = ({
   selected,
   label,
@@ -209,11 +179,7 @@ const ChipSwatch = ({
   />
 );
 
-/**
- * A tincture to pick. Bespoke on purpose and the only thing here that is: it is
- * a swatch of one specific colour, which is the one control the design system
- * has no token for — the colour IS the value.
- */
+/** Bespoke control: a swatch of one specific colour, the one thing with no design-system token. */
 const Swatch = ({
   colour,
   selected,
@@ -223,8 +189,7 @@ const Swatch = ({
   colour: number;
   selected: boolean;
   onClick: () => void;
-  /** Which row this is, for a screen reader. The tooltip shows only the hex —
-      the row is already labelled right above it for anyone who can see it. */
+  /** Row name for screen readers; the tooltip shows only the hex. */
   label: string;
 }): ReactElement => (
   <Tooltip content={hexs(colour)}>
@@ -252,11 +217,7 @@ const CrestGlyph = ({ charge }: { charge: string }): ReactElement => (
   </svg>
 );
 
-/**
- * The mark, drawn by the same emitter that paints the banner flying over the
- * world. A second SVG copy for the DOM would be the same shield drawn twice and
- * drifting apart by the second change.
- */
+/** Reuses the same emitter that paints the world's banner, to avoid two shield implementations drifting apart. */
 const CrestPreview = ({ crest }: { crest: WorldCrest }): ReactElement => {
   const url = useMemo(() => crestDataUrl(crest), [crest]);
 
@@ -274,30 +235,14 @@ const CrestPreview = ({ crest }: { crest: WorldCrest }): ReactElement => {
 interface CrestBenchProps {
   userId: string;
   crest: WorldCrest | null;
-  /**
-   * What is flying over the world right now, for a reader who has never touched
-   * the crest. Derived by the caller from the same districts the renderer used,
-   * so opening the bench shows the mark they can already see rather than a
-   * second, differently-derived one.
-   */
+  /** Must derive from the same districts the renderer used, so the bench opens showing the mark already visible on the world. */
   suggestion: WorldCrest | null;
   onChange: (crest: WorldCrest) => void;
 }
 
 /**
- * The standard: a charge out of the monuments you have raised, tinctures out of
- * the districts you founded, and a division that is free because a division
- * encodes nothing. You cannot build one that lies.
- *
- * Committing writes the WHOLE crest rather than the one field that changed:
- * until somebody touches it there is no stored crest at all, so patching a
- * single key onto nothing would save a division with no charge under it.
- *
- * It draws its full height on the FIRST frame. Only the catalogue needs the
- * network — what the shield currently looks like, what the rows are called and
- * which divisions exist are all in hand — so the entitlements land into two rows
- * of placeholders rather than into a one-line "loading" that then grows into a
- * section and shoves the sky, the look and the Save button down the panel.
+ * Commits the whole crest, not a patch: until saved there is no stored crest, so writing one key would leave a division with no charge under it.
+ * Renders full height on the first frame — only the catalogue needs the network, so entitlements land into placeholder rows instead of growing the panel.
  */
 const CrestBench = ({
   userId,
@@ -305,7 +250,10 @@ const CrestBench = ({
   suggestion,
   onChange,
 }: CrestBenchProps): ReactElement => {
-  const { entitlements, isPending } = useWorldEntitlements(userId, true);
+  const { entitlements, isPending, isError } = useWorldEntitlements(
+    userId,
+    true,
+  );
   const charges = useMemo(
     () =>
       (entitlements ?? [])
@@ -321,15 +269,13 @@ const CrestBench = ({
     [entitlements],
   );
 
-  /* Eligibility is having built something, and it is answered WITHOUT the query:
-     `suggestion` is derived from the same districts the renderer used and by the
-     same rule the API applies, so a world with nothing raised says so on the
-     first frame instead of after a round trip that could only agree. A stored
-     crest is proof on its own — you cannot un-earn a charge. */
-  /* The second term is the API having the last word: if it grants nothing after
-     all, its answer wins over the derivation. That path does shift the panel,
-     and it should — the two disagreeing is a real event, not a loading state. */
-  if ((!crest && !suggestion) || (!isPending && !charges.length)) {
+  const earned = crest ?? suggestion;
+  /* Eligibility is answered without the query: `suggestion` derives from the
+     same districts by the same rule the API applies, and a stored crest is
+     proof on its own. The second term is the API having the last word when it
+     genuinely grants nothing — a failed request is not that answer, so it gets
+     its own state below instead of masquerading as "nothing earned". */
+  if (!earned || (!isPending && !isError && !charges.length)) {
     return (
       <Typography
         type={TypographyType.Caption1}
@@ -340,9 +286,21 @@ const CrestBench = ({
     );
   }
 
-  /* The stored crest, then the one already flying, and only then a first-of-each
-     assembly — which is reachable when the API has granted something the
-     renderer's own derivation did not pick. */
+  if (isError && !entitlements) {
+    return (
+      <div className="flex items-start gap-3">
+        <CrestPreview crest={earned} />
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Quaternary}
+        >
+          Your charges could not be loaded. Try again in a moment.
+        </Typography>
+      </div>
+    );
+  }
+
+  /* Falls back stored crest -> suggestion -> first-of-each, reachable only when the API grants something the renderer's derivation missed. */
   const current: WorldCrest = crest ??
     suggestion ?? {
       charge: charges[0],
@@ -436,9 +394,6 @@ const CrestBench = ({
         </div>
       </Row>
 
-      {/* Real work, this line: it is where a reader finds out the catalogue IS
-          the portrait. Without it the charge row reads as a short list of icons
-          rather than as the list of things they have built. */}
       <Typography
         type={TypographyType.Caption1}
         color={TypographyColor.Quaternary}
@@ -458,16 +413,7 @@ interface SkyBenchProps {
   onChange: (sky: WorldSky) => void;
 }
 
-/**
- * Eight palettes and five hours: forty skies.
- *
- * Two axes rather than one list of forty, because two axes is what makes a sky
- * feel FOUND instead of picked — you arrive at a combination nobody put in a
- * menu. Both are free because neither carries a fact: the sky used to report
- * whichever realm you had been reading lately, and losing that readout is
- * exactly what let it be handed over. Which quarters of the map are large says
- * the same thing, permanently and unfakeably.
- */
+/** Palette and hour are two independent, purely decorative axes — neither encodes any reading data. */
 const SkyBench = ({ sky, onChange }: SkyBenchProps): ReactElement => (
   <>
     <Row label="Palette">
@@ -503,24 +449,7 @@ interface LookBenchProps {
   onChange: (look: WorldLook) => void;
 }
 
-/**
- * Six starting points and the seven knobs that fork one.
- *
- * The knobs are on screen rather than behind a disclosure, which is how the lab
- * had them and the reason is the same: a preset is a starting point, and the
- * whole claim of this section is that your taste gets the last word. Folded away
- * they read as an advanced mode nobody is expected to open, which is the
- * opposite of the offer.
- *
- * Moving one deselects the presets and that is the entire ceremony. A look of
- * your own does not have to be named, saved or confirmed — it is just what the
- * knobs are set to, and clicking any preset is how you leave it again.
- *
- * Called a LOOK everywhere in the code and "Vibes" on the panel. The API field,
- * the engine's uniforms and devcraft all say `look`, so renaming the code to
- * follow one label would put a translation layer between this file and the three
- * things it talks to.
- */
+/** Called `look` in code/API/engine and "Vibes" on the panel — don't rename the code to match the label, it would add a translation layer against devcraft and the API field. */
 const LookBench = ({ look, onChange }: LookBenchProps): ReactElement => {
   return (
     <>
@@ -531,8 +460,7 @@ const LookBench = ({ look, onChange }: LookBenchProps): ReactElement => {
               key={preset.id}
               label={preset.n}
               tooltip={preset.d}
-              /* Picking a preset throws the fork away, which is the honest
-                 reading of the gesture — you clicked a different look. */
+              /* Picking a preset discards any fork of the current look. */
               selected={!look.mine && preset.id === look.id}
               icon={<ChipSwatch from={preset.sw[0]} to={preset.sw[1]} />}
               onClick={() => onChange(lookFromPreset(preset.id))}
@@ -543,9 +471,7 @@ const LookBench = ({ look, onChange }: LookBenchProps): ReactElement => {
 
       <Row label="Fine-tune">
         <div className="flex flex-col gap-3">
-          {/* One row per knob: name, track, number. Stacked label-over-slider is
-              twice the height for seven of them, and the rail has a crest and a
-              preset row above it and a Save under it. */}
+          {/* One row per knob (not stacked label/slider) — seven knobs must fit under the crest and preset rows above a fixed-height rail. */}
           {KNOBS.map(({ k, n, min, max, step }) => (
             <div key={k} className="flex items-center gap-2">
               <Typography
@@ -564,9 +490,7 @@ const LookBench = ({ look, onChange }: LookBenchProps): ReactElement => {
                 max={max}
                 step={step}
                 value={[look[k]]}
-                /* Any knob turns the preset into a look of your own. It is not
-                   a mode you enter, it is what happens the moment you disagree
-                   with one. */
+                /* Moving any knob forks the preset into a custom look. */
                 onValueChange={([value]) =>
                   onChange(forkLook(look, { [k]: value }))
                 }
@@ -586,12 +510,7 @@ const LookBench = ({ look, onChange }: LookBenchProps): ReactElement => {
   );
 };
 
-/**
- * The bench's own title bar. It replaces the rail's "Back to profile" rather
- * than sitting under it: while the bench is open the way out is out of the
- * bench, and two back affordances one above the other is a reader guessing
- * which one loses their edits.
- */
+/** Replaces the rail's "Back to profile" rather than sitting alongside it — two back affordances would leave a reader guessing which one loses their edits. */
 function WorldCustomizeHeader({
   onCancel,
 }: {
@@ -620,15 +539,8 @@ interface WorldCustomizeProps {
 }
 
 /**
- * What the gear opens: the one place a world can be made somebody's own.
- *
- * Every edit lands on the world behind the panel immediately — this is a bench
- * over a live frame, not a form with a preview pane — and Save is what makes it
- * survive a reload. Cancel puts the world back the way it was found.
- *
- * Land, level, density and monuments are not in here and never will be. Those
- * are the portrait: the reading writes them, and nothing on this panel can make
- * a world claim to be bigger than it was read into being.
+ * Every edit updates the live world behind the panel immediately; Save persists it, Cancel reverts.
+ * Land, level, density and monuments are intentionally excluded — those come only from reading activity, never from this panel.
  */
 function WorldCustomize({
   userId,
@@ -644,8 +556,7 @@ function WorldCustomize({
 
   return (
     <div className="flex flex-col gap-5">
-      {/* One label, not two. The heading names the field, so the field's own
-          label is there for a screen reader and nowhere else. */}
+      {/* Section heading names the field; TextField's own label is sr-only to avoid duplicating it visually. */}
       <Section title="Name">
         <TextField
           inputId="world-name"
@@ -665,10 +576,7 @@ function WorldCustomize({
                 variant={ButtonVariant.Tertiary}
                 size={ButtonSize.Small}
                 icon={<MagicIcon />}
-                /* ✦ does not reroll. It walks a fixed list of shapes built from
-                   the same facts, so pressing it four times and landing back on
-                   the first one is possible. A suggestion you accept is still a
-                   name you chose, so it commits. */
+                /* Walks a fixed list of suggestions (not random) — cycling can land back on the first one. */
                 onClick={() => {
                   const next = (suggestion + 1) % suggestions.length;
                   setSuggestion(next);
@@ -726,15 +634,7 @@ function WorldCustomize({
   );
 }
 
-/**
- * The bench's own shell: a scrolling column with a bar bolted to the bottom.
- *
- * The bar is OUTSIDE the scroller rather than sticky inside it. Sticky only
- * pins an element once the content is long enough to push it off — so on a
- * short bench it comes to rest wherever the sections happen to end, floating in
- * the middle of the rail. A footer that is sometimes at the bottom is worse
- * than one that never is.
- */
+/** Action bar sits outside the scroller rather than sticky inside it — sticky only pins once content overflows, so on a short bench it would float mid-rail instead of anchoring to the bottom. */
 function WorldBench({
   draft,
   children,
@@ -798,14 +698,7 @@ export function WorldCustomizeRail({
   );
 }
 
-/**
- * The same bench below laptop, where there is no rail for it to replace.
- *
- * It takes the whole screen rather than opening as a drawer over the map: every
- * control in here changes what the world looks like, and a sheet covering the
- * bottom half of a phone leaves a strip of world too small to judge a grade by.
- * The world is still live underneath — closing it is one tap away.
- */
+/** Takes the whole screen rather than a drawer over the map — every control changes the world's look, and a partial sheet would leave too little world visible to judge. Closing is still one tap away. */
 export function WorldCustomizeSheet({
   draft,
   ...props

--- a/packages/webapp/components/world/WorldHeader.tsx
+++ b/packages/webapp/components/world/WorldHeader.tsx
@@ -116,10 +116,6 @@ export function WorldHeader({
           nativeLazyLoading
         />
         <div className="flex min-w-0 flex-1 flex-col">
-          {/* The world's name when it has one, and the reader's when it does
-              not: the avatar beside this and the profile link under it already
-              say whose place it is, so the line is free to say what the place
-              is called. */}
           <Typography type={TypographyType.Footnote} bold truncate>
             {state.open ? state.open.name : worldName || user.name}
           </Typography>

--- a/packages/webapp/components/world/WorldHeader.tsx
+++ b/packages/webapp/components/world/WorldHeader.tsx
@@ -6,7 +6,10 @@ import {
   ProfilePicture,
 } from '@dailydotdev/shared/src/components/ProfilePicture';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
-import { ArrowIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  ArrowIcon,
+  SettingsIcon,
+} from '@dailydotdev/shared/src/components/icons';
 import {
   Button,
   ButtonSize,
@@ -18,6 +21,7 @@ import {
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import { WorldImmersiveToggle, WorldMark } from './WorldMark';
+import { WorldNudge } from './WorldNudge';
 import { WorldSignupCta } from './WorldSignupCta';
 import { WorldViewerAction } from './WorldViewerAction';
 import type { WorldState } from './worldState';
@@ -26,12 +30,17 @@ import { worldCounts } from './worldState';
 const WorldHeaderActions = memo(function WorldHeaderActions({
   user,
   unbuilt,
+  showNudge,
+  onCustomize,
 }: {
   user: PublicProfile;
   unbuilt?: boolean;
+  showNudge?: boolean;
+  onCustomize?: () => void;
 }): ReactElement {
   return (
     <>
+      {!!showNudge && !!onCustomize && <WorldNudge onCustomize={onCustomize} />}
       <WorldViewerAction user={user} block />
       {/* Nothing here on unbuilt ground: the one ask stands on the world. */}
       {!unbuilt && <WorldSignupCta compact />}
@@ -45,8 +54,14 @@ interface WorldHeaderProps {
   /** Six realms of bare ground: every number is a zero and nothing is standing. */
   unbuilt?: boolean;
   isImmersive: boolean;
+  /** What the owner calls the place, or nothing if they never named it. */
+  worldName?: string;
+  /** The owner has never made this place theirs. */
+  showNudge?: boolean;
   onToggleImmersive: () => void;
   onLeaveRealm: () => void;
+  /** Only on your own world: nobody else's place is yours to dress. */
+  onCustomize?: () => void;
 }
 
 /**
@@ -60,8 +75,11 @@ export function WorldHeader({
   state,
   unbuilt,
   isImmersive,
+  worldName,
+  showNudge,
   onToggleImmersive,
   onLeaveRealm,
+  onCustomize,
 }: WorldHeaderProps): ReactElement {
   const backIcon = <ArrowIcon className="-rotate-90" />;
   const backProps = {
@@ -98,8 +116,12 @@ export function WorldHeader({
           nativeLazyLoading
         />
         <div className="flex min-w-0 flex-1 flex-col">
+          {/* The world's name when it has one, and the reader's when it does
+              not: the avatar beside this and the profile link under it already
+              say whose place it is, so the line is free to say what the place
+              is called. */}
           <Typography type={TypographyType.Footnote} bold truncate>
-            {state.open ? state.open.name : user.name}
+            {state.open ? state.open.name : worldName || user.name}
           </Typography>
           <Typography
             type={TypographyType.Caption1}
@@ -111,6 +133,17 @@ export function WorldHeader({
             {unbuilt ? 'Open ground' : worldCounts(state)}
           </Typography>
         </div>
+        {!!onCustomize && (
+          <Button
+            type="button"
+            aria-label="Customise this world"
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            icon={<SettingsIcon />}
+            className="flex-none"
+            onClick={onCustomize}
+          />
+        )}
         <WorldImmersiveToggle
           isImmersive={isImmersive}
           onToggleImmersive={onToggleImmersive}
@@ -119,7 +152,12 @@ export function WorldHeader({
       </div>
       {/* Behind a memo boundary, like the rail's header block: neither reads the
           day, and the engine pushes a new state object every frame of a replay. */}
-      <WorldHeaderActions user={user} unbuilt={unbuilt} />
+      <WorldHeaderActions
+        user={user}
+        unbuilt={unbuilt}
+        showNudge={showNudge}
+        onCustomize={onCustomize}
+      />
     </header>
   );
 }

--- a/packages/webapp/components/world/WorldNudge.tsx
+++ b/packages/webapp/components/world/WorldNudge.tsx
@@ -18,17 +18,7 @@ interface WorldNudgeProps {
   className?: string;
 }
 
-/**
- * Shown once, on your own world, until you have made something of it.
- *
- * The gear is in the header the whole time, and a gear is a thing you find
- * rather than a thing you are offered — which is fine for a setting and wrong
- * for the half of this feature that is the point. So a world nobody has named,
- * dressed or graded says so, and stops saying it the moment they have.
- *
- * It goes away on the first customisation rather than on a dismissal: there is
- * nothing to dismiss once the answer is yes.
- */
+/** Disappears on the first customisation, not on a dismissal — there is nothing to dismiss once the world has been made someone's own. */
 export function WorldNudge({
   onCustomize,
   className,
@@ -40,9 +30,6 @@ export function WorldNudge({
         className,
       )}
     >
-      {/* Three lines that say three different things: what is missing, whose
-          the place is, and what to do about it. The first draft had all three
-          saying "name this world". */}
       <Typography type={TypographyType.Footnote} bold>
         This world is still unnamed
       </Typography>

--- a/packages/webapp/components/world/WorldNudge.tsx
+++ b/packages/webapp/components/world/WorldNudge.tsx
@@ -1,0 +1,66 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { SettingsIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+
+interface WorldNudgeProps {
+  onCustomize: () => void;
+  className?: string;
+}
+
+/**
+ * Shown once, on your own world, until you have made something of it.
+ *
+ * The gear is in the header the whole time, and a gear is a thing you find
+ * rather than a thing you are offered — which is fine for a setting and wrong
+ * for the half of this feature that is the point. So a world nobody has named,
+ * dressed or graded says so, and stops saying it the moment they have.
+ *
+ * It goes away on the first customisation rather than on a dismissal: there is
+ * nothing to dismiss once the answer is yes.
+ */
+export function WorldNudge({
+  onCustomize,
+  className,
+}: WorldNudgeProps): ReactElement {
+  return (
+    <div
+      className={classNames(
+        'flex flex-col items-start gap-2 rounded-12 border border-border-subtlest-tertiary bg-surface-float p-3',
+        className,
+      )}
+    >
+      {/* Three lines that say three different things: what is missing, whose
+          the place is, and what to do about it. The first draft had all three
+          saying "name this world". */}
+      <Typography type={TypographyType.Footnote} bold>
+        This world is still unnamed
+      </Typography>
+      <Typography
+        type={TypographyType.Caption1}
+        color={TypographyColor.Tertiary}
+      >
+        Your reading built the place. How it looks is yours.
+      </Typography>
+      <Button
+        type="button"
+        variant={ButtonVariant.Primary}
+        size={ButtonSize.Small}
+        icon={<SettingsIcon />}
+        onClick={onCustomize}
+      >
+        Make it yours
+      </Button>
+    </div>
+  );
+}

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -13,7 +13,11 @@ import {
   TruncateText,
 } from '@dailydotdev/shared/src/components/utilities';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
-import { ArrowIcon, InfoIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  ArrowIcon,
+  InfoIcon,
+  SettingsIcon,
+} from '@dailydotdev/shared/src/components/icons';
 import {
   Button,
   ButtonSize,
@@ -30,9 +34,13 @@ import {
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import type { Author } from '@dailydotdev/shared/src/graphql/comments';
+import type { WorldDistrict } from '../../graphql/world';
+import { WorldCustomizeRail } from './WorldCustomize';
 import { WorldImmersiveToggle } from './WorldMark';
+import { WorldNudge } from './WorldNudge';
 import { WorldSignupCta } from './WorldSignupCta';
 import { WorldViewerAction } from './WorldViewerAction';
+import type { WorldDraft } from './useWorldDraft';
 import type { WorldState } from './worldState';
 
 const STAT_INFO: [string, string][] = [
@@ -103,12 +111,18 @@ const Stat = ({ label, value }: { label: string; value: string }) => (
  */
 const WorldPanelHeader = memo(function WorldPanelHeader({
   user,
+  worldName,
   isImmersive,
   onToggleImmersive,
+  onCustomize,
 }: {
   user: PublicProfile;
+  /** What the owner calls the place, or nothing if they never named it. */
+  worldName?: string;
   isImmersive: boolean;
   onToggleImmersive: () => void;
+  /** Only on your own world: nobody else's place is yours to dress. */
+  onCustomize?: () => void;
 }): ReactElement {
   /* A profile carries everything a comment author does, but types its handle as
      optional, and the comment components do not. One that has no handle has no
@@ -137,10 +151,24 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
             Back to profile
           </Button>
         </Link>
-        <WorldImmersiveToggle
-          isImmersive={isImmersive}
-          onToggleImmersive={onToggleImmersive}
-        />
+        <div className="flex flex-none items-center">
+          {!!onCustomize && (
+            <Tooltip content="Make it yours">
+              <Button
+                type="button"
+                aria-label="Customise this world"
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={<SettingsIcon />}
+                onClick={onCustomize}
+              />
+            </Tooltip>
+          )}
+          <WorldImmersiveToggle
+            isImmersive={isImmersive}
+            onToggleImmersive={onToggleImmersive}
+          />
+        </div>
       </div>
       {/* The same block a comment puts its author in (avatar, name, handle,
           and the user card on hover), so a reader meets a person the same way
@@ -169,6 +197,19 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
           )}
         </div>
       </div>
+      {/* Only once it has one. An unnamed world shows nothing here rather than
+          the suggestion it would be given — the suggestion belongs in the
+          bench's placeholder, where disagreeing with it is the point. */}
+      {!!worldName && (
+        <Typography
+          tag={TypographyTag.H1}
+          type={TypographyType.Body}
+          bold
+          className="break-words"
+        >
+          {worldName}
+        </Typography>
+      )}
       <WorldViewerAction user={user} />
     </header>
   );
@@ -183,10 +224,19 @@ interface WorldPanelProps {
   /** Six realms of bare ground: every number is a zero and nothing is standing. */
   unbuilt?: boolean;
   isImmersive: boolean;
+  worldName?: string;
+  /** Open on your own world, and only there. */
+  draft?: WorldDraft;
+  districts?: WorldDistrict[];
+  /** The owner has never made this place theirs. */
+  showNudge?: boolean;
   onToggleImmersive: () => void;
   onFocus: (key: string) => void;
   onLeaveRealm: () => void;
 }
+
+const RAIL =
+  'pointer-events-auto absolute inset-y-0 left-0 z-1 flex w-80 flex-col gap-3 overflow-y-auto border-r border-border-subtlest-tertiary bg-background-default p-4';
 
 /**
  * The lab's left rail: who this world belongs to and what is in it. Every
@@ -199,25 +249,41 @@ export function WorldPanel({
   state,
   unbuilt,
   isImmersive,
+  worldName,
+  draft,
+  districts,
+  showNudge,
   onToggleImmersive,
   onFocus,
   onLeaveRealm,
 }: WorldPanelProps): ReactElement {
   const { open, rank = [] } = state;
 
+  /* The bench takes the rail rather than opening beside it. There is one column
+     on this page and the world needs the rest of the screen, so what is in the
+     column changes and nothing moves. */
+  if (draft?.isOpen && draft.settings) {
+    return (
+      <WorldCustomizeRail
+        userId={user.id}
+        draft={draft}
+        districts={districts}
+        settings={draft.settings}
+      />
+    );
+  }
+
   return (
-    <aside
-      data-world-overlay
-      className={classNames(
-        'pointer-events-auto absolute inset-y-0 left-0 z-1 flex w-80 flex-col gap-3',
-        'overflow-y-auto border-r border-border-subtlest-tertiary bg-background-default p-4',
-      )}
-    >
+    <aside data-world-overlay className={RAIL}>
       <WorldPanelHeader
         user={user}
+        worldName={worldName}
         isImmersive={isImmersive}
         onToggleImmersive={onToggleImmersive}
+        onCustomize={draft?.open}
       />
+
+      {!!showNudge && !!draft && <WorldNudge onCustomize={draft.open} />}
 
       {/* Four across, on one line. DataTile is the right component for a stats
           page and the wrong one for a rail this narrow: its card and its own

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -197,9 +197,7 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
           )}
         </div>
       </div>
-      {/* Only once it has one. An unnamed world shows nothing here rather than
-          the suggestion it would be given — the suggestion belongs in the
-          bench's placeholder, where disagreeing with it is the point. */}
+      {/* An unnamed world shows nothing here — the suggestion belongs in the bench's placeholder, not this heading. */}
       {!!worldName && (
         <Typography
           tag={TypographyTag.H1}
@@ -259,9 +257,7 @@ export function WorldPanel({
 }: WorldPanelProps): ReactElement {
   const { open, rank = [] } = state;
 
-  /* The bench takes the rail rather than opening beside it. There is one column
-     on this page and the world needs the rest of the screen, so what is in the
-     column changes and nothing moves. */
+  /* Bench replaces the rail's contents rather than opening beside it — the single column changes, nothing else moves. */
   if (draft?.isOpen && draft.settings) {
     return (
       <WorldCustomizeRail

--- a/packages/webapp/components/world/WorldPrivate.tsx
+++ b/packages/webapp/components/world/WorldPrivate.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { ArrowIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import { WorldStage, WorldStageIdentity } from './WorldBoot';
+
+interface WorldPrivateProps {
+  user: PublicProfile;
+}
+
+/**
+ * A world its owner has hidden.
+ *
+ * Nothing of it is drawn — not the map, not the timeline, not the crest. That is
+ * the whole meaning of the switch: the crest is the piece built to travel, so
+ * hiding a world is a real cost rather than a cosmetic toggle, and half-honouring
+ * it here would be the same as not honouring it. The renderer is never handed a
+ * model, so there is nothing standing behind this screen to be caught.
+ *
+ * It is stated rather than dressed up as an error. "Could not be loaded" would
+ * be a lie about a decision somebody made deliberately.
+ */
+export function WorldPrivate({ user }: WorldPrivateProps): ReactElement {
+  const { user: viewer } = useAuthContext();
+
+  return (
+    <WorldStage>
+      <WorldStageIdentity user={user} />
+
+      <Typography
+        type={TypographyType.Callout}
+        color={TypographyColor.Tertiary}
+        className="max-w-sm"
+      >
+        This world is private. {user.name} has kept it to themselves.
+      </Typography>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        <Link href={`/${user.username || user.id}`} passHref>
+          <Button
+            tag="a"
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Small}
+            icon={<ArrowIcon className="-rotate-90" />}
+          >
+            Back to profile
+          </Button>
+        </Link>
+        {!!viewer && (
+          <Link href={`/world/${viewer.username || viewer.id}`} passHref>
+            <Button
+              tag="a"
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Small}
+            >
+              See your own world
+            </Button>
+          </Link>
+        )}
+      </div>
+    </WorldStage>
+  );
+}

--- a/packages/webapp/components/world/WorldPrivate.tsx
+++ b/packages/webapp/components/world/WorldPrivate.tsx
@@ -20,18 +20,7 @@ interface WorldPrivateProps {
   user: PublicProfile;
 }
 
-/**
- * A world its owner has hidden.
- *
- * Nothing of it is drawn — not the map, not the timeline, not the crest. That is
- * the whole meaning of the switch: the crest is the piece built to travel, so
- * hiding a world is a real cost rather than a cosmetic toggle, and half-honouring
- * it here would be the same as not honouring it. The renderer is never handed a
- * model, so there is nothing standing behind this screen to be caught.
- *
- * It is stated rather than dressed up as an error. "Could not be loaded" would
- * be a lie about a decision somebody made deliberately.
- */
+/** Renderer is never handed a model for a hidden world — nothing (map, timeline, crest) is drawn, so there's nothing behind this screen to leak. */
 export function WorldPrivate({ user }: WorldPrivateProps): ReactElement {
   const { user: viewer } = useAuthContext();
 

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -3,18 +3,27 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
 import { WorldBoot } from './WorldBoot';
+import { WorldCustomizeSheet } from './WorldCustomize';
 import { WorldHeader } from './WorldHeader';
-import { WorldInvite } from './WorldInvite';
+import { useIsOwnWorld, WorldInvite } from './WorldInvite';
 import { WorldImmersiveToggle, WorldMark } from './WorldMark';
 import { WorldPanel } from './WorldPanel';
+import { WorldPrivate } from './WorldPrivate';
 import { WorldRiding } from './WorldRiding';
 import { WorldStatus } from './WorldStatus';
 import { WorldTimeline } from './WorldTimeline';
 import type { WorldEngine, WorldState } from './worldState';
 import type { UserWorldResult } from './useUserWorld';
+import { useWorldDraft } from './useWorldDraft';
 import { buildWorld } from './engine/buildWorld';
 import { createWorldEngine } from './engine/world';
 import { buildUnbuiltWorld } from './unbuiltWorld';
+import {
+  isWorldCustomised,
+  resolveCrest,
+  resolveLook,
+  resolveSky,
+} from './worldCustomization';
 
 const INITIAL: WorldState = {
   status: 'loading',
@@ -64,8 +73,19 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
   const [isImmersive, setIsImmersive] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);
 
-  const { districts, timeline, isPending, isHistoryPending, isEmpty, error } =
-    world;
+  const {
+    districts,
+    timeline,
+    settings,
+    isPending,
+    isHistoryPending,
+    isEmpty,
+    isPrivate,
+    error,
+  } = world;
+  const isOwn = useIsOwnWorld(user);
+  const draft = useWorldDraft(user.id, settings);
+  const { applied } = draft;
 
   /* The app keeps a permanent scrollbar gutter on the body so feeds don't jump
      when they grow. Nothing on this page scrolls, and a fixed layer is laid out
@@ -185,6 +205,22 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     user?.id,
   ]);
 
+  /* The owner's look and the owner's mark, not the viewer's: both are properties
+     of the world, so everybody who visits sees the place the way it was dressed.
+     While the bench is open these read the draft instead, which is what makes
+     every chip land on the frame behind the panel rather than on a preview. */
+  useEffect(() => {
+    engineRef.current?.setLook(resolveLook(applied));
+  }, [applied]);
+
+  useEffect(() => {
+    engineRef.current?.setCrest(resolveCrest(applied, user.id, districts));
+  }, [applied, districts, user.id]);
+
+  useEffect(() => {
+    engineRef.current?.setSky(resolveSky(applied));
+  }, [applied]);
+
   useEffect(() => {
     if (isImmersive) {
       engineRef.current?.setPadding(PAD_IMMERSIVE);
@@ -243,6 +279,29 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     [],
   );
 
+  /* The bench is the owner's, and only the owner's. Everything else on this page
+     is the same for everybody who visits. */
+  const ownerDraft = isOwn ? draft : undefined;
+  const worldName = applied?.name ?? undefined;
+  const showNudge = isOwn && !isWorldCustomised(applied);
+
+  /* Nothing of a hidden world is drawn — not the map, not the timeline, not the
+     crest — so this stands in front of every other state, including the boot
+     screen it would otherwise sit behind for a round trip. */
+  if (isPrivate) {
+    return (
+      <div className="fixed inset-0 overflow-hidden bg-background-default">
+        {/* Kept mounted and empty. The engine took this node on mount and holds
+            a WebGL context on it; unmounting it here would leak the context
+            rather than release it, and browsers cap those low enough that the
+            third private world somebody visits would stop rendering. Nothing is
+            ever drawn into it: `load` is only reached with districts in hand. */}
+        <div ref={mountRef} className="absolute inset-0" />
+        <WorldPrivate user={user} />
+      </div>
+    );
+  }
+
   return (
     <div className="fixed inset-0 overflow-hidden bg-background-default">
       <div ref={mountRef} className="absolute inset-0" />
@@ -255,19 +314,38 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
               state={state}
               unbuilt={isUnbuilt}
               isImmersive={isImmersive}
+              worldName={worldName}
+              draft={ownerDraft}
+              districts={districts}
+              showNudge={showNudge}
               onToggleImmersive={onToggleImmersive}
               onFocus={onFocus}
               onLeaveRealm={onLeaveRealm}
             />
           ) : (
-            <WorldHeader
-              user={user}
-              state={state}
-              unbuilt={isUnbuilt}
-              isImmersive={isImmersive}
-              onToggleImmersive={onToggleImmersive}
-              onLeaveRealm={onLeaveRealm}
-            />
+            <>
+              <WorldHeader
+                user={user}
+                state={state}
+                unbuilt={isUnbuilt}
+                isImmersive={isImmersive}
+                worldName={worldName}
+                showNudge={showNudge && !draft.isOpen}
+                onToggleImmersive={onToggleImmersive}
+                onLeaveRealm={onLeaveRealm}
+                onCustomize={ownerDraft?.open}
+              />
+              {/* No rail down here for the bench to take, so it takes the
+                  screen. The world stays live underneath it. */}
+              {!!ownerDraft?.isOpen && !!ownerDraft.settings && (
+                <WorldCustomizeSheet
+                  userId={user.id}
+                  draft={ownerDraft}
+                  districts={districts}
+                  settings={ownerDraft.settings}
+                />
+              )}
+            </>
           )}
           {/* On screen while the growth log is still on the wire, inert, in the
               place it will be live in. It is the last thing to arrive and the

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -205,10 +205,9 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     user?.id,
   ]);
 
-  /* The owner's look and the owner's mark, not the viewer's: both are properties
-     of the world, so everybody who visits sees the place the way it was dressed.
-     While the bench is open these read the draft instead, which is what makes
-     every chip land on the frame behind the panel rather than on a preview. */
+  /* Look and crest are the world's, not the viewer's, so every visitor sees them
+     as dressed. While the bench is open these read the draft instead, so chips
+     land live on the frame behind the panel. */
   useEffect(() => {
     engineRef.current?.setLook(resolveLook(applied));
   }, [applied]);
@@ -279,23 +278,21 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     [],
   );
 
-  /* The bench is the owner's, and only the owner's. Everything else on this page
-     is the same for everybody who visits. */
+  /* The bench is the owner's only; everything else here is the same for every visitor. */
   const ownerDraft = isOwn ? draft : undefined;
   const worldName = applied?.name ?? undefined;
-  const showNudge = isOwn && !isWorldCustomised(applied);
+  /* Never on an unbuilt world: WorldInvite already makes the one ask there,
+     and it makes it nowhere else. */
+  const showNudge = isOwn && !isUnbuilt && !isWorldCustomised(applied);
 
-  /* Nothing of a hidden world is drawn — not the map, not the timeline, not the
-     crest — so this stands in front of every other state, including the boot
-     screen it would otherwise sit behind for a round trip. */
+  /* A hidden world draws nothing — no map, timeline or crest — so this returns
+     before the boot screen too. */
   if (isPrivate) {
     return (
       <div className="fixed inset-0 overflow-hidden bg-background-default">
-        {/* Kept mounted and empty. The engine took this node on mount and holds
-            a WebGL context on it; unmounting it here would leak the context
-            rather than release it, and browsers cap those low enough that the
-            third private world somebody visits would stop rendering. Nothing is
-            ever drawn into it: `load` is only reached with districts in hand. */}
+        {/* Kept mounted and empty: the engine holds a WebGL context on this node,
+            and unmounting would leak it rather than release it. `load` is never
+            reached here since there are no districts. */}
         <div ref={mountRef} className="absolute inset-0" />
         <WorldPrivate user={user} />
       </div>
@@ -335,8 +332,8 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
                 onLeaveRealm={onLeaveRealm}
                 onCustomize={ownerDraft?.open}
               />
-              {/* No rail down here for the bench to take, so it takes the
-                  screen. The world stays live underneath it. */}
+              {/* No rail here for the bench, so it takes the whole screen; the
+                  world stays live underneath. */}
               {!!ownerDraft?.isOpen && !!ownerDraft.settings && (
                 <WorldCustomizeSheet
                   userId={user.id}

--- a/packages/webapp/components/world/engine/crest.js
+++ b/packages/webapp/components/world/engine/crest.js
@@ -1,0 +1,175 @@
+/* ============================================================== the standard
+   devcraft `world-lab.html`'s crest bench, lifted out whole.
+
+   Its own module rather than part of the renderer, because both halves of the
+   page draw the same mark: the engine hangs it on a banner over the world, and
+   React paints it into the panel and into the chip row of the bench. One
+   emitter, two canvases — a second SVG copy for the DOM would be the same
+   shield drawn twice and drifting apart by the second change.
+
+   Nothing here touches three.js or the DOM beyond a 2D context, which is what
+   lets the React side import it.
+
+   The composition rule is the whole design:
+
+     CHARGE     — only from signature monuments you have actually unlocked
+     TINCTURES  — only from the accents of districts you actually founded
+     DIVISION   — free, because a division is pure geometry and carries no fact
+
+   So the crest is assembled ENTIRELY out of your reading and arranged entirely
+   by you. You cannot build one that lies: a crest with the anvil on it belongs
+   to somebody who reads systems, and a reader with one district gets exactly
+   one charge to choose from — which is not a poor version of the feature, it IS
+   their identity, stated more sharply than a wide reader's ever gets stated.
+   The API is the authority on what has been earned (`userWorldEntitlements`);
+   this file only knows how to draw what it is handed. */
+
+/* Paths are written in a 100-unit box centred on the origin and filled with the
+   EVEN-ODD rule, which is what lets a ring be two circles and a dot inside a
+   ring be three, with no winding to keep track of. */
+const _c=(x,y,r)=>`M${x-r},${y}a${r},${r} 0 1 0 ${r*2},0a${r},${r} 0 1 0 ${-r*2},0Z`;
+const _r=(x,y,w,h)=>`M${x-w/2},${y-h/2}h${w}v${h}h${-w}Z`;
+/* A groove across the wound cop, used as a HOLE: two of them are what stop a
+   tapered cone from reading as a plain cone. Half-widths have to stay inside
+   the cop at the groove's LOWEST point, or the ends fall outside the shape and
+   even-odd fills them into wings. */
+const _gv=(y,w,h)=>`M-${w},${y} L${w},${y} L${w+1},${y+h} L-${w+1},${y+h} Z`;
+/* One glyph per signature in REALMS — twenty-six, because the charge has to be
+   able to name any district in the taxonomy. They are deliberately blunt: a
+   crest is read at 22px in a chip and at share-card size in a corner, and
+   anything with interior detail is a smudge at both. */
+export const CHARGES={
+  obelisk:   {n:'OBELISK',   d:`M0,-46 L11,-33 L8,42 L-8,42 L-11,-33 Z`},
+  roost:     {n:'ROOST',     d:`${_r(0,2,8,88)}${_r(0,-28,52,8)}${_r(0,-6,40,8)}${_r(0,16,28,8)}`},
+  conduit:   {n:'CONDUIT',   d:`M-42,28 A42,42 0 0 1 42,28 L30,28 A30,30 0 0 0 -30,28 Z M-18,28 A18,18 0 0 1 18,28 L8,28 A8,8 0 0 0 -8,28 Z${_r(0,38,92,10)}`},
+  orrery:    {n:'ORRERY',    d:`${_c(0,0,42)}${_c(0,0,32)}${_c(0,0,13)}`},
+  aqueduct:  {n:'AQUEDUCT',  d:`${_r(0,-30,88,14)}M-40,44 L-40,-16 L-14,-16 L-14,44 L-24,44 L-24,-4 L-30,-4 L-30,44 Z M14,44 L14,-16 L40,-16 L40,44 L30,44 L30,-4 L24,-4 L24,44 Z`},
+  wardring:  {n:'WARD RING', d:`${_c(0,0,44)}${_c(0,0,34)}M0,-22 L20,-12 L20,10 L0,26 L-20,10 L-20,-12 Z`},
+  coil:      {n:'SERPENT STEPS', d:`M-44,44 L-44,18 L-17,18 L-17,-8 L10,-8 L10,-34 L44,-34 L44,44 Z`},
+  /* Follows the monument, which is the rule for every charge in here — a crest
+     is a picture of something you built, so when the thing changes the picture
+     is wrong rather than merely dated. This was a barred rectangle drawn from
+     the old weaving frame, and a grid is the one shape a crest cannot afford
+     anyway: at chip size it is indistinguishable from a missing image, which is
+     the exact complaint the frame itself collected.
+     The whorl is drawn as two wings clear of the shaft rather than as a disc
+     across it — a disc would overlap the shaft, and two overlapping solids
+     under even-odd is a slot cut through the middle of both. */
+  loom:      {n:'GREAT SPINDLE',
+              d:`M0,-48 L5,-37 L-5,-37 Z${_r(0,-27,7,22)}`
+               +`M-19,-34 L-4,-34 L-4,-26 L-12,-26 Z`
+               +`M19,-34 L4,-34 L4,-26 L12,-26 Z`
+               +`M-10,-16 L10,-16 L21,32 L-21,32 Z`
+               +`${_gv(-2,12,5)}${_gv(10,15,5)}${_r(0,38.5,46,13)}`},
+  canopywalk:{n:'CANOPY',    d:`${_r(-34,10,12,72)}${_r(34,10,12,72)}${_r(0,-12,80,10)}${_r(0,10,80,6)}`},
+  greenhouse:{n:'GREENHOUSE',d:`M0,-44 L44,-8 L44,44 L-44,44 L-44,-8 Z M0,-26 L28,-2 L28,30 L-28,30 L-28,-2 Z${_r(0,14,8,32)}`},
+  wellspring:{n:'WELLSPRING',d:`M-40,4 L40,4 L32,44 L-32,44 Z${_r(0,-26,10,44)}${_c(0,-38,12)}`},
+  bigwheel:  {n:'GREAT WHEEL',d:`${_c(0,0,44)}${_c(0,0,33)}${_c(0,0,11)}${_r(0,0,8,66)}${_r(0,0,66,8)}M-27,-33 L-21,-39 L27,33 L21,39 Z M27,-33 L33,-27 L-21,39 L-27,33 Z`},
+  anvilyard: {n:'ANVIL',     d:`M-46,-21 L-24,-31 L34,-31 L34,-12 L14,-12 L14,12 L30,12 L30,31 L-30,31 L-30,12 L-14,12 L-14,-12 L-24,-12 Z`},
+  crucible:  {n:'CRUCIBLE',  d:`M-30,-24 L30,-24 L20,32 L-20,32 Z${_r(0,40,60,10)}${_r(0,-32,44,10)}`},
+  pipeorgan: {n:'PIPES',     d:`${_r(-26,6,16,76)}${_r(0,-2,16,92)}${_r(26,10,16,68)}`},
+  watchfire: {n:'WATCHFIRE', d:`M0,-44 C22,-18 26,0 12,20 C22,4 6,-4 0,-16 C-6,-4 -22,4 -12,20 C-26,0 -22,-18 0,-44 Z${_r(0,36,56,14)}`},
+  drydock:   {n:'DRY DOCK',  d:`M-44,-6 L44,-6 L28,30 L-28,30 Z${_r(0,-30,8,48)}${_r(0,40,72,8)}`},
+  crane:     {n:'CRANE',     d:`${_r(-24,4,14,88)}M-34,-46 L44,-46 L44,-34 L-34,-34 Z${_r(38,-16,7,36)}${_r(38,6,20,14)}`},
+  containers:{n:'CONTAINERS',d:`${_r(-22,-26,40,26)}${_r(22,-26,40,26)}${_r(0,4,84,26)}${_r(-22,34,40,26)}${_r(22,34,40,26)}`},
+  lighthouse:{n:'LIGHTHOUSE',d:`M-16,-34 L16,-34 L26,38 L-26,38 Z${_r(0,-42,30,10)}M-46,-24 L-26,-30 L-26,-18 Z M46,-24 L26,-30 L26,-18 Z`},
+  keep:      {n:'KEEP',      d:`M-34,-34 L-22,-34 L-22,-24 L-6,-24 L-6,-34 L6,-34 L6,-24 L22,-24 L22,-34 L34,-34 L34,42 L-34,42 Z${_r(0,20,18,30)}`},
+  library:   {n:'LIBRARY',   d:`M-42,-30 L-4,-22 L-4,34 L-42,26 Z M42,-30 L4,-22 L4,34 L42,26 Z`},
+  vault:     {n:'VAULT',     d:`${_c(0,0,44)}${_c(0,0,32)}${_c(0,0,10)}${_r(0,0,6,84)}${_r(0,0,84,6)}`},
+  workshop:  {n:'WORKSHOP',  d:`M-41,-31 L-31,-41 L41,31 L31,41 Z M31,-41 L41,-31 L-31,41 L-41,31 Z`},
+  market:    {n:'MARKET',    d:`M-46,-24 L46,-24 L34,4 L-34,4 Z${_r(-24,24,10,44)}${_r(24,24,10,44)}${_r(0,42,60,8)}`},
+  clocktower:{n:'CLOCK',     d:`M0,-48 L30,-25 L-30,-25 Z${_r(0,10,46,70)}${_c(0,-4,16)}${_c(0,-4,8)}`},
+};
+
+/* Six ways to cut a field. Free choice on purpose — a division encodes nothing,
+   so it is the axis where taste is allowed to be taste. Each returns the region
+   painted in the SECOND tincture, over a field already filled with the first. */
+export const DIVISIONS=[
+  {id:'plain',   n:'PLAIN',     f:null},
+  {id:'pale',    n:'PER PALE',  f:(x,w,h)=>`M0,-${h} h${w} v${h*2} h-${w} Z`},
+  {id:'fess',    n:'PER FESS',  f:(x,w,h)=>`M-${w},0 h${w*2} v${h} h-${w*2} Z`},
+  {id:'bend',    n:'PER BEND',  f:(x,w,h)=>`M-${w},-${h} L${w},-${h} L-${w},${h} Z`},
+  {id:'chevron', n:'CHEVRON',   f:(x,w,h)=>`M0,-${h*0.2} L${w},${h} L-${w},${h} Z`},
+  {id:'quarter', n:'QUARTERLY', f:(x,w,h)=>`M0,-${h} h${w} v${h} h-${w} Z M-${w},0 h${w} v${h} h-${w} Z`},
+];
+
+export const hexs=v=>'#'+v.toString(16).padStart(6,'0');
+
+/* The rule of tincture, automated. Classic heraldry forbids colour on colour
+   for exactly the reason it matters here — a charge has to survive at chip
+   size — so the charge takes whichever of salt or pepper stands furthest from
+   the field it is sitting on. Nobody has to be told this rule; they just never
+   manage to build an illegible crest.
+   Computed off the integer rather than through a THREE.Color, because this
+   module is imported by React and pulling three.js in behind a chip preview
+   would be most of a megabyte for a luminance. */
+const _lum=hex=>((hex>>16&255)*0.2126+(hex>>8&255)*0.7152+(hex&255)*0.0722)/255;
+
+/* ONE renderer, to a canvas, and the panel uses its data URL as a background
+   image. */
+export const SHIELD=(w,h)=>{
+  /* A heater shield: square shoulders, straight flanks for the top third, then
+     a curve into a point. Drawn as a path so it can be used to clip the field
+     and stroked afterwards for the bordure. */
+  const p=new Path2D();
+  p.moveTo(-w/2,-h/2); p.lineTo(w/2,-h/2); p.lineTo(w/2,-h*0.06);
+  p.bezierCurveTo(w/2,h*0.30, w*0.26,h*0.44, 0,h/2);
+  p.bezierCurveTo(-w*0.26,h*0.44, -w/2,h*0.30, -w/2,-h*0.06);
+  p.closePath(); return p;
+};
+/* Two shapes off one drawing. A shield is the mark; a BANNER is that same
+   field pulled out to a rectangle, which is what a real banner of arms is and
+   what a piece of cloth in a 3D scene has to be — a shield-shaped mesh would
+   need alpha, and an alpha-tested plane comes back from the outline pass ringed
+   as a full rectangle anyway, because the normal-buffer override material is
+   opaque by definition. Rectangular and opaque, the outline traces the cloth,
+   which is the correct answer rather than a workaround. */
+export function drawCrest(g,W_,H_,c,banner){
+  g.clearRect(0,0,W_,H_);
+  g.save(); g.translate(W_/2,H_/2);
+  const w=banner?W_:W_*0.88, h=banner?H_:H_*0.88;
+  const sh=banner?null:SHIELD(w,h);
+  g.save(); if(sh) g.clip(sh,'evenodd');
+  g.fillStyle=hexs(c.a); g.fillRect(-W_,-H_,W_*2,H_*2);
+  const div=DIVISIONS.find(d=>d.id===c.div)||DIVISIONS[0];
+  if(div.f){ g.fillStyle=hexs(c.b); g.fill(new Path2D(div.f(0,W_,H_)),'evenodd'); }
+  g.restore();
+  /* The charge sits on the field at 62% of the shield's width, which keeps it
+     clear of the bordure and clear of the point. */
+  const ch=CHARGES[c.charge]||CHARGES.obelisk;
+  const s=w*(banner?0.66:0.62)/100;
+  /* Averaged over both tinctures rather than over the one behind the charge:
+     under QUARTERLY the charge crosses all four quarters, so "the colour it is
+     sitting on" is not a single colour and picking either one loses half of it. */
+  const L=div.f?(_lum(c.a)+_lum(c.b))/2:_lum(c.a);
+  g.fillStyle=L>0.34?'#0F1218':'#FFFFFF';
+  g.save(); g.translate(0,banner?0:-h*0.02); g.scale(s,s);
+  g.fill(new Path2D(ch.d),'evenodd');
+  g.restore();
+  /* A bordure in the charge's own colour, so the mark reads as one object
+     against a bright sky and against a dark panel without a second setting. */
+  g.lineWidth=Math.max(1.5,w*0.045); g.strokeStyle=g.fillStyle;
+  g.globalAlpha=0.55;
+  if(sh) g.stroke(sh);
+  else { const i=g.lineWidth; g.strokeRect(-W_/2+i/2,-H_/2+i/2,W_-i,H_-i); }
+  g.globalAlpha=1;
+  g.restore();
+}
+
+/* Cached by the crest's own contents, because the panel, the chips and the
+   world all ask for it and the answer only changes when a chip is clicked.
+   `null` on the server and anywhere else without a canvas: the mark is chrome,
+   and a page that cannot draw it renders without it rather than throwing. */
+let _crestC=null, _crestKey='', _crestURL='';
+export function crestDataUrl(c){
+  if(!c||typeof document==='undefined') return '';
+  const key=c.charge+c.div+c.a+c.b;
+  if(key===_crestKey) return _crestURL;
+  if(!_crestC){ _crestC=document.createElement('canvas');
+                _crestC.width=176; _crestC.height=208; }
+  const g=_crestC.getContext('2d');
+  if(!g) return '';
+  _crestKey=key;
+  drawCrest(g,176,208,c);
+  return _crestURL=_crestC.toDataURL();
+}

--- a/packages/webapp/components/world/engine/crest.js
+++ b/packages/webapp/components/world/engine/crest.js
@@ -1,43 +1,18 @@
-/* ============================================================== the standard
-   devcraft `world-lab.html`'s crest bench, lifted out whole.
+/* Lifted from devcraft `world-lab.html`'s crest bench. Its own module, touching
+   nothing but a 2D canvas context, so the engine's banner and React's panel/chip
+   row draw off one emitter instead of two SVG copies drifting apart.
+   Charge and tincture only come from monuments unlocked / districts founded
+   (per `userWorldEntitlements`); division is free geometry. */
 
-   Its own module rather than part of the renderer, because both halves of the
-   page draw the same mark: the engine hangs it on a banner over the world, and
-   React paints it into the panel and into the chip row of the bench. One
-   emitter, two canvases — a second SVG copy for the DOM would be the same
-   shield drawn twice and drifting apart by the second change.
-
-   Nothing here touches three.js or the DOM beyond a 2D context, which is what
-   lets the React side import it.
-
-   The composition rule is the whole design:
-
-     CHARGE     — only from signature monuments you have actually unlocked
-     TINCTURES  — only from the accents of districts you actually founded
-     DIVISION   — free, because a division is pure geometry and carries no fact
-
-   So the crest is assembled ENTIRELY out of your reading and arranged entirely
-   by you. You cannot build one that lies: a crest with the anvil on it belongs
-   to somebody who reads systems, and a reader with one district gets exactly
-   one charge to choose from — which is not a poor version of the feature, it IS
-   their identity, stated more sharply than a wide reader's ever gets stated.
-   The API is the authority on what has been earned (`userWorldEntitlements`);
-   this file only knows how to draw what it is handed. */
-
-/* Paths are written in a 100-unit box centred on the origin and filled with the
-   EVEN-ODD rule, which is what lets a ring be two circles and a dot inside a
-   ring be three, with no winding to keep track of. */
+/* Paths are written in a 100-unit box centred on the origin, filled EVEN-ODD so
+   a ring can be two circles and a dot-in-ring three, with no winding to track. */
 const _c=(x,y,r)=>`M${x-r},${y}a${r},${r} 0 1 0 ${r*2},0a${r},${r} 0 1 0 ${-r*2},0Z`;
 const _r=(x,y,w,h)=>`M${x-w/2},${y-h/2}h${w}v${h}h${-w}Z`;
-/* A groove across the wound cop, used as a HOLE: two of them are what stop a
-   tapered cone from reading as a plain cone. Half-widths have to stay inside
-   the cop at the groove's LOWEST point, or the ends fall outside the shape and
-   even-odd fills them into wings. */
+/* A groove cut as a HOLE. Half-widths must stay inside the cop at the groove's
+   LOWEST point, or the ends fall outside the shape and even-odd fills them into wings. */
 const _gv=(y,w,h)=>`M-${w},${y} L${w},${y} L${w+1},${y+h} L-${w+1},${y+h} Z`;
-/* One glyph per signature in REALMS — twenty-six, because the charge has to be
-   able to name any district in the taxonomy. They are deliberately blunt: a
-   crest is read at 22px in a chip and at share-card size in a corner, and
-   anything with interior detail is a smudge at both. */
+/* One glyph per signature in REALMS, deliberately blunt: a crest is read at
+   22px in a chip and at share-card size, and interior detail is a smudge at both. */
 export const CHARGES={
   obelisk:   {n:'OBELISK',   d:`M0,-46 L11,-33 L8,42 L-8,42 L-11,-33 Z`},
   roost:     {n:'ROOST',     d:`${_r(0,2,8,88)}${_r(0,-28,52,8)}${_r(0,-6,40,8)}${_r(0,16,28,8)}`},
@@ -46,15 +21,8 @@ export const CHARGES={
   aqueduct:  {n:'AQUEDUCT',  d:`${_r(0,-30,88,14)}M-40,44 L-40,-16 L-14,-16 L-14,44 L-24,44 L-24,-4 L-30,-4 L-30,44 Z M14,44 L14,-16 L40,-16 L40,44 L30,44 L30,-4 L24,-4 L24,44 Z`},
   wardring:  {n:'WARD RING', d:`${_c(0,0,44)}${_c(0,0,34)}M0,-22 L20,-12 L20,10 L0,26 L-20,10 L-20,-12 Z`},
   coil:      {n:'SERPENT STEPS', d:`M-44,44 L-44,18 L-17,18 L-17,-8 L10,-8 L10,-34 L44,-34 L44,44 Z`},
-  /* Follows the monument, which is the rule for every charge in here — a crest
-     is a picture of something you built, so when the thing changes the picture
-     is wrong rather than merely dated. This was a barred rectangle drawn from
-     the old weaving frame, and a grid is the one shape a crest cannot afford
-     anyway: at chip size it is indistinguishable from a missing image, which is
-     the exact complaint the frame itself collected.
-     The whorl is drawn as two wings clear of the shaft rather than as a disc
-     across it — a disc would overlap the shaft, and two overlapping solids
-     under even-odd is a slot cut through the middle of both. */
+  /* Whorl drawn as two wings clear of the shaft rather than a disc across it:
+     two overlapping solids under even-odd cut a slot through the middle of both. */
   loom:      {n:'GREAT SPINDLE',
               d:`M0,-48 L5,-37 L-5,-37 Z${_r(0,-27,7,22)}`
                +`M-19,-34 L-4,-34 L-4,-26 L-12,-26 Z`
@@ -81,9 +49,8 @@ export const CHARGES={
   clocktower:{n:'CLOCK',     d:`M0,-48 L30,-25 L-30,-25 Z${_r(0,10,46,70)}${_c(0,-4,16)}${_c(0,-4,8)}`},
 };
 
-/* Six ways to cut a field. Free choice on purpose — a division encodes nothing,
-   so it is the axis where taste is allowed to be taste. Each returns the region
-   painted in the SECOND tincture, over a field already filled with the first. */
+/* Six ways to cut a field. Each returns the region painted in the SECOND
+   tincture, over a field already filled with the first. */
 export const DIVISIONS=[
   {id:'plain',   n:'PLAIN',     f:null},
   {id:'pale',    n:'PER PALE',  f:(x,w,h)=>`M0,-${h} h${w} v${h*2} h-${w} Z`},
@@ -95,35 +62,25 @@ export const DIVISIONS=[
 
 export const hexs=v=>'#'+v.toString(16).padStart(6,'0');
 
-/* The rule of tincture, automated. Classic heraldry forbids colour on colour
-   for exactly the reason it matters here — a charge has to survive at chip
-   size — so the charge takes whichever of salt or pepper stands furthest from
-   the field it is sitting on. Nobody has to be told this rule; they just never
-   manage to build an illegible crest.
-   Computed off the integer rather than through a THREE.Color, because this
-   module is imported by React and pulling three.js in behind a chip preview
-   would be most of a megabyte for a luminance. */
+/* The charge takes whichever of salt or pepper stands furthest from the field,
+   computed off the integer rather than a THREE.Color since this module is
+   imported by React and three.js would be a lot to pull in for a luminance. */
 const _lum=hex=>((hex>>16&255)*0.2126+(hex>>8&255)*0.7152+(hex&255)*0.0722)/255;
 
 /* ONE renderer, to a canvas, and the panel uses its data URL as a background
    image. */
 export const SHIELD=(w,h)=>{
-  /* A heater shield: square shoulders, straight flanks for the top third, then
-     a curve into a point. Drawn as a path so it can be used to clip the field
-     and stroked afterwards for the bordure. */
+  /* A heater shield, drawn as a path so it can clip the field and be stroked
+     afterwards for the bordure. */
   const p=new Path2D();
   p.moveTo(-w/2,-h/2); p.lineTo(w/2,-h/2); p.lineTo(w/2,-h*0.06);
   p.bezierCurveTo(w/2,h*0.30, w*0.26,h*0.44, 0,h/2);
   p.bezierCurveTo(-w*0.26,h*0.44, -w/2,h*0.30, -w/2,-h*0.06);
   p.closePath(); return p;
 };
-/* Two shapes off one drawing. A shield is the mark; a BANNER is that same
-   field pulled out to a rectangle, which is what a real banner of arms is and
-   what a piece of cloth in a 3D scene has to be — a shield-shaped mesh would
-   need alpha, and an alpha-tested plane comes back from the outline pass ringed
-   as a full rectangle anyway, because the normal-buffer override material is
-   opaque by definition. Rectangular and opaque, the outline traces the cloth,
-   which is the correct answer rather than a workaround. */
+/* BANNER pulls the same field to a rectangle rather than a shield shape: a
+   shield-shaped mesh needs alpha, and an alpha-tested plane comes back from the
+   outline pass ringed as a full rectangle anyway. */
 export function drawCrest(g,W_,H_,c,banner){
   g.clearRect(0,0,W_,H_);
   g.save(); g.translate(W_/2,H_/2);
@@ -138,9 +95,8 @@ export function drawCrest(g,W_,H_,c,banner){
      clear of the bordure and clear of the point. */
   const ch=CHARGES[c.charge]||CHARGES.obelisk;
   const s=w*(banner?0.66:0.62)/100;
-  /* Averaged over both tinctures rather than over the one behind the charge:
-     under QUARTERLY the charge crosses all four quarters, so "the colour it is
-     sitting on" is not a single colour and picking either one loses half of it. */
+  /* Averaged over both tinctures: under QUARTERLY the charge crosses all four
+     quarters, so there is no single colour it is sitting on. */
   const L=div.f?(_lum(c.a)+_lum(c.b))/2:_lum(c.a);
   g.fillStyle=L>0.34?'#0F1218':'#FFFFFF';
   g.save(); g.translate(0,banner?0:-h*0.02); g.scale(s,s);
@@ -156,10 +112,8 @@ export function drawCrest(g,W_,H_,c,banner){
   g.restore();
 }
 
-/* Cached by the crest's own contents, because the panel, the chips and the
-   world all ask for it and the answer only changes when a chip is clicked.
-   `null` on the server and anywhere else without a canvas: the mark is chrome,
-   and a page that cannot draw it renders without it rather than throwing. */
+/* Cached by the crest's own contents. `null` on the server and anywhere without
+   a canvas: the mark is chrome, so a page that cannot draw it renders without it. */
 let _crestC=null, _crestKey='', _crestURL='';
 export function crestDataUrl(c){
   if(!c||typeof document==='undefined') return '';

--- a/packages/webapp/components/world/engine/look.js
+++ b/packages/webapp/components/world/engine/look.js
@@ -1,0 +1,101 @@
+/* ================================================================== the look
+   The film a world is photographed through: six graded presets and the seven
+   knobs that fork one into a look of your own.
+
+   Its own module for the same reason the crest is: the renderer pushes these
+   numbers into the grade, outline and bloom passes, and the bench in the panel
+   has to list the presets, their swatches and their ranges. Verbatim from
+   devcraft `world-lab.html`, with `fx` carried as booleans rather than 1/0 —
+   that is the shape the API stores and the shape that travels.
+
+   A look is a property of the WORLD rather than of whoever is looking at it:
+   the grade its owner picks is the grade every visitor sees it through. */
+
+export const LOOK_DEFS=[
+  {id:'diorama', n:'DIORAMA', sw:[0x272A32,0xF5F6FA],
+   d:'The file\'s own art direction: soft ink on every silhouette, a warm key, and nothing pushed.',
+   fx:{post:true,bloom:true,outline:true},
+   sat:1.00, lift:0.05, vig:0.17, grain:0.026, warm:0.00, duo:0.00,
+   duoA:0x272A32, duoB:0xF5F6FA, ink:0x2A2438, ol:0.24, bl:1.00},
+  {id:'ink', n:'INK', sw:[0x1E2229,0xEBEEF5],
+   d:'Illustrated rather than lit. Lines carry the shapes and the colour steps back behind them.',
+   fx:{post:true,bloom:true,outline:true},
+   sat:0.74, lift:0.04, vig:0.26, grain:0.050, warm:-0.08, duo:0.00,
+   duoA:0x1E2229, duoB:0xEBEEF5, ink:0x1E2229, ol:0.78, bl:0.55},
+  {id:'sun', n:'SUNPRINT', sw:[0x713015,0xFFF3B7],
+   d:'No lines at all, and the glow let off its leash — an overexposed afternoon.',
+   fx:{post:true,bloom:true,outline:false},
+   sat:1.12, lift:0.03, vig:0.10, grain:0.018, warm:0.50, duo:0.00,
+   duoA:0x713015, duoB:0xFFF3B7, ink:0x2A2438, ol:0.24, bl:1.90},
+  {id:'blue', n:'BLUEPRINT', sw:[0x0B42C1,0xEBEEF5],
+   d:'A cyanotype of your own world. The ramp does the colour, the outlines do the drawing.',
+   fx:{post:true,bloom:true,outline:true},
+   sat:0.30, lift:0.02, vig:0.20, grain:0.030, warm:-0.20, duo:0.82,
+   duoA:0x0B42C1, duoB:0xEBEEF5, ink:0x00A0AB, ol:0.82, bl:0.50},
+  {id:'riso', n:'RISO', sw:[0xCB3160,0xFFE877],
+   d:'Two inks and visible tooth. The one look that reads as printed rather than rendered.',
+   fx:{post:true,bloom:true,outline:true},
+   sat:0.92, lift:0.03, vig:0.14, grain:0.085, warm:0.18, duo:0.58,
+   duoA:0xCB3160, duoB:0xFFE877, ink:0xA51A14, ol:0.34, bl:1.10},
+  {id:'storm', n:'STORM', sw:[0x1E2229,0xBAC4DA],
+   d:'Cold, closed in, and heavily cornered.',
+   fx:{post:true,bloom:true,outline:true},
+   sat:0.82, lift:0.07, vig:0.44, grain:0.055, warm:-0.45, duo:0.30,
+   duoA:0x1E2229, duoB:0xBAC4DA, ink:0x0F1218, ol:0.30, bl:1.25},
+];
+
+/* Seven knobs, and the list is short on purpose: every one of them changes the
+   whole frame at a glance. A slider whose effect has to be hunted for is a
+   slider that teaches somebody their taste does not matter. */
+export const LOOK_KNOBS=[
+  {k:'ol',    n:'Outline', min:0,    max:1,    step:0.02},
+  {k:'bl',    n:'Glow',    min:0,    max:2.6,  step:0.05},
+  {k:'duo',   n:'Duotone', min:0,    max:1,    step:0.02},
+  {k:'warm',  n:'Warmth',  min:-1,   max:1,    step:0.02},
+  {k:'sat',   n:'Colour',  min:0,    max:1.6,  step:0.02},
+  {k:'grain', n:'Grain',   min:0,    max:0.12, step:0.002},
+  {k:'vig',   n:'Corners', min:0,    max:0.6,  step:0.01},
+];
+
+/** What a preset becomes the moment a knob moves. Never a `base`. */
+export const LOOK_FORKED_ID='mine';
+
+export const lookPreset=id=>LOOK_DEFS.find(l=>l.id===id)||LOOK_DEFS[0];
+
+/* Percent for anything that reads as an amount, three decimals for grain, which
+   lives entirely inside the first two. */
+export const fmtKnob=(k,v)=>k==='grain'?v.toFixed(3).slice(1)
+  :k==='bl'||k==='sat'?v.toFixed(2)
+  :`${Math.round(v*100)}`;
+
+/**
+ * A look as it is stored: every knob, both duotone inks, the ink colour and the
+ * three passes, plus which preset it was forked from.
+ *
+ * `name` is stored empty and stays that way. A look of your own is what the
+ * knobs are set to, not a thing you have to christen before you may keep it —
+ * the field exists because the API's schema has one, and clicking a preset is
+ * how you leave a fork rather than a second, named object to manage.
+ *
+ * `base` records which preset a fork started from. Nothing reads it yet; it is
+ * stored because it is the fact you cannot recover afterwards.
+ */
+export const lookFromPreset=id=>{
+  const src=lookPreset(id);
+  return {
+    id:src.id, base:src.id, mine:false, name:'',
+    ol:src.ol, bl:src.bl, duo:src.duo, warm:src.warm, sat:src.sat,
+    grain:src.grain, vig:src.vig, lift:src.lift,
+    duoA:src.duoA, duoB:src.duoB, ink:src.ink,
+    fx:{...src.fx},
+  };
+};
+
+export const DEFAULT_LOOK_ID=LOOK_DEFS[0].id;
+
+/* The fork. Any knob turns the preset into a look of your own — it is not a
+   mode you enter, it is what happens the moment you disagree with one. */
+export const forkLook=(look,patch)=>({
+  ...look, ...patch,
+  ...(look.mine?null:{id:LOOK_FORKED_ID, base:look.id, mine:true}),
+});

--- a/packages/webapp/components/world/engine/look.js
+++ b/packages/webapp/components/world/engine/look.js
@@ -1,15 +1,8 @@
-/* ================================================================== the look
-   The film a world is photographed through: six graded presets and the seven
-   knobs that fork one into a look of your own.
-
-   Its own module for the same reason the crest is: the renderer pushes these
-   numbers into the grade, outline and bloom passes, and the bench in the panel
-   has to list the presets, their swatches and their ranges. Verbatim from
-   devcraft `world-lab.html`, with `fx` carried as booleans rather than 1/0 —
-   that is the shape the API stores and the shape that travels.
-
-   A look is a property of the WORLD rather than of whoever is looking at it:
-   the grade its owner picks is the grade every visitor sees it through. */
+/* Six graded presets and the seven knobs that fork one, verbatim from devcraft
+   `world-lab.html` (`fx` as booleans, the shape the API stores). Its own module
+   so both the renderer's passes and the panel's bench list the same table.
+   A look is a property of the world, not the viewer: the owner's grade is what
+   every visitor sees it through. */
 
 export const LOOK_DEFS=[
   {id:'diorama', n:'DIORAMA', sw:[0x272A32,0xF5F6FA],
@@ -44,9 +37,7 @@ export const LOOK_DEFS=[
    duoA:0x1E2229, duoB:0xBAC4DA, ink:0x0F1218, ol:0.30, bl:1.25},
 ];
 
-/* Seven knobs, and the list is short on purpose: every one of them changes the
-   whole frame at a glance. A slider whose effect has to be hunted for is a
-   slider that teaches somebody their taste does not matter. */
+/* Kept to seven on purpose: each one should change the whole frame at a glance. */
 export const LOOK_KNOBS=[
   {k:'ol',    n:'Outline', min:0,    max:1,    step:0.02},
   {k:'bl',    n:'Glow',    min:0,    max:2.6,  step:0.05},
@@ -72,13 +63,9 @@ export const fmtKnob=(k,v)=>k==='grain'?v.toFixed(3).slice(1)
  * A look as it is stored: every knob, both duotone inks, the ink colour and the
  * three passes, plus which preset it was forked from.
  *
- * `name` is stored empty and stays that way. A look of your own is what the
- * knobs are set to, not a thing you have to christen before you may keep it —
- * the field exists because the API's schema has one, and clicking a preset is
- * how you leave a fork rather than a second, named object to manage.
- *
- * `base` records which preset a fork started from. Nothing reads it yet; it is
- * stored because it is the fact you cannot recover afterwards.
+ * `name` stays empty — a look of your own is just the knobs, never a thing to
+ * christen. `base` records which preset a fork started from; nothing reads it
+ * yet, but it can't be recovered afterwards.
  */
 export const lookFromPreset=id=>{
   const src=lookPreset(id);
@@ -93,8 +80,7 @@ export const lookFromPreset=id=>{
 
 export const DEFAULT_LOOK_ID=LOOK_DEFS[0].id;
 
-/* The fork. Any knob turns the preset into a look of your own — it is not a
-   mode you enter, it is what happens the moment you disagree with one. */
+/* Any knob turns the preset into a look of your own; not a mode you enter. */
 export const forkLook=(look,patch)=>({
   ...look, ...patch,
   ...(look.mine?null:{id:LOOK_FORKED_ID, base:look.id, mine:true}),

--- a/packages/webapp/components/world/engine/sky.js
+++ b/packages/webapp/components/world/engine/sky.js
@@ -1,0 +1,74 @@
+import { mixTok, T } from './taxonomy';
+
+/* ================================================================== the sky
+   The sky USED to be a readout: whichever realm you had been reading lately
+   owned it, ranked never blended. It was devcraft's answer to "where does
+   recency live", and as a piece of information design it worked.
+
+   It is not that any more, and the reason is worth writing down. The sky is the
+   single biggest thing on screen and the only channel that survives at
+   share-card size — which makes it simultaneously the best readout in the world
+   and the thing that decides what this page LOOKS like. Those two claims cannot
+   both be honoured, and the readout is the one that loses: the same fact is
+   already carried, permanently and unfakeably, by which quarters of the map are
+   large. Recency was the weakest thing the sky could have been spending itself
+   on, and paying for it in a world whose colour changed under its owner the
+   moment the growth log landed was paying twice.
+
+   So the reading sky is gone and the sky is GIVEN AWAY instead. Note what is
+   still not on offer: land, level, density, monuments. Those are the portrait.
+   The sky could be handed over precisely because losing it as a readout costs
+   the portrait nothing; nothing else is that cheap.
+
+   Two axes rather than one list, because two axes is what makes a sky feel
+   FOUND instead of picked: eight palettes and five hours is forty skies.
+
+   Its own module so the bench in the panel can list the same eight and five the
+   renderer paints from — a second copy of these tables would drift by the first
+   palette anybody added. */
+
+export const SKY_PAL = [
+  {id:'brand',   n:'Brand dusk', a:mixTok(T.onion20,T.salt10,0.24), b:T.cheese10},
+  {id:'clear',   n:'Clear day',  a:mixTok(T.water10,T.salt10,0.16), b:T.salt0},
+  {id:'blossom', n:'Blossom',    a:mixTok(T.bacon10,T.salt10,0.28), b:T.cheese10},
+  {id:'ember',   n:'Ember',      a:mixTok(T.onion90,T.bun40,0.22),  b:T.bun20},
+  {id:'seaglass',n:'Seaglass',   a:mixTok(T.blue40,T.salt10,0.32),  b:T.lettuce10},
+  {id:'orchid',  n:'Orchid',     a:mixTok(T.cabbage40,T.salt10,0.18),b:T.bacon10},
+  {id:'harvest', n:'Harvest',    a:mixTok(T.cheese40,T.salt10,0.12), b:T.bun10},
+  {id:'slate',   n:'Slate',      a:mixTok(T.pepper10,T.salt50,0.44), b:T.salt40},
+];
+
+/* The hour moves the sun and nothing else moves with it, which is the whole
+   reason it can be given away for free: the sun is placed once and never
+   animated, so re-aiming it costs one environment repaint and zero per-frame
+   work. `tint`/`ka`/`kb`/`mul` are how an hour reaches the SKY as well as the
+   light — a palette dragged toward one colour and scaled down. Without it,
+   night is a bright noon sky with the lamps turned up, which reads as an
+   eclipse rather than an evening.
+   DAY is the file's original lighting rig to the decimal, so it is the default
+   and nothing about the locked art direction moves unless somebody asks. */
+export const SKY_HOUR = [
+  {id:'dawn', n:'Dawn',  sun:[0.9,0.42,0.55],  sunC:0xFFD9C8, sunI:1.5,
+   hemiI:0.30, fillI:0.72, rimI:0.52, exp:0.90, tint:0xFF879F, ka:0.24, kb:0.34, mul:0.94},
+  {id:'day',  n:'Day',   sun:[0.62,1.5,0.4],   sunC:0xFFF3B7, sunI:2.0,
+   hemiI:0.30, fillI:0.80, rimI:0.40, exp:0.93, tint:0xFFFFFF, ka:0.00, kb:0.00, mul:1.00},
+  {id:'gold', n:'Golden',sun:[-0.35,0.55,0.86],sunC:0xFFE24C, sunI:2.1,
+   hemiI:0.26, fillI:0.70, rimI:0.58, exp:0.96, tint:0xFFAB81, ka:0.30, kb:0.26, mul:0.97},
+  {id:'dusk', n:'Dusk',  sun:[-0.85,0.26,-0.3],sunC:0xFFAB81, sunI:1.15,
+   hemiI:0.24, fillI:0.66, rimI:0.66, exp:0.86, tint:0x6B56DD, ka:0.42, kb:0.22, mul:0.84},
+  /* The one that repays the whole feature. Everything emissive in this world —
+     lamps, beacons, the orrery, lit windows, the ley lines — is already on the
+     bloom layer and already sized for daylight, so dropping the key by 4x hands
+     the frame to them without a single new light being added. It is also the
+     best share card the file can produce, which is not a coincidence: a world
+     at night is a world whose ONLY bright parts are the parts you built. */
+  {id:'night',n:'Night', sun:[-0.5,0.34,-0.62],sunC:0x9FB6FF, sunI:0.50,
+   hemiI:0.15, fillI:0.40, rimI:0.60, exp:0.80, tint:0x141A2E, ka:0.72, kb:0.46, mul:0.58},
+];
+
+/* Where a sky starts before anybody touches it — the file's own art direction,
+   which is what every world was painted with before the bench existed. */
+export const DEFAULT_SKY = { pal: 'brand', hour: 'day' };
+
+export const skyPalOf=id=>SKY_PAL.find(p=>p.id===id)||SKY_PAL[0];
+export const skyHourOf=id=>SKY_HOUR.find(h=>h.id===id)||SKY_HOUR[1];

--- a/packages/webapp/components/world/engine/sky.js
+++ b/packages/webapp/components/world/engine/sky.js
@@ -1,31 +1,9 @@
 import { mixTok, T } from './taxonomy';
 
-/* ================================================================== the sky
-   The sky USED to be a readout: whichever realm you had been reading lately
-   owned it, ranked never blended. It was devcraft's answer to "where does
-   recency live", and as a piece of information design it worked.
-
-   It is not that any more, and the reason is worth writing down. The sky is the
-   single biggest thing on screen and the only channel that survives at
-   share-card size — which makes it simultaneously the best readout in the world
-   and the thing that decides what this page LOOKS like. Those two claims cannot
-   both be honoured, and the readout is the one that loses: the same fact is
-   already carried, permanently and unfakeably, by which quarters of the map are
-   large. Recency was the weakest thing the sky could have been spending itself
-   on, and paying for it in a world whose colour changed under its owner the
-   moment the growth log landed was paying twice.
-
-   So the reading sky is gone and the sky is GIVEN AWAY instead. Note what is
-   still not on offer: land, level, density, monuments. Those are the portrait.
-   The sky could be handed over precisely because losing it as a readout costs
-   the portrait nothing; nothing else is that cheap.
-
-   Two axes rather than one list, because two axes is what makes a sky feel
-   FOUND instead of picked: eight palettes and five hours is forty skies.
-
-   Its own module so the bench in the panel can list the same eight and five the
-   renderer paints from — a second copy of these tables would drift by the first
-   palette anybody added. */
+/* The sky is customisable, not a recency readout (which quarters of the map are
+   large already carries that fact). Two axes rather than one list — eight
+   palettes by five hours makes a sky feel FOUND instead of picked. Its own
+   module so the bench in the panel lists the same tables the renderer paints from. */
 
 export const SKY_PAL = [
   {id:'brand',   n:'Brand dusk', a:mixTok(T.onion20,T.salt10,0.24), b:T.cheese10},
@@ -38,15 +16,10 @@ export const SKY_PAL = [
   {id:'slate',   n:'Slate',      a:mixTok(T.pepper10,T.salt50,0.44), b:T.salt40},
 ];
 
-/* The hour moves the sun and nothing else moves with it, which is the whole
-   reason it can be given away for free: the sun is placed once and never
-   animated, so re-aiming it costs one environment repaint and zero per-frame
-   work. `tint`/`ka`/`kb`/`mul` are how an hour reaches the SKY as well as the
-   light — a palette dragged toward one colour and scaled down. Without it,
-   night is a bright noon sky with the lamps turned up, which reads as an
-   eclipse rather than an evening.
-   DAY is the file's original lighting rig to the decimal, so it is the default
-   and nothing about the locked art direction moves unless somebody asks. */
+/* The sun is placed once and never animated, so re-aiming it costs one repaint
+   and zero per-frame work. `tint`/`ka`/`kb`/`mul` drag the palette toward one
+   colour and scale it down so the SKY moves with the light, not just the lamps.
+   DAY matches the original lighting rig to the decimal and is the default. */
 export const SKY_HOUR = [
   {id:'dawn', n:'Dawn',  sun:[0.9,0.42,0.55],  sunC:0xFFD9C8, sunI:1.5,
    hemiI:0.30, fillI:0.72, rimI:0.52, exp:0.90, tint:0xFF879F, ka:0.24, kb:0.34, mul:0.94},
@@ -56,18 +29,13 @@ export const SKY_HOUR = [
    hemiI:0.26, fillI:0.70, rimI:0.58, exp:0.96, tint:0xFFAB81, ka:0.30, kb:0.26, mul:0.97},
   {id:'dusk', n:'Dusk',  sun:[-0.85,0.26,-0.3],sunC:0xFFAB81, sunI:1.15,
    hemiI:0.24, fillI:0.66, rimI:0.66, exp:0.86, tint:0x6B56DD, ka:0.42, kb:0.22, mul:0.84},
-  /* The one that repays the whole feature. Everything emissive in this world —
-     lamps, beacons, the orrery, lit windows, the ley lines — is already on the
-     bloom layer and already sized for daylight, so dropping the key by 4x hands
-     the frame to them without a single new light being added. It is also the
-     best share card the file can produce, which is not a coincidence: a world
-     at night is a world whose ONLY bright parts are the parts you built. */
+  /* Dropping the key by 4x hands the frame to whatever is already on the bloom
+     layer (lamps, beacons, lit windows) without adding a single new light. */
   {id:'night',n:'Night', sun:[-0.5,0.34,-0.62],sunC:0x9FB6FF, sunI:0.50,
    hemiI:0.15, fillI:0.40, rimI:0.60, exp:0.80, tint:0x141A2E, ka:0.72, kb:0.46, mul:0.58},
 ];
 
-/* Where a sky starts before anybody touches it — the file's own art direction,
-   which is what every world was painted with before the bench existed. */
+/* The file's own art direction: what every world was painted with before the bench. */
 export const DEFAULT_SKY = { pal: 'brand', hour: 'day' };
 
 export const skyPalOf=id=>SKY_PAL.find(p=>p.id===id)||SKY_PAL[0];

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -5,6 +5,9 @@ import { ShaderPass }     from 'three/addons/postprocessing/ShaderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { WORLD_CSS } from './styles';
+import { drawCrest } from './crest';
+import { DEFAULT_LOOK_ID, lookFromPreset } from './look';
+import { DEFAULT_SKY, skyHourOf, skyPalOf } from './sky';
 import {
   LEVELS,
   levelOf,
@@ -30,8 +33,10 @@ import {
        engine keeps only the DOM that has to be positioned by projecting a world
        point to a pixel — labels, leader lines, the ride reticle, the toast feed
        — and pushes everything else out through `onState`;
-     - the customisation benches are gone for this pass: no sky palette, no
-       names, no crest, no look presets, no FX switches. Defaults only.
+     - the district nameplates are gone: a district's name is the taxonomy's.
+       The sky, the crest and the look come in through `setSky`, `setCrest` and
+       `setLook`, driven by what the owner saved rather than by a panel the
+       engine owns its own DOM for.
 
    One engine per page. Every accumulator the art builders share lives inside
    this closure, so two of them would not collide — but two WebGL contexts over
@@ -5309,72 +5314,15 @@ function leaveRealm(){
   updateHud(); renderRank(true); buildAir(); placeClouds();
 }
 
-/* ================================================================== the sky */
-/* The sky USED to be a readout: whichever realm you had been reading lately
-   owned it, ranked never blended. It was the file's answer to "where does
-   recency live", and as a piece of information design it worked.
-
-   It is not that any more, and the reason is worth writing down. The sky is the
-   single biggest thing on screen and the only channel that survives at
-   share-card size — which makes it simultaneously the best readout in the world
-   and the thing that decides what this page LOOKS like. Those two claims cannot
-   both be honoured, and the readout is the one that loses: the same fact is
-   already carried, permanently and unfakeably, by which quarters of the map are
-   large. Recency was the weakest thing the sky could have been spending itself
-   on, and paying for it in a world whose colour changed per reader — and
-   changed again under them the moment the growth log landed — was paying twice.
-
-   So the sky is fixed. One palette, one hour, the same for everybody. Note what
-   is NOT on offer: land, level, density, monuments. Those are the portrait.
-
-   Two axes rather than a list, because two axes is what makes a sky feel FOUND
-   instead of picked: eight palettes and five hours is forty skies. That is a
-   customisation feature and it is out of this pass — the list stays because it
-   costs nothing and it is what the feature comes back as. */
-const SKY_PAL=[
-  {id:'brand',   n:'BRAND DUSK', a:mixTok(T.onion20,T.salt10,0.24), b:T.cheese10},
-  {id:'clear',   n:'CLEAR DAY',  a:mixTok(T.water10,T.salt10,0.16), b:T.salt0},
-  {id:'blossom', n:'BLOSSOM',    a:mixTok(T.bacon10,T.salt10,0.28), b:T.cheese10},
-  {id:'ember',   n:'EMBER',      a:mixTok(T.onion90,T.bun40,0.22),  b:T.bun20},
-  {id:'seaglass',n:'SEAGLASS',   a:mixTok(T.blue40,T.salt10,0.32),  b:T.lettuce10},
-  {id:'orchid',  n:'ORCHID',     a:mixTok(T.cabbage40,T.salt10,0.18),b:T.bacon10},
-  {id:'harvest', n:'HARVEST',    a:mixTok(T.cheese40,T.salt10,0.12), b:T.bun10},
-  {id:'slate',   n:'SLATE',      a:mixTok(T.pepper10,T.salt50,0.44), b:T.salt40},
-];
-/* The hour moves the sun and nothing else moves with it, which is the whole
-   reason it can be given away for free: the sun is placed once and never
-   animated, so re-aiming it costs one environment repaint and zero per-frame
-   work. `tint`/`ka`/`kb`/`mul` are how an hour reaches the SKY as well as the
-   light — a palette dragged toward one colour and scaled down. Without it,
-   night is a bright noon sky with the lamps turned up, which reads as an
-   eclipse rather than an evening.
-   DAY is the file's original lighting rig to the decimal, so it is the default
-   and nothing about the locked art direction moves unless somebody asks. */
-const SKY_HOUR=[
-  {id:'dawn', n:'DAWN',  sun:[0.9,0.42,0.55],  sunC:0xFFD9C8, sunI:1.5,
-   hemiI:0.30, fillI:0.72, rimI:0.52, exp:0.90, tint:0xFF879F, ka:0.24, kb:0.34, mul:0.94},
-  {id:'day',  n:'DAY',   sun:[0.62,1.5,0.4],   sunC:0xFFF3B7, sunI:2.0,
-   hemiI:0.30, fillI:0.80, rimI:0.40, exp:0.93, tint:0xFFFFFF, ka:0.00, kb:0.00, mul:1.00},
-  {id:'gold', n:'GOLDEN',sun:[-0.35,0.55,0.86],sunC:0xFFE24C, sunI:2.1,
-   hemiI:0.26, fillI:0.70, rimI:0.58, exp:0.96, tint:0xFFAB81, ka:0.30, kb:0.26, mul:0.97},
-  {id:'dusk', n:'DUSK',  sun:[-0.85,0.26,-0.3],sunC:0xFFAB81, sunI:1.15,
-   hemiI:0.24, fillI:0.66, rimI:0.66, exp:0.86, tint:0x6B56DD, ka:0.42, kb:0.22, mul:0.84},
-  /* The one that repays the whole feature. Everything emissive in this world —
-     lamps, beacons, the orrery, lit windows, the ley lines — is already on the
-     bloom layer and already sized for daylight, so dropping the key by 4x hands
-     the frame to them without a single new light being added. It is also the
-     best share card the file can produce, which is not a coincidence: a world
-     at night is a world whose ONLY bright parts are the parts you built. */
-  {id:'night',n:'NIGHT', sun:[-0.5,0.34,-0.62],sunC:0x9FB6FF, sunI:0.50,
-   hemiI:0.15, fillI:0.40, rimI:0.60, exp:0.80, tint:0x141A2E, ka:0.72, kb:0.46, mul:0.58},
-];
-const SKY={pal:'brand',hour:'day'};
-const skyPalOf=id=>SKY_PAL.find(p=>p.id===id)||SKY_PAL[0];
-const skyHourOf=id=>SKY_HOUR.find(h=>h.id===id)||SKY_HOUR[1];
+/* The sky, its eight palettes and its five hours, all in `sky.js` — the bench
+   in the panel lists the same tables this paints from. What is NOT there is the
+   reading sky: whichever realm you had read lately used to own the colour, and
+   that readout is the thing the sky was freed from rather than a preset. */
+const SKY={...DEFAULT_SKY};
 
 /* Repainting a sky regenerates the PMREM environment, so it is guarded by a key
-   rather than by a flag. Nothing moves the key while a world is up any more, so
-   this now runs exactly once per load. */
+   rather than by a flag: the bench can set the same palette twice, and picking
+   an hour you are already on must not cost an environment rebuild. */
 let skyKey='';
 function applySky(){
   const p=skyPalOf(SKY.pal), h=skyHourOf(SKY.hour);
@@ -5403,6 +5351,21 @@ function applySky(){
   hemi.color.setHex(A).lerp(new THREE.Color(0xFFFFFF),0.55);
   hemi.intensity=h.hemiI;
   paintSky(A,B,HZ);
+  /* The banner is lit by the map in daylight and by its own emissive after
+     dark. A piece of cloth lit by a key at a quarter strength is a piece of
+     cloth you cannot read, and NIGHT is the hour where the crest matters most —
+     it is the best share card this file can produce. */
+  if(stdCloth) stdCloth.material.emissiveIntensity=clamp(1-h.sunI/2,0,0.8);
+}
+/* Palette and hour, both of them free: neither carries a fact. The sky used to
+   be a readout — whichever realm you had been reading lately owned it — and
+   that is the one thing NOT on offer here, because the same fact is already
+   carried permanently by which quarters of the map are large. What is left is
+   the only channel big enough to make a place feel like yours. */
+function skySet(next){
+  if(!next)return;
+  SKY.pal=next.pal||SKY.pal; SKY.hour=next.hour||SKY.hour;
+  applySky();
 }
 
 /* ================================================================ the names
@@ -6710,44 +6673,11 @@ function sizePost(){
 sizePost();
 
 /* ================================================================= the look
-   The lab offered six graded looks and seven knobs, forked into "mine" the
-   moment you moved one. That is customisation and it is out of this pass, so
-   what is left is DIORAMA — the file's own art direction — pushed once into the
-   passes. The rest of the presets stay listed because they cost nothing and
-   they are what the feature comes back as. */
-const LOOK_DEFS=[
-  {id:'diorama', n:'DIORAMA',
-   d:'The file\'s own art direction: soft ink on every silhouette, a warm key, and nothing pushed.',
-   fx:{post:1,bloom:1,outline:1},
-   sat:1.00, lift:0.05, vig:0.17, grain:0.026, warm:0.00, duo:0.00,
-   duoA:0x272A32, duoB:0xF5F6FA, ink:0x2A2438, ol:0.24, bl:1.00},
-  {id:'ink', n:'INK',
-   d:'Illustrated rather than lit. Lines carry the shapes and the colour steps back behind them.',
-   fx:{post:1,bloom:1,outline:1},
-   sat:0.74, lift:0.04, vig:0.26, grain:0.050, warm:-0.08, duo:0.00,
-   duoA:0x1E2229, duoB:0xEBEEF5, ink:0x1E2229, ol:0.78, bl:0.55},
-  {id:'sun', n:'SUNPRINT',
-   d:'No lines at all, and the glow let off its leash — an overexposed afternoon.',
-   fx:{post:1,bloom:1,outline:0},
-   sat:1.12, lift:0.03, vig:0.10, grain:0.018, warm:0.50, duo:0.00,
-   duoA:0x713015, duoB:0xFFF3B7, ink:0x2A2438, ol:0.24, bl:1.90},
-  {id:'blue', n:'BLUEPRINT',
-   d:'A cyanotype of your own world. The ramp does the colour, the outlines do the drawing.',
-   fx:{post:1,bloom:1,outline:1},
-   sat:0.30, lift:0.02, vig:0.20, grain:0.030, warm:-0.20, duo:0.82,
-   duoA:0x0B42C1, duoB:0xEBEEF5, ink:0x00A0AB, ol:0.82, bl:0.50},
-  {id:'riso', n:'RISO',
-   d:'Two inks and visible tooth. The one look that reads as printed rather than rendered.',
-   fx:{post:1,bloom:1,outline:1},
-   sat:0.92, lift:0.03, vig:0.14, grain:0.085, warm:0.18, duo:0.58,
-   duoA:0xCB3160, duoB:0xFFE877, ink:0xA51A14, ol:0.34, bl:1.10},
-  {id:'storm', n:'STORM',
-   d:'Cold, closed in, and heavily cornered. Pairs with NIGHT and with nothing else.',
-   fx:{post:1,bloom:1,outline:1},
-   sat:0.82, lift:0.07, vig:0.44, grain:0.055, warm:-0.45, duo:0.30,
-   duoA:0x1E2229, duoB:0xBAC4DA, ink:0x0F1218, ol:0.30, bl:1.25},
-];
-const LOOK={...LOOK_DEFS[0]};
+   Six graded presets and the seven knobs that fork one, in `look.js` because
+   the bench in the panel lists the same table this pushes into the passes.
+   The world starts on DIORAMA — the file's own art direction — and is told
+   about its owner's look once the settings land. */
+const LOOK={...lookFromPreset(DEFAULT_LOOK_ID)};
 
 function lookPush(){
   const u=gradePass.material.uniforms;
@@ -6760,15 +6690,161 @@ function lookPush(){
   /* An outline strength of zero still pays for a full normal-and-depth pass, so
      the switch follows the slider to the floor rather than leaving a pass
      rendering nothing. Same for the glow. */
-  FX.outline=LOOK.ol>0.005 && LOOK.fx.outline!==0;
-  FX.bloom  =LOOK.bl>0.005 && LOOK.fx.bloom!==0;
-  FX.post   =LOOK.fx.post!==0;
+  FX.outline=LOOK.ol>0.005 && LOOK.fx.outline!==false;
+  FX.bloom  =LOOK.bl>0.005 && LOOK.fx.bloom!==false;
+  FX.post   =LOOK.fx.post!==false;
 }
-function lookSet(id){
-  const src=LOOK_DEFS.find(l=>l.id===id); if(!src)return;
-  Object.assign(LOOK,src); lookPush();
+/* A WHOLE look, not a preset id: the panel forks a preset the moment a knob
+   moves, so what the page has in its hand is already an object rather than a
+   name, and anything it does not carry stays at the preset it was forked from
+   rather than at whatever the previous look happened to leave behind. */
+function lookSet(next){
+  const base=lookFromPreset(next&&next.base?next.base:(next&&next.id)||DEFAULT_LOOK_ID);
+  Object.assign(LOOK,base,next,{fx:{...base.fx,...(next&&next.fx)}});
+  lookPush();
 }
 lookPush();
+
+/* ============================================================= the standard
+   The crest is the piece of all this that TRAVELS, and that is the argument for
+   flying it here. A name and a look are yours privately — they change what your
+   world is like to sit in. Neither survives being seen by somebody else for two
+   seconds in a feed, which is the only test that matters for the loop this
+   product is built on. A mark does.
+
+   What is on the shield is decided elsewhere (`crest.js` draws it, the API says
+   what has been earned). This end owns one question only: where it stands. */
+let CREST=null;
+/* The cloth's own canvas, repainted only when the crest changes. Separate from
+   the panel's copy in `crest.js`, because the two are different shapes — and
+   because toDataURL() on the panel's would otherwise have to run every time the
+   flag wanted a texture. */
+let _flagC=null, _flagT=null, _flagKey='';
+function crestTex(){
+  if(!CREST) return null;
+  const key=CREST.charge+CREST.div+CREST.a+CREST.b;
+  if(!_flagC){ _flagC=document.createElement('canvas');
+               _flagC.width=192; _flagC.height=232;
+               _flagT=new THREE.CanvasTexture(_flagC);
+               _flagT.colorSpace=THREE.SRGBColorSpace;
+               _flagT.anisotropy=4; }
+  if(key!==_flagKey){ _flagKey=key;
+    drawCrest(_flagC.getContext('2d'),192,232,CREST,true);
+    _flagT.needsUpdate=true; }
+  return _flagT;
+}
+
+/* One flag, on the highest ground of the biggest thing on screen — the largest
+   realm out at world zoom, the largest district once you have walked into one.
+
+   ONE, and that is the decision worth defending. A standard on every island
+   would be six copies of the same mark competing with the realm names, and a
+   mark you see six times at once stops being a mark and becomes wallpaper. A
+   capital has one flag. Where it stands is also information: it moves to
+   whatever you have read most, so over a replay it migrates across the map, and
+   watching it move is watching your own attention move.
+
+   It lives at scene level rather than under a district, because a district is
+   disposed and rebuilt on every level-up and the flag has nothing to do with
+   any one of them. It is the world's, not the town's. */
+const stdRoot=new THREE.Group(); scene.add(stdRoot);
+/* The banner hangs off a pivot rather than off the root, and the pivot is what
+   turns to face the camera. Two things were wrong with rotating the cloth on
+   its own: the cloth's plane ran through the pole's axis, so a billboarded
+   banner sliced the pole down the middle at every angle — and the crossbar,
+   left behind in the root, went on pointing wherever it was first built while
+   the cloth swung away from it. The bar, its finials and the cloth are one
+   assembly; they turn together, and they hang in FRONT. */
+const stdPivot=new THREE.Group();
+const STD_POLE=13.2, STD_W=3.6, STD_H=4.35;
+/* Far enough forward to clear the pole at its widest plus everything the wave
+   can do, which is what the one-sided ripple below exists to bound. */
+const STD_FWD=0.30;
+let stdCloth=null, stdBase=null;
+{
+  const metal=mixTok(T.salt40,T.pepper10,0.42);
+  const pole=meshOf(new THREE.CylinderGeometry(0.10,0.15,STD_POLE,7),
+    mat(metal,{rough:0.45,metal:0.15}));
+  pole.position.y=STD_POLE/2; stdRoot.add(pole);
+  const fin=meshOf(new THREE.OctahedronGeometry(0.30),mat(T.cheese40,{rough:0.3}));
+  fin.position.y=STD_POLE+0.18; stdRoot.add(fin);
+
+  stdPivot.position.y=STD_POLE-0.35; stdRoot.add(stdPivot);
+  const bar=meshOf(boxG(STD_W+0.55,0.15,0.15),mat(metal,{rough:0.45}));
+  bar.position.z=STD_FWD*0.6; stdPivot.add(bar);
+  for(const sx of [-1,1]){
+    const k=meshOf(new THREE.OctahedronGeometry(0.17),mat(T.cheese40,{rough:0.3}));
+    k.position.set(sx*(STD_W/2+0.32),0,STD_FWD*0.6); stdPivot.add(k);
+  }
+  /* Its own material, never the shared cache: a cached material is keyed by
+     colour, and hanging a texture on one would put this crest on every surface
+     in the world that happened to share its hex. */
+  const cm=new THREE.MeshStandardMaterial({roughness:0.88,
+    side:THREE.DoubleSide,flatShading:false,
+    emissive:0xFFFFFF,emissiveIntensity:0});
+  stdCloth=new THREE.Mesh(new THREE.PlaneGeometry(STD_W,STD_H,10,7),cm);
+  stdCloth.position.set(0,-0.12-STD_H/2,STD_FWD);
+  stdPivot.add(stdCloth);
+  stdBase=stdCloth.geometry.attributes.position.array.slice();
+  stdRoot.visible=false;
+}
+/* Throttled rather than dirty-flagged. The target is the argmax of ~40 numbers
+   and changes on level-ups, on entering a realm, on leaving one and on every
+   scrubbed day — four call sites and a fifth to forget, against one reduce
+   twice a second. */
+let stdT=0;
+function placeStandard(t){
+  if(t-stdT<0.45)return; stdT=t;
+  /* No crest is not an empty shield: a world that has raised nothing has no
+     mark, so it flies no pole either. */
+  if(!W||!CREST||W.unbuilt){ stdRoot.visible=false; return; }
+  const list=(OPEN?OPEN.list.filter(d=>d.shown>0&&d.built)
+                 :W.quarters.filter(q=>q.shown>0&&q.island));
+  if(!list.length){ stdRoot.visible=false; return; }
+  let x=list[0]; for(const o of list) if(o.shown>x.shown) x=o;
+  const R=OPEN?spec(Math.max(1,x.level||levelOf(x.shown))).radius:(x.builtR||6);
+  /* A fixed world bearing, not a camera-relative one: the flag is planted in
+     the ground and the ground does not turn when you do. 0.55 of the radius
+     keeps it off the plateau's centre, which is where the signature monument
+     already stands and where a pole through the middle of somebody's obelisk
+     would be the first thing anyone noticed. */
+  const a=2.15;
+  stdRoot.position.set(x.x+Math.cos(a)*R*0.55,(x.baseY||0)+0.2,
+                       x.z+Math.sin(a)*R*0.55);
+  stdRoot.scale.setScalar(clamp(R/9,0.8,1.6));
+  stdRoot.visible=true;
+}
+/* The cloth turns to face the camera, and only the cloth. A flag edge-on is a
+   line, and a mark nobody can read is not a mark — this is the same argument
+   the label layer makes about a plate nobody can fit. The pole stays put, so
+   what you see is a banner swinging on its bar rather than the world rotating. */
+function stdWave(t){
+  if(!stdRoot.visible)return;
+  stdPivot.rotation.y=Math.PI/2-yaw;
+  const p=stdCloth.geometry.attributes.position;
+  for(let i=0;i<p.count;i++){
+    const x=stdBase[i*3], y=stdBase[i*3+1];
+    /* Anchored along the top edge and loosest at the bottom corners, which is
+       how cloth on a crossbar actually moves. A uniform ripple reads as a
+       flag painted on a rippling sheet of tin.
+       BIASED FORWARD, never behind: the two waves sum to 0.18 either way and
+       the 0.19 bias puts the trough a hair in front of the rest plane, so the
+       cloth billows out and back to flat instead of swinging through the pole
+       it is hanging on. Cheaper than any amount of clearance, because clearance
+       enough to survive a symmetric wave is clearance you can see. */
+    const hang=(STD_H/2-y)/STD_H;
+    p.setZ(i,(Math.sin(t*1.7+x*1.1+y*0.5)*0.13
+             +Math.sin(t*2.9+x*2.3)*0.05+0.19)*hang);
+  }
+  p.needsUpdate=true;
+}
+function crestSet(c){
+  CREST=c||null;
+  const tex=crestTex();
+  stdCloth.material.map=tex; stdCloth.material.emissiveMap=tex;
+  stdCloth.material.needsUpdate=true;
+  if(!CREST) stdRoot.visible=false;
+}
 
 /* Anything that glows joins the bloom layer. Driven off the material rather
    than a list, so a monument added later is included without being registered
@@ -7686,6 +7762,7 @@ function tick(){
        rather than leave them where they were left. */
     if(!POV.bird&&!curtained){ layoutLabels(); layoutFx(t); }
     else labelKey='';
+    placeStandard(t); stdWave(t);
     /* After the labels, because it has the last word on the label of whatever
        it is holding. */
     handUpdate(t,dt);
@@ -7749,7 +7826,12 @@ return {
   attachSpark: c=>drawSpark(c),
   /* The overlay stands on the world, so the camera fit has to know where. */
   setPadding: p=>{ Object.assign(PAD,p); if(W) frameWorld(); },
+  /* A whole look and a whole crest, both of them the owner's rather than the
+     viewer's: what a world is photographed through and what flies over it are
+     properties of the place, so a visitor is shown them too. */
   setLook: lookSet,
+  setCrest: crestSet,
+  setSky: skySet,
   setViewFlags: v=>{ Object.assign(VIEW,v);
     if(W){ paintBorders();
            clouds.visible=VIEW.sky;

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -34,9 +34,8 @@ import {
        point to a pixel — labels, leader lines, the ride reticle, the toast feed
        — and pushes everything else out through `onState`;
      - the district nameplates are gone: a district's name is the taxonomy's.
-       The sky, the crest and the look come in through `setSky`, `setCrest` and
-       `setLook`, driven by what the owner saved rather than by a panel the
-       engine owns its own DOM for.
+       Sky, crest and look now come in via `setSky`/`setCrest`/`setLook`,
+       driven by what the owner saved.
 
    One engine per page. Every accumulator the art builders share lives inside
    this closure, so two of them would not collide — but two WebGL contexts over
@@ -5315,14 +5314,12 @@ function leaveRealm(){
 }
 
 /* The sky, its eight palettes and its five hours, all in `sky.js` — the bench
-   in the panel lists the same tables this paints from. What is NOT there is the
-   reading sky: whichever realm you had read lately used to own the colour, and
-   that readout is the thing the sky was freed from rather than a preset. */
+   in the panel lists the same tables this paints from. */
 const SKY={...DEFAULT_SKY};
 
 /* Repainting a sky regenerates the PMREM environment, so it is guarded by a key
-   rather than by a flag: the bench can set the same palette twice, and picking
-   an hour you are already on must not cost an environment rebuild. */
+   rather than by a flag: the bench can set the same palette twice, or an hour
+   it is already on, and neither should force a rebuild. */
 let skyKey='';
 function applySky(){
   const p=skyPalOf(SKY.pal), h=skyHourOf(SKY.hour);
@@ -5352,16 +5349,9 @@ function applySky(){
   hemi.intensity=h.hemiI;
   paintSky(A,B,HZ);
   /* The banner is lit by the map in daylight and by its own emissive after
-     dark. A piece of cloth lit by a key at a quarter strength is a piece of
-     cloth you cannot read, and NIGHT is the hour where the crest matters most —
-     it is the best share card this file can produce. */
+     dark, or it is unreadable at NIGHT — the hour where the crest matters most. */
   if(stdCloth) stdCloth.material.emissiveIntensity=clamp(1-h.sunI/2,0,0.8);
 }
-/* Palette and hour, both of them free: neither carries a fact. The sky used to
-   be a readout — whichever realm you had been reading lately owned it — and
-   that is the one thing NOT on offer here, because the same fact is already
-   carried permanently by which quarters of the map are large. What is left is
-   the only channel big enough to make a place feel like yours. */
 function skySet(next){
   if(!next)return;
   SKY.pal=next.pal||SKY.pal; SKY.hour=next.hour||SKY.hour;
@@ -6673,10 +6663,8 @@ function sizePost(){
 sizePost();
 
 /* ================================================================= the look
-   Six graded presets and the seven knobs that fork one, in `look.js` because
-   the bench in the panel lists the same table this pushes into the passes.
-   The world starts on DIORAMA — the file's own art direction — and is told
-   about its owner's look once the settings land. */
+   Presets and knobs live in `look.js`, which the bench in the panel reads too.
+   The world starts on DIORAMA and is told about its owner's look once settings land. */
 const LOOK={...lookFromPreset(DEFAULT_LOOK_ID)};
 
 function lookPush(){
@@ -6694,10 +6682,8 @@ function lookPush(){
   FX.bloom  =LOOK.bl>0.005 && LOOK.fx.bloom!==false;
   FX.post   =LOOK.fx.post!==false;
 }
-/* A WHOLE look, not a preset id: the panel forks a preset the moment a knob
-   moves, so what the page has in its hand is already an object rather than a
-   name, and anything it does not carry stays at the preset it was forked from
-   rather than at whatever the previous look happened to leave behind. */
+/* A WHOLE look, not a preset id — the panel already forks on the first knob
+   move, so anything `next` doesn't carry stays at the preset it forked from. */
 function lookSet(next){
   const base=lookFromPreset(next&&next.base?next.base:(next&&next.id)||DEFAULT_LOOK_ID);
   Object.assign(LOOK,base,next,{fx:{...base.fx,...(next&&next.fx)}});
@@ -6706,19 +6692,11 @@ function lookSet(next){
 lookPush();
 
 /* ============================================================= the standard
-   The crest is the piece of all this that TRAVELS, and that is the argument for
-   flying it here. A name and a look are yours privately — they change what your
-   world is like to sit in. Neither survives being seen by somebody else for two
-   seconds in a feed, which is the only test that matters for the loop this
-   product is built on. A mark does.
-
    What is on the shield is decided elsewhere (`crest.js` draws it, the API says
    what has been earned). This end owns one question only: where it stands. */
 let CREST=null;
-/* The cloth's own canvas, repainted only when the crest changes. Separate from
-   the panel's copy in `crest.js`, because the two are different shapes — and
-   because toDataURL() on the panel's would otherwise have to run every time the
-   flag wanted a texture. */
+/* The cloth's own canvas, repainted only when the crest changes and kept
+   separate from the panel's copy in `crest.js` — the two are different shapes. */
 let _flagC=null, _flagT=null, _flagKey='';
 function crestTex(){
   if(!CREST) return null;
@@ -6734,27 +6712,13 @@ function crestTex(){
   return _flagT;
 }
 
-/* One flag, on the highest ground of the biggest thing on screen — the largest
-   realm out at world zoom, the largest district once you have walked into one.
-
-   ONE, and that is the decision worth defending. A standard on every island
-   would be six copies of the same mark competing with the realm names, and a
-   mark you see six times at once stops being a mark and becomes wallpaper. A
-   capital has one flag. Where it stands is also information: it moves to
-   whatever you have read most, so over a replay it migrates across the map, and
-   watching it move is watching your own attention move.
-
-   It lives at scene level rather than under a district, because a district is
-   disposed and rebuilt on every level-up and the flag has nothing to do with
-   any one of them. It is the world's, not the town's. */
+/* One flag, on the highest ground of the biggest thing on screen. Lives at scene
+   level rather than under a district, because a district is disposed and
+   rebuilt on every level-up and the flag has nothing to do with any one of them. */
 const stdRoot=new THREE.Group(); scene.add(stdRoot);
-/* The banner hangs off a pivot rather than off the root, and the pivot is what
-   turns to face the camera. Two things were wrong with rotating the cloth on
-   its own: the cloth's plane ran through the pole's axis, so a billboarded
-   banner sliced the pole down the middle at every angle — and the crossbar,
-   left behind in the root, went on pointing wherever it was first built while
-   the cloth swung away from it. The bar, its finials and the cloth are one
-   assembly; they turn together, and they hang in FRONT. */
+/* The banner hangs off a pivot, not the root, so the bar, its finials and the
+   cloth turn together to face the camera — rotating the cloth alone sliced the
+   billboarded plane through the pole's axis at every angle. */
 const stdPivot=new THREE.Group();
 const STD_POLE=13.2, STD_W=3.6, STD_H=4.35;
 /* Far enough forward to clear the pole at its widest plus everything the wave
@@ -6776,9 +6740,8 @@ let stdCloth=null, stdBase=null;
     const k=meshOf(new THREE.OctahedronGeometry(0.17),mat(T.cheese40,{rough:0.3}));
     k.position.set(sx*(STD_W/2+0.32),0,STD_FWD*0.6); stdPivot.add(k);
   }
-  /* Its own material, never the shared cache: a cached material is keyed by
-     colour, and hanging a texture on one would put this crest on every surface
-     in the world that happened to share its hex. */
+  /* Its own material, never the shared cache: that one is keyed by colour, and
+     hanging a texture on it would put this crest on every surface sharing its hex. */
   const cm=new THREE.MeshStandardMaterial({roughness:0.88,
     side:THREE.DoubleSide,flatShading:false,
     emissive:0xFFFFFF,emissiveIntensity:0});
@@ -6788,10 +6751,9 @@ let stdCloth=null, stdBase=null;
   stdBase=stdCloth.geometry.attributes.position.array.slice();
   stdRoot.visible=false;
 }
-/* Throttled rather than dirty-flagged. The target is the argmax of ~40 numbers
-   and changes on level-ups, on entering a realm, on leaving one and on every
-   scrubbed day — four call sites and a fifth to forget, against one reduce
-   twice a second. */
+/* Throttled rather than dirty-flagged: the target changes on level-ups, entering
+   or leaving a realm and every scrubbed day — cheaper as one reduce twice a
+   second than four call sites (and a fifth to forget). */
 let stdT=0;
 function placeStandard(t){
   if(t-stdT<0.45)return; stdT=t;
@@ -6803,35 +6765,25 @@ function placeStandard(t){
   if(!list.length){ stdRoot.visible=false; return; }
   let x=list[0]; for(const o of list) if(o.shown>x.shown) x=o;
   const R=OPEN?spec(Math.max(1,x.level||levelOf(x.shown))).radius:(x.builtR||6);
-  /* A fixed world bearing, not a camera-relative one: the flag is planted in
-     the ground and the ground does not turn when you do. 0.55 of the radius
-     keeps it off the plateau's centre, which is where the signature monument
-     already stands and where a pole through the middle of somebody's obelisk
-     would be the first thing anyone noticed. */
+  /* A fixed world bearing, not a camera-relative one. 0.55 of the radius keeps
+     it off the plateau's centre, where the signature monument already stands. */
   const a=2.15;
   stdRoot.position.set(x.x+Math.cos(a)*R*0.55,(x.baseY||0)+0.2,
                        x.z+Math.sin(a)*R*0.55);
   stdRoot.scale.setScalar(clamp(R/9,0.8,1.6));
   stdRoot.visible=true;
 }
-/* The cloth turns to face the camera, and only the cloth. A flag edge-on is a
-   line, and a mark nobody can read is not a mark — this is the same argument
-   the label layer makes about a plate nobody can fit. The pole stays put, so
-   what you see is a banner swinging on its bar rather than the world rotating. */
+/* The cloth turns to face the camera, and only the cloth — the pole stays put,
+   so what you see is a banner swinging on its bar rather than the world rotating. */
 function stdWave(t){
   if(!stdRoot.visible)return;
   stdPivot.rotation.y=Math.PI/2-yaw;
   const p=stdCloth.geometry.attributes.position;
   for(let i=0;i<p.count;i++){
     const x=stdBase[i*3], y=stdBase[i*3+1];
-    /* Anchored along the top edge and loosest at the bottom corners, which is
-       how cloth on a crossbar actually moves. A uniform ripple reads as a
-       flag painted on a rippling sheet of tin.
-       BIASED FORWARD, never behind: the two waves sum to 0.18 either way and
-       the 0.19 bias puts the trough a hair in front of the rest plane, so the
-       cloth billows out and back to flat instead of swinging through the pole
-       it is hanging on. Cheaper than any amount of clearance, because clearance
-       enough to survive a symmetric wave is clearance you can see. */
+    /* Anchored along the top edge, loosest at the bottom corners, like cloth on
+       a crossbar. BIASED FORWARD, never behind: the 0.19 bias keeps the cloth
+       billowing out and back to flat instead of swinging through the pole. */
     const hang=(STD_H/2-y)/STD_H;
     p.setZ(i,(Math.sin(t*1.7+x*1.1+y*0.5)*0.13
              +Math.sin(t*2.9+x*2.3)*0.05+0.19)*hang);
@@ -7826,9 +7778,7 @@ return {
   attachSpark: c=>drawSpark(c),
   /* The overlay stands on the world, so the camera fit has to know where. */
   setPadding: p=>{ Object.assign(PAD,p); if(W) frameWorld(); },
-  /* A whole look and a whole crest, both of them the owner's rather than the
-     viewer's: what a world is photographed through and what flies over it are
-     properties of the place, so a visitor is shown them too. */
+  /* Look and crest are the owner's, not the viewer's, so every visitor is shown them too. */
   setLook: lookSet,
   setCrest: crestSet,
   setSky: skySet,

--- a/packages/webapp/components/world/useUserWorld.ts
+++ b/packages/webapp/components/world/useUserWorld.ts
@@ -1,5 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import {
+  ApiError,
+  getApiError,
+  gqlClient,
+} from '@dailydotdev/shared/src/graphql/common';
 import {
   generateQueryKey,
   RequestKey,
@@ -10,6 +15,7 @@ import type {
   UserWorldTimelineData,
   WorldDistrict,
   WorldGrowth,
+  WorldSettings,
 } from '../../graphql/world';
 import {
   USER_WORLD_QUERY,
@@ -19,44 +25,69 @@ import {
 export interface UserWorldResult {
   districts?: WorldDistrict[];
   timeline?: WorldGrowth[];
+  /** Null once settled: the owner has never customised anything. */
+  settings?: WorldSettings | null;
   /** The world can be raised: this is the whole of the critical path. */
   isPending: boolean;
   /** The history is still on the wire. The world stands without it. */
   isHistoryPending: boolean;
   isEmpty: boolean;
+  /** Hidden by its owner, and the viewer is not the owner. */
+  isPrivate: boolean;
   error?: Error;
 }
+
+export const userWorldQueryKey = (userId?: string): unknown[] =>
+  generateQueryKey(
+    RequestKey.UserWorld,
+    userId ? { id: userId } : undefined,
+  ) as unknown[];
 
 /**
  * Two queries, not one, and only the small one is waited for.
  *
- * The districts are at most forty rows and they are everything the world needs
- * to stand up: the layout packs islands by lifetime totals, and those are on
- * this query. The growth log is the same world's whole history, tens of
- * thousands of rows on a four-year reader, and it is only ever needed to REPLAY
- * the place. So the world is raised off the districts and the log is folded in
- * underneath it when it lands (`attachHistory`), which costs nothing to look at
- * because the day it is folded in on is the world already on screen.
+ * The first is everything the world needs to stand up: at most forty districts
+ * and the owner's customisations, batched into a single round trip because
+ * neither half can draw without the other — the districts decide what is
+ * standing and the settings decide what it is photographed through, so asking
+ * separately buys either a frame of the wrong look or a second wait for it.
+ *
+ * The growth log is the same world's whole history, tens of thousands of rows on
+ * a four-year reader, and it is only ever needed to REPLAY the place. So the
+ * world is raised off the first query and the log is folded in underneath it
+ * when it lands (`attachHistory`), which costs nothing to look at because the
+ * day it is folded in on is the world already on screen.
  *
  * The timeline is allowed to fail. The world still stands without it; it simply
  * has no history to walk, which is what `replayable` on the model reports.
  */
 export const useUserWorld = (userId?: string): UserWorldResult => {
-  const districts = useQuery({
-    queryKey: generateQueryKey(
-      RequestKey.UserWorld,
-      userId ? { id: userId } : undefined,
-    ),
+  const world = useQuery({
+    queryKey: userWorldQueryKey(userId),
     queryFn: async () => {
       const res = await gqlClient.request<UserWorldData>(USER_WORLD_QUERY, {
         id: userId,
       });
-      return res.userWorld;
+      return {
+        districts: res.userWorld,
+        settings: res.userWorldSettings ?? null,
+      };
     },
     enabled: !!userId,
     staleTime: StaleTime.Default,
+    // A refused world is refused for as long as its owner keeps it that way,
+    // and three more round trips do not change the answer.
+    retry: false,
   });
-  const hasDistricts = !!districts.data?.length;
+  const districts = world.data?.districts;
+  const hasDistricts = !!districts?.length;
+  /* Not an error to report: a hidden world is a world the viewer is not allowed
+     to see rather than one that failed, so it gets its own screen and never
+     "this world could not be loaded". */
+  const isPrivate = !!getApiError(
+    world.error as unknown as ApiErrorResult,
+    ApiError.Forbidden,
+  );
 
   const timeline = useQuery({
     queryKey: generateQueryKey(
@@ -76,11 +107,13 @@ export const useUserWorld = (userId?: string): UserWorldResult => {
   });
 
   return {
-    districts: districts.data,
+    districts,
     timeline: timeline.data,
-    isPending: districts.isPending,
+    settings: world.data?.settings,
+    isPending: world.isPending,
     isHistoryPending: hasDistricts && timeline.isPending,
-    isEmpty: districts.isSuccess && !hasDistricts,
-    error: (districts.error as Error) ?? undefined,
+    isEmpty: world.isSuccess && !hasDistricts,
+    isPrivate,
+    error: isPrivate ? undefined : (world.error as Error) ?? undefined,
   };
 };

--- a/packages/webapp/components/world/useUserWorld.ts
+++ b/packages/webapp/components/world/useUserWorld.ts
@@ -44,22 +44,8 @@ export const userWorldQueryKey = (userId?: string): unknown[] =>
   ) as unknown[];
 
 /**
- * Two queries, not one, and only the small one is waited for.
- *
- * The first is everything the world needs to stand up: at most forty districts
- * and the owner's customisations, batched into a single round trip because
- * neither half can draw without the other — the districts decide what is
- * standing and the settings decide what it is photographed through, so asking
- * separately buys either a frame of the wrong look or a second wait for it.
- *
- * The growth log is the same world's whole history, tens of thousands of rows on
- * a four-year reader, and it is only ever needed to REPLAY the place. So the
- * world is raised off the first query and the log is folded in underneath it
- * when it lands (`attachHistory`), which costs nothing to look at because the
- * day it is folded in on is the world already on screen.
- *
- * The timeline is allowed to fail. The world still stands without it; it simply
- * has no history to walk, which is what `replayable` on the model reports.
+ * Districts+settings in one blocking round trip; the heavy growth log loads
+ * behind the standing world and may fail without taking it down.
  */
 export const useUserWorld = (userId?: string): UserWorldResult => {
   const world = useQuery({
@@ -75,14 +61,15 @@ export const useUserWorld = (userId?: string): UserWorldResult => {
     },
     enabled: !!userId,
     staleTime: StaleTime.Default,
-    // A refused world is refused for as long as its owner keeps it that way,
-    // and three more round trips do not change the answer.
-    retry: false,
+    // A refused world stays refused, so FORBIDDEN skips the usual retries.
+    retry: (failureCount, retryError) =>
+      getApiError(retryError as unknown as ApiErrorResult, ApiError.Forbidden)
+        ? false
+        : failureCount < 3,
   });
   const districts = world.data?.districts;
   const hasDistricts = !!districts?.length;
-  /* Not an error to report: a hidden world is a world the viewer is not allowed
-     to see rather than one that failed, so it gets its own screen and never
+  /* Not an error to report: a hidden world gets its own screen, never
      "this world could not be loaded". */
   const isPrivate = !!getApiError(
     world.error as unknown as ApiErrorResult,

--- a/packages/webapp/components/world/useWorldDraft.ts
+++ b/packages/webapp/components/world/useWorldDraft.ts
@@ -20,11 +20,7 @@ export interface WorldDraft {
   save: () => Promise<void>;
   isSaving: boolean;
   error?: string;
-  /**
-   * What the world is drawn with right now: the draft while the bench is open,
-   * and what is stored otherwise. The bench edits a LIVE frame — every chip
-   * lands on the world behind it — so this is what the engine is told about.
-   */
+  /** What the engine is told: the draft while the bench is open, stored settings otherwise. */
   applied: WorldSettings | null;
 }
 
@@ -48,13 +44,8 @@ const toDraft = (settings?: WorldSettings | null): WorldDraftSettings =>
     : EMPTY;
 
 /**
- * Only what actually changed.
- *
- * The mutation is a patch: an absent key leaves the stored value alone and an
- * explicit null clears it back to the derived suggestion. Sending all four every
- * time would turn "I renamed my world" into a write that also pins the crest and
- * the look at whatever the suggestion happened to be that day, which is exactly
- * what the API refuses to do on its own side.
+ * Only what actually changed: an absent key leaves the stored value alone, an
+ * explicit null clears it back to the derived suggestion.
  */
 export const worldSettingsPatch = (
   draft: WorldDraftSettings,
@@ -81,8 +72,8 @@ export const worldSettingsPatch = (
   return patch;
 };
 
-/* What the API refused, in its own words — a rejected crest says which charge or
-   tincture was not earned, and that is more useful than anything written here. */
+/* What the API refused, in its own words — a rejected crest names the charge or
+   tincture that was not earned. */
 const reasonFor = (error?: Error): string | undefined => {
   if (!error) {
     return undefined;
@@ -106,17 +97,21 @@ export const useWorldDraft = (
       return;
     }
     const patch = worldSettingsPatch(settings, saved);
-    /* A bench somebody opened and closed again is not a write. The API upserts
-       nothing for an empty patch either, but this also spares the round trip. */
+    // An untouched bench is not a write; an empty patch spares the round trip.
     if (Object.keys(patch).length) {
-      await persist(patch);
+      try {
+        await persist(patch);
+      } catch {
+        // The mutation's own error state carries the message; the bench stays
+        // open so nothing typed is lost.
+        return;
+      }
     }
     setSettings(null);
   }, [persist, saved, settings]);
 
-  /* The draft while the bench is open, so a chip is on the world before it is
-     saved, and the stored settings the moment it closes — which is what makes
-     Cancel put the place back the way it was found. */
+  /* The draft while the bench is open, stored settings the moment it closes —
+     what makes Cancel put the place back the way it was found. */
   const applied = useMemo<WorldSettings | null>(
     () => (settings ? { ...toDraft(saved), ...settings } : saved ?? null),
     [saved, settings],

--- a/packages/webapp/components/world/useWorldDraft.ts
+++ b/packages/webapp/components/world/useWorldDraft.ts
@@ -1,0 +1,136 @@
+import { useCallback, useMemo, useState } from 'react';
+import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import type { WorldSettings } from '../../graphql/world';
+import type { WorldSettingsPatch } from './useWorldSettings';
+import { useUpdateWorldSettings } from './useWorldSettings';
+
+/** The four customisations, with the "never touched it" shape filled in. */
+export type WorldDraftSettings = Pick<
+  WorldSettings,
+  'name' | 'sky' | 'crest' | 'look' | 'private'
+>;
+
+export interface WorldDraft {
+  isOpen: boolean;
+  /** Non-null exactly while the bench is open. */
+  settings: WorldDraftSettings | null;
+  setSettings: (next: WorldDraftSettings) => void;
+  open: () => void;
+  cancel: () => void;
+  save: () => Promise<void>;
+  isSaving: boolean;
+  error?: string;
+  /**
+   * What the world is drawn with right now: the draft while the bench is open,
+   * and what is stored otherwise. The bench edits a LIVE frame — every chip
+   * lands on the world behind it — so this is what the engine is told about.
+   */
+  applied: WorldSettings | null;
+}
+
+const EMPTY: WorldDraftSettings = {
+  name: null,
+  sky: null,
+  crest: null,
+  look: null,
+  private: false,
+};
+
+const toDraft = (settings?: WorldSettings | null): WorldDraftSettings =>
+  settings
+    ? {
+        name: settings.name,
+        sky: settings.sky,
+        crest: settings.crest,
+        look: settings.look,
+        private: settings.private,
+      }
+    : EMPTY;
+
+/**
+ * Only what actually changed.
+ *
+ * The mutation is a patch: an absent key leaves the stored value alone and an
+ * explicit null clears it back to the derived suggestion. Sending all four every
+ * time would turn "I renamed my world" into a write that also pins the crest and
+ * the look at whatever the suggestion happened to be that day, which is exactly
+ * what the API refuses to do on its own side.
+ */
+export const worldSettingsPatch = (
+  draft: WorldDraftSettings,
+  saved?: WorldSettings | null,
+): WorldSettingsPatch => {
+  const base = toDraft(saved);
+  const patch: WorldSettingsPatch = {};
+  const name = draft.name?.trim() || null;
+  if (name !== (base.name?.trim() || null)) {
+    patch.name = name;
+  }
+  if (JSON.stringify(draft.sky) !== JSON.stringify(base.sky)) {
+    patch.sky = draft.sky;
+  }
+  if (JSON.stringify(draft.crest) !== JSON.stringify(base.crest)) {
+    patch.crest = draft.crest;
+  }
+  if (JSON.stringify(draft.look) !== JSON.stringify(base.look)) {
+    patch.look = draft.look;
+  }
+  if (draft.private !== base.private) {
+    patch.private = draft.private;
+  }
+  return patch;
+};
+
+/* What the API refused, in its own words — a rejected crest says which charge or
+   tincture was not earned, and that is more useful than anything written here. */
+const reasonFor = (error?: Error): string | undefined => {
+  if (!error) {
+    return undefined;
+  }
+  const [first] = (error as unknown as ApiErrorResult)?.response?.errors ?? [];
+  return first?.message ?? 'That could not be saved. Try again in a moment.';
+};
+
+export const useWorldDraft = (
+  userId: string,
+  saved?: WorldSettings | null,
+): WorldDraft => {
+  const [settings, setSettings] = useState<WorldDraftSettings | null>(null);
+  const { save: persist, isSaving, error } = useUpdateWorldSettings(userId);
+
+  const open = useCallback(() => setSettings(toDraft(saved)), [saved]);
+  const cancel = useCallback(() => setSettings(null), []);
+
+  const save = useCallback(async () => {
+    if (!settings) {
+      return;
+    }
+    const patch = worldSettingsPatch(settings, saved);
+    /* A bench somebody opened and closed again is not a write. The API upserts
+       nothing for an empty patch either, but this also spares the round trip. */
+    if (Object.keys(patch).length) {
+      await persist(patch);
+    }
+    setSettings(null);
+  }, [persist, saved, settings]);
+
+  /* The draft while the bench is open, so a chip is on the world before it is
+     saved, and the stored settings the moment it closes — which is what makes
+     Cancel put the place back the way it was found. */
+  const applied = useMemo<WorldSettings | null>(
+    () => (settings ? { ...toDraft(saved), ...settings } : saved ?? null),
+    [saved, settings],
+  );
+
+  return {
+    isOpen: !!settings,
+    settings,
+    setSettings,
+    open,
+    cancel,
+    save,
+    isSaving,
+    error: reasonFor(error),
+    applied,
+  };
+};

--- a/packages/webapp/components/world/useWorldSettings.ts
+++ b/packages/webapp/components/world/useWorldSettings.ts
@@ -1,0 +1,96 @@
+import { useCallback } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import {
+  generateQueryKey,
+  RequestKey,
+  StaleTime,
+} from '@dailydotdev/shared/src/lib/query';
+import type {
+  UpdateUserWorldSettingsData,
+  UserWorldEntitlementsData,
+  WorldDistrict,
+  WorldEntitlement,
+  WorldSettings,
+} from '../../graphql/world';
+import {
+  UPDATE_USER_WORLD_SETTINGS_MUTATION,
+  USER_WORLD_ENTITLEMENTS_QUERY,
+} from '../../graphql/world';
+import { userWorldQueryKey } from './useUserWorld';
+
+/** What a save sends: an absent key is left alone, an explicit null clears it. */
+export type WorldSettingsPatch = Partial<
+  Pick<WorldSettings, 'name' | 'sky' | 'crest' | 'look' | 'private'>
+>;
+
+/**
+ * Everything this world may be dressed with, and what granted each one.
+ *
+ * Lazy on purpose, in both directions: it is only asked for once the owner opens
+ * the bench, and only ever for their own world. It is what an EDITOR needs
+ * rather than what displaying a world needs — the API folds the districts
+ * through the grant tables to answer it, and a visitor never touches that path.
+ */
+export const useWorldEntitlements = (
+  userId: string | undefined,
+  enabled: boolean,
+): { entitlements?: WorldEntitlement[]; isPending: boolean } => {
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(
+      RequestKey.UserWorldEntitlements,
+      userId ? { id: userId } : undefined,
+    ),
+    queryFn: async () => {
+      const res = await gqlClient.request<UserWorldEntitlementsData>(
+        USER_WORLD_ENTITLEMENTS_QUERY,
+        { id: userId },
+      );
+      return res.userWorldEntitlements;
+    },
+    enabled: !!userId && enabled,
+    staleTime: StaleTime.Default,
+  });
+
+  return { entitlements: data, isPending: enabled && isPending };
+};
+
+export interface UpdateWorldSettings {
+  save: (patch: WorldSettingsPatch) => Promise<void>;
+  isSaving: boolean;
+  error?: Error;
+}
+
+export const useUpdateWorldSettings = (userId: string): UpdateWorldSettings => {
+  const client = useQueryClient();
+  const { mutateAsync, isPending, error } = useMutation({
+    mutationFn: async (patch: WorldSettingsPatch) => {
+      const res = await gqlClient.request<UpdateUserWorldSettingsData>(
+        UPDATE_USER_WORLD_SETTINGS_MUTATION,
+        patch,
+      );
+      return res.updateUserWorldSettings;
+    },
+    /* Written straight into the cache the world was raised from rather than
+       invalidated: the mutation answers in the same shape the query does, and a
+       refetch would take the world back to its stored look for as long as the
+       round trip lasted — while the owner is looking at the change they just
+       made. The districts on that entry are untouched, so nothing rebuilds. */
+    onSuccess: (settings) =>
+      client.setQueryData<{
+        districts: WorldDistrict[];
+        settings: WorldSettings | null;
+      }>(userWorldQueryKey(userId), (previous) =>
+        previous ? { ...previous, settings: settings ?? null } : previous,
+      ),
+  });
+
+  const save = useCallback(
+    async (patch: WorldSettingsPatch) => {
+      await mutateAsync(patch);
+    },
+    [mutateAsync],
+  );
+
+  return { save, isSaving: isPending, error: (error as Error) ?? undefined };
+};

--- a/packages/webapp/components/world/useWorldSettings.ts
+++ b/packages/webapp/components/world/useWorldSettings.ts
@@ -25,18 +25,18 @@ export type WorldSettingsPatch = Partial<
 >;
 
 /**
- * Everything this world may be dressed with, and what granted each one.
- *
- * Lazy on purpose, in both directions: it is only asked for once the owner opens
- * the bench, and only ever for their own world. It is what an EDITOR needs
- * rather than what displaying a world needs — the API folds the districts
- * through the grant tables to answer it, and a visitor never touches that path.
+ * Everything this world may be dressed with, and what granted each one. Lazy:
+ * only asked for once the owner opens the bench, and only for their own world.
  */
 export const useWorldEntitlements = (
   userId: string | undefined,
   enabled: boolean,
-): { entitlements?: WorldEntitlement[]; isPending: boolean } => {
-  const { data, isPending } = useQuery({
+): {
+  entitlements?: WorldEntitlement[];
+  isPending: boolean;
+  isError: boolean;
+} => {
+  const { data, isPending, isError } = useQuery({
     queryKey: generateQueryKey(
       RequestKey.UserWorldEntitlements,
       userId ? { id: userId } : undefined,
@@ -52,7 +52,7 @@ export const useWorldEntitlements = (
     staleTime: StaleTime.Default,
   });
 
-  return { entitlements: data, isPending: enabled && isPending };
+  return { entitlements: data, isPending: enabled && isPending, isError };
 };
 
 export interface UpdateWorldSettings {
@@ -71,11 +71,9 @@ export const useUpdateWorldSettings = (userId: string): UpdateWorldSettings => {
       );
       return res.updateUserWorldSettings;
     },
-    /* Written straight into the cache the world was raised from rather than
-       invalidated: the mutation answers in the same shape the query does, and a
-       refetch would take the world back to its stored look for as long as the
-       round trip lasted — while the owner is looking at the change they just
-       made. The districts on that entry are untouched, so nothing rebuilds. */
+    /* Written straight into the cache rather than invalidated: a refetch would
+       take the world back to its stored look for the round trip. Districts on
+       that entry are untouched, so nothing rebuilds. */
     onSuccess: (settings) =>
       client.setQueryData<{
         districts: WorldDistrict[];

--- a/packages/webapp/components/world/worldCustomization.ts
+++ b/packages/webapp/components/world/worldCustomization.ts
@@ -1,0 +1,225 @@
+import { DEFAULT_LOOK_ID, lookFromPreset } from './engine/look';
+import { DEFAULT_SKY } from './engine/sky';
+import { NICHE_OF, REALM_OF } from './engine/taxonomy';
+import type {
+  WorldCrest,
+  WorldDistrict,
+  WorldLook,
+  WorldSettings,
+  WorldSky,
+} from '../../graphql/world';
+
+/**
+ * Where a world starts before anybody touches it.
+ *
+ * The API stores what was chosen and answers null for what was not, deliberately:
+ * this side has to render a world with no settings row at all, so a second set
+ * of defaults over there would only be a copy that could disagree with these.
+ */
+
+export const WORLD_NAME_MAX_LENGTH = 30;
+
+/** Reads at which a district raises the monument a crest can be built out of. */
+const CREST_CHARGE_MIN_READS = 3;
+
+/* The taxonomy is the renderer's, and it is JavaScript on purpose — it is
+   ported near-verbatim from devcraft so every future diff against the source
+   stays readable. These are the two shapes this file reads out of it. */
+const NICHES = NICHE_OF as Record<
+  string,
+  { sig: string; accent: number; accent2: number }
+>;
+const REALMS = REALM_OF as Record<string, { id: string; name: string }>;
+
+interface RankedDistrict {
+  slug: string;
+  reads: number;
+  sig: string;
+  accent: number;
+  accent2: number;
+  realmId: string;
+  realmName: string;
+}
+
+/**
+ * The districts the taxonomy can place, largest first. Anything it does not
+ * know is dropped for the same reason the renderer drops it: the art is the
+ * authority on what exists, and a niche with no district built for it cannot
+ * appear on a shield either.
+ */
+const rank = (districts?: WorldDistrict[]): RankedDistrict[] =>
+  (districts ?? [])
+    .map(({ niche, reads }) => ({
+      slug: niche?.slug,
+      niche: NICHES[niche?.slug],
+      reads,
+    }))
+    .filter(({ niche, reads }) => !!niche && reads > 0)
+    .map(({ niche, reads, slug }) => ({
+      slug,
+      reads,
+      sig: niche.sig,
+      accent: niche.accent,
+      accent2: niche.accent2,
+      realmId: REALMS[slug].id,
+      realmName: REALMS[slug].name,
+    }))
+    .sort((a, b) => b.reads - a.reads);
+
+/* Roles come from BREADTH and epithets from VOLUME, so the two halves of the
+   title are two different facts rather than the same one twice — a title has to
+   be true before it is flattering, and "the relentless devotee" is a real
+   description of someone who read one subject nine hundred times. */
+const ROLES = [
+  'devotee',
+  'scholar',
+  'wanderer',
+  'cartographer',
+  'archivist',
+  'magpie',
+];
+const EPITHETS = [
+  'quiet',
+  'steady',
+  'patient',
+  'relentless',
+  'sleepless',
+  'untiring',
+];
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));
+
+const sentence = (value: string) =>
+  value.charAt(0).toUpperCase() + value.slice(1);
+
+/**
+ * Names for one world, built off the same facts, longest shapes first.
+ *
+ * The suggestion is the placeholder rather than the stored value: an untouched
+ * world shows the name it would have been given anyway, and the user's job is
+ * to disagree with it rather than to invent one. ✦ walks this list rather than
+ * rerolling noise, so pressing it round comes back to where it started.
+ *
+ * Everything returned FITS. `The relentless cartographer of Artisan's Quarter`
+ * is a better name than any of the short ones and it is 47 characters, so the
+ * richest shapes are offered and then filtered rather than never written — and
+ * the last two carry no realm or no epithet, which is what bounds them below the
+ * limit whatever the taxonomy grows into. Offering a name the field cannot hold
+ * is worse than offering a plainer one: ✦ COMMITS what it shows, so an
+ * over-length suggestion is a save the API rejects.
+ */
+export const worldSuggestions = (districts?: WorldDistrict[]): string[] => {
+  const ranked = rank(districts);
+  if (!ranked.length) {
+    return ['My world'];
+  }
+
+  const reads = ranked.reduce((sum, d) => sum + d.reads, 0);
+  const byRealm = new Map<string, { name: string; reads: number }>();
+  ranked.forEach((d) => {
+    const realm = byRealm.get(d.realmId) ?? { name: d.realmName, reads: 0 };
+    realm.reads += d.reads;
+    byRealm.set(d.realmId, realm);
+  });
+  const realm = [...byRealm.values()].sort((a, b) => b.reads - a.reads)[0].name;
+
+  const role = ROLES[clamp(byRealm.size - 1, 0, ROLES.length - 1)];
+  const epithet =
+    EPITHETS[
+      clamp(
+        Math.floor(Math.log2(Math.max(2, reads)) / 2.2),
+        0,
+        EPITHETS.length - 1,
+      )
+    ];
+
+  const shapes = [
+    `The ${epithet} ${role} of ${realm}`,
+    `${realm}, in ${ranked.length} districts`,
+    `The ${role}'s ${realm}`,
+    `${sentence(epithet)} ${realm}`,
+    `The ${epithet} ${role}`,
+    `The ${realm}`,
+  ];
+
+  return [...new Set(shapes)].filter(
+    (name) => name.length <= WORLD_NAME_MAX_LENGTH,
+  );
+};
+
+/* Kept as ids rather than importing the division table, which carries the path
+   emitters and belongs to whatever is drawing a shield. */
+const DIVISION_IDS = [
+  'plain',
+  'pale',
+  'fess',
+  'bend',
+  'chevron',
+  'quarter',
+] as const;
+
+/**
+ * Every world has a crest suggested from day one, derived the same way its name
+ * is: the largest district gives the charge, the top two give the tinctures, and
+ * the division comes off the user id — so the suggestion is already personal.
+ *
+ * Null when the reading behind it has raised nothing. Eligibility is having
+ * built something: a world with nothing behind it has no mark rather than a
+ * starter one, and an empty shield is the honest answer rather than a poor one.
+ */
+export const suggestedCrest = (
+  userId: string,
+  districts?: WorldDistrict[],
+): WorldCrest | null => {
+  const ranked = rank(districts);
+  const top = ranked[0];
+  if (!top || top.reads < CREST_CHARGE_MIN_READS) {
+    return null;
+  }
+
+  const second = ranked[1] ?? top;
+  /* Off the user id rather than off the reading, because a division encodes
+     nothing — this only has to be stable and personal, so that two people who
+     read the same subject are not handed the same shield. */
+  const hash = [...userId].reduce(
+    (total, char) => (total * 31 + char.charCodeAt(0)) % 1e9,
+    0,
+  );
+
+  return {
+    charge: top.sig,
+    div: DIVISION_IDS[hash % DIVISION_IDS.length],
+    a: top.accent,
+    b: second.accent,
+  };
+};
+
+/** What flies over this world: what the owner chose, or the suggestion. */
+export const resolveCrest = (
+  settings: Pick<WorldSettings, 'crest'> | null | undefined,
+  userId: string,
+  districts?: WorldDistrict[],
+): WorldCrest | null => settings?.crest ?? suggestedCrest(userId, districts);
+
+/** What the world is photographed through: the owner's look, or DIORAMA. */
+export const resolveLook = (
+  settings: Pick<WorldSettings, 'look'> | null | undefined,
+): WorldLook => settings?.look ?? lookFromPreset(DEFAULT_LOOK_ID);
+
+/** What hangs over it: the owner's sky, or the file's own art direction. */
+export const resolveSky = (
+  settings: Pick<WorldSettings, 'sky'> | null | undefined,
+): WorldSky => settings?.sky ?? DEFAULT_SKY;
+
+/**
+ * Whether the owner has ever made this world theirs.
+ *
+ * `private` is not part of the test on purpose: hiding a world is a decision
+ * about who may see it rather than something you made of it, and a reader who
+ * only ever flipped that switch has still not named the place.
+ */
+export const isWorldCustomised = (
+  settings: WorldSettings | null | undefined,
+): boolean =>
+  !!(settings?.name || settings?.sky || settings?.crest || settings?.look);

--- a/packages/webapp/components/world/worldCustomization.ts
+++ b/packages/webapp/components/world/worldCustomization.ts
@@ -9,22 +9,14 @@ import type {
   WorldSky,
 } from '../../graphql/world';
 
-/**
- * Where a world starts before anybody touches it.
- *
- * The API stores what was chosen and answers null for what was not, deliberately:
- * this side has to render a world with no settings row at all, so a second set
- * of defaults over there would only be a copy that could disagree with these.
- */
+/* API stores null for anything unchosen rather than a default, so defaults live only here — a second copy server-side could disagree with these. */
 
 export const WORLD_NAME_MAX_LENGTH = 30;
 
 /** Reads at which a district raises the monument a crest can be built out of. */
 const CREST_CHARGE_MIN_READS = 3;
 
-/* The taxonomy is the renderer's, and it is JavaScript on purpose — it is
-   ported near-verbatim from devcraft so every future diff against the source
-   stays readable. These are the two shapes this file reads out of it. */
+/* Ported near-verbatim from devcraft's JS renderer so future diffs against the source stay readable. */
 const NICHES = NICHE_OF as Record<
   string,
   { sig: string; accent: number; accent2: number }
@@ -41,12 +33,7 @@ interface RankedDistrict {
   realmName: string;
 }
 
-/**
- * The districts the taxonomy can place, largest first. Anything it does not
- * know is dropped for the same reason the renderer drops it: the art is the
- * authority on what exists, and a niche with no district built for it cannot
- * appear on a shield either.
- */
+/** Districts the taxonomy can place, largest first; anything unknown to it is dropped, matching what the renderer can draw. */
 const rank = (districts?: WorldDistrict[]): RankedDistrict[] =>
   (districts ?? [])
     .map(({ niche, reads }) => ({
@@ -66,10 +53,7 @@ const rank = (districts?: WorldDistrict[]): RankedDistrict[] =>
     }))
     .sort((a, b) => b.reads - a.reads);
 
-/* Roles come from BREADTH and epithets from VOLUME, so the two halves of the
-   title are two different facts rather than the same one twice — a title has to
-   be true before it is flattering, and "the relentless devotee" is a real
-   description of someone who read one subject nine hundred times. */
+/* Role comes from breadth (realm count), epithet from volume (read count) — two independent facts, not the same one twice. */
 const ROLES = [
   'devotee',
   'scholar',
@@ -94,20 +78,8 @@ const sentence = (value: string) =>
   value.charAt(0).toUpperCase() + value.slice(1);
 
 /**
- * Names for one world, built off the same facts, longest shapes first.
- *
- * The suggestion is the placeholder rather than the stored value: an untouched
- * world shows the name it would have been given anyway, and the user's job is
- * to disagree with it rather than to invent one. ✦ walks this list rather than
- * rerolling noise, so pressing it round comes back to where it started.
- *
- * Everything returned FITS. `The relentless cartographer of Artisan's Quarter`
- * is a better name than any of the short ones and it is 47 characters, so the
- * richest shapes are offered and then filtered rather than never written — and
- * the last two carry no realm or no epithet, which is what bounds them below the
- * limit whatever the taxonomy grows into. Offering a name the field cannot hold
- * is worse than offering a plainer one: ✦ COMMITS what it shows, so an
- * over-length suggestion is a save the API rejects.
+ * Longest shapes first, then filtered to WORLD_NAME_MAX_LENGTH — an over-length suggestion would be a save the API rejects, since accepting one commits it.
+ * Used as the placeholder rather than a stored default, so an untouched world shows the name it would've had anyway.
  */
 export const worldSuggestions = (districts?: WorldDistrict[]): string[] => {
   const ranked = rank(districts);
@@ -148,8 +120,7 @@ export const worldSuggestions = (districts?: WorldDistrict[]): string[] => {
   );
 };
 
-/* Kept as ids rather than importing the division table, which carries the path
-   emitters and belongs to whatever is drawing a shield. */
+/* Kept as ids rather than importing the division table, which carries path emitters that belong to the shield renderer. */
 const DIVISION_IDS = [
   'plain',
   'pale',
@@ -159,15 +130,7 @@ const DIVISION_IDS = [
   'quarter',
 ] as const;
 
-/**
- * Every world has a crest suggested from day one, derived the same way its name
- * is: the largest district gives the charge, the top two give the tinctures, and
- * the division comes off the user id — so the suggestion is already personal.
- *
- * Null when the reading behind it has raised nothing. Eligibility is having
- * built something: a world with nothing behind it has no mark rather than a
- * starter one, and an empty shield is the honest answer rather than a poor one.
- */
+/** Returns null when the top district hasn't raised CREST_CHARGE_MIN_READS — an unbuilt world gets no mark rather than a starter one. */
 export const suggestedCrest = (
   userId: string,
   districts?: WorldDistrict[],
@@ -179,9 +142,7 @@ export const suggestedCrest = (
   }
 
   const second = ranked[1] ?? top;
-  /* Off the user id rather than off the reading, because a division encodes
-     nothing — this only has to be stable and personal, so that two people who
-     read the same subject are not handed the same shield. */
+  /* Off the user id rather than the reading — a division encodes nothing, it just needs to be stable and personal. */
   const hash = [...userId].reduce(
     (total, char) => (total * 31 + char.charCodeAt(0)) % 1e9,
     0,
@@ -212,13 +173,7 @@ export const resolveSky = (
   settings: Pick<WorldSettings, 'sky'> | null | undefined,
 ): WorldSky => settings?.sky ?? DEFAULT_SKY;
 
-/**
- * Whether the owner has ever made this world theirs.
- *
- * `private` is not part of the test on purpose: hiding a world is a decision
- * about who may see it rather than something you made of it, and a reader who
- * only ever flipped that switch has still not named the place.
- */
+/** `private` is deliberately excluded — hiding a world is a visibility decision, not something made of it. */
 export const isWorldCustomised = (
   settings: WorldSettings | null | undefined,
 ): boolean =>

--- a/packages/webapp/components/world/worldState.ts
+++ b/packages/webapp/components/world/worldState.ts
@@ -1,5 +1,6 @@
 import { formatDataTileValue } from '@dailydotdev/shared/src/lib/numberFormat';
 import { pluralize } from '@dailydotdev/shared/src/lib/strings';
+import type { WorldCrest, WorldLook, WorldSky } from '../../graphql/world';
 
 /**
  * What the engine pushes at the overlay.
@@ -100,7 +101,12 @@ export interface WorldEngine {
   frameWorld: () => void;
   attachSpark: (canvas: HTMLCanvasElement | null) => void;
   setPadding: (pad: Partial<Record<'l' | 'r' | 't' | 'b', number>>) => void;
-  setLook: (id: string) => void;
+  /** A whole look, not a preset id: a moved knob forks the preset into one. */
+  setLook: (look: WorldLook) => void;
+  /** The mark flying over the world, or nothing if it has raised none. */
+  setCrest: (crest: WorldCrest | null) => void;
+  /** Palette and hour. Repaints the environment, so it is key-guarded inside. */
+  setSky: (sky: WorldSky) => void;
   setViewFlags: (flags: Partial<Record<string, boolean>>) => void;
   dispose: () => void;
 }

--- a/packages/webapp/graphql/world.ts
+++ b/packages/webapp/graphql/world.ts
@@ -18,14 +18,158 @@ export interface WorldGrowth {
   reads: number;
 }
 
-export interface UserWorldData {
-  userWorld: WorldDistrict[];
-}
-
 export interface UserWorldTimelineData {
   userWorldTimeline: WorldGrowth[];
 }
 
+/**
+ * Two axes rather than a list, because two axes is what makes a sky feel found
+ * instead of picked. Neither carries a fact: the sky used to be a readout of
+ * what you had been reading lately, and that is exactly the thing it was freed
+ * from so it could be given away.
+ */
+export interface WorldSky {
+  /** brand, clear, blossom, ember, seaglass, orchid, harvest or slate. */
+  pal: string;
+  /** Where the sun sits: dawn, day, gold, dusk or night. */
+  hour: string;
+}
+
+export interface WorldCrest {
+  /** Signature of a monument the owner has raised. */
+  charge: string;
+  div: string;
+  /** Field tincture, as a 24-bit RGB integer. */
+  a: number;
+  b: number;
+}
+
+export interface WorldLookFx {
+  post: boolean;
+  bloom: boolean;
+  outline: boolean;
+}
+
+/** The seven knobs that fork a preset into a look of your own. */
+export type WorldLookKnob =
+  | 'ol'
+  | 'bl'
+  | 'duo'
+  | 'warm'
+  | 'sat'
+  | 'grain'
+  | 'vig';
+
+export interface WorldLook {
+  id: string;
+  /** The preset this was forked from, so reverting has somewhere to go. */
+  base: string;
+  mine: boolean;
+  name: string;
+  ol: number;
+  bl: number;
+  duo: number;
+  warm: number;
+  sat: number;
+  grain: number;
+  vig: number;
+  lift: number;
+  duoA: number;
+  duoB: number;
+  ink: number;
+  fx: WorldLookFx;
+}
+
+/**
+ * What a user has made of their own world. Every field is null until they
+ * change it, and the client owns every display default — it has to render a
+ * world with no settings at all, so a second set of defaults on the API side
+ * would only be a copy that could disagree with this one.
+ */
+export interface WorldSettings {
+  name: string | null;
+  sky: WorldSky | null;
+  crest: WorldCrest | null;
+  look: WorldLook | null;
+  private: boolean;
+}
+
+/** What granted an entitlement: `base`, or `niche:<slug>`. */
+export interface WorldEntitlement {
+  kind: 'charge' | 'tincture' | string;
+  /** A charge signature, or a tincture as `#rrggbb`. */
+  id: string;
+  source: string;
+}
+
+export interface UserWorldData {
+  userWorld: WorldDistrict[];
+  userWorldSettings: WorldSettings | null;
+}
+
+export interface UserWorldEntitlementsData {
+  userWorldEntitlements: WorldEntitlement[];
+}
+
+export interface UpdateUserWorldSettingsData {
+  updateUserWorldSettings: WorldSettings | null;
+}
+
+const WORLD_SETTINGS_FRAGMENT = gql`
+  fragment WorldSettings on UserWorldSettings {
+    name
+    sky {
+      pal
+      hour
+    }
+    crest {
+      charge
+      div
+      a
+      b
+    }
+    look {
+      id
+      base
+      mine
+      name
+      ol
+      bl
+      duo
+      warm
+      sat
+      grain
+      vig
+      lift
+      duoA
+      duoB
+      ink
+      fx {
+        post
+        bloom
+        outline
+      }
+    }
+    private
+  }
+`;
+
+/**
+ * Everything the world needs to stand up, in one round trip.
+ *
+ * The two halves are asked for together because neither can draw without the
+ * other: the districts decide what is standing, and the settings decide what it
+ * is photographed through and what flies over it — so fetching them separately
+ * means either a frame of the wrong look or a second wait before the first one.
+ * The growth log is NOT in here: it is the same world's whole history, tens of
+ * thousands of rows, and the world stands without it.
+ *
+ * The settings are asked for on every world, not just your own — a look belongs
+ * to the place rather than to whoever is looking at it. They are also the only
+ * thing that can tell a private world from an empty one: privacy is applied to
+ * the districts in SQL, so both come back as an empty list, and this errors with
+ * FORBIDDEN instead.
+ */
 export const USER_WORLD_QUERY = gql`
   query UserWorld($id: ID!) {
     userWorld(id: $id) {
@@ -37,7 +181,46 @@ export const USER_WORLD_QUERY = gql`
       lastReadAt
       activeDays
     }
+    userWorldSettings(id: $id) {
+      ...WorldSettings
+    }
   }
+  ${WORLD_SETTINGS_FRAGMENT}
+`;
+
+/**
+ * What the bench needs rather than what displaying a world needs, which is why
+ * it is separate and only ever asked for once the owner opens the bench.
+ */
+export const USER_WORLD_ENTITLEMENTS_QUERY = gql`
+  query UserWorldEntitlements($id: ID!) {
+    userWorldEntitlements(id: $id) {
+      kind
+      id
+      source
+    }
+  }
+`;
+
+export const UPDATE_USER_WORLD_SETTINGS_MUTATION = gql`
+  mutation UpdateUserWorldSettings(
+    $name: String
+    $sky: UserWorldSkyInput
+    $crest: UserWorldCrestInput
+    $look: UserWorldLookInput
+    $private: Boolean
+  ) {
+    updateUserWorldSettings(
+      name: $name
+      sky: $sky
+      crest: $crest
+      look: $look
+      private: $private
+    ) {
+      ...WorldSettings
+    }
+  }
+  ${WORLD_SETTINGS_FRAGMENT}
 `;
 
 /**

--- a/packages/webapp/graphql/world.ts
+++ b/packages/webapp/graphql/world.ts
@@ -22,12 +22,7 @@ export interface UserWorldTimelineData {
   userWorldTimeline: WorldGrowth[];
 }
 
-/**
- * Two axes rather than a list, because two axes is what makes a sky feel found
- * instead of picked. Neither carries a fact: the sky used to be a readout of
- * what you had been reading lately, and that is exactly the thing it was freed
- * from so it could be given away.
- */
+/** Two free-form axes rather than a list of presets — neither carries a fact. */
 export interface WorldSky {
   /** brand, clear, blossom, ember, seaglass, orchid, harvest or slate. */
   pal: string;
@@ -81,10 +76,8 @@ export interface WorldLook {
 }
 
 /**
- * What a user has made of their own world. Every field is null until they
- * change it, and the client owns every display default — it has to render a
- * world with no settings at all, so a second set of defaults on the API side
- * would only be a copy that could disagree with this one.
+ * What a user has made of their own world. Null fields mean unset; the client
+ * owns every display default.
  */
 export interface WorldSettings {
   name: string | null;
@@ -155,20 +148,11 @@ const WORLD_SETTINGS_FRAGMENT = gql`
 `;
 
 /**
- * Everything the world needs to stand up, in one round trip.
- *
- * The two halves are asked for together because neither can draw without the
- * other: the districts decide what is standing, and the settings decide what it
- * is photographed through and what flies over it — so fetching them separately
- * means either a frame of the wrong look or a second wait before the first one.
- * The growth log is NOT in here: it is the same world's whole history, tens of
- * thousands of rows, and the world stands without it.
- *
- * The settings are asked for on every world, not just your own — a look belongs
- * to the place rather than to whoever is looking at it. They are also the only
- * thing that can tell a private world from an empty one: privacy is applied to
- * the districts in SQL, so both come back as an empty list, and this errors with
- * FORBIDDEN instead.
+ * Districts and settings in one round trip — neither can draw without the
+ * other. The growth log is NOT in here (tens of thousands of rows on a
+ * long-tenured world; fetched separately). A private world comes back as
+ * FORBIDDEN rather than an empty list, which is what distinguishes it from one
+ * that is simply empty.
  */
 export const USER_WORLD_QUERY = gql`
   query UserWorld($id: ID!) {
@@ -188,10 +172,7 @@ export const USER_WORLD_QUERY = gql`
   ${WORLD_SETTINGS_FRAGMENT}
 `;
 
-/**
- * What the bench needs rather than what displaying a world needs, which is why
- * it is separate and only ever asked for once the owner opens the bench.
- */
+/** What the bench needs, not what displaying a world needs — asked for only once the owner opens it. */
 export const USER_WORLD_ENTITLEMENTS_QUERY = gql`
   query UserWorldEntitlements($id: ID!) {
     userWorldEntitlements(id: $id) {

--- a/packages/webapp/pages/world/[userId].tsx
+++ b/packages/webapp/pages/world/[userId].tsx
@@ -3,8 +3,11 @@ import React from 'react';
 import { NextSeo } from 'next-seo';
 import type { NextSeoProps } from 'next-seo/lib/types';
 import dynamic from 'next/dynamic';
+import type { GetStaticPropsContext, GetStaticPropsResult } from 'next';
+import type { ParsedUrlQuery } from 'querystring';
 import { useRouter } from 'next/router';
 import Custom404 from '@dailydotdev/shared/src/components/Custom404';
+import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
 import type { ProfileLayoutProps } from '../../components/layouts/ProfileLayout';
 import {
   getProfileSeoDefaults,
@@ -19,8 +22,76 @@ import {
 } from '../../components/world/WorldBoot';
 import { useUserWorld } from '../../components/world/useUserWorld';
 
-export const getStaticProps = getProfileStaticProps;
 export const getStaticPaths = getProfileStaticPaths;
+
+interface WorldPageProps extends ProfileLayoutProps {
+  /** What the owner calls the place, or null if they have never named it. */
+  worldName?: string | null;
+}
+
+interface WorldParams extends ParsedUrlQuery {
+  userId: string;
+}
+
+/**
+ * The world's name, read at build time so it can reach the share card.
+ *
+ * A plain fetch rather than the app's client: this runs on the server, where
+ * there is no session to send and nothing to cache into. The same GraphQL error
+ * the client reads as "private" is what keeps this page out of the index.
+ * Anything else — a network blip, a schema change — leaves the name off the card
+ * and the page indexable, which is the harmless direction to fail in.
+ */
+const getWorldSeoData = async (
+  userId: string,
+): Promise<{ name: string | null; isPrivate: boolean }> => {
+  try {
+    const res = await fetch(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: `query UserWorldName($id: ID!) {
+          userWorldSettings(id: $id) { name }
+        }`,
+        variables: { id: userId },
+      }),
+    });
+    const body = await res.json();
+    const isPrivate = !!body?.errors?.some(
+      ({ extensions }: { extensions?: { code?: string } }) =>
+        extensions?.code === 'FORBIDDEN',
+    );
+
+    return { name: body?.data?.userWorldSettings?.name ?? null, isPrivate };
+  } catch {
+    return { name: null, isPrivate: false };
+  }
+};
+
+export async function getStaticProps(
+  context: GetStaticPropsContext<WorldParams>,
+): Promise<GetStaticPropsResult<WorldPageProps>> {
+  const result = (await getProfileStaticProps(
+    context,
+  )) as GetStaticPropsResult<ProfileLayoutProps>;
+
+  if (!('props' in result) || !result.props.user) {
+    return result as GetStaticPropsResult<WorldPageProps>;
+  }
+
+  const world = await getWorldSeoData(result.props.user.id);
+
+  return {
+    ...result,
+    props: {
+      ...result.props,
+      worldName: world.name,
+      // A world its owner has hidden has nothing to index, and a crawler that
+      // followed a share link is exactly who this is for.
+      noindex: result.props.noindex || world.isPrivate,
+    },
+  };
+}
 
 /**
  * The renderer is ~700 KB of three.js and a WebGL context, and it reads
@@ -50,7 +121,8 @@ const WorldView = dynamic(
 const ProfileWorldPage = ({
   user,
   noindex,
-}: ProfileLayoutProps): ReactElement | null => {
+  worldName,
+}: WorldPageProps): ReactElement | null => {
   const { isFallback } = useRouter();
   /* Asked for HERE rather than inside the view, which is the whole point: the
      renderer is most of a megabyte and the districts are one small query, and
@@ -71,11 +143,19 @@ const ProfileWorldPage = ({
     return <WorldBoot />;
   }
 
+  /* The name its owner gave the place leads, because that is what the link is
+     OF. Without one the page is still theirs, so it says whose it is — the same
+     line it carried before a world could be named. */
+  const title = worldName
+    ? `${worldName} — ${user.name}'s world`
+    : `${user.name}'s world (@${user.username})`;
   const seo: NextSeoProps = getProfileSeoDefaults(
     user,
     {
-      ...getPageSeoTitles(`${user.name}'s world (@${user.username})`),
-      description: `See the world ${user.name}'s reading built on daily.dev. Every topic they read grows a district in it.`,
+      ...getPageSeoTitles(title),
+      description: `See ${worldName ? `${worldName}, the` : 'the'} world ${
+        user.name
+      }'s reading built on daily.dev. Every topic they read grows a district in it.`,
     },
     noindex,
   );


### PR DESCRIPTION
The world at `/world/:userId` was a read-only portrait. This adds the half that makes it somebody's: a gear in the rail opens a bench where the owner names the place, flies a crest, picks a sky and grades the whole frame.

Consumes the API from dailydotdev/daily-api#4044.

## The rule this keeps

The split the API encodes is the point. The **reading** writes the world — which districts exist, how large they are, where they rank — and the **hand** writes only the dressing. Nothing on this panel can make a world claim to be bigger than it was read into being.

- **Crest** is assembled strictly out of monuments raised and accents of districts founded, so it cannot be built to lie. Only the division is free, because a division encodes nothing. The API is the authority on what has been earned (`userWorldEntitlements`); the client only draws what it is handed.
- **Sky** and **look** carry no fact at all, which is exactly why they can be given away. The sky used to be a readout of whichever realm you had read lately — *that* is the thing it was freed from, not the palettes.
- **Land, level, density, monuments** are not on the panel and never will be.

## What a visitor sees

The **owner's** choices, not their own. A look and a crest are properties of the place, so they are served to everybody who visits.

The private flag is honoured whole: no map, no timeline, no crest, its own screen, and the page drops out of the index. It is also the only thing that can tell a private world from an unbuilt one — privacy is applied to the districts in SQL so both come back empty, and `userWorldSettings` errors with `FORBIDDEN` instead.

## Notes for review

- **One round trip raises the world.** `userWorld` and `userWorldSettings` are batched, because neither half can draw without the other — asking separately buys either a frame of the wrong look or a second wait. The growth log stays separate (tens of thousands of rows) and entitlements stay lazy (owner only, bench only).
- **Name suggestions always fit the field.** The star button *commits* what it shows, so an over-length suggestion is a save the API rejects. The generator offers the rich shapes and filters to what fits; two shapes that carry no realm or no epithet are the floor. Exhaustive test over every realm x breadth x volume.
- **No layout shift when the bench opens.** Almost nothing in the crest section needs the network — the shield comes from the client-side derivation, the row labels and all six divisions are static — so only the two rows that *are* the catalogue are placeheld, and eligibility is decided off the districts by the same rule the API applies.
- **Engine seams.** `setSky`, `setCrest` and `setLook` on the renderer; the crest, look and sky tables live in their own modules so the bench lists the same tables the renderer paints from. The engine files stay near-verbatim devcraft ports (they are eslint-ignored on purpose), so casing and labels are adapted at render rather than edited in the tables.
- **Shared change:** `Slider` gained an optional `thumbLabel` (Radix puts `role="slider"` on the thumb, so an `aria-label` on the root reached nothing — a bench of seven read as unnamed) and a `compact` variant. Both additive; the existing boost modals are untouched.

## Test plan

- [x] `worldCustomization`, `WorldCustomize`, `useUserWorld`, `buildWorld`, `unbuiltWorld`, `WorldInvite` - 50 passing
- [x] Full shared suite - 2154 passing
- [x] `typecheck-strict-changed`, webapp + shared lint
- [x] Manually on a real world: nudge to bench, live regrade, save returns to the panel, reload persists, share-card title picks up the world name
- [ ] Private path is covered by tests rather than exercised live - it would have hidden a real world

https://claude.ai/code/session_01UMNkFfCEauDTJQ9xCMQpMK

### Preview domain
https://feat-world-customization.preview.app.daily.dev