### PR TITLE
feat: shareable stack card image page and profile share button

### DIFF
--- a/packages/shared/src/features/profile/components/stack/ProfileUserStack.tsx
+++ b/packages/shared/src/features/profile/components/stack/ProfileUserStack.tsx
@@ -29,7 +29,9 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '../../../../components/buttons/Button';
-import { PlusIcon } from '../../../../components/icons';
+import { PlusIcon, ShareIcon } from '../../../../components/icons';
+import { useShareOrCopyLink } from '../../../../hooks/useShareOrCopyLink';
+import { apiUrl } from '../../../../lib/config';
 import { UserStackSection } from './UserStackSection';
 import { UserStackModal } from './UserStackModal';
 import type {
@@ -238,6 +240,16 @@ export function ProfileUserStack({
     activeItemId && stackItems.find((item) => item.id === activeItemId);
 
   const hasItems = stackItems.length > 0;
+
+  const [, onShareStack] = useShareOrCopyLink({
+    link: `${apiUrl}/og/stack/${user.id}.png`,
+    text: 'Check out my developer stack on daily.dev!',
+    logObject: (provider) => ({
+      event_name: LogEvent.ShareUserStack,
+      target_id: user.id,
+      extra: JSON.stringify({ provider }),
+    }),
+  });
   const visibleSections = getVisibleSections(sections);
 
   if (!hasItems && !isOwner) {
@@ -254,16 +266,28 @@ export function ProfileUserStack({
         >
           Stack & Tools
         </Typography>
-        {isOwner && canAddMore && (
-          <Button
-            variant={ButtonVariant.Tertiary}
-            size={ButtonSize.Small}
-            icon={<PlusIcon />}
-            onClick={handleOpenModal}
-          >
-            Add
-          </Button>
-        )}
+        <div className="flex items-center gap-1">
+          {isOwner && hasItems && (
+            <Button
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.Small}
+              icon={<ShareIcon />}
+              onClick={() => onShareStack()}
+            >
+              Share
+            </Button>
+          )}
+          {isOwner && canAddMore && (
+            <Button
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.Small}
+              icon={<PlusIcon />}
+              onClick={handleOpenModal}
+            >
+              Add
+            </Button>
+          )}
+        </div>
       </div>
 
       {hasItems ? (

--- a/packages/shared/src/features/profile/components/stack/StackShareCard.spec.tsx
+++ b/packages/shared/src/features/profile/components/stack/StackShareCard.spec.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { PublicProfile } from '../../../../lib/user';
+import type { UserStack } from '../../../../graphql/user/userStack';
+import { StackShareCard } from './StackShareCard';
+
+const user = {
+  id: 'u1',
+  name: 'Chris Bongers',
+  username: 'dailydevtips',
+  image: 'https://daily.dev/avatar.png',
+} as PublicProfile;
+
+const buildItem = (overrides: Partial<UserStack>): UserStack => ({
+  id: `item-${Math.random()}`,
+  tool: { id: 't1', title: 'TypeScript', faviconUrl: null },
+  section: 'Primary',
+  position: 0,
+  startedAt: null,
+  icon: null,
+  title: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('StackShareCard', () => {
+  it('renders user identity and grouped sections', () => {
+    render(
+      <StackShareCard
+        user={user}
+        items={[
+          buildItem({ section: 'Primary' }),
+          buildItem({
+            section: 'Learning',
+            tool: { id: 't2', title: 'Rust', faviconUrl: null },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('Chris Bongers')).toBeInTheDocument();
+    expect(screen.getByText('@dailydevtips · my stack')).toBeInTheDocument();
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+    expect(screen.getByText('Learning')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('Rust')).toBeInTheDocument();
+  });
+
+  it('caps output at three sections and four tools per section', () => {
+    const items = [
+      ...['Primary', 'Hobby', 'Learning', 'Past'].map((section) =>
+        buildItem({ section }),
+      ),
+      ...Array.from({ length: 6 }, (_, index) =>
+        buildItem({
+          section: 'Primary',
+          tool: {
+            id: `extra-${index}`,
+            title: `Tool ${index}`,
+            faviconUrl: null,
+          },
+        }),
+      ),
+    ];
+
+    render(<StackShareCard user={user} items={items} />);
+
+    expect(screen.getByText('Primary')).toBeInTheDocument();
+    expect(screen.getByText('Learning')).toBeInTheDocument();
+    expect(screen.queryByText('Past')).not.toBeInTheDocument();
+    expect(
+      screen.getByText('Primary').nextElementSibling?.children,
+    ).toHaveLength(4);
+  });
+
+  it('derives years shipping from the earliest startedAt', () => {
+    const currentYear = new Date().getFullYear();
+
+    render(
+      <StackShareCard
+        user={user}
+        items={[
+          buildItem({ startedAt: `${currentYear - 8}-03-01` }),
+          buildItem({
+            section: 'Hobby',
+            startedAt: `${currentYear - 2}-01-01`,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('8 yrs')).toBeInTheDocument();
+    expect(
+      screen.getByText(`'${String(currentYear - 8).slice(-2)}`),
+    ).toBeInTheDocument();
+  });
+
+  it('hides years shipping when no item has startedAt', () => {
+    render(<StackShareCard user={user} items={[buildItem({})]} />);
+
+    expect(screen.queryByText(/yrs/)).not.toBeInTheDocument();
+  });
+
+  it('prefers item title and icon overrides over tool defaults', () => {
+    render(
+      <StackShareCard
+        user={user}
+        items={[
+          buildItem({
+            title: 'TS (strict mode)',
+            icon: 'https://daily.dev/custom.png',
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('TS (strict mode)')).toBeInTheDocument();
+    expect(screen.queryByText('TypeScript')).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/features/profile/components/stack/StackShareCard.tsx
+++ b/packages/shared/src/features/profile/components/stack/StackShareCard.tsx
@@ -1,0 +1,166 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { PublicProfile } from '../../../../lib/user';
+import type { UserStack } from '../../../../graphql/user/userStack';
+import { buildSectionsState, getVisibleSections } from './dnd';
+
+const MAX_SECTIONS = 3;
+const MAX_TOOLS_PER_SECTION = 4;
+
+const FALLBACK_TILE_STYLES = [
+  { background: 'rgba(186,86,225,.22)', color: '#D9A6F2' },
+  { background: 'rgba(74,126,238,.2)', color: '#7BA7FF' },
+  { background: 'rgba(87,224,135,.16)', color: '#57E087' },
+  { background: 'rgba(255,226,76,.14)', color: '#FFE24C' },
+  { background: 'rgba(229,94,80,.16)', color: '#F57869' },
+];
+
+const getStartedYear = (item: UserStack): number | null => {
+  if (!item.startedAt) {
+    return null;
+  }
+  const year = new Date(item.startedAt).getFullYear();
+  return Number.isNaN(year) ? null : year;
+};
+
+const getYearsShipping = (items: UserStack[]): number | null => {
+  const years = items
+    .map(getStartedYear)
+    .filter((year): year is number => year !== null);
+  if (!years.length) {
+    return null;
+  }
+  const span = new Date().getFullYear() - Math.min(...years);
+  return span > 0 ? span : null;
+};
+
+const StackTool = ({
+  item,
+  index,
+}: {
+  item: UserStack;
+  index: number;
+}): ReactElement => {
+  const title = item.title ?? item.tool.title;
+  const iconUrl = item.icon || item.tool.faviconUrl;
+  const startedYear = getStartedYear(item);
+  const tile = FALLBACK_TILE_STYLES[index % FALLBACK_TILE_STYLES.length];
+
+  return (
+    <div className="border-white/10 bg-white/5 flex items-center gap-3.5 rounded-20 border px-4 py-3">
+      {iconUrl ? (
+        <img
+          src={iconUrl}
+          alt=""
+          className="size-8 flex-none rounded-10 object-contain"
+        />
+      ) : (
+        <span
+          className="grid size-8 flex-none place-items-center rounded-10 text-base font-bold"
+          style={tile}
+        >
+          {title.charAt(0).toUpperCase()}
+        </span>
+      )}
+      <span className="flex-1 truncate text-[23px] font-bold text-white">
+        {title}
+      </span>
+      {startedYear && (
+        <span className="font-mono text-[17px] text-raw-salt-90/64">
+          &apos;{String(startedYear).slice(-2)}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export interface StackShareCardProps {
+  user: PublicProfile;
+  items: UserStack[];
+}
+
+export const StackShareCard = ({
+  user,
+  items,
+}: StackShareCardProps): ReactElement => {
+  const sections = buildSectionsState(items);
+  const visibleSections = getVisibleSections(sections).slice(0, MAX_SECTIONS);
+  const yearsShipping = getYearsShipping(items);
+
+  return (
+    <div
+      className="relative flex h-[630px] w-[1200px] flex-col overflow-hidden bg-[#0A0D12] p-14"
+      style={{
+        backgroundImage: [
+          'radial-gradient(60% 90% at 100% 0%, rgba(107,86,221,.26), transparent 60%)',
+          'radial-gradient(50% 80% at 0% 100%, rgba(186,86,225,.18), transparent 55%)',
+        ].join(', '),
+      }}
+    >
+      <div className="flex items-center gap-6">
+        {user.image && (
+          <img
+            src={user.image}
+            alt=""
+            className="size-[100px] flex-none rounded-26 object-cover"
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[40px] font-bold leading-tight text-white">
+            {user.name}
+          </div>
+          <div className="mt-1 font-mono text-[23px] text-raw-salt-90/64">
+            @{user.username} · my stack
+          </div>
+        </div>
+        <div className="flex-none text-right">
+          {yearsShipping && (
+            <div className="font-mono text-[25px] text-raw-salt-50">
+              <b className="text-[31px] text-accent-cheese-default">
+                {yearsShipping} yrs
+              </b>{' '}
+              shipping
+            </div>
+          )}
+          <div className="mt-2 text-[24px] font-bold text-white">
+            daily<span className="font-normal text-raw-salt-90">.dev</span>
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="mt-8 grid flex-1 gap-7"
+        style={{
+          gridTemplateColumns: `repeat(${
+            visibleSections.length || 1
+          }, minmax(0, 1fr))`,
+        }}
+      >
+        {visibleSections.map((section) => (
+          <div key={section} className="min-w-0">
+            <h5 className="border-white/10 mb-4 border-b pb-2.5 text-lg font-bold uppercase tracking-widest text-raw-salt-90/64">
+              {section}
+            </h5>
+            <div className="flex flex-col gap-3">
+              {sections[section]
+                .slice(0, MAX_TOOLS_PER_SECTION)
+                .map((item, index) => (
+                  <StackTool key={item.id} item={item} index={index} />
+                ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="flex items-center justify-between gap-6">
+        <span className="font-mono text-[22px] text-raw-salt-90">
+          app.daily.dev/
+          <b className="font-semibold text-[#D9A6F2]">{user.username}</b>
+        </span>
+        <span className="text-[19px] text-raw-salt-90/64">
+          Where developers grow together
+        </span>
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -440,6 +440,7 @@ export enum LogEvent {
   UpdateUserStack = 'update user stack',
   RemoveUserStack = 'remove user stack',
   ReorderUserStack = 'reorder user stack',
+  ShareUserStack = 'share user stack',
   // Hot Takes
   StartAddHotTake = 'start add hot take',
   AddHotTake = 'add hot take',

--- a/packages/webapp/pages/image-generator/share/stack/[userId].tsx
+++ b/packages/webapp/pages/image-generator/share/stack/[userId].tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type {
+  GetStaticPathsResult,
+  GetStaticPropsContext,
+  GetStaticPropsResult,
+} from 'next';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { getProfile } from '@dailydotdev/shared/src/lib/user';
+import type { UserStack } from '@dailydotdev/shared/src/graphql/user/userStack';
+import { getUserStack } from '@dailydotdev/shared/src/graphql/user/userStack';
+import { StackShareCard } from '@dailydotdev/shared/src/features/profile/components/stack/StackShareCard';
+
+export async function getStaticPaths(): Promise<GetStaticPathsResult> {
+  return { paths: [], fallback: 'blocking' };
+}
+
+interface PageProps {
+  user: PublicProfile;
+  items: UserStack[];
+}
+
+export async function getStaticProps({
+  params,
+}: GetStaticPropsContext): Promise<GetStaticPropsResult<PageProps>> {
+  const userId = params?.userId;
+
+  if (!userId || typeof userId !== 'string') {
+    return {
+      notFound: true,
+      revalidate: false,
+    };
+  }
+
+  try {
+    const [user, stack] = await Promise.all([
+      getProfile(userId),
+      getUserStack(userId),
+    ]);
+
+    const items = stack.edges.map(({ node }) => node);
+
+    if (!items.length) {
+      return {
+        notFound: true,
+        revalidate: 60,
+      };
+    }
+
+    return {
+      props: { user, items },
+      revalidate: 60,
+    };
+  } catch (err) {
+    return {
+      notFound: true,
+      revalidate: 60,
+    };
+  }
+}
+
+const StackSharePage = ({ user, items }: PageProps): ReactElement => {
+  return (
+    <div id="screenshot_wrapper" className="w-fit">
+      <StackShareCard user={user} items={items} />
+    </div>
+  );
+};
+
+export default StackSharePage;


### PR DESCRIPTION
## Changes

- New `StackShareCard` component rendering a user's stack as a 1200×630 share card (sections via the same `buildSectionsState`/`getVisibleSections` grouping as the profile, using-since years, earliest-year "yrs shipping" flair, favicon with letter-tile fallback). Capped at 3 sections × 4 tools.
- New `/image-generator/share/stack/[userId]` page (badge-page pattern: `fallback: 'blocking'`, ISR 60s, 404 on missing user or empty stack) wrapping the card in `#screenshot_wrapper` for the scraper.
- Share button on the profile stack section (owner with items) sharing `${apiUrl}/og/stack/${user.id}.png` via `useShareOrCopyLink`, logged as new `ShareUserStack` event.

Pairs with dailydotdev/daily-api#4048 (adds `stack` to the /og allowlist) — API side must deploy first.

## Testing

- 5 RTL specs for the card (grouping, caps, years derivation, overrides).
- `typecheck-strict-changed` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-stack-share-card.preview.app.daily.dev