### PR TITLE
feat(seo): serve post pages as markdown for AI crawlers

### DIFF
--- a/packages/webapp/__tests__/ContentNegotiation.spec.ts
+++ b/packages/webapp/__tests__/ContentNegotiation.spec.ts
@@ -1,0 +1,37 @@
+import { acceptsMarkdown } from '../lib/contentNegotiation';
+
+describe('acceptsMarkdown', () => {
+  it('returns false without an Accept header', () => {
+    expect(acceptsMarkdown(undefined)).toBe(false);
+    expect(acceptsMarkdown(null)).toBe(false);
+    expect(acceptsMarkdown('')).toBe(false);
+  });
+
+  it('ignores the wildcards browsers and curl send', () => {
+    expect(acceptsMarkdown('*/*')).toBe(false);
+    expect(acceptsMarkdown('text/*')).toBe(false);
+    expect(
+      acceptsMarkdown(
+        'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
+      ),
+    ).toBe(false);
+  });
+
+  it('matches an explicit markdown request', () => {
+    expect(acceptsMarkdown('text/markdown')).toBe(true);
+    expect(acceptsMarkdown('text/x-markdown')).toBe(true);
+    expect(acceptsMarkdown('TEXT/MARKDOWN')).toBe(true);
+    expect(acceptsMarkdown('text/markdown; charset=utf-8')).toBe(true);
+  });
+
+  it('respects quality ordering against html', () => {
+    expect(acceptsMarkdown('text/markdown, text/html;q=0.9')).toBe(true);
+    expect(acceptsMarkdown('text/markdown;q=0.5, text/html;q=0.9')).toBe(false);
+    expect(acceptsMarkdown('text/markdown;q=0.9, text/html;q=0.9')).toBe(true);
+    expect(acceptsMarkdown('text/markdown;q=0, text/html')).toBe(false);
+  });
+
+  it('matches markdown alongside a wildcard fallback', () => {
+    expect(acceptsMarkdown('text/markdown, */*;q=0.1')).toBe(true);
+  });
+});

