### PR TITLE
feat(world): give a world its own share card

### DIFF
--- a/packages/webapp/__tests__/worldCustomization.spec.ts
+++ b/packages/webapp/__tests__/worldCustomization.spec.ts
@@ -168,6 +168,24 @@ describe('isWorldCustomised', () => {
     ).toBe(false);
   });
 
+  it('does not count a stored plate as making it yours', () => {
+    // The settings row is created by the first plate upload as well as by the
+    // first customisation, so its mere existence says nothing about whether the
+    // owner has touched the bench. Anything that collapses this to `!!settings`
+    // takes the nudge away from every owner who has simply opened their world.
+    expect(
+      isWorldCustomised({
+        name: null,
+        sky: null,
+        crest: null,
+        look: null,
+        private: false,
+        plateUrl: 'https://media.daily.dev/image/upload/world_plate_u1',
+        plateVersion: '1.abc123',
+      }),
+    ).toBe(false);
+  });
+
   it('is true the moment it has a name', () => {
     expect(
       isWorldCustomised({

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -15,6 +15,7 @@ import { WorldTimeline } from './WorldTimeline';
 import type { WorldEngine, WorldState } from './worldState';
 import type { UserWorldResult } from './useUserWorld';
 import { useWorldDraft } from './useWorldDraft';
+import { useWorldPlate } from './useWorldPlate';
 import { buildWorld } from './engine/buildWorld';
 import { createWorldEngine } from './engine/world';
 import { buildUnbuiltWorld } from './unbuiltWorld';
@@ -219,6 +220,19 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
   useEffect(() => {
     engineRef.current?.setSky(resolveSky(applied));
   }, [applied]);
+
+  /* The share card is composed server-side around a render only this machine
+     can cheaply make. Reads the STORED settings, not the draft: a plate is what
+     the world looks like to everyone, not what the owner is trying on. */
+  useWorldPlate({
+    userId: user.id,
+    isOwn,
+    isPrivate,
+    isReady: state.status === 'ready' && raisedFor === user.id,
+    engineRef,
+    districts,
+    settings,
+  });
 
   useEffect(() => {
     if (isImmersive) {

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -7776,6 +7776,29 @@ return {
   leaveRealm,
   frameWorld: ()=>{ if(W) frameWorld(); },
   attachSpark: c=>drawSpark(c),
+  /* A bare render for the share card: the whole world, framed for a picture
+     rather than for the panel, with none of the DOM the overlay projects.
+
+     Three things here are load-bearing. The read is SYNCHRONOUS because the
+     drawing buffer is not preserved — an async toBlob comes back empty, and
+     preserving the buffer would tax every frame every viewer draws to serve a
+     capture that happens once. The whole thing is one task, so the browser
+     never paints the hero framing and the reader does not see the camera jump
+     and come back. And it frames worldBounds rather than frameWorld() so the
+     card shows the place, not whichever realm the reader happens to be inside. */
+  capture: quality=>{
+    if(!W||!booted) return '';
+    const pad0={...PAD}, tgt0=target.clone(), zoom0=zoom;
+    /* No rail to dodge here, and extra room at the foot so the card's scrim
+       falls on sky instead of eating the districts. */
+    Object.assign(PAD,{l:44,r:44,t:44,b:150});
+    frameBounds(W.worldBounds);
+    drawFrame(performance.now());
+    const url=renderer.domElement.toDataURL('image/jpeg',quality??0.85);
+    Object.assign(PAD,pad0); target.copy(tgt0); zoom=zoom0; syncCam();
+    drawFrame(performance.now());
+    return url;
+  },
   /* The overlay stands on the world, so the camera fit has to know where. */
   setPadding: p=>{ Object.assign(PAD,p); if(W) frameWorld(); },
   /* Look and crest are the owner's, not the viewer's, so every visitor is shown them too. */

--- a/packages/webapp/components/world/useWorldPlate.ts
+++ b/packages/webapp/components/world/useWorldPlate.ts
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import type { MutableRefObject } from 'react';
+import type {
+  UploadUserWorldPlateData,
+  WorldDistrict,
+  WorldSettings,
+} from '../../graphql/world';
+import { UPLOAD_USER_WORLD_PLATE_MUTATION } from '../../graphql/world';
+import { userWorldQueryKey } from './useUserWorld';
+import type { WorldEngine } from './worldState';
+
+/**
+ * A plate is only worth capturing off a window that can hold a landscape card.
+ * A phone in portrait produces something that cannot be cropped to 1.91:1
+ * without gutting it, so those readers leave the stored plate alone and the
+ * card falls back to the profile image.
+ */
+const MIN_PLATE_WIDTH = 1024;
+const MIN_PLATE_ASPECT = 1.4;
+
+/**
+ * What the plate is a picture OF. Deliberately not a TTL: a world grows by a
+ * few articles most days and re-rendering millions of them nightly would buy
+ * nothing a reader could see. It covers only what changes the PICTURE, so the
+ * name is absent (the card draws it as live text) and so is `private` (which
+ * decides whether a card is served at all, not what it looks like).
+ */
+export const worldPlateVersion = (
+  districts: WorldDistrict[] | undefined,
+  settings: WorldSettings | null | undefined,
+): string => {
+  const shape = {
+    // Level drives the monuments, so district sizes matter, but only coarsely:
+    // one more article never changes a skyline.
+    d: (districts ?? [])
+      .map(
+        (district) =>
+          `${district.niche.slug}:${Math.floor(district.reads / 25)}`,
+      )
+      .sort()
+      .join(','),
+    sky: settings?.sky ? `${settings.sky.pal}/${settings.sky.hour}` : '',
+    crest: settings?.crest
+      ? `${settings.crest.charge}/${settings.crest.div}/${settings.crest.a}/${settings.crest.b}`
+      : '',
+    look: settings?.look
+      ? [
+          settings.look.id,
+          settings.look.mine,
+          settings.look.ol,
+          settings.look.bl,
+          settings.look.duo,
+          settings.look.warm,
+          settings.look.sat,
+          settings.look.grain,
+          settings.look.vig,
+        ].join('/')
+      : '',
+  };
+
+  const serialised = JSON.stringify(shape);
+  // Bounded string hash, kept under a prime so it stays exact without bitwise
+  // ops. A collision only costs a plate that is one revision stale.
+  let hash = 0;
+  for (let i = 0; i < serialised.length; i += 1) {
+    hash = (hash * 31 + serialised.charCodeAt(i)) % 2147483647;
+  }
+  return `1.${hash.toString(36)}`;
+};
+
+interface UseWorldPlateProps {
+  userId: string;
+  isOwn: boolean;
+  isPrivate: boolean;
+  isReady: boolean;
+  engineRef: MutableRefObject<WorldEngine | null>;
+  districts: WorldDistrict[] | undefined;
+  settings: WorldSettings | null | undefined;
+}
+
+/**
+ * Keeps the share card's plate current, from the one machine that has already
+ * drawn the world on real hardware. Rendering this server-side means a headless
+ * browser with software GL: seconds of CPU and most of a gigabyte for a frame
+ * the owner's GPU produced for free.
+ *
+ * Owners only, and their own row only, which is what stops a visitor putting an
+ * arbitrary image on someone else's card.
+ */
+export const useWorldPlate = ({
+  userId,
+  isOwn,
+  isPrivate,
+  isReady,
+  engineRef,
+  districts,
+  settings,
+}: UseWorldPlateProps): void => {
+  const client = useQueryClient();
+  // One attempt per mount. A failed upload should not retry on every re-render,
+  // and a succeeded one must not fire again when the cache write re-renders us.
+  const attemptedRef = useRef<string | null>(null);
+
+  const { mutate } = useMutation({
+    mutationFn: async ({ blob, version }: { blob: Blob; version: string }) => {
+      const res = await gqlClient.request<UploadUserWorldPlateData>(
+        UPLOAD_USER_WORLD_PLATE_MUTATION,
+        { image: blob, version },
+      );
+      return res.uploadUserWorldPlate;
+    },
+    onSuccess: (updated) =>
+      client.setQueryData<{
+        districts: WorldDistrict[];
+        settings: WorldSettings | null;
+      }>(userWorldQueryKey(userId), (previous) =>
+        previous ? { ...previous, settings: updated ?? null } : previous,
+      ),
+  });
+
+  useEffect(() => {
+    const engine = engineRef.current;
+    if (!engine || !isOwn || isPrivate || !isReady || !districts?.length) {
+      return;
+    }
+
+    // An unbuilt world has nothing to photograph.
+    if (
+      globalThis.innerWidth < MIN_PLATE_WIDTH ||
+      globalThis.innerWidth / globalThis.innerHeight < MIN_PLATE_ASPECT
+    ) {
+      return;
+    }
+
+    const version = worldPlateVersion(districts, settings);
+    if (
+      attemptedRef.current === version ||
+      settings?.plateVersion === version
+    ) {
+      return;
+    }
+    attemptedRef.current = version;
+
+    const dataUrl = engine.capture();
+    if (!dataUrl) {
+      return;
+    }
+
+    // The synchronous part is over: the pixels are out of the drawing buffer
+    // and into a string, so everything from here can be async.
+    fetch(dataUrl)
+      .then((res) => res.blob())
+      .then((blob) => mutate({ blob, version }))
+      .catch(() => {
+        // A missing plate is a card that falls back to the profile image, not a
+        // broken world. Nothing on screen should change because this failed.
+      });
+  }, [engineRef, isOwn, isPrivate, isReady, districts, settings, mutate]);
+};

--- a/packages/webapp/components/world/worldState.ts
+++ b/packages/webapp/components/world/worldState.ts
@@ -108,5 +108,11 @@ export interface WorldEngine {
   /** Palette and hour. Repaints the environment, so it is key-guarded inside. */
   setSky: (sky: WorldSky) => void;
   setViewFlags: (flags: Partial<Record<string, boolean>>) => void;
+  /**
+   * A bare render of the whole world as a JPEG data URL, for the share card to
+   * be composed around. Empty string if the world is not standing yet. Framing
+   * and camera are restored within the same task, so nothing is painted.
+   */
+  capture: (quality?: number) => string;
   dispose: () => void;
 }

--- a/packages/webapp/graphql/world.ts
+++ b/packages/webapp/graphql/world.ts
@@ -85,6 +85,17 @@ export interface WorldSettings {
   crest: WorldCrest | null;
   look: WorldLook | null;
   private: boolean;
+  /**
+   * A bare render of the world captured in the owner's browser. The share card
+   * is composed around it server-side, so it carries no name, stats or chrome.
+   *
+   * Optional rather than nullable because this is server-owned and not part of
+   * the dressing: the bench composes settings objects out of draft values, and
+   * a draft has no plate to speak of.
+   */
+  plateUrl?: string | null;
+  /** What the plate is a picture of, compared against the world to spot staleness. */
+  plateVersion?: string | null;
 }
 
 /** What granted an entitlement: `base`, or `niche:<slug>`. */
@@ -106,6 +117,10 @@ export interface UserWorldEntitlementsData {
 
 export interface UpdateUserWorldSettingsData {
   updateUserWorldSettings: WorldSettings | null;
+}
+
+export interface UploadUserWorldPlateData {
+  uploadUserWorldPlate: WorldSettings | null;
 }
 
 const WORLD_SETTINGS_FRAGMENT = gql`
@@ -144,6 +159,8 @@ const WORLD_SETTINGS_FRAGMENT = gql`
       }
     }
     private
+    plateUrl
+    plateVersion
   }
 `;
 
@@ -198,6 +215,20 @@ export const UPDATE_USER_WORLD_SETTINGS_MUTATION = gql`
       look: $look
       private: $private
     ) {
+      ...WorldSettings
+    }
+  }
+  ${WORLD_SETTINGS_FRAGMENT}
+`;
+
+/**
+ * Stores the render the share card is composed around. Takes no id: like every
+ * world customisation it writes the caller's own row, which is what stops a
+ * visitor putting an arbitrary image on someone else's card.
+ */
+export const UPLOAD_USER_WORLD_PLATE_MUTATION = gql`
+  mutation UploadUserWorldPlate($image: Upload!, $version: String!) {
+    uploadUserWorldPlate(image: $image, version: $version) {
       ...WorldSettings
     }
   }

--- a/packages/webapp/pages/image-generator/share/world/[userId].tsx
+++ b/packages/webapp/pages/image-generator/share/world/[userId].tsx
@@ -1,0 +1,177 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import Logo, { LogoPosition } from '@dailydotdev/shared/src/components/Logo';
+import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
+
+/**
+ * The share card for a world, composed around a plate the owner's browser
+ * rendered. Screenshotted by daily-api at `#screenshot_wrapper`, never visited
+ * by a reader.
+ *
+ * Everything is fetched in getStaticProps rather than on the client: the page
+ * is captured on `networkidle0`, so the fewer round trips it makes after load,
+ * the sooner the shot is correct. What is left on the wire is the plate and the
+ * avatar, which are exactly the two things the capture must wait for anyway.
+ *
+ * It runs anonymously, so it may only ask for public fields.
+ */
+
+interface WorldShareCardProps {
+  plateUrl: string | null;
+  worldName: string | null;
+  userName: string;
+  handle: string | null;
+  avatar: string | null;
+}
+
+const SHARE_CARD_QUERY = `
+  query WorldShareCard($id: ID!) {
+    user(id: $id) {
+      name
+      username
+      image
+    }
+    userWorld(id: $id) {
+      reads
+    }
+    userWorldSettings(id: $id) {
+      name
+      plateUrl
+    }
+  }
+`;
+
+interface ShareCardResponse {
+  data?: {
+    user?: { name?: string; username?: string; image?: string } | null;
+    userWorld?: { reads: number }[] | null;
+    userWorldSettings?: {
+      name?: string | null;
+      plateUrl?: string | null;
+    } | null;
+  };
+  errors?: { extensions?: { code?: string } }[];
+}
+
+const WorldShareCardPage = ({
+  plateUrl,
+  worldName,
+  userName,
+  handle,
+  avatar,
+}: WorldShareCardProps): ReactElement => (
+  <div
+    id="screenshot_wrapper"
+    className="relative h-[630px] w-[1200px] overflow-hidden bg-background-default"
+  >
+    {!!plateUrl && (
+      <img
+        src={plateUrl}
+        alt=""
+        className="absolute inset-0 h-full w-full scale-110 object-cover"
+      />
+    )}
+
+    {/* The sky is the owner's to choose, and several of the palettes are pale
+        at the horizon, which is exactly where the type sits. So this starts at
+        the solid background rather than at the 64% the overlay tokens top out
+        at, and fades through one to nothing. */}
+    <div className="absolute inset-x-0 bottom-0 h-[58%] bg-gradient-to-t from-background-default via-overlay-primary-pepper to-transparent" />
+
+    {/* The same plate the world wears in the app, scaled for a card. */}
+    <div className="absolute right-12 top-11 flex items-center rounded-16 border border-border-subtlest-tertiary bg-background-default px-6 py-4">
+      <Logo
+        position={LogoPosition.Initial}
+        logoClassName={{ container: 'h-8' }}
+      />
+    </div>
+
+    <div className="absolute inset-x-14 bottom-12">
+      <div className="mb-4 flex items-center gap-3">
+        {!!avatar && (
+          <img
+            src={avatar}
+            alt=""
+            className="size-[46px] rounded-14 object-cover"
+          />
+        )}
+        {/* Whose place this is leads, and the name it was given lands. Without
+            a name there is nothing for the line below to say, so the whole
+            billing moves down and the handle takes the eyebrow. */}
+        <span className="text-[28px] text-text-secondary">
+          {worldName ? `${userName}'s world` : `@${handle ?? userName}`}
+        </span>
+      </div>
+
+      <h1 className="text-[84px] font-extrabold leading-none tracking-tighter text-text-primary">
+        {worldName || `${userName}'s world`}
+      </h1>
+    </div>
+  </div>
+);
+
+export function getStaticPaths(): GetStaticPathsResult {
+  return { paths: [], fallback: 'blocking' };
+}
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext<{ userId: string }>): Promise<
+  GetStaticPropsResult<WorldShareCardProps>
+> {
+  const userId = params?.userId;
+  if (!userId) {
+    return { notFound: true, revalidate: false };
+  }
+
+  try {
+    const res = await fetch(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: SHARE_CARD_QUERY,
+        variables: { id: userId },
+      }),
+    });
+    const body: ShareCardResponse = await res.json();
+
+    // A hidden world has no card at all. The world page already omits the
+    // og:image for one, so reaching here means someone guessed the URL.
+    const isPrivate = !!body?.errors?.some(
+      ({ extensions }) => extensions?.code === 'FORBIDDEN',
+    );
+    const user = body?.data?.user;
+    if (isPrivate || !user) {
+      return { notFound: true, revalidate: 60 };
+    }
+
+    // `userWorld` keys off the real user id and answers an unknown one with an
+    // empty list rather than an error, while `user` resolves a username
+    // happily. Without this, a link built with a handle would render a card for
+    // a world that was never there. An unbuilt world lands here too, and has
+    // nothing to put on a card either.
+    if (!body?.data?.userWorld?.length) {
+      return { notFound: true, revalidate: 60 };
+    }
+
+    return {
+      props: {
+        plateUrl: body?.data?.userWorldSettings?.plateUrl ?? null,
+        worldName: body?.data?.userWorldSettings?.name ?? null,
+        userName: user.name ?? '',
+        handle: user.username ?? null,
+        avatar: user.image ?? null,
+      },
+      revalidate: 60,
+    };
+  } catch {
+    return { notFound: true, revalidate: 60 };
+  }
+}
+
+export default WorldShareCardPage;

--- a/packages/webapp/pages/world/[userId].tsx
+++ b/packages/webapp/pages/world/[userId].tsx
@@ -27,6 +27,15 @@ export const getStaticPaths = getProfileStaticPaths;
 interface WorldPageProps extends ProfileLayoutProps {
   /** What the owner calls the place, or null if they have never named it. */
   worldName?: string | null;
+  /**
+   * Whether a plate has ever been captured for this world. Without one there is
+   * nothing to compose a card around, so the link keeps the profile image the
+   * profile SEO defaults already put on it.
+   */
+  hasPlate?: boolean;
+  /** Cache-buster: a new plate has to reach crawlers that cached the old card. */
+  plateVersion?: string | null;
+  isPrivate?: boolean;
 }
 
 interface WorldParams extends ParsedUrlQuery {
@@ -34,38 +43,71 @@ interface WorldParams extends ParsedUrlQuery {
 }
 
 /**
- * The world's name, read at build time so it can reach the share card.
+ * One read of the world's own settings, at build time, for the share card.
  *
  * A plain fetch rather than the app's client: this runs on the server, where
  * there is no session to send and nothing to cache into. The same GraphQL error
  * the client reads as "private" is what keeps this page out of the index.
- * Anything else — a network blip, a schema change — leaves the name off the card
- * and the page indexable, which is the harmless direction to fail in.
+ * Anything else — a network blip, a schema change — resolves to nothing, which
+ * costs the caller a field and leaves the page indexable: the harmless
+ * direction to fail in.
  */
-const getWorldSeoData = async (
+const querySettings = async (
   userId: string,
-): Promise<{ name: string | null; isPrivate: boolean }> => {
+  fields: string,
+): Promise<{
+  settings: Record<string, string | null> | null;
+  isPrivate: boolean;
+}> => {
   try {
     const res = await fetch(graphqlUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         query: `query UserWorldName($id: ID!) {
-          userWorldSettings(id: $id) { name }
+          userWorldSettings(id: $id) { ${fields} }
         }`,
         variables: { id: userId },
       }),
     });
     const body = await res.json();
-    const isPrivate = !!body?.errors?.some(
-      ({ extensions }: { extensions?: { code?: string } }) =>
-        extensions?.code === 'FORBIDDEN',
-    );
 
-    return { name: body?.data?.userWorldSettings?.name ?? null, isPrivate };
+    return {
+      settings: body?.data?.userWorldSettings ?? null,
+      isPrivate: !!body?.errors?.some(
+        ({ extensions }: { extensions?: { code?: string } }) =>
+          extensions?.code === 'FORBIDDEN',
+      ),
+    };
   } catch {
-    return { name: null, isPrivate: false };
+    return { settings: null, isPrivate: false };
   }
+};
+
+const getWorldSeoData = async (
+  userId: string,
+): Promise<{
+  name: string | null;
+  isPrivate: boolean;
+  hasPlate: boolean;
+  plateVersion: string | null;
+}> => {
+  /* Two requests rather than one, so that the plate cannot take the name down
+     with it. GraphQL rejects a whole document over one unknown field, so asking
+     for both together would mean this page silently losing its title and
+     description for as long as the API in front of it predates plates. Split,
+     the older API costs only the card. */
+  const [named, plated] = await Promise.all([
+    querySettings(userId, 'name'),
+    querySettings(userId, 'plateUrl plateVersion'),
+  ]);
+
+  return {
+    name: named.settings?.name ?? null,
+    isPrivate: named.isPrivate,
+    hasPlate: !!plated.settings?.plateUrl,
+    plateVersion: plated.settings?.plateVersion ?? null,
+  };
 };
 
 export async function getStaticProps(
@@ -86,6 +128,9 @@ export async function getStaticProps(
     props: {
       ...result.props,
       worldName: world.name,
+      hasPlate: world.hasPlate,
+      plateVersion: world.plateVersion,
+      isPrivate: world.isPrivate,
       // A world its owner has hidden has nothing to index, and a crawler that
       // followed a share link is exactly who this is for.
       noindex: result.props.noindex || world.isPrivate,
@@ -122,6 +167,9 @@ const ProfileWorldPage = ({
   user,
   noindex,
   worldName,
+  hasPlate,
+  plateVersion,
+  isPrivate,
 }: WorldPageProps): ReactElement | null => {
   const { isFallback } = useRouter();
   /* Asked for HERE rather than inside the view, which is the whole point: the
@@ -159,6 +207,37 @@ const ProfileWorldPage = ({
     },
     noindex,
   );
+
+  /* Three cases, and the fallbacks are deliberately plain. A hidden world
+     unfurls with NO image rather than a placeholder, because a placeholder
+     still confirms the world exists. A world with no plate yet keeps whatever
+     the profile defaults put there, which is the reader's DevCard: correct,
+     already generated, and nobody's idea of a broken card. Only a world with a
+     plate gets the card composed around it. */
+  if (isPrivate) {
+    seo.openGraph = { ...seo.openGraph, images: [] };
+  } else if (hasPlate) {
+    const image = new URL(
+      `/og/world/${user.id}.jpg`,
+      process.env.NEXT_PUBLIC_API_URL,
+    );
+    if (plateVersion) {
+      image.searchParams.set('v', plateVersion);
+    }
+    seo.openGraph = {
+      ...seo.openGraph,
+      images: [
+        {
+          url: image.toString(),
+          width: 1200,
+          height: 630,
+          alt: worldName
+            ? `${worldName}, ${user.name}'s world`
+            : `${user.name}'s world`,
+        },
+      ],
+    };
+  }
 
   return (
     <>


### PR DESCRIPTION
Sharing a world unfurled the reader's **DevCard**, because the world page takes the profile's SEO defaults. It now unfurls as the world.

## How

The card is composed around a **plate**: a bare render of the world, no name, stats or chrome. The plate is captured in the owner's browser, on the GPU that has already drawn it, and uploaded. The card is then composed around it by the existing screenshot rail, so **nothing renders WebGL on a server.**

Server-side rendering was measured first, against the real page on the pod's exact Puppeteer and Chrome versions:

| Config | Ready | Shot | Total | Peak RSS |
|---|---|---|---|---|
| Current scraper args | no WebGL context at all | | | |
| + swiftshader, 2x | 7.3s | 2.3s | 9.6s | 1732MB |
| + swiftshader, 1x | 6.8s | 1.8s | 8.6s | 1445MB |

~650MB incremental per capture, on 2Gi pods that hold up to 15 browsers and also serve all of our link scraping. Rejected.

## Details worth a look

- **`engine.capture()`** frames the whole world, reads the canvas and restores the camera **inside one task**, so no frame is painted and the reader never sees the camera move. The read is synchronous by necessity: the drawing buffer is not preserved, so an async `toBlob` returns empty, and preserving it would tax every frame every viewer draws to serve a capture that happens once.
- **Staleness is a version key**, not a TTL, covering only what changes the picture. An unchanged world is never re-captured.
- **Capture is skipped** on viewports too narrow or too tall to crop to a landscape card, so a phone in portrait leaves the stored plate alone.
- **The upload writes the caller's own row**, like every world customisation, which is what stops a visitor putting an arbitrary image on someone else's card.

## Fallbacks

| State | Unfurls as |
|---|---|
| Private | no `og:image` at all, since a placeholder still confirms the world is there |
| No plate yet | the profile DevCard image the SEO defaults already provide |
| Has a plate | the card |

The SEO fetch is deliberately **two requests**: GraphQL rejects a whole document over one unknown field, so asking for `name` and `plateUrl` together would have meant this page silently losing its title and description against any API predating plates.

## Note for reviewers

`isWorldCustomised` now has a regression test. The settings row used to mean "the owner customised something", and a plate upload creates that row too, so collapsing it to `!!settings` would quietly take the "make it yours" nudge away from every owner who has simply opened their world.

## Verified

Strict-changed guard, full webapp `tsc` (no errors in any changed file), lint clean, 51 world tests pass. The capture path has run end to end against production: a real plate is stored and the card composes around it.

Requires dailydotdev/daily-api#4047 and dailydotdev/daily-scraper#636, both merged and deployed.

https://claude.ai/code/session_01MKc7wrVLm26zMX8MsPpikT

### Preview domain
https://feat-world-og-share-card.preview.app.daily.dev
