### PR TITLE
fix(comments): hide the sort toggle when the comments section is empty

### DIFF
--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -1,27 +1,18 @@
 import type { ReactElement } from 'react';
-import React, { useContext, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
-import { useQuery } from '@tanstack/react-query';
-import AuthContext from '../../contexts/AuthContext';
-import type {
-  Comment,
-  PostCommentsData,
-  SortCommentsBy,
-} from '../../graphql/comments';
-import { POST_COMMENTS_QUERY } from '../../graphql/comments';
+import type { Comment, SortCommentsBy } from '../../graphql/comments';
 import type { Post } from '../../graphql/posts';
 import type { MainCommentProps } from '../comments/MainComment';
 import MainComment from '../comments/MainComment';
 import PlaceholderCommentList from '../comments/PlaceholderCommentList';
-import { useRequestProtocol } from '../../hooks/useRequestProtocol';
-import { initialDataKey } from '../../lib/constants';
 import { Origin } from '../../lib/log';
 import type { CommentClassName } from '../fields/MarkdownInput/CommentMarkdownInput';
 import { useDeleteComment } from '../../hooks/comments/useDeleteComment';
+import { usePostComments } from '../../hooks/comments/usePostComments';
 import { lazyCommentThreshold } from '../utilities';
 import { isNullOrUndefined } from '../../lib/func';
 import { useCommentContentPreferenceMutationSubscription } from './useCommentContentPreferenceMutationSubscription';
-import { generateCommentsQueryKey } from '../../lib/query';
 import { CharmEmptyState } from '../charm/CharmEmptyState';
 import { cloudinaryCharmNoComments } from '../../lib/image';
 
@@ -74,28 +65,16 @@ export function PostComments({
   const { id } = post;
   const container = useRef<HTMLDivElement | null>(null);
   const isModalThread = threadCommentOrigins.has(origin);
-  const { tokenRefreshed } = useContext(AuthContext);
-  const { requestMethod } = useRequestProtocol();
-  const queryKey = generateCommentsQueryKey({ postId: id, sortBy });
-  const { data: comments, isLoading: isLoadingComments } =
-    useQuery<PostCommentsData>({
-      queryKey,
-
-      queryFn: (): Promise<PostCommentsData> =>
-        requestMethod(
-          POST_COMMENTS_QUERY,
-          { postId: id, [initialDataKey]: comments, first: 500, sortBy },
-          { requestKey: JSON.stringify(queryKey) },
-        ),
-      enabled: !!id && tokenRefreshed,
-      refetchInterval: 60 * 1000,
-      refetchOnWindowFocus: false,
-    });
+  const {
+    queryKey,
+    comments,
+    isLoading: isLoadingComments,
+    commentsCount,
+  } = usePostComments({ postId: id, sortBy });
 
   useCommentContentPreferenceMutationSubscription({ queryKey });
 
   const { hash: commentHash } = globalThis?.window?.location || {};
-  const commentsCount = comments?.postComments?.edges?.length || 0;
   const commentRef = useRef<HTMLElement | null>(null);
   const { deleteComment } = useDeleteComment();
 

--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -32,6 +32,7 @@ import { usePlusSubscription } from '../../hooks/usePlusSubscription';
 import SocialBar from '../cards/socials/SocialBar';
 import { PostContentReminder } from './common/PostContentReminder';
 import { useSettingsContext } from '../../contexts/SettingsContext';
+import { usePostComments } from '../../hooks/comments/usePostComments';
 
 const AuthorOnboarding = dynamic(
   () => import(/* webpackChunkName: "authorOnboarding" */ './AuthorOnboarding'),
@@ -61,6 +62,7 @@ function PostEngagements({
   const postQueryKey = ['post', post.id];
   const { sortCommentsBy: sortBy, updateSortCommentsBy: setSortBy } =
     useSettingsContext();
+  const { commentsCount } = usePostComments({ postId: post.id, sortBy });
   const { user, showLogin } = useAuthContext();
   const { isPlus } = usePlusSubscription();
   const commentRef = useRef<NewCommentRef>();
@@ -127,31 +129,35 @@ function PostEngagements({
       <PostContentReminder post={post} />
       <PostContentShare post={post} />
       {linkClicked && <SocialBar post={post} className="mt-6" />}
-      <span className="mt-3 flex flex-row items-center">
-        <Typography type={TypographyType.Callout}>Sort:</Typography>
-        <Button
-          className="ml-1 !px-0"
-          iconPosition={ButtonIconPosition.Right}
-          size={ButtonSize.Small}
-          icon={
-            <TimeSortIcon
-              secondary
-              className={sortBy === SortCommentsBy.OldestFirst && 'rotate-180'}
-            />
-          }
-          onClick={() =>
-            setSortBy(
-              sortBy === SortCommentsBy.NewestFirst
-                ? SortCommentsBy.OldestFirst
-                : SortCommentsBy.NewestFirst,
-            )
-          }
-        >
-          {sortBy === SortCommentsBy.NewestFirst
-            ? 'Newest first'
-            : 'Oldest first'}
-        </Button>
-      </span>
+      {commentsCount > 0 && (
+        <span className="mt-3 flex flex-row items-center">
+          <Typography type={TypographyType.Callout}>Sort:</Typography>
+          <Button
+            className="ml-1 !px-0"
+            iconPosition={ButtonIconPosition.Right}
+            size={ButtonSize.Small}
+            icon={
+              <TimeSortIcon
+                secondary
+                className={
+                  sortBy === SortCommentsBy.OldestFirst && 'rotate-180'
+                }
+              />
+            }
+            onClick={() =>
+              setSortBy(
+                sortBy === SortCommentsBy.NewestFirst
+                  ? SortCommentsBy.OldestFirst
+                  : SortCommentsBy.NewestFirst,
+              )
+            }
+          >
+            {sortBy === SortCommentsBy.NewestFirst
+              ? 'Newest first'
+              : 'Oldest first'}
+          </Button>
+        </span>
+      )}
       <NewComment
         className={{ container: 'mt-3 hidden tablet:flex' }}
         post={post}

--- a/packages/shared/src/components/post/focus/DiscussionMetaBar.tsx
+++ b/packages/shared/src/components/post/focus/DiscussionMetaBar.tsx
@@ -9,6 +9,7 @@ import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
 import { TimeSortIcon } from '../../icons/Sort/Time';
 import { AnalyticsIcon } from '../../icons';
 import { SortCommentsBy } from '../../../graphql/comments';
+import { usePostComments } from '../../../hooks/comments/usePostComments';
 import { ClickableText } from '../../buttons/ClickableText';
 import Link from '../../utilities/Link';
 import { largeNumberFormat } from '../../../lib';
@@ -36,6 +37,7 @@ export const DiscussionMetaBar = ({
   const { onShowUpvoted } = useUpvoteQuery();
   const { sortCommentsBy: sortBy, updateSortCommentsBy: setSortBy } =
     useSettingsContext();
+  const { commentsCount } = usePostComments({ postId: post.id, sortBy });
   const upvotes = post.numUpvotes || 0;
   const comments = post.numComments || 0;
   const canSeeAnalytics = canViewPostAnalytics({ user, post });
@@ -74,27 +76,29 @@ export const DiscussionMetaBar = ({
             </ClickableText>
           </Link>
         )}
-        <Button
-          type="button"
-          size={ButtonSize.XSmall}
-          variant={ButtonVariant.Tertiary}
-          icon={
-            <TimeSortIcon
-              secondary
-              className={isNewestFirst ? undefined : 'rotate-180'}
-            />
-          }
-          onClick={() =>
-            setSortBy(
-              isNewestFirst
-                ? SortCommentsBy.OldestFirst
-                : SortCommentsBy.NewestFirst,
-            )
-          }
-          aria-label={sortLabel}
-          title={sortLabel}
-          className="!text-text-secondary"
-        />
+        {commentsCount > 0 && (
+          <Button
+            type="button"
+            size={ButtonSize.XSmall}
+            variant={ButtonVariant.Tertiary}
+            icon={
+              <TimeSortIcon
+                secondary
+                className={isNewestFirst ? undefined : 'rotate-180'}
+              />
+            }
+            onClick={() =>
+              setSortBy(
+                isNewestFirst
+                  ? SortCommentsBy.OldestFirst
+                  : SortCommentsBy.NewestFirst,
+              )
+            }
+            aria-label={sortLabel}
+            title={sortLabel}
+            className="!text-text-secondary"
+          />
+        )}
       </div>
       {rightSlot && (
         <div className="flex shrink-0 items-center [&_.mr-2]:!mr-0 [&_.mt-4]:!mt-0 [&_.mt-6]:!mt-0">

--- a/packages/shared/src/components/post/focus/PostDiscussionPanel.tsx
+++ b/packages/shared/src/components/post/focus/PostDiscussionPanel.tsx
@@ -24,6 +24,7 @@ import { ClickableText } from '../../buttons/ClickableText';
 import { IconSize } from '../../Icon';
 import { TimeSortIcon } from '../../icons/Sort/Time';
 import { SortCommentsBy } from '../../../graphql/comments';
+import { usePostComments } from '../../../hooks/comments/usePostComments';
 import { DiscussionMetaBar } from './DiscussionMetaBar';
 import { DiscussionShareRow } from './DiscussionShareRow';
 
@@ -78,6 +79,7 @@ export const PostDiscussionPanel = ({
 }: PostDiscussionPanelProps): ReactElement => {
   const { sortCommentsBy: sortBy, updateSortCommentsBy: setSortBy } =
     useSettingsContext();
+  const { commentsCount } = usePostComments({ postId: post.id, sortBy });
   const isNewestFirst = sortBy === SortCommentsBy.NewestFirst;
   const commentRef = useRef<NewCommentRef | null>(null);
   const [isComposerOpen, setIsComposerOpen] = useState(false);
@@ -168,7 +170,7 @@ export const PostDiscussionPanel = ({
         />
       </div>
       <DiscussionShareRow post={post} withSquads />
-      {showSortHeader && (
+      {showSortHeader && commentsCount > 0 && (
         // A text link (not a button) so it aligns flush-left with the comments
         // below it; `mb-2` adds breathing room before the first comment.
         <ClickableText

--- a/packages/shared/src/components/post/reader/EngagementRail.tsx
+++ b/packages/shared/src/components/post/reader/EngagementRail.tsx
@@ -30,6 +30,7 @@ import { TimeSortIcon } from '../../icons/Sort/Time';
 import { AnalyticsIcon, ArrowIcon } from '../../icons';
 import { PostMenuOptions } from '../PostMenuOptions';
 import { SortCommentsBy } from '../../../graphql/comments';
+import { usePostComments } from '../../../hooks/comments/usePostComments';
 import { Tooltip } from '../../tooltip/Tooltip';
 import { ClickableText } from '../../buttons/ClickableText';
 import Link from '../../utilities/Link';
@@ -96,6 +97,7 @@ export function EngagementRail({
   const { user } = useAuthContext();
   const { sortCommentsBy: sortBy, updateSortCommentsBy: setSortBy } =
     useSettingsContext();
+  const { commentsCount } = usePostComments({ postId: post.id, sortBy });
   const commentRef = useRef<NewCommentRef | null>(null);
   const [isComposerOpen, setIsComposerOpen] = useState(false);
   const { onShowUpvoted } = useUpvoteQuery();
@@ -283,29 +285,31 @@ export function EngagementRail({
                 </Link>
               )}
             </div>
-            <Button
-              type="button"
-              size={ButtonSize.XSmall}
-              variant={ButtonVariant.Tertiary}
-              iconPosition={ButtonIconPosition.Right}
-              icon={
-                <TimeSortIcon
-                  secondary
-                  className={isNewestFirst ? undefined : 'rotate-180'}
-                />
-              }
-              onClick={() =>
-                setSortBy(
-                  isNewestFirst
-                    ? SortCommentsBy.OldestFirst
-                    : SortCommentsBy.NewestFirst,
-                )
-              }
-              aria-label={sortLabel}
-              className="!text-text-tertiary"
-            >
-              {isNewestFirst ? 'Newest first' : 'Oldest first'}
-            </Button>
+            {commentsCount > 0 && (
+              <Button
+                type="button"
+                size={ButtonSize.XSmall}
+                variant={ButtonVariant.Tertiary}
+                iconPosition={ButtonIconPosition.Right}
+                icon={
+                  <TimeSortIcon
+                    secondary
+                    className={isNewestFirst ? undefined : 'rotate-180'}
+                  />
+                }
+                onClick={() =>
+                  setSortBy(
+                    isNewestFirst
+                      ? SortCommentsBy.OldestFirst
+                      : SortCommentsBy.NewestFirst,
+                  )
+                }
+                aria-label={sortLabel}
+                className="!text-text-tertiary"
+              >
+                {isNewestFirst ? 'Newest first' : 'Oldest first'}
+              </Button>
+            )}
           </div>
           <NewComment
             post={post}

--- a/packages/shared/src/hooks/comments/usePostComments.ts
+++ b/packages/shared/src/hooks/comments/usePostComments.ts
@@ -1,0 +1,54 @@
+import { useContext } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import AuthContext from '../../contexts/AuthContext';
+import type { PostCommentsData, SortCommentsBy } from '../../graphql/comments';
+import { POST_COMMENTS_QUERY } from '../../graphql/comments';
+import { useRequestProtocol } from '../useRequestProtocol';
+import { initialDataKey } from '../../lib/constants';
+import { generateCommentsQueryKey } from '../../lib/query';
+
+interface UsePostCommentsProps {
+  postId: string;
+  sortBy?: SortCommentsBy;
+}
+
+interface UsePostCommentsResult {
+  queryKey: ReturnType<typeof generateCommentsQueryKey>;
+  comments?: PostCommentsData;
+  isLoading: boolean;
+  commentsCount: number;
+}
+
+/**
+ * Shared by the comment list and the surfaces around it (sort toggles, meta
+ * bars), so they read the same cache entry and can't disagree on whether the
+ * post has comments.
+ */
+export const usePostComments = ({
+  postId,
+  sortBy,
+}: UsePostCommentsProps): UsePostCommentsResult => {
+  const { tokenRefreshed } = useContext(AuthContext);
+  const { requestMethod } = useRequestProtocol();
+  const queryKey = generateCommentsQueryKey({ postId, sortBy });
+  const { data: comments, isLoading } = useQuery<PostCommentsData>({
+    queryKey,
+
+    queryFn: (): Promise<PostCommentsData> =>
+      requestMethod(
+        POST_COMMENTS_QUERY,
+        { postId, [initialDataKey]: comments, first: 500, sortBy },
+        { requestKey: JSON.stringify(queryKey) },
+      ),
+    enabled: !!postId && tokenRefreshed,
+    refetchInterval: 60 * 1000,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    queryKey,
+    comments,
+    isLoading,
+    commentsCount: comments?.postComments?.edges?.length || 0,
+  };
+};

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -19,7 +19,11 @@ import {
   VIEW_POST_MUTATION,
 } from '@dailydotdev/shared/src/graphql/posts';
 import type { PostCommentsData } from '@dailydotdev/shared/src/graphql/comments';
-import { POST_COMMENTS_QUERY } from '@dailydotdev/shared/src/graphql/comments';
+import {
+  POST_COMMENTS_QUERY,
+  SortCommentsBy,
+} from '@dailydotdev/shared/src/graphql/comments';
+import commentFixture from '@dailydotdev/shared/__tests__/fixture/comment';
 import type { Action } from '@dailydotdev/shared/src/graphql/actions';
 import {
   ActionType,
@@ -208,6 +212,27 @@ const createCommentsMock = (): MockedGraphQLResponse<PostCommentsData> => ({
       postComments: {
         pageInfo: {},
         edges: [],
+      },
+    },
+  },
+});
+
+const createPostCommentsMock = (
+  edges: PostCommentsData['postComments']['edges'] = [],
+): MockedGraphQLResponse<PostCommentsData> => ({
+  request: {
+    query: POST_COMMENTS_QUERY,
+    variables: {
+      postId: '0e4005b2d3cf191f8c44c2718a457a1e',
+      first: 500,
+      sortBy: SortCommentsBy.OldestFirst,
+    },
+  },
+  result: {
+    data: {
+      postComments: {
+        pageInfo: {},
+        edges,
       },
     },
   },
@@ -586,6 +611,23 @@ it('should show impressions when it is greater than zero', async () => {
   ]);
   const el = await screen.findByTestId('statsBar');
   expect(el).toHaveTextContent('15 Impressions');
+});
+
+it('should hide the comments sort toggle when the comments empty state shows', async () => {
+  renderPost({}, [createPostMock(), createPostCommentsMock()]);
+  await screen.findByText('No comments yet');
+  expect(screen.queryByText('Sort:')).not.toBeInTheDocument();
+  expect(screen.queryByText('Oldest first')).not.toBeInTheDocument();
+});
+
+it('should show the comments sort toggle when there are comments', async () => {
+  renderPost({}, [
+    createPostMock({ numComments: 1 }),
+    createPostCommentsMock([{ node: commentFixture }]),
+  ]);
+  await screen.findByText('Oldest first');
+  expect(screen.getByText('Sort:')).toBeInTheDocument();
+  expect(screen.queryByText('No comments yet')).not.toBeInTheDocument();
 });
 
 it('should not show author link when author is null', async () => {

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -182,6 +182,12 @@ const strictSkipList = new Set([
   // image refs, Button prop unions, ConditionalWrapper element returns) live on
   // unrelated lines and should be addressed in a dedicated cleanup PR.
   'packages/shared/src/components/squads/Details.tsx',
+  // Comment-sort empty state — touched only to gate the sort strip on the
+  // comment count. Pre-existing strict violations (post.source optionality,
+  // the icon's `condition && class` className, mutable comment ref, the
+  // `false | (() => void)` onSignUp) live on unrelated lines and should be
+  // addressed in a dedicated cleanup PR.
+  'packages/shared/src/components/post/PostEngagements.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
The comment sort control rendered even when a post had no comments, so the "No comments yet" empty state sat under a "Sort: Newest first" strip with nothing to sort.

## Changes

- Extracted the post comments query into a shared `usePostComments` hook so the comment list and the surfaces around it read the same cache entry (same query key — no extra request) and can't disagree on whether a post has comments.
- Gated the sort control on the comment count across every surface that renders one next to `PostComments`: the classic post page strip (`PostEngagements`), the reader rail (`EngagementRail`), the focus-card sort header (`PostDiscussionPanel`), and the discussion meta bar (`DiscussionMetaBar`).
- Added `PostPage` tests: sort hidden when the empty state renders, shown when a comment exists.

## Key decisions

- The count comes from the comments query rather than `post.numComments`, so the toggle can never disagree with what the list actually renders.
- While the query loads, the toggle stays hidden (placeholders show) and appears once comments arrive — no flash of a control that then disappears.
- The new tests use a `createPostCommentsMock` helper: the existing `createCommentsMock` declares variables (`after: ''`) that never matched the real request, so it doesn't actually resolve the query. Left in place for the tests that use it.
- `PostEngagements.tsx` was added to the strict-typecheck skip list. Its four strict violations (`post.source` optionality, the icon `className`, the mutable comment ref, the `false | (() => void)` `onSignUp`) are pre-existing on unrelated lines — verified identical against the original file — and should be cleaned up separately.

## Verification

shared (2170), webapp (399), and extension (43) test suites pass; lint clean on changed files; `typecheck-strict-changed.js` passes.

Closes ENG-1929

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1929-feedback-bug-report-hid.preview.app.daily.dev