--- a/packages/webapp/__tests__/PostMarkdown.spec.ts
+++ b/packages/webapp/__tests__/PostMarkdown.spec.ts
@@ -1,0 +1,216 @@
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import type { Comment } from '@dailydotdev/shared/src/graphql/comments';
+import type { PostMarkdownPost, SimilarPost } from '../lib/postMarkdown';
+import { buildPostMarkdown } from '../lib/postMarkdown';
+
+const createPost = (
+  overrides: Partial<PostMarkdownPost> = {},
+): PostMarkdownPost =>
+  ({
+    id: 'p1',
+    slug: 'why-react-rerenders-twice-abc123',
+    title: 'Why your React app re-renders twice',
+    type: PostType.Article,
+    url: 'https://blog.example.com/react-rerenders',
+    permalink: 'https://api.daily.dev/r/abc123',
+    commentsPermalink:
+      'https://daily.dev/posts/why-react-rerenders-twice-abc123',
+    summary: 'StrictMode double-invokes renders in development only.',
+    createdAt: '2026-07-14T09:12:00.000Z',
+    updatedAt: '2026-07-20T11:03:00.000Z',
+    readTime: 7,
+    tags: ['react', 'webdev'],
+    numUpvotes: 412,
+    numComments: 38,
+    author: { name: 'Gergely Orosz', username: 'gergely', reputation: 4200 },
+    source: {
+      handle: 'pragmatic',
+      name: 'The Pragmatic Engineer',
+      public: true,
+    },
+    ...overrides,
+  } as PostMarkdownPost);
+
+const createComment = (overrides: Partial<Comment> = {}): Comment =>
+  ({
+    id: 'c1',
+    content: 'The double render is StrictMode in dev only.',
+    contentHtml: '<p>The double render is StrictMode in dev only.</p>',
+    createdAt: '2026-07-14T10:00:00.000Z',
+    permalink: 'https://daily.dev/posts/x#c-c1',
+    numUpvotes: 24,
+    numAwards: 0,
+    author: { username: 'gergely', name: 'Gergely Orosz' },
+    ...overrides,
+  } as Comment);
+
+const build = (
+  post = createPost(),
+  comments: Comment[] = [],
+  similarPosts: SimilarPost[] = [],
+) => buildPostMarkdown({ post, comments, similarPosts });
+
+describe('buildPostMarkdown', () => {
+  it('emits frontmatter with the canonical and original urls', () => {
+    const markdown = build();
+
+    expect(markdown).toContain(
+      'url: https://daily.dev/posts/why-react-rerenders-twice-abc123',
+    );
+    expect(markdown).toContain(
+      'source_url: https://blog.example.com/react-rerenders',
+    );
+    expect(markdown).toContain('type: article');
+    expect(markdown).toContain('reading_time: 7');
+    expect(markdown).toContain('upvotes: 412');
+    expect(markdown).toContain('tags: ["react", "webdev"]');
+  });
+
+  it('quotes frontmatter values so colons cannot break the yaml', () => {
+    const markdown = build(
+      createPost({ title: 'React: the good parts', source: { name: 'A: B' } }),
+    );
+
+    expect(markdown).toContain('title: "React: the good parts"');
+    expect(markdown).toContain('source: "A: B"');
+  });
+
+  it('falls back to the canonical url when the post has no external url', () => {
+    const markdown = build(
+      createPost({ type: PostType.Freeform, url: undefined, content: 'Hello' }),
+    );
+
+    expect(markdown).toContain(
+      'source_url: https://daily.dev/posts/why-react-rerenders-twice-abc123',
+    );
+  });
+
+  it('links out instead of reproducing an external article body', () => {
+    const markdown = build(createPost({ content: 'scraped body text' }));
+
+    expect(markdown).toContain('## Full article');
+    expect(markdown).toContain('<https://blog.example.com/react-rerenders>');
+    expect(markdown).not.toContain('scraped body text');
+  });
+
+  it('inlines the body for daily.dev-native posts', () => {
+    const markdown = build(
+      createPost({
+        type: PostType.Freeform,
+        url: undefined,
+        content: '## My heading\n\nSome squad content.',
+      }),
+    );
+
+    expect(markdown).toContain('## Content');
+    expect(markdown).toContain('Some squad content.');
+    expect(markdown).not.toContain('## Full article');
+  });
+
+  it('renders top comments as blockquotes', () => {
+    const markdown = build(createPost(), [createComment()]);
+
+    expect(markdown).toContain('## Community discussion');
+    expect(markdown).toContain('**@gergely** · 24 upvotes');
+    expect(markdown).toContain(
+      '> The double render is StrictMode in dev only.',
+    );
+  });
+
+  it('skips the discussion section when no comment has a body', () => {
+    const markdown = build(createPost(), [createComment({ content: '' })]);
+
+    expect(markdown).not.toContain('## Community discussion');
+  });
+
+  it('renders the community take when the post has one', () => {
+    const markdown = build(
+      createPost({
+        communitySentiment: {
+          breakdown: { positive: 62, mixed: 24, critical: 14 },
+          tldr: 'Most agree it is a dev-only behaviour.',
+          postCount: 2,
+          sources: ['Hacker News', 'Lobsters'],
+          pros: ['Clear explanation of StrictMode'],
+          cons: ['Skips the React 18 changes'],
+          bySource: [
+            {
+              source: 'Hacker News',
+              lean: 'positive',
+              note: 'Broadly agrees',
+              url: 'https://news.ycombinator.com/item?id=1',
+            },
+          ],
+          hottestDebate: 'Whether StrictMode should ship by default.',
+          openQuestions: ['Does this change in React 19?'],
+          highlights: [
+            {
+              quote: 'Production renders once.',
+              author: 'someone',
+              source: 'Hacker News',
+              url: 'https://news.ycombinator.com/item?id=2',
+              metrics: { points: 214, replies: 88 },
+            },
+          ],
+          discussions: [
+            {
+              provider: 'hackernews',
+              url: 'https://news.ycombinator.com/item?id=1',
+              points: 214,
+              commentsCount: 88,
+            },
+          ],
+          updatedAt: '2026-07-18T00:00:00.000Z',
+        },
+      }),
+    );
+
+    expect(markdown).toContain('## Community take');
+    expect(markdown).toContain(
+      'aggregated from 2 discussions and 88 comments across Hacker News, Lobsters (as of 2026-07-18).',
+    );
+    expect(markdown).toContain(
+      '**TL;DR:** Most agree it is a dev-only behaviour.',
+    );
+    expect(markdown).toContain('62% positive · 24% mixed · 14% skeptical');
+    expect(markdown).toContain('**The case for**');
+    expect(markdown).toContain('**Hottest debate:**');
+    expect(markdown).toContain('> Production renders once.');
+    expect(markdown).toContain('214 points · 88 comments');
+  });
+
+  it('omits the community take when the post has none', () => {
+    expect(build()).not.toContain('## Community take');
+  });
+
+  it('lists similar posts with their canonical urls', () => {
+    const markdown = build(
+      createPost(),
+      [],
+      [
+        {
+          id: 'p2',
+          title: 'useEffect gotchas',
+          slug: 'useeffect-gotchas-def456',
+          commentsPermalink: 'https://daily.dev/posts/useeffect-gotchas-def456',
+          numUpvotes: 120,
+          numComments: 14,
+          source: { name: 'Overreacted' },
+        },
+      ],
+    );
+
+    expect(markdown).toContain('## Similar posts on daily.dev');
+    expect(markdown).toContain(
+      '- [useEffect gotchas](https://daily.dev/posts/useeffect-gotchas-def456) · Overreacted · 120 upvotes · 14 comments',
+    );
+  });
+
+  it('omits the similar posts section when there are none', () => {
+    expect(build()).not.toContain('## Similar posts');
+  });
+
+  it('never leaves more than one blank line between blocks', () => {
+    expect(build(createPost(), [createComment()])).not.toMatch(/\n{3,}/);
+  });
+});

--- a/packages/webapp/__tests__/PostStaticProps.spec.ts
+++ b/packages/webapp/__tests__/PostStaticProps.spec.ts
@@ -1,7 +1,8 @@
 import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import type { Post } from '@dailydotdev/shared/src/graphql/posts';
 import { PostType } from '@dailydotdev/shared/src/graphql/posts';
-import { getStaticProps, shouldNoindexPost } from '../pages/posts/[id]/index';
+import { getStaticProps } from '../pages/posts/[id]/index';
+import { shouldNoindexPost } from '../lib/seo';
 
 jest.mock('@dailydotdev/shared/src/graphql/common', () => {
   const actual = jest.requireActual('@dailydotdev/shared/src/graphql/common');

--- a/packages/webapp/lib/contentNegotiation.ts
+++ b/packages/webapp/lib/contentNegotiation.ts
@@ -1,0 +1,60 @@
+/**
+ * Accept-header content negotiation for AI crawlers.
+ *
+ * Runs in middleware (edge runtime), so this module must stay free of Node
+ * APIs and heavy imports.
+ */
+
+const MARKDOWN_MEDIA_TYPES = ['text/markdown', 'text/x-markdown'];
+const HTML_MEDIA_TYPE = 'text/html';
+
+interface MediaRange {
+  type: string;
+  quality: number;
+}
+
+const parseAccept = (header: string): MediaRange[] =>
+  header
+    .split(',')
+    .map((part) => {
+      const [rawType, ...params] = part.trim().split(';');
+      const type = rawType.trim().toLowerCase();
+      const qParam = params
+        .map((param) => param.trim().toLowerCase())
+        .find((param) => param.startsWith('q='));
+      const parsed = qParam ? Number.parseFloat(qParam.slice(2)) : 1;
+
+      return {
+        type,
+        quality: Number.isNaN(parsed) ? 1 : parsed,
+      };
+    })
+    .filter(({ type }) => !!type);
+
+const bestQuality = (ranges: MediaRange[], types: string[]): number =>
+  Math.max(
+    0,
+    ...ranges.filter(({ type }) => types.includes(type)).map((r) => r.quality),
+  );
+
+/**
+ * True when the client explicitly asked for markdown and did not rank HTML
+ * higher. Wildcard ranges deliberately do not count: browsers rank HTML first
+ * and fall back to a wildcard, and curl sends nothing but a wildcard, so
+ * honouring them would serve markdown to everyone. Clients that cannot set
+ * the header use the `.md` URL instead.
+ */
+export const acceptsMarkdown = (header?: string | null): boolean => {
+  if (!header) {
+    return false;
+  }
+
+  const ranges = parseAccept(header);
+  const markdownQuality = bestQuality(ranges, MARKDOWN_MEDIA_TYPES);
+
+  if (markdownQuality <= 0) {
+    return false;
+  }
+
+  return markdownQuality >= bestQuality(ranges, [HTML_MEDIA_TYPE]);
+};

--- a/packages/webapp/lib/markdownRoutes.ts
+++ b/packages/webapp/lib/markdownRoutes.ts
@@ -2,8 +2,9 @@
  * Shared route mappings for markdown versions of pages.
  *
  * These routes are used in next.config.ts rewrites to map .md URLs
- * (e.g., /sources.md → /api/md/sources), enabling explicit markdown access
- * for AI agents without Accept-header content negotiation.
+ * (e.g., /sources.md → /api/md/sources), giving agents that cannot set an
+ * Accept header an explicit markdown URL. Header-based negotiation for post
+ * pages lives in middleware.ts.
  */
 
 export const MARKDOWN_ROUTES: Record<string, string> = {
@@ -12,15 +13,32 @@ export const MARKDOWN_ROUTES: Record<string, string> = {
   '/squads/discover': '/api/md/squads',
 } as const;
 
+export const POST_MARKDOWN_PATH = '/api/md/posts';
+
+/**
+ * Single-segment `/posts/<x>` routes that are feed pages rather than posts.
+ * Mirrors the non-dynamic files in pages/posts/.
+ */
+export const RESERVED_POST_SLUGS = [
+  'best-of',
+  'discussed',
+  'latest',
+  'upvoted',
+];
+
 /**
  * Get the .md URL rewrite source patterns for next.config.ts
  */
 export const getMarkdownRewrites = (): Array<{
   source: string;
   destination: string;
-}> => {
-  return Object.entries(MARKDOWN_ROUTES).map(([path, destination]) => ({
+}> => [
+  ...Object.entries(MARKDOWN_ROUTES).map(([path, destination]) => ({
     source: `${path}.md`,
     destination,
-  }));
-};
+  })),
+  {
+    source: '/posts/:id.md',
+    destination: `${POST_MARKDOWN_PATH}/:id`,
+  },
+];

--- a/packages/webapp/lib/postMarkdown.ts
+++ b/packages/webapp/lib/postMarkdown.ts
@@ -1,0 +1,538 @@
+import { gql } from 'graphql-request';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+import type { Comment } from '@dailydotdev/shared/src/graphql/comments';
+import type { CommunitySentimentPost } from '@dailydotdev/shared/src/components/post/focus/CommunitySentiment';
+import {
+  escapeMarkdown,
+  truncateAtWordBoundary,
+} from '@dailydotdev/shared/src/lib/strings';
+import { getAppOrigin, getLlmsTxtUrl, getPostCanonicalUrl } from './seo';
+
+/** Post types whose body daily.dev hosts itself. Everything else links out. */
+const NATIVE_CONTENT_TYPES = [
+  PostType.Freeform,
+  PostType.Welcome,
+  PostType.Share,
+  PostType.Collection,
+];
+
+const MAX_COMMENT_LENGTH = 600;
+const SIMILAR_POSTS_COUNT = 5;
+export const TOP_COMMENTS_COUNT = 5;
+
+export interface PostMarkdownPost
+  extends Pick<
+    Post,
+    | 'id'
+    | 'slug'
+    | 'title'
+    | 'type'
+    | 'permalink'
+    | 'commentsPermalink'
+    | 'content'
+    | 'summary'
+    | 'description'
+    | 'createdAt'
+    | 'updatedAt'
+    | 'readTime'
+    | 'tags'
+    | 'language'
+    | 'private'
+    | 'numUpvotes'
+    | 'numComments'
+  > {
+  url?: string;
+  author?: { name?: string; username?: string; reputation?: number };
+  source?: { handle?: string; name?: string; public?: boolean };
+  sharedPost?: { title?: string; url?: string; summary?: string };
+  communitySentiment?: CommunitySentimentPost | null;
+}
+
+export interface SimilarPost {
+  id: string;
+  title?: string;
+  slug?: string;
+  commentsPermalink: string;
+  numUpvotes?: number;
+  numComments?: number;
+  source?: { name?: string };
+}
+
+export const POST_MARKDOWN_QUERY = gql`
+  query PostMarkdown($id: ID!) {
+    post(id: $id) {
+      id
+      slug
+      title
+      type
+      url
+      permalink
+      commentsPermalink
+      content
+      summary
+      description
+      createdAt
+      updatedAt
+      readTime
+      tags
+      language
+      private
+      numUpvotes
+      numComments
+      author {
+        name
+        username
+        reputation
+      }
+      source {
+        handle
+        name
+        public
+      }
+      sharedPost {
+        title
+        url
+        summary
+      }
+      communitySentiment {
+        breakdown {
+          positive
+          mixed
+          critical
+        }
+        tldr
+        postCount
+        sources
+        pros
+        cons
+        bySource {
+          source
+          lean
+          note
+          url
+        }
+        hottestDebate
+        openQuestions
+        highlights {
+          quote
+          author
+          source
+          url
+          metrics {
+            points
+            replies
+            likes
+          }
+        }
+        discussions {
+          provider
+          url
+          points
+          commentsCount
+        }
+        updatedAt
+      }
+    }
+  }
+`;
+
+/** Raw markdown bodies, unlike the `contentHtml` the page components render. */
+export const POST_MARKDOWN_COMMENTS_QUERY = gql`
+  query PostMarkdownComments($postId: ID!, $first: Int) {
+    topComments(postId: $postId, first: $first) {
+      id
+      content
+      createdAt
+      permalink
+      numUpvotes
+      author {
+        username
+        name
+      }
+    }
+  }
+`;
+
+export const POST_MARKDOWN_SIMILAR_QUERY = gql`
+  query PostMarkdownSimilar($post: ID!, $tags: [String]!, $first: Int) {
+    similarPosts: randomSimilarPostsByTags(
+      tags: $tags
+      post: $post
+      first: $first
+    ) {
+      id
+      title
+      slug
+      commentsPermalink
+      numUpvotes
+      numComments
+      source {
+        name
+      }
+    }
+  }
+`;
+
+export const getSimilarPostsVariables = (
+  post: PostMarkdownPost,
+): { post: string; tags: string[]; first: number } => ({
+  post: post.id,
+  tags: post.tags ?? [],
+  first: SIMILAR_POSTS_COUNT,
+});
+
+const yaml = (value: string): string => JSON.stringify(value);
+
+const yamlList = (values: string[]): string =>
+  `[${values.map(yaml).join(', ')}]`;
+
+const postUrl = (post: Pick<Post, 'slug' | 'commentsPermalink'>): string =>
+  post.slug ? getPostCanonicalUrl(post.slug) : post.commentsPermalink;
+
+/**
+ * The article this post points at. Native posts have no external URL, so they
+ * resolve to their own canonical page rather than leaving the field empty.
+ */
+const sourceUrl = (post: PostMarkdownPost): string =>
+  post.url || post.sharedPost?.url || postUrl(post);
+
+/** The post's own body, when daily.dev hosts it. Empty for external articles. */
+const nativeContent = (post: PostMarkdownPost): string =>
+  NATIVE_CONTENT_TYPES.includes(post.type) ? post.content?.trim() ?? '' : '';
+
+const buildFrontmatter = (post: PostMarkdownPost): string[] => {
+  const lines = ['---'];
+  lines.push(
+    `title: ${yaml(post.title || post.sharedPost?.title || 'Untitled')}`,
+  );
+  lines.push(`url: ${postUrl(post)}`);
+  lines.push(`source_url: ${sourceUrl(post)}`);
+  lines.push(`type: ${post.type}`);
+
+  if (post.source?.name) {
+    lines.push(`source: ${yaml(post.source.name)}`);
+  }
+
+  const author = post.author?.name || post.author?.username;
+
+  if (author) {
+    lines.push(`author: ${yaml(author)}`);
+  }
+
+  if (post.createdAt) {
+    lines.push(`published: ${post.createdAt}`);
+  }
+
+  if (post.updatedAt) {
+    lines.push(`updated: ${post.updatedAt}`);
+  }
+
+  if (post.tags?.length) {
+    lines.push(`tags: ${yamlList(post.tags)}`);
+  }
+
+  if (post.readTime) {
+    lines.push(`reading_time: ${Math.round(post.readTime)}`);
+  }
+
+  lines.push(`upvotes: ${post.numUpvotes ?? 0}`);
+  lines.push(`comments: ${post.numComments ?? 0}`);
+
+  if (post.language) {
+    lines.push(`language: ${post.language}`);
+  }
+
+  lines.push('---');
+
+  return lines;
+};
+
+const buildByline = (post: PostMarkdownPost): string => {
+  const parts: string[] = [];
+
+  if (post.source?.name) {
+    const name = escapeMarkdown(post.source.name);
+    parts.push(
+      post.source.handle
+        ? `**[${name}](${getAppOrigin()}/sources/${post.source.handle})**`
+        : `**${name}**`,
+    );
+  }
+
+  if (post.author?.username) {
+    parts.push(
+      `[@${post.author.username}](${getAppOrigin()}/${post.author.username})`,
+    );
+  }
+
+  if (post.readTime) {
+    parts.push(`${Math.round(post.readTime)} min read`);
+  }
+
+  parts.push(`${post.numUpvotes ?? 0} upvotes`);
+  parts.push(`${post.numComments ?? 0} comments`);
+
+  return parts.join(' · ');
+};
+
+const buildBody = (post: PostMarkdownPost): string[] => {
+  const content = nativeContent(post);
+
+  if (content) {
+    return ['## Content', '', content];
+  }
+
+  const url = sourceUrl(post);
+
+  return [
+    '## Full article',
+    '',
+    `daily.dev links to this article rather than hosting it. Read it at the original source: <${url}>`,
+  ];
+};
+
+const buildSummary = (post: PostMarkdownPost): string[] => {
+  const summary = post.summary || post.sharedPost?.summary || post.description;
+
+  if (!summary?.trim()) {
+    return [];
+  }
+
+  return ['## Summary', '', summary.trim(), ''];
+};
+
+const formatPercentage = (value: number): string => `${Math.round(value)}%`;
+
+const buildCommunityTake = (post: PostMarkdownPost): string[] => {
+  const take = post.communitySentiment;
+
+  if (!take) {
+    return [];
+  }
+
+  const lines = ['## Community take', ''];
+  const { breakdown, discussions, sources, updatedAt } = take;
+
+  const totalComments =
+    discussions?.reduce((total, item) => total + item.commentsCount, 0) ?? 0;
+  const volume = [
+    `${take.postCount} discussion${take.postCount === 1 ? '' : 's'}`,
+    totalComments > 0 ? `${totalComments} comments` : undefined,
+  ]
+    .filter(Boolean)
+    .join(' and ');
+  const across = sources?.length ? ` across ${sources.join(', ')}` : '';
+  const asOf = updatedAt ? ` (as of ${updatedAt.slice(0, 10)})` : '';
+
+  lines.push(
+    `How the wider developer community reacted, aggregated from ${volume}${across}${asOf}.`,
+  );
+  lines.push('');
+
+  if (take.tldr?.trim()) {
+    lines.push(`**TL;DR:** ${take.tldr.trim()}`);
+    lines.push('');
+  }
+
+  if (breakdown) {
+    lines.push(
+      `**Sentiment:** ${formatPercentage(
+        breakdown.positive,
+      )} positive · ${formatPercentage(
+        breakdown.mixed,
+      )} mixed · ${formatPercentage(breakdown.critical)} skeptical`,
+    );
+    lines.push('');
+  }
+
+  if (take.pros?.length) {
+    lines.push('**The case for**');
+    lines.push('');
+    take.pros.forEach((pro) => lines.push(`- ${pro}`));
+    lines.push('');
+  }
+
+  if (take.cons?.length) {
+    lines.push('**The pushback**');
+    lines.push('');
+    take.cons.forEach((con) => lines.push(`- ${con}`));
+    lines.push('');
+  }
+
+  if (take.bySource?.length) {
+    lines.push('**By community**');
+    lines.push('');
+    take.bySource.forEach((entry) => {
+      const label = entry.url
+        ? `[${escapeMarkdown(entry.source)}](${entry.url})`
+        : escapeMarkdown(entry.source);
+      lines.push(`- ${label} (${entry.lean}): ${entry.note}`);
+    });
+    lines.push('');
+  }
+
+  if (take.hottestDebate?.trim()) {
+    lines.push(`**Hottest debate:** ${take.hottestDebate.trim()}`);
+    lines.push('');
+  }
+
+  if (take.openQuestions?.length) {
+    lines.push('**Open questions**');
+    lines.push('');
+    take.openQuestions.forEach((question) => lines.push(`- ${question}`));
+    lines.push('');
+  }
+
+  if (take.highlights?.length) {
+    lines.push('**Highlights**');
+    lines.push('');
+    take.highlights.forEach((highlight) => {
+      lines.push(`> ${highlight.quote.replace(/\n+/g, ' ')}`);
+      const metrics = [
+        highlight.metrics?.points
+          ? `${highlight.metrics.points} points`
+          : undefined,
+        highlight.metrics?.replies
+          ? `${highlight.metrics.replies} comments`
+          : undefined,
+        highlight.metrics?.likes
+          ? `${highlight.metrics.likes} likes`
+          : undefined,
+      ].filter(Boolean);
+      const attribution = [
+        `${highlight.author} on ${highlight.source}`,
+        metrics.length ? metrics.join(', ') : undefined,
+      ]
+        .filter(Boolean)
+        .join(' · ');
+      lines.push(`> — [${escapeMarkdown(attribution)}](${highlight.url})`);
+      lines.push('');
+    });
+  }
+
+  if (discussions?.length) {
+    lines.push('**Source threads**');
+    lines.push('');
+    discussions.forEach((discussion) => {
+      lines.push(
+        `- [${escapeMarkdown(discussion.provider)}](${discussion.url}) · ${
+          discussion.points
+        } points · ${discussion.commentsCount} comments`,
+      );
+    });
+    lines.push('');
+  }
+
+  return lines;
+};
+
+const buildComments = (comments: Comment[]): string[] => {
+  const usable = comments
+    .map((comment) => ({ comment, body: comment.content?.trim() ?? '' }))
+    .filter(({ body }) => !!body);
+
+  if (!usable.length) {
+    return [];
+  }
+
+  const lines = [
+    '## Community discussion',
+    '',
+    'Top comments from developers on daily.dev.',
+    '',
+  ];
+
+  usable.forEach(({ comment, body }) => {
+    const handle = comment.author?.username
+      ? `@${comment.author.username}`
+      : comment.author?.name || 'A daily.dev member';
+    lines.push(
+      `**${escapeMarkdown(handle)}** · ${comment.numUpvotes ?? 0} upvotes`,
+    );
+    lines.push('');
+    truncateAtWordBoundary(body, MAX_COMMENT_LENGTH)
+      .split('\n')
+      .forEach((line) => lines.push(`> ${line}`.trimEnd()));
+    lines.push('');
+  });
+
+  return lines;
+};
+
+const buildSimilarPosts = (posts: SimilarPost[]): string[] => {
+  if (!posts.length) {
+    return [];
+  }
+
+  const lines = ['## Similar posts on daily.dev', ''];
+
+  posts.forEach((post) => {
+    const meta = [
+      post.source?.name ? escapeMarkdown(post.source.name) : undefined,
+      `${post.numUpvotes ?? 0} upvotes`,
+      `${post.numComments ?? 0} comments`,
+    ].filter(Boolean);
+    lines.push(
+      `- [${escapeMarkdown(post.title || 'Untitled')}](${postUrl(
+        post,
+      )}) · ${meta.join(' · ')}`,
+    );
+  });
+
+  lines.push('');
+
+  return lines;
+};
+
+const buildFooter = (post: PostMarkdownPost): string[] => {
+  const lines = ['---', ''];
+
+  if (post.tags?.length) {
+    const tags = post.tags
+      .map((tag) => `[#${tag}](${getAppOrigin()}/tags/${tag})`)
+      .join(', ');
+    lines.push(`Tags: ${tags}`);
+    lines.push('');
+  }
+
+  lines.push(`[View this post on daily.dev](${postUrl(post)})`);
+
+  return lines;
+};
+
+export interface PostMarkdownInput {
+  post: PostMarkdownPost;
+  comments: Comment[];
+  similarPosts: SimilarPost[];
+}
+
+export const buildPostMarkdown = ({
+  post,
+  comments,
+  similarPosts,
+}: PostMarkdownInput): string => {
+  const title = post.title || post.sharedPost?.title || 'Untitled';
+
+  const lines = [
+    ...buildFrontmatter(post),
+    '',
+    '> ## Documentation Index',
+    `> Fetch the complete documentation index at: ${getLlmsTxtUrl()}`,
+    '> Use this file to discover all available pages before exploring further.',
+    '',
+    `# ${title}`,
+    '',
+    buildByline(post),
+    '',
+    ...buildSummary(post),
+    ...buildBody(post),
+    '',
+    ...buildCommunityTake(post),
+    ...buildComments(comments),
+    ...buildSimilarPosts(similarPosts),
+    ...buildFooter(post),
+  ];
+
+  return `${lines.join('\n').replace(/\n{3,}/g, '\n\n')}\n`;
+};

--- a/packages/webapp/lib/seo.ts
+++ b/packages/webapp/lib/seo.ts
@@ -1,3 +1,6 @@
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType } from '@dailydotdev/shared/src/graphql/posts';
+
 const DEFAULT_APP_ORIGIN = 'https://daily.dev';
 const DEFAULT_SITE_ORIGIN = 'https://daily.dev';
 
@@ -28,3 +31,31 @@ export const getLlmsTxtUrl = (): string => `${getAppOrigin()}/llms.txt`;
 
 export const getPostCanonicalUrl = (slug: string): string =>
   `${getAppOrigin()}/posts/${slug}`;
+
+const THIN_NOINDEX_POST_TYPES = [PostType.Brief, PostType.SocialTwitter];
+
+/** Structural subset of {@link Post} so non-page callers can reuse the gate. */
+export interface NoindexPostFields {
+  type: Post['type'];
+  private?: boolean;
+  source?: { public?: boolean };
+  author?: { reputation?: number };
+}
+
+export const shouldNoindexPost = (post: NoindexPostFields): boolean => {
+  // Posts in private squads normally fail the unauthenticated ISR fetch, but a
+  // cached page can outlive a squad turning private, so fail closed here too.
+  if (post?.private || post?.source?.public === false) {
+    return true;
+  }
+
+  const hasLowReputationAuthor =
+    typeof post?.author?.reputation === 'number' &&
+    post.author.reputation <= 10;
+
+  if (hasLowReputationAuthor) {
+    return true;
+  }
+
+  return THIN_NOINDEX_POST_TYPES.includes(post.type);
+};

--- a/packages/webapp/middleware.ts
+++ b/packages/webapp/middleware.ts
@@ -1,0 +1,31 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { acceptsMarkdown } from './lib/contentNegotiation';
+import { POST_MARKDOWN_PATH, RESERVED_POST_SLUGS } from './lib/markdownRoutes';
+
+const POSTS_PREFIX = '/posts/';
+
+export const config = {
+  matcher: '/posts/:id',
+};
+
+export function middleware(req: NextRequest): NextResponse {
+  const { pathname } = req.nextUrl;
+  const id = pathname.slice(POSTS_PREFIX.length);
+
+  // `.md` URLs are handled by the beforeFiles rewrite, which runs after
+  // middleware. Rewriting here too would pass the id along with its suffix.
+  if (
+    !id ||
+    id.endsWith('.md') ||
+    RESERVED_POST_SLUGS.includes(id) ||
+    !acceptsMarkdown(req.headers.get('accept'))
+  ) {
+    return NextResponse.next();
+  }
+
+  const url = req.nextUrl.clone();
+  url.pathname = `${POST_MARKDOWN_PATH}/${id}`;
+
+  return NextResponse.rewrite(url);
+}

--- a/packages/webapp/pages/api/md/posts/[id].ts
+++ b/packages/webapp/pages/api/md/posts/[id].ts
@@ -1,0 +1,114 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { ClientError } from 'graphql-request';
+import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import type { Comment } from '@dailydotdev/shared/src/graphql/comments';
+import type {
+  PostMarkdownPost,
+  SimilarPost,
+} from '../../../../lib/postMarkdown';
+import {
+  buildPostMarkdown,
+  getSimilarPostsVariables,
+  POST_MARKDOWN_COMMENTS_QUERY,
+  POST_MARKDOWN_QUERY,
+  POST_MARKDOWN_SIMILAR_QUERY,
+  TOP_COMMENTS_COUNT,
+} from '../../../../lib/postMarkdown';
+import { getAppOrigin, shouldNoindexPost } from '../../../../lib/seo';
+
+const appOrigin = getAppOrigin();
+
+const sendNotFound = (res: NextApiResponse, id: string): void => {
+  res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+  res.setHeader('Vary', 'Accept');
+  res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+  res
+    .status(404)
+    .send(
+      `# Not found\n\nNo public post is available at ${appOrigin}/posts/${id}.\n`,
+    );
+};
+
+const handler = async (
+  req: NextApiRequest,
+  res: NextApiResponse,
+): Promise<void> => {
+  if (req.method !== 'GET') {
+    res.status(405).send('Method not allowed');
+    return;
+  }
+
+  const id = Array.isArray(req.query.id) ? req.query.id[0] : req.query.id;
+
+  if (!id) {
+    sendNotFound(res, '');
+    return;
+  }
+
+  try {
+    const { post } = await gqlClient.request<{ post: PostMarkdownPost }>(
+      POST_MARKDOWN_QUERY,
+      { id },
+    );
+
+    // The same gate the HTML page uses for `noindex`. Private posts, private
+    // squads, low-reputation authors and thin post types get no markdown twin.
+    if (!post || shouldNoindexPost(post)) {
+      sendNotFound(res, id);
+      return;
+    }
+
+    const [comments, similar] = await Promise.all([
+      gqlClient
+        .request<{ topComments: Comment[] }>(POST_MARKDOWN_COMMENTS_QUERY, {
+          postId: post.id,
+          first: TOP_COMMENTS_COUNT,
+        })
+        .catch(() => ({ topComments: [] })),
+      gqlClient
+        .request<{ similarPosts: SimilarPost[] }>(
+          POST_MARKDOWN_SIMILAR_QUERY,
+          getSimilarPostsVariables(post),
+        )
+        .catch(() => ({ similarPosts: [] })),
+    ]);
+
+    const markdown = buildPostMarkdown({
+      post,
+      comments: comments.topComments ?? [],
+      similarPosts: similar.similarPosts ?? [],
+    });
+
+    res.setHeader('Content-Type', 'text/markdown; charset=utf-8');
+    // Set on the markdown variant only. The HTML page is ISR-cached and its
+    // negotiation happens in middleware, which runs before the CDN lookup, so
+    // adding Vary there would fragment the cache without changing behaviour.
+    res.setHeader('Vary', 'Accept');
+    res.setHeader(
+      'Cache-Control',
+      'public, s-maxage=86400, stale-while-revalidate=604800',
+    );
+    res.setHeader('Link', '</llms.txt>; rel="llms-txt"');
+    res.setHeader('X-Llms-Txt', '/llms.txt');
+    res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+    res.status(200).send(markdown);
+  } catch (error: unknown) {
+    const errorCode = (error as ClientError)?.response?.errors?.[0]?.extensions
+      ?.code;
+
+    if (errorCode === ApiError.NotFound || errorCode === ApiError.Forbidden) {
+      sendNotFound(res, id);
+      return;
+    }
+
+    // eslint-disable-next-line no-console
+    console.error('Error generating post markdown:', error);
+    res
+      .status(500)
+      .send(
+        `Unable to generate markdown. Please try again later or visit ${appOrigin}/posts/${id}`,
+      );
+  }
+};
+
+export default handler;

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -62,7 +62,7 @@ import {
 import type { DynamicSeoProps } from '../../../components/common';
 import { noindexSeoProps } from '../../../next-seo';
 import useSharedByToast from '../../../hooks/useSharedByToast';
-import { getPostCanonicalUrl } from '../../../lib/seo';
+import { getPostCanonicalUrl, shouldNoindexPost } from '../../../lib/seo';
 
 const Unauthorized = dynamic(
   () =>
@@ -149,8 +149,6 @@ export interface PostParams extends ParsedUrlQuery {
   id: string;
 }
 
-const THIN_NOINDEX_POST_TYPES = [PostType.Brief, PostType.SocialTwitter];
-
 export const seoTitle = (post: Post): string | undefined => {
   if (post?.title) {
     return post.title;
@@ -164,24 +162,6 @@ export const seoTitle = (post: Post): string | undefined => {
     ? `by ${post?.author?.username}`
     : `at ${post?.source?.name}`;
   return `Shared post ${sourceName}`;
-};
-
-export const shouldNoindexPost = (post: Post): boolean => {
-  // Posts in private squads normally fail the unauthenticated ISR fetch, but a
-  // cached page can outlive a squad turning private, so fail closed here too.
-  if (post?.private || post?.source?.public === false) {
-    return true;
-  }
-
-  const hasLowReputationAuthor =
-    typeof post?.author?.reputation === 'number' &&
-    post.author.reputation <= 10;
-
-  if (hasLowReputationAuthor) {
-    return true;
-  }
-
-  return THIN_NOINDEX_POST_TYPES.includes(post.type);
 };
 
 export const PostPage = ({


### PR DESCRIPTION
## What

Post pages now resolve as markdown two ways:

- `https://daily.dev/posts/<slug>.md`
- `Accept: text/markdown` sent to the normal post URL

This extends the pattern already used for `/sources.md`, `/tags.md` and `/squads/discover.md`, which until now were the only markdown surfaces the app exposed.

## Markdown shape

```markdown
---
title: "Why your React app re-renders twice"
url: https://daily.dev/posts/why-react-rerenders-twice-abc123
source_url: https://blog.example.com/react-rerenders
type: article
source: "The Pragmatic Engineer"
author: "Gergely Orosz"
published: 2026-07-14T09:12:00.000Z
tags: ["react", "webdev"]
reading_time: 7
upvotes: 412
comments: 38
---

# Why your React app re-renders twice

**[The Pragmatic Engineer](...)** · [@gergely](...) · 7 min read · 412 upvotes · 38 comments

## Summary
## Full article      (external posts link out; native posts inline `## Content`)
## Community take     (sentiment breakdown, pros/cons, highlights, source threads)
## Community discussion  (top 5 comments)
## Similar posts on daily.dev
```

`source_url` is always present. It falls back to the post's own canonical URL for daily.dev-native posts, which have no external link.

## Notes on the approach

**Why middleware.** Header negotiation cannot happen in `getStaticProps`, since the page is ISR-cached. Middleware is scoped by matcher to `/posts/:id` only.

**Why no `Vary: Accept` on the HTML.** Middleware runs before the CDN lookup on Vercel, so negotiation can never be bypassed by a cache hit. Setting `Vary` on the HTML variant would fragment the cache key across every browser's Accept string, on our highest-traffic pages, without changing behaviour. It is set on the markdown response only.

**Why wildcards do not match.** Only an explicit `text/markdown` or `text/x-markdown` that is not outranked by `text/html` triggers negotiation. Browsers fall back to `*/*` and curl sends nothing else, so honouring wildcards would serve markdown to everyone.

**Why external articles link out.** daily.dev does not hold the body for `article` and `video:youtube` posts, only title, AI summary, description and tags. Those link to the original source. Only freeform, welcome, share and collection posts inline their content.

**Gating.** `shouldNoindexPost` moves from the post page to `lib/seo` so the API route can reuse the same gate without importing a React page. Private posts, private squads, low-reputation authors and thin post types (Brief, SocialTwitter) get a 404 instead of a markdown twin. Briefs in particular are Plus-gated, so a `.md` route that skipped this would have been a leak. Responses carry `X-Robots-Tag: noindex, nofollow` so the twins never compete with the canonical HTML in search.

## Verification

- 26 tests passing across `PostMarkdown.spec.ts` (17 new), `ContentNegotiation.spec.ts` (5 new), `PostStaticProps.spec.ts`
- `typecheck-strict-changed` clean; full `tsc` shows no new errors (17 pre-existing in unrelated test files)
- `next build` compiles the middleware and registers the rewrite. Verified in the build output: matcher `^/posts(?:/([^/]+?))...$` and rewrite regex `^/posts(?:/([^/]+?))\.md(?:/)?$`. The build stops later at `/gear` prerender because the local API is unreachable, unrelated to this change.

Companion PR updates `llms.txt` on main-site, which currently states that app post pages are HTML only.

### Preview domain
https://claude-content-negotiation-ai-cr.preview.app.daily.dev