### PR TITLE
fix(feed): open the post modal with a shallow push

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -44,6 +44,7 @@ import defaultFeedPage from '../../__tests__/fixture/feed';
 import defaultUser from '../../__tests__/fixture/loggedUser';
 import ad from '../../__tests__/fixture/ad';
 import type { LoggedUser } from '../lib/user';
+import { webappUrl } from '../lib/constants';
 import {
   AcquisitionChannel,
   USER_ACQUISITION_MUTATION,
@@ -1327,6 +1328,54 @@ describe('Feed logged in', () => {
     const [first] = await screen.findAllByLabelText('Comments');
     fireEvent.click(first);
     await screen.findByRole('dialog');
+  });
+
+  it('should open the post modal with a shallow push', async () => {
+    const push = jest.fn().mockResolvedValue(true);
+    jest.mocked(useRouter).mockImplementation(() => ({
+      route: '/',
+      pathname: '/',
+      query: {},
+      asPath: '/',
+      push,
+      replace: jest.fn(),
+      basePath: '',
+      isLocaleDomain: true,
+      prefetch: jest.fn(),
+      beforePopState: jest.fn(),
+      reload: jest.fn(),
+      back: jest.fn(),
+      forward: jest.fn(),
+      isFallback: false,
+      isReady: true,
+      isPreview: false,
+      events: {
+        on: jest.fn(),
+        off: jest.fn(),
+        emit: jest.fn(),
+      },
+    }));
+
+    nock('http://localhost:3000')
+      .persist()
+      .post('/graphql', (body: { query?: string }) =>
+        Boolean(body.query?.includes('mutation ViewPost(')),
+      )
+      .reply(200, { data: { viewPost: { _: true } } });
+
+    renderComponent();
+    const [first] = await screen.findAllByLabelText(
+      'Eminem Quotes Generator - Simple PHP RESTful API',
+    );
+    fireEvent.click(first);
+
+    await waitFor(() =>
+      expect(push).toHaveBeenCalledWith(
+        expect.stringContaining('pmid=4f354bb73009e4adfa5dbcbf9b3c4ebf'),
+        `${webappUrl}posts/4f354bb73009e4adfa5dbcbf9b3c4ebf`,
+        { scroll: false, shallow: true },
+      ),
+    );
   });
 
   const createPostMock = (

--- a/packages/shared/src/hooks/usePostModalNavigation.ts
+++ b/packages/shared/src/hooks/usePostModalNavigation.ts
@@ -161,8 +161,12 @@ export const usePostModalNavigation = ({
           }),
         );
 
+        // shallow keeps the feed route: the masked `/posts/:id` URL matches the
+        // markdown middleware matcher, and a non-shallow push lets the server
+        // resolve it into a real post-page navigation instead of the modal
         await router.push(newPathname, `${webappUrl}posts/${postId}`, {
           scroll: false,
+          shallow: true,
         });
       }
       if (post?.type === PostType.Share) {


### PR DESCRIPTION
## Problem

Clicking a feed card navigates straight to the post page instead of opening the post modal.

## Cause

The modal is not a real navigation. `usePostModalNavigation` pushes the *feed* route with a `pmid` query param while masking the URL as `/posts/:slug`:

```ts
await router.push(newPathname, `${webappUrl}posts/${postId}`, { scroll: false });
//                ^ stays on the feed route                    ^ URL bar only
```

#6439 added the webapp's first `middleware.ts`, matching `/posts/:id`. Once any middleware exists, the pages router stops trusting the caller's `href` for a masked push:

- `router.js:948` — `isMiddlewareMatch = !options.shallow && await matchesMiddleware({ asPath: as, … })`
- `router.js:84` — the client tests **only the path regexp** (`has` conditions are server-side), so `/posts/:slug` matches
- `router.js:1059` — `if ('route' in routeInfo && isMiddlewareMatch) { pathname = routeInfo.route; route = pathname; }`

That last line discards the `href` and substitutes the server-resolved route for `as`, turning the modal push into a real `/posts/[id]` navigation.

The pre-existing `/posts/:id` rewrite in `next.config.ts` never caused this: config rewrites ship in the routes manifest and resolve client-side. Middleware forces a server round-trip and a route override. Webapp only; the extension has no Next middleware.

## Fix

`shallow: true` short-circuits the `isMiddlewareMatch` check, so the router keeps the feed route and the modal opens again.

## Verification

- New test `should open the post modal with a shallow push` clicks a real feed card and asserts the push args. Verified it fails on the unfixed code and passes with the fix.
- `shared` Feed suite 47/47; full `webapp` suite 55 suites / 418 tests green; ESLint clean.
- The strict-typecheck guard flags 13 errors in `usePostModalNavigation.ts`, all pre-existing: the identical set appears when running the same check against the untouched file at `main`.

## Known gaps

**Browser Forward back into an open modal** still hard-navigates. Next replays the history entry with `shallow: options.shallow && this._shallow` (`router.js:527`), and `this._shallow` reflects the entry being left (the feed, non-shallow), so the replay comes out non-shallow. Much narrower than the reported bug, and it lands on a valid post page rather than breaking.

**This fix is load-bearing in a non-obvious way.** Any future middleware matcher covering a path used as a masked `as` URL reintroduces the same class of bug, and only the new test guards it. Moving the markdown negotiation into a `beforeFiles` rewrite with a header `has` condition, or into the post page's `getServerSideProps`, would remove the hazard at the source. Worth doing as a follow-up; this unblocks the regression now.

https://claude.ai/code/session_012M55ANDSjkGna27sWkq2CZ

### Preview domain
https://fix-feed-card-modal-shallow-push.preview.app.daily.dev