### PR TITLE
fix: persist original language selection

### DIFF
--- a/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsAISection.spec.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsAISection.spec.tsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import nock from 'nock';
+import { QueryClient } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
+import defaultUser from '../../../../../__tests__/fixture/loggedUser';
+import { defaultQueryClientTestingConfig } from '../../../../../__tests__/helpers/tanstack-query';
+import type { LoggedUser } from '../../../../lib/user';
+import { LogEvent, TargetType } from '../../../../lib/log';
+import { RequestKey } from '../../../../lib/query';
+import { UPDATE_USER_PROFILE_MUTATION } from '../../../../graphql/users';
+import { FeedSettingsAISection } from './FeedSettingsAISection';
+
+jest.mock('../../../../hooks/useFeedSettings', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ isLoading: false })),
+}));
+
+const renderComponent = ({
+  user = defaultUser,
+  updateUser = jest.fn(),
+  logEvent = jest.fn(),
+  queryClient = new QueryClient(defaultQueryClientTestingConfig),
+}: {
+  user?: LoggedUser;
+  updateUser?: jest.Mock;
+  logEvent?: jest.Mock;
+  queryClient?: QueryClient;
+} = {}) => {
+  return {
+    ...render(
+      <TestBootProvider
+        client={queryClient}
+        auth={{ user, updateUser }}
+        log={{ logEvent }}
+      >
+        <FeedSettingsAISection />
+      </TestBootProvider>,
+    ),
+    logEvent,
+    updateUser,
+    queryClient,
+  };
+};
+
+const mockUpdateUserProfile = (
+  onBody: (body: Record<string, unknown>) => void,
+) => {
+  nock('http://localhost:3000')
+    .post('/graphql', (body: Record<string, unknown>) => {
+      if (body.query !== UPDATE_USER_PROFILE_MUTATION) {
+        return false;
+      }
+
+      onBody(body);
+      return true;
+    })
+    .reply(200, { data: { updateUserProfile: { id: defaultUser.id } } });
+};
+
+describe('FeedSettingsAISection', () => {
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  it('should send null when reverting the language to original', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const updateUser = jest.fn();
+    const logEvent = jest.fn();
+    mockUpdateUserProfile((body) => {
+      requestBody = body;
+    });
+
+    renderComponent({
+      user: { ...defaultUser, isPlus: true, language: 'de' },
+      updateUser,
+      logEvent,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'German' }));
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'Original language' }),
+    );
+
+    await waitFor(() =>
+      expect(requestBody).toMatchObject({
+        variables: { data: { language: null } },
+      }),
+    );
+    expect(updateUser).toHaveBeenCalledWith(
+      expect.objectContaining({ language: null }),
+    );
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.ChangeSettings,
+      target_type: TargetType.Language,
+      target_id: 'original',
+    });
+  });
+
+  it('should still send the selected language', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    mockUpdateUserProfile((body) => {
+      requestBody = body;
+    });
+
+    renderComponent({
+      user: { ...defaultUser, isPlus: true, language: null },
+    });
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Original language' }),
+    );
+    await userEvent.click(screen.getByRole('menuitem', { name: 'German' }));
+
+    await waitFor(() =>
+      expect(requestBody).toMatchObject({
+        variables: { data: { language: 'de' } },
+      }),
+    );
+  });
+
+  it('should invalidate feed and post query keys after a successful clear', async () => {
+    const queryClient = new QueryClient(defaultQueryClientTestingConfig);
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    mockUpdateUserProfile(() => undefined);
+
+    renderComponent({
+      user: { ...defaultUser, isPlus: true, language: 'de' },
+      queryClient,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'German' }));
+    await userEvent.click(
+      screen.getByRole('menuitem', { name: 'Original language' }),
+    );
+
+    await waitFor(() =>
+      expect(invalidateQueries).toHaveBeenCalledWith({
+        queryKey: [RequestKey.Post],
+        exact: false,
+        type: 'all',
+      }),
+    );
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: [RequestKey.Bookmarks],
+      exact: false,
+      type: 'all',
+    });
+  });
+
+  it('should disable language selection for non-Plus users', () => {
+    renderComponent({
+      user: { ...defaultUser, isPlus: false, language: 'de' },
+    });
+
+    expect(screen.getByRole('button', { name: 'German' })).toBeDisabled();
+  });
+});

--- a/packages/shared/src/components/profile/LanguageDropdown.tsx
+++ b/packages/shared/src/components/profile/LanguageDropdown.tsx
@@ -17,7 +17,7 @@ type ClassName = {
 
 type Props = {
   className?: ClassName;
-  defaultValue?: string;
+  defaultValue?: string | null;
   onChange?: (value: string | undefined, index: number) => void;
   icon?: ReactElement<IconProps>;
   disabled?: boolean;
@@ -99,7 +99,7 @@ export const LanguageDropdown = ({
         icon={icon}
         disabled={disabled}
       />
-      {name && selectedIndex > -1 && (
+      {name && selectedIndex > -1 && values[selectedIndex] && (
         <input
           type="text"
           className="hidden"

--- a/packages/shared/src/contexts/BootProvider.spec.tsx
+++ b/packages/shared/src/contexts/BootProvider.spec.tsx
@@ -688,3 +688,21 @@ it('should set the calling platform header on the gql client', async () => {
   );
   setHeaderSpy.mockRestore();
 });
+
+it('should unset the content language header when user language is cleared', async () => {
+  gqlClient.setHeader('content-language', 'de');
+  const unsetHeaderSpy = jest.spyOn(gqlClient, 'unsetHeader');
+
+  renderComponent(<AuthMock />, {
+    ...defaultBootData,
+    user: { ...defaultUser, isPlus: true, language: null },
+  });
+
+  await waitFor(() =>
+    expect(unsetHeaderSpy).toHaveBeenCalledWith('content-language'),
+  );
+  expect(
+    Reflect.get(Reflect.get(gqlClient, 'options'), 'headers'),
+  ).not.toHaveProperty('content-language');
+  unsetHeaderSpy.mockRestore();
+});

--- a/packages/shared/src/hooks/useLanguage.ts
+++ b/packages/shared/src/hooks/useLanguage.ts
@@ -10,7 +10,7 @@ import { OtherFeedPage, RequestKey } from '../lib/query';
 import { useToastNotification } from './useToastNotification';
 
 export type UseLanguage = {
-  onLanguageChange: (value?: string) => void;
+  onLanguageChange: (value?: string | null) => void;
 };
 
 export const useLanguage = (): UseLanguage => {
@@ -20,19 +20,21 @@ export const useLanguage = (): UseLanguage => {
   const { displayToast } = useToastNotification();
 
   const { mutate: onLanguageChange } = useMutation({
-    mutationFn: async (value?: string) => {
+    mutationFn: async (value?: string | null) => {
       if (!user) {
         throw new Error('Cannot update language without an authenticated user');
       }
 
+      const language = value ?? null;
+
       await updateUser({
         ...user,
-        language: value,
+        language,
       });
 
       await gqlClient.request(UPDATE_USER_PROFILE_MUTATION, {
         data: {
-          language: value,
+          language,
         },
       });
     },
@@ -41,7 +43,7 @@ export const useLanguage = (): UseLanguage => {
       logEvent({
         event_name: LogEvent.ChangeSettings,
         target_type: TargetType.Language,
-        target_id: value,
+        target_id: value ?? 'original',
       });
     },
 

--- a/packages/shared/src/lib/auth.ts
+++ b/packages/shared/src/lib/auth.ts
@@ -136,7 +136,7 @@ export interface SocialRegistrationParameters {
   acceptedMarketing?: boolean;
   optOutMarketing?: boolean;
   experienceLevel?: string;
-  language?: string;
+  language?: string | null;
 }
 
 export const isNativeAuthSupported = (provider: string): boolean =>

--- a/packages/shared/src/lib/boot.ts
+++ b/packages/shared/src/lib/boot.ts
@@ -80,7 +80,7 @@ export type Boot = {
    */
   marketingCtaVariants?: MarketingCtaVariant[];
   feeds: Feed[];
-  language?: string;
+  language?: string | null;
   geo: {
     ip?: string;
     region?: string;

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -127,7 +127,7 @@ export interface UserProfile {
   cover?: string;
   experienceLevel?: keyof typeof UserExperienceLevel;
   hideExperience?: boolean;
-  language?: string;
+  language?: string | null;
   defaultFeedId?: string;
   readme?: string;
   image?: string;


### PR DESCRIPTION
Issue: https://linear.app/dailydev/issue/ENG-1924/feedback-bug-report-unable-to-revert-to-original-language-in-ai

## Summary
- Normalize the AI Superpowers language update so choosing Original language sends an explicit `null` instead of an omitted `undefined` field.
- Keep optimistic user state and nullable language types aligned with the API contract.
- Track clears with `target_id: original` and add regression coverage for serialized mutation payloads, cache invalidation, Plus gating, and `content-language` header clearing.

## Key decisions
- Keep `NULL` as the canonical original-language state; no API schema or migration change needed.
- Scope the fix to `useLanguage` rather than changing generic GraphQL client serialization semantics.

Closes ENG-1924

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1924-feedback-bug-report-una.preview.app.daily.dev