### PR TITLE
feat: add captureShareImage util for element-to-OG-image capture

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -125,6 +125,7 @@
     "@tiptap/extension-placeholder": "^3.22.5",
     "@tiptap/react": "^3.22.5",
     "@tiptap/starter-kit": "^3.22.5",
+    "@zumer/snapdom": "^2.23.1",
     "border-beam": "1.3.0",
     "check-password-strength": "^2.0.10",
     "cmdk": "^1.0.0",

--- a/packages/shared/src/lib/blob.ts
+++ b/packages/shared/src/lib/blob.ts
@@ -8,6 +8,22 @@ export const blobToBase64 = (blob: Blob): Promise<string> =>
     reader.readAsDataURL(blob);
   });
 
+interface DownloadBlobProps {
+  filename: string;
+  blob: Blob;
+}
+
+export const downloadBlob = ({ filename, blob }: DownloadBlobProps): void => {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+};
+
 interface DownloadProps {
   filename: string;
   url: string;
@@ -18,13 +34,7 @@ export const downloadUrl = async ({
   url,
 }: DownloadProps): Promise<void> => {
   const file = await fetch(url);
-  const imageBlog = await file.blob();
-  const imageURL = URL.createObjectURL(imageBlog);
+  const blob = await file.blob();
 
-  const link = document.createElement('a');
-  link.href = imageURL;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
+  downloadBlob({ filename, blob });
 };

--- a/packages/shared/src/lib/imageShare/captureShareImage.spec.ts
+++ b/packages/shared/src/lib/imageShare/captureShareImage.spec.ts
@@ -1,0 +1,214 @@
+import { snapdom } from '@zumer/snapdom';
+import {
+  markAlphas,
+  markPaths,
+  wordmarkAlphas,
+  wordmarkFillRules,
+  wordmarkPaths,
+} from '../../svg/logoGeometry';
+import type {
+  CaptureShareImageOptions,
+  CaptureTarget,
+} from './captureShareImage';
+import {
+  captureShareImage,
+  SHARE_IMAGE_HEIGHT,
+  SHARE_IMAGE_WIDTH,
+} from './captureShareImage';
+
+jest.mock('@zumer/snapdom', () => ({ snapdom: jest.fn() }));
+
+const THEME = {
+  backgroundColor: 'rgb(1, 2, 3)',
+  borderTopColor: 'rgba(4, 5, 6, 0.2)',
+  color: 'rgb(7, 8, 9)',
+};
+
+type FillRectCall = { args: number[]; fillStyle: string };
+type DrawImageCall = { args: number[] };
+type FillCall = { d: string; rule?: CanvasFillRule; alpha: number };
+
+let fillRects: FillRectCall[];
+let drawImages: DrawImageCall[];
+let fills: FillCall[];
+let constructedPaths: string[];
+let source: { width: number; height: number };
+
+class FakePath2D {
+  constructor(public d: string) {
+    constructedPaths.push(d);
+  }
+}
+
+const createContext = () => {
+  const context = {
+    fillStyle: '',
+    globalAlpha: 1,
+    imageSmoothingQuality: 'low',
+    save: jest.fn(),
+    restore: jest.fn(),
+    translate: jest.fn(),
+    scale: jest.fn(),
+    fillRect: jest.fn((...args: number[]) => {
+      fillRects.push({ args, fillStyle: context.fillStyle });
+    }),
+    drawImage: jest.fn((_: unknown, ...args: number[]) => {
+      drawImages.push({ args });
+    }),
+    fill: jest.fn((path: FakePath2D, rule?: CanvasFillRule) => {
+      fills.push({ d: path.d, rule, alpha: context.globalAlpha });
+    }),
+  };
+
+  return context;
+};
+
+const sized = (width: number, height: number): HTMLElement => {
+  const element = document.createElement('div');
+  element.getBoundingClientRect = () =>
+    ({ width, height } as unknown as DOMRect);
+  document.body.appendChild(element);
+
+  return element;
+};
+
+const snapdomMock = jest.mocked(snapdom);
+
+const capture = (
+  target: CaptureTarget,
+  options?: CaptureShareImageOptions,
+): Promise<Blob> => captureShareImage(target, options);
+
+beforeEach(() => {
+  fillRects = [];
+  drawImages = [];
+  fills = [];
+  constructedPaths = [];
+  source = { width: 400, height: 100 };
+
+  document.body.innerHTML = '';
+
+  (global as unknown as { Path2D: unknown }).Path2D = FakePath2D;
+
+  snapdomMock.mockResolvedValue({
+    toCanvas: async () => source,
+  } as unknown as Awaited<ReturnType<typeof snapdom>>);
+
+  jest
+    .spyOn(window, 'getComputedStyle')
+    .mockReturnValue(THEME as unknown as CSSStyleDeclaration);
+
+  jest
+    .spyOn(HTMLCanvasElement.prototype, 'getContext')
+    .mockImplementation(
+      () => createContext() as unknown as CanvasRenderingContext2D,
+    );
+
+  jest
+    .spyOn(HTMLCanvasElement.prototype, 'toBlob')
+    .mockImplementation((callback) => callback(new Blob(['png'])));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('captureShareImage', () => {
+  it('accepts a bare element and a ref alike', async () => {
+    const element = sized(600, 300);
+
+    await expect(capture(element)).resolves.toBeInstanceOf(Blob);
+    await expect(capture({ current: element })).resolves.toBeInstanceOf(Blob);
+  });
+
+  it('refuses a ref that is not mounted', async () => {
+    await expect(capture({ current: null })).rejects.toThrow('not mounted');
+  });
+
+  it('refuses an element with no size', async () => {
+    await expect(capture(sized(0, 0))).rejects.toThrow('has no size');
+  });
+
+  it('leaves no theme probe behind in the target', async () => {
+    const element = sized(600, 300);
+    await capture(element);
+
+    expect(element.childElementCount).toBe(0);
+  });
+
+  it('fills the frame and the bar from one background, so they cannot seam', async () => {
+    await capture(sized(600, 300));
+
+    const frame = fillRects[0];
+    const bar = fillRects[1];
+    const border = fillRects[2];
+
+    expect(frame.args).toEqual([0, 0, SHARE_IMAGE_WIDTH, SHARE_IMAGE_HEIGHT]);
+    expect(bar.args).toEqual([0, 558, SHARE_IMAGE_WIDTH, 72]);
+    expect(bar.fillStyle).toBe(frame.fillStyle);
+    expect(frame.fillStyle).toBe(THEME.backgroundColor);
+
+    expect(border.args).toEqual([0, 558, SHARE_IMAGE_WIDTH, 2]);
+    expect(border.fillStyle).toBe(THEME.borderTopColor);
+  });
+
+  it('honours an explicit frame background without moving the bar', async () => {
+    await capture(sized(600, 300), { frameBackgroundColor: 'rgb(9, 9, 9)' });
+
+    expect(fillRects[0].fillStyle).toBe('rgb(9, 9, 9)');
+    expect(fillRects[1].fillStyle).toBe(THEME.backgroundColor);
+  });
+
+  it('draws the bar logo from the shared geometry, stroke for stroke', async () => {
+    await capture(sized(600, 300));
+
+    expect(constructedPaths).toEqual([...markPaths, ...wordmarkPaths]);
+    expect(fills.map(({ alpha }) => alpha)).toEqual([
+      ...markAlphas,
+      ...wordmarkAlphas,
+    ]);
+    expect(fills.slice(markPaths.length).map(({ rule }) => rule)).toEqual([
+      ...wordmarkFillRules,
+    ]);
+  });
+
+  it('contains the capture inside the padded frame', async () => {
+    await capture(sized(600, 300));
+
+    const [x, y, width, height] = drawImages[0].args;
+    expect(width).toBeCloseTo(1104);
+    expect(height).toBeCloseTo(276);
+    expect(x).toBeCloseTo(48);
+    expect(y).toBeCloseTo(141);
+  });
+
+  it('reclaims the bar height and re-centres when unbranded', async () => {
+    await capture(sized(600, 300), { branded: false });
+
+    const [, y] = drawImages[0].args;
+    expect(y).toBeCloseTo(177);
+    expect(fills).toHaveLength(0);
+    expect(fillRects).toHaveLength(1);
+  });
+
+  it('lets padding drive the content box', async () => {
+    await capture(sized(600, 300), { padding: 0 });
+
+    const [x, y, width, height] = drawImages[0].args;
+    expect(width).toBeCloseTo(1200);
+    expect(height).toBeCloseTo(300);
+    expect(x).toBeCloseTo(0);
+    expect(y).toBeCloseTo(129);
+  });
+
+  it('derives the capture scale from the fit, ignoring a caller override', async () => {
+    await capture(sized(600, 300), {
+      scale: 99,
+    } as unknown as CaptureShareImageOptions);
+
+    expect(snapdomMock.mock.calls[0][1]).toMatchObject({
+      scale: 1.54,
+      embedFonts: true,
+    });
+  });
+});

--- a/packages/shared/src/lib/imageShare/captureShareImage.ts
+++ b/packages/shared/src/lib/imageShare/captureShareImage.ts
@@ -1,0 +1,185 @@
+import type { RefObject } from 'react';
+import { createElement } from 'react';
+import type { SnapdomOptions } from '@zumer/snapdom';
+import LogoIcon from '../../svg/LogoIcon';
+import LogoText from '../../svg/LogoText';
+
+export const SHARE_IMAGE_WIDTH = 1200;
+export const SHARE_IMAGE_HEIGHT = 630;
+
+const LOGO_BAR_HEIGHT = 72;
+const LOGO_BAR_BORDER = 2;
+const LOGO_HEIGHT = 26;
+const LOGO_GAP = 8;
+const LOGO_ICON_RATIO = 35 / 20;
+const LOGO_TEXT_RATIO = 77 / 20;
+
+export type CaptureTarget = HTMLElement | RefObject<HTMLElement>;
+
+export interface CaptureShareImageOptions extends SnapdomOptions {
+  padding?: number;
+  frameBackgroundColor?: string;
+  branded?: boolean;
+}
+
+const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+
+const resolveFrameBackground = (): string => {
+  const rootStyle = getComputedStyle(document.documentElement);
+  const rootBackground = rootStyle.backgroundColor;
+
+  if (rootBackground && rootBackground !== TRANSPARENT) {
+    return rootBackground;
+  }
+
+  const themeBackground = rootStyle
+    .getPropertyValue('--theme-background-default')
+    .trim();
+
+  if (themeBackground) {
+    return themeBackground;
+  }
+
+  return getComputedStyle(document.body).backgroundColor;
+};
+
+const svgToImage = async (markup: string): Promise<HTMLImageElement> => {
+  const image = new Image();
+  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(markup)}`;
+  await image.decode();
+
+  return image;
+};
+
+const drawLogoBar = async (
+  context: CanvasRenderingContext2D,
+): Promise<void> => {
+  const { renderToStaticMarkup } = await import('react-dom/server');
+  const rootStyle = getComputedStyle(document.documentElement);
+  const themeColor = rootStyle.getPropertyValue('--theme-text-primary').trim();
+  const color = themeColor || getComputedStyle(document.body).color;
+  const barBackground = rootStyle
+    .getPropertyValue('--theme-background-default')
+    .trim();
+  const barBorder = rootStyle
+    .getPropertyValue('--theme-border-subtlest-tertiary')
+    .trim();
+
+  const barTop = SHARE_IMAGE_HEIGHT - LOGO_BAR_HEIGHT;
+
+  if (barBackground) {
+    context.fillStyle = barBackground;
+    context.fillRect(0, barTop, SHARE_IMAGE_WIDTH, LOGO_BAR_HEIGHT);
+  }
+
+  if (barBorder) {
+    context.fillStyle = barBorder;
+    context.fillRect(0, barTop, SHARE_IMAGE_WIDTH, LOGO_BAR_BORDER);
+  }
+
+  const toSizedMarkup = (markup: string, width: number): string =>
+    markup
+      .replace('<svg ', `<svg width="${width}" height="${LOGO_HEIGHT}" `)
+      .replace(/var\(--theme-text-primary\)/g, color);
+
+  const iconWidth = LOGO_HEIGHT * LOGO_ICON_RATIO;
+  const textWidth = LOGO_HEIGHT * LOGO_TEXT_RATIO;
+  const [icon, text] = await Promise.all([
+    svgToImage(
+      toSizedMarkup(renderToStaticMarkup(createElement(LogoIcon)), iconWidth),
+    ),
+    svgToImage(
+      toSizedMarkup(renderToStaticMarkup(createElement(LogoText)), textWidth),
+    ),
+  ]);
+
+  const totalWidth = iconWidth + LOGO_GAP + textWidth;
+  const x = (SHARE_IMAGE_WIDTH - totalWidth) / 2;
+  const y = barTop + (LOGO_BAR_HEIGHT - LOGO_HEIGHT) / 2;
+
+  context.drawImage(icon, x, y, iconWidth, LOGO_HEIGHT);
+  context.drawImage(text, x + iconWidth + LOGO_GAP, y, textWidth, LOGO_HEIGHT);
+};
+
+export async function captureShareImage(
+  target: CaptureTarget,
+  options: CaptureShareImageOptions = {},
+): Promise<Blob> {
+  const element = target instanceof HTMLElement ? target : target.current;
+
+  if (!element) {
+    throw new Error('captureShareImage: target element is not mounted');
+  }
+
+  const {
+    padding = 48,
+    frameBackgroundColor,
+    branded = true,
+    ...snapOptions
+  } = options;
+  const barHeight = branded ? LOGO_BAR_HEIGHT : 0;
+  const contentWidth = SHARE_IMAGE_WIDTH - padding * 2;
+  const contentHeight = SHARE_IMAGE_HEIGHT - padding * 2 - barHeight;
+
+  const rect = element.getBoundingClientRect();
+
+  if (!rect.width || !rect.height) {
+    throw new Error('captureShareImage: target element has no size');
+  }
+
+  const fitScale = Math.min(
+    contentWidth / rect.width,
+    contentHeight / rect.height,
+  );
+  const captureScale = Math.max(1, fitScale);
+
+  const { snapdom } = await import('@zumer/snapdom');
+  const result = await snapdom(element, {
+    embedFonts: true,
+    scale: captureScale,
+    ...snapOptions,
+  });
+  const source = await result.toCanvas();
+
+  const canvas = document.createElement('canvas');
+  canvas.width = SHARE_IMAGE_WIDTH;
+  canvas.height = SHARE_IMAGE_HEIGHT;
+  const context = canvas.getContext('2d');
+
+  if (!context) {
+    throw new Error('captureShareImage: canvas 2d context unavailable');
+  }
+
+  context.fillStyle = frameBackgroundColor ?? resolveFrameBackground();
+  context.fillRect(0, 0, canvas.width, canvas.height);
+
+  const drawScale = Math.min(
+    contentWidth / source.width,
+    contentHeight / source.height,
+  );
+  const drawWidth = source.width * drawScale;
+  const drawHeight = source.height * drawScale;
+
+  context.imageSmoothingQuality = 'high';
+  context.drawImage(
+    source,
+    (canvas.width - drawWidth) / 2,
+    padding + (contentHeight - drawHeight) / 2,
+    drawWidth,
+    drawHeight,
+  );
+
+  if (branded) {
+    await drawLogoBar(context);
+  }
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('captureShareImage: failed to encode PNG'));
+      }
+    }, 'image/png');
+  });
+}

--- a/packages/shared/src/lib/imageShare/captureShareImage.ts
+++ b/packages/shared/src/lib/imageShare/captureShareImage.ts
@@ -1,8 +1,16 @@
 import type { RefObject } from 'react';
-import { createElement } from 'react';
 import type { SnapdomOptions } from '@zumer/snapdom';
-import LogoIcon from '../../svg/LogoIcon';
-import LogoText from '../../svg/LogoText';
+import {
+  markAlphas,
+  MARK_HEIGHT,
+  markPaths,
+  MARK_WIDTH,
+  wordmarkAlphas,
+  wordmarkFillRules,
+  wordmarkPaths,
+  WORDMARK_HEIGHT,
+  WORDMARK_WIDTH,
+} from '../../svg/logoGeometry';
 
 export const SHARE_IMAGE_WIDTH = 1200;
 export const SHARE_IMAGE_HEIGHT = 630;
@@ -11,101 +19,105 @@ const LOGO_BAR_HEIGHT = 72;
 const LOGO_BAR_BORDER = 2;
 const LOGO_HEIGHT = 26;
 const LOGO_GAP = 8;
-const LOGO_ICON_RATIO = 35 / 20;
-const LOGO_TEXT_RATIO = 77 / 20;
 
 export type CaptureTarget = HTMLElement | RefObject<HTMLElement>;
 
-export interface CaptureShareImageOptions extends SnapdomOptions {
+export interface CaptureShareImageOptions
+  extends Omit<SnapdomOptions, 'scale' | 'width' | 'height'> {
   padding?: number;
   frameBackgroundColor?: string;
   branded?: boolean;
 }
 
-const TRANSPARENT = 'rgba(0, 0, 0, 0)';
+interface ShareImageTheme {
+  background: string;
+  border: string;
+  logo: string;
+}
 
-const resolveFrameBackground = (): string => {
-  const rootStyle = getComputedStyle(document.documentElement);
-  const rootBackground = rootStyle.backgroundColor;
+const PROBE_STYLE = [
+  'position:fixed',
+  'top:0',
+  'left:0',
+  'width:0',
+  'height:0',
+  'visibility:hidden',
+  'pointer-events:none',
+  'background-color:var(--theme-background-default)',
+  'border-top:1px solid var(--theme-border-subtlest-tertiary)',
+  'color:var(--theme-text-primary)',
+].join(';');
 
-  if (rootBackground && rootBackground !== TRANSPARENT) {
-    return rootBackground;
-  }
+const resolveTheme = (element: HTMLElement): ShareImageTheme => {
+  const probe = element.ownerDocument.createElement('div');
+  probe.style.cssText = PROBE_STYLE;
+  element.appendChild(probe);
 
-  const themeBackground = rootStyle
-    .getPropertyValue('--theme-background-default')
-    .trim();
+  const style = getComputedStyle(probe);
+  const theme = {
+    background: style.backgroundColor,
+    border: style.borderTopColor,
+    logo: style.color,
+  };
 
-  if (themeBackground) {
-    return themeBackground;
-  }
+  probe.remove();
 
-  return getComputedStyle(document.body).backgroundColor;
+  return theme;
 };
 
-const svgToImage = async (markup: string): Promise<HTMLImageElement> => {
-  const image = new Image();
-  image.src = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(markup)}`;
-  await image.decode();
-
-  return image;
-};
-
-const drawLogoBar = async (
+const fillPaths = (
   context: CanvasRenderingContext2D,
-): Promise<void> => {
-  const { renderToStaticMarkup } = await import('react-dom/server');
-  const rootStyle = getComputedStyle(document.documentElement);
-  const themeColor = rootStyle.getPropertyValue('--theme-text-primary').trim();
-  const color = themeColor || getComputedStyle(document.body).color;
-  const barBackground = rootStyle
-    .getPropertyValue('--theme-background-default')
-    .trim();
-  const barBorder = rootStyle
-    .getPropertyValue('--theme-border-subtlest-tertiary')
-    .trim();
+  paths: string[],
+  alphas: number[],
+  rules?: readonly CanvasFillRule[],
+): void => {
+  paths.forEach((path, index) => {
+    context.globalAlpha = alphas[index] ?? 1;
+    context.fill(new Path2D(path), rules?.[index] ?? 'nonzero');
+  });
 
+  context.globalAlpha = 1;
+};
+
+const drawLogoBar = (
+  context: CanvasRenderingContext2D,
+  theme: ShareImageTheme,
+): void => {
   const barTop = SHARE_IMAGE_HEIGHT - LOGO_BAR_HEIGHT;
 
-  if (barBackground) {
-    context.fillStyle = barBackground;
-    context.fillRect(0, barTop, SHARE_IMAGE_WIDTH, LOGO_BAR_HEIGHT);
-  }
+  context.fillStyle = theme.background;
+  context.fillRect(0, barTop, SHARE_IMAGE_WIDTH, LOGO_BAR_HEIGHT);
 
-  if (barBorder) {
-    context.fillStyle = barBorder;
-    context.fillRect(0, barTop, SHARE_IMAGE_WIDTH, LOGO_BAR_BORDER);
-  }
+  context.fillStyle = theme.border;
+  context.fillRect(0, barTop, SHARE_IMAGE_WIDTH, LOGO_BAR_BORDER);
 
-  const toSizedMarkup = (markup: string, width: number): string =>
-    markup
-      .replace('<svg ', `<svg width="${width}" height="${LOGO_HEIGHT}" `)
-      .replace(/var\(--theme-text-primary\)/g, color);
+  const markScale = LOGO_HEIGHT / MARK_HEIGHT;
+  const wordmarkScale = LOGO_HEIGHT / WORDMARK_HEIGHT;
+  const markWidth = MARK_WIDTH * markScale;
+  const wordmarkWidth = WORDMARK_WIDTH * wordmarkScale;
+  const left = (SHARE_IMAGE_WIDTH - (markWidth + LOGO_GAP + wordmarkWidth)) / 2;
+  const top = barTop + (LOGO_BAR_HEIGHT - LOGO_HEIGHT) / 2;
 
-  const iconWidth = LOGO_HEIGHT * LOGO_ICON_RATIO;
-  const textWidth = LOGO_HEIGHT * LOGO_TEXT_RATIO;
-  const [icon, text] = await Promise.all([
-    svgToImage(
-      toSizedMarkup(renderToStaticMarkup(createElement(LogoIcon)), iconWidth),
-    ),
-    svgToImage(
-      toSizedMarkup(renderToStaticMarkup(createElement(LogoText)), textWidth),
-    ),
-  ]);
+  context.fillStyle = theme.logo;
 
-  const totalWidth = iconWidth + LOGO_GAP + textWidth;
-  const x = (SHARE_IMAGE_WIDTH - totalWidth) / 2;
-  const y = barTop + (LOGO_BAR_HEIGHT - LOGO_HEIGHT) / 2;
+  context.save();
+  context.translate(left, top);
+  context.scale(markScale, markScale);
+  fillPaths(context, markPaths, markAlphas);
+  context.restore();
 
-  context.drawImage(icon, x, y, iconWidth, LOGO_HEIGHT);
-  context.drawImage(text, x + iconWidth + LOGO_GAP, y, textWidth, LOGO_HEIGHT);
+  context.save();
+  context.translate(left + markWidth + LOGO_GAP, top);
+  context.scale(wordmarkScale, wordmarkScale);
+  fillPaths(context, wordmarkPaths, wordmarkAlphas, wordmarkFillRules);
+  context.restore();
 };
 
 export async function captureShareImage(
   target: CaptureTarget,
   options: CaptureShareImageOptions = {},
 ): Promise<Blob> {
-  const element = target instanceof HTMLElement ? target : target.current;
+  const element = 'current' in target ? target.current : target;
 
   if (!element) {
     throw new Error('captureShareImage: target element is not mounted');
@@ -127,6 +139,8 @@ export async function captureShareImage(
     throw new Error('captureShareImage: target element has no size');
   }
 
+  const theme = resolveTheme(element);
+
   const fitScale = Math.min(
     contentWidth / rect.width,
     contentHeight / rect.height,
@@ -136,8 +150,8 @@ export async function captureShareImage(
   const { snapdom } = await import('@zumer/snapdom');
   const result = await snapdom(element, {
     embedFonts: true,
-    scale: captureScale,
     ...snapOptions,
+    scale: captureScale,
   });
   const source = await result.toCanvas();
 
@@ -150,7 +164,7 @@ export async function captureShareImage(
     throw new Error('captureShareImage: canvas 2d context unavailable');
   }
 
-  context.fillStyle = frameBackgroundColor ?? resolveFrameBackground();
+  context.fillStyle = frameBackgroundColor ?? theme.background;
   context.fillRect(0, 0, canvas.width, canvas.height);
 
   const drawScale = Math.min(
@@ -170,7 +184,7 @@ export async function captureShareImage(
   );
 
   if (branded) {
-    await drawLogoBar(context);
+    drawLogoBar(context, theme);
   }
 
   return new Promise<Blob>((resolve, reject) => {

--- a/packages/shared/src/lib/imageShare/devCaptureShareImage.ts
+++ b/packages/shared/src/lib/imageShare/devCaptureShareImage.ts
@@ -1,0 +1,48 @@
+import type {
+  CaptureShareImageOptions,
+  CaptureTarget,
+} from './captureShareImage';
+import { captureShareImage } from './captureShareImage';
+
+export interface DevCaptureShareImageOptions extends CaptureShareImageOptions {
+  download?: boolean;
+  filename?: string;
+}
+
+export async function devCaptureShareImage(
+  target: CaptureTarget,
+  options: DevCaptureShareImageOptions = {},
+): Promise<Blob> {
+  const {
+    download = true,
+    filename = 'daily-capture',
+    ...captureOptions
+  } = options;
+  const blob = await captureShareImage(target, captureOptions);
+
+  if (download) {
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = `${filename}.png`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  }
+
+  return blob;
+}
+
+declare global {
+  interface Window {
+    captureShareImage?: typeof devCaptureShareImage;
+  }
+}
+
+export function installCaptureShareImage(): void {
+  if (typeof window === 'undefined' || window.captureShareImage) {
+    return;
+  }
+
+  window.captureShareImage = devCaptureShareImage;
+}

--- a/packages/shared/src/lib/imageShare/devCaptureShareImage.ts
+++ b/packages/shared/src/lib/imageShare/devCaptureShareImage.ts
@@ -3,6 +3,7 @@ import type {
   CaptureTarget,
 } from './captureShareImage';
 import { captureShareImage } from './captureShareImage';
+import { downloadBlob } from '../blob';
 
 export interface DevCaptureShareImageOptions extends CaptureShareImageOptions {
   download?: boolean;
@@ -15,19 +16,13 @@ export async function devCaptureShareImage(
 ): Promise<Blob> {
   const {
     download = true,
-    filename = 'daily-capture',
+    filename = 'dailydotdev-capture',
     ...captureOptions
   } = options;
   const blob = await captureShareImage(target, captureOptions);
 
   if (download) {
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement('a');
-    anchor.href = url;
-    anchor.download = `${filename}.png`;
-    document.body.appendChild(anchor);
-    anchor.click();
-    anchor.remove();
+    downloadBlob({ filename: `${filename}.png`, blob });
   }
 
   return blob;

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -43,6 +43,7 @@ import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
 import { DndContextProvider } from '@dailydotdev/shared/src/contexts/DndContext';
 import { structuredCloneJsonPolyfill } from '@dailydotdev/shared/src/lib/structuredClone';
 import { fromCDN } from '@dailydotdev/shared/src/lib';
+import { installCaptureShareImage } from '@dailydotdev/shared/src/lib/imageShare/devCaptureShareImage';
 import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth';
 import { useCheckCoresRole } from '@dailydotdev/shared/src/hooks/useCheckCoresRole';
 import {
@@ -429,6 +430,12 @@ export default function App(
   useError();
   useManualScrollRestoration();
   useScrollbarWidth();
+
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'development') {
+      installCaptureShareImage();
+    }
+  }, []);
 
   const { Component, pageProps, router } = props;
   const { dehydratedState } = pageProps;

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -43,7 +43,6 @@ import { useThemedAsset } from '@dailydotdev/shared/src/hooks/utils';
 import { DndContextProvider } from '@dailydotdev/shared/src/contexts/DndContext';
 import { structuredCloneJsonPolyfill } from '@dailydotdev/shared/src/lib/structuredClone';
 import { fromCDN } from '@dailydotdev/shared/src/lib';
-import { installCaptureShareImage } from '@dailydotdev/shared/src/lib/imageShare/devCaptureShareImage';
 import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth';
 import { useCheckCoresRole } from '@dailydotdev/shared/src/hooks/useCheckCoresRole';
 import {
@@ -432,9 +431,13 @@ export default function App(
   useScrollbarWidth();
 
   useEffect(() => {
-    if (process.env.NODE_ENV === 'development') {
-      installCaptureShareImage();
+    if (process.env.NODE_ENV !== 'development') {
+      return;
     }
+
+    import('@dailydotdev/shared/src/lib/imageShare/devCaptureShareImage').then(
+      ({ installCaptureShareImage }) => installCaptureShareImage(),
+    );
   }, []);
 
   const { Component, pageProps, router } = props;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -447,6 +447,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.22.5
         version: 3.22.5
+      '@zumer/snapdom':
+        specifier: ^2.23.1
+        version: 2.23.1
       border-beam:
         specifier: 1.3.0
         version: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1124,7 +1127,7 @@ importers:
     dependencies:
       '@dailydotdev/world-kit':
         specifier: 0.1.1
-        version: link:../world-kit
+        version: 0.1.1
 
   packages/world-kit: {}
 
@@ -1899,6 +1902,9 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       postcss-selector-parser: ^7.0.0
+
+  '@dailydotdev/world-kit@0.1.1':
+    resolution: {integrity: sha512-t5pzFaCP5vbh7rjAb+lZ4L/wwSAwEVNFvHEfiL42nHBa/lOuFoMBQPTldEKuBW1mQlSAl3q4bh0ZQezpHhn6cA==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -4833,6 +4839,9 @@ packages:
 
   '@xtuc/long@4.2.2':
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
+  '@zumer/snapdom@2.23.1':
+    resolution: {integrity: sha512-r+6LRFXIpzTxlvGBjTr7mhvVW05TozgyE1QFmvO1hbchdbl4Km5/7DIkeyl2+nEVbz8Sp6/K2g4b86pXhCrFIQ==}
 
   abab@2.0.6:
     resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
@@ -8817,7 +8826,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.2:
@@ -11389,6 +11397,8 @@ snapshots:
   '@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.0.0)':
     dependencies:
       postcss-selector-parser: 7.0.0
+
+  '@dailydotdev/world-kit@0.1.1': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -14225,6 +14235,8 @@ snapshots:
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
+
+  '@zumer/snapdom@2.23.1': {}
 
   abab@2.0.6: {}
 


### PR DESCRIPTION
Captures any element (or React ref) via lazy-loaded snapdom and composes it onto a 1200x630 OG-sized PNG: contain-fit with theme-aware frame background and an optional branded bottom bar mirroring the app header (background-default fill, subtlest-tertiary top border, header logo rendered from LogoIcon/LogoText with theme color resolved at capture time). Dev builds expose window.captureShareImage for console testing.

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://dev-take-pic.preview.app.daily.dev