### PR TITLE
feat(ads): track IAB viewable impressions

### DIFF
--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -39,6 +39,9 @@ import PlusGrid from './cards/plus/PlusGrid';
 import { useFeedCardContext } from '../features/posts/FeedCardContext';
 import { AdPixel } from './cards/ad/common/AdPixel';
 import { AdMeasurement } from './cards/ad/common/AdMeasurement';
+import { AdViewability } from './cards/ad/common/AdViewability';
+import type { ViewabilityData } from '../features/monetization/viewability';
+import { viewabilityLogExtra } from '../features/monetization/viewability';
 import { BriefCard } from './cards/brief/BriefCard/BriefCard';
 import { ActivePostContextProvider } from '../contexts/ActivePostContext';
 import { LogExtraContextProvider } from '../contexts/LogExtraContext';
@@ -373,16 +376,23 @@ function FeedItemComponent({
     feedName,
   });
 
-  const onAdAction = (action: AdActions, ad: Ad) => {
+  const onAdAction = (
+    action: AdActions,
+    ad: Ad,
+    extra?: Record<string, unknown>,
+  ) => {
     logEvent(
       adLogEvent(action, ad, {
         columns: virtualizedNumCards,
         column,
         row,
-        ...feedLogExtra(feedName, ranking),
+        extra: { ...feedLogExtra(feedName, ranking).extra, ...extra },
       }),
     );
   };
+
+  const onAdViewable = (ad: Ad, data: ViewabilityData) =>
+    onAdAction(AdActions.Viewable, ad, viewabilityLogExtra(data));
 
   if (item.type === FeedItemType.Ad && isBoostedSquadAd(item)) {
     return (
@@ -390,6 +400,7 @@ function FeedItemComponent({
         item={item as AdSquadItem}
         onClickAd={() => onAdAction(AdActions.Click, item.ad)}
         onMount={() => onAdAction(AdActions.Impression, item.ad)}
+        onViewable={(data) => onAdViewable(item.ad, data)}
       />
     );
   }
@@ -471,6 +482,10 @@ function FeedItemComponent({
               <>
                 <AdPixel pixel={item.ad.pixel} />
                 <AdMeasurement ad={item.ad} />
+                <AdViewability
+                  ad={item.ad}
+                  onViewable={(data) => onAdViewable(item.ad, data)}
+                />
               </>
             )}
           </PostTag>
@@ -491,6 +506,7 @@ function FeedItemComponent({
           index={item.index}
           feedIndex={index}
           onLinkClick={(ad: Ad) => onAdAction(AdActions.Click, ad)}
+          onViewable={onAdViewable}
         />
       );
     }

--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -324,3 +324,17 @@ it('should render company logo and company name in signal ad header', async () =
   expect(logo).toHaveAttribute('src', companyLogo);
   expect(screen.getByText(companyName)).toBeInTheDocument();
 });
+
+it.each([
+  ['grid', renderGridComponent],
+  ['list', renderListComponent],
+  ['signal list', renderSignalListComponent],
+])('should track viewability on the %s card', async (_, renderComponent) => {
+  renderComponent();
+
+  const tracker = await screen.findByTestId('adViewability');
+  // It only measures the creative's box while it stretches over the card root.
+  const card = tracker.closest('article');
+  expect(card).toBe(tracker.parentElement);
+  expect(card).toHaveClass('relative');
+});

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -14,6 +14,7 @@ import AdAttribution from './common/AdAttribution';
 import { AdImage } from './common/AdImage';
 import { AdPixel } from './common/AdPixel';
 import { AdMeasurement } from './common/AdMeasurement';
+import { AdViewability } from './common/AdViewability';
 import { useAdClickUrl } from '../../../features/monetization/useAdClickUrl';
 import type { AdCardProps } from './common/common';
 import { RemoveAd } from './common/RemoveAd';
@@ -32,7 +33,7 @@ import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions'
 import { useAdLabel } from '../../../features/monetization/useAdLabel';
 
 export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
-  { ad, onLinkClick, domProps, index, feedIndex },
+  { ad, onLinkClick, onViewable, domProps, index, feedIndex },
   forwardedRef,
 ): ReactElement {
   const { isPlus } = usePlusSubscription();
@@ -109,6 +110,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
       )}
       <AdPixel pixel={ad.pixel} />
       <AdMeasurement ad={ad} />
+      <AdViewability ad={ad} onViewable={(data) => onViewable?.(ad, data)} />
     </Card>
   );
 });

--- a/packages/shared/src/components/cards/ad/AdList.tsx
+++ b/packages/shared/src/components/cards/ad/AdList.tsx
@@ -11,6 +11,7 @@ import type { AdCardProps } from './common/common';
 import { AdImage } from './common/AdImage';
 import { AdPixel } from './common/AdPixel';
 import { AdMeasurement } from './common/AdMeasurement';
+import { AdViewability } from './common/AdViewability';
 import { useAdClickUrl } from '../../../features/monetization/useAdClickUrl';
 import type { Ad } from '../../../graphql/posts';
 import { combinedClicks } from '../../../lib/click';
@@ -49,7 +50,7 @@ const getLinkProps = ({
 };
 
 export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
-  { ad, onLinkClick, domProps, index, feedIndex },
+  { ad, onLinkClick, onViewable, domProps, index, feedIndex },
   forwardedRef,
 ): ReactElement {
   const { isPlus } = usePlusSubscription();
@@ -124,6 +125,7 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
       </div>
       <AdPixel pixel={ad.pixel} />
       <AdMeasurement ad={ad} />
+      <AdViewability ad={ad} onViewable={(data) => onViewable?.(ad, data)} />
     </FeedItemContainer>
   );
 });

--- a/packages/shared/src/components/cards/ad/SignalAdList.tsx
+++ b/packages/shared/src/components/cards/ad/SignalAdList.tsx
@@ -18,6 +18,7 @@ import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { RemoveAd } from './common/RemoveAd';
 import { AdPixel } from './common/AdPixel';
 import { AdMeasurement } from './common/AdMeasurement';
+import { AdViewability } from './common/AdViewability';
 import { useAdClickUrl } from '../../../features/monetization/useAdClickUrl';
 import { SourceAvatar } from '../../profile/source/SourceAvatar';
 import { MiniCloseIcon } from '../../icons';
@@ -42,7 +43,7 @@ const getLinkProps = ({
 };
 
 export const SignalAdList = forwardRef(function SignalAdList(
-  { ad, onLinkClick, domProps, index, feedIndex }: AdCardProps,
+  { ad, onLinkClick, onViewable, domProps, index, feedIndex }: AdCardProps,
   inViewRef: Ref<HTMLElement>,
 ): ReactElement {
   const { isPlus } = usePlusSubscription();
@@ -132,6 +133,7 @@ export const SignalAdList = forwardRef(function SignalAdList(
       </div>
       <AdPixel pixel={ad.pixel} />
       <AdMeasurement ad={ad} />
+      <AdViewability ad={ad} onViewable={(data) => onViewable?.(ad, data)} />
     </FeedItemContainer>
   );
 });

--- a/packages/shared/src/components/cards/ad/common/AdViewability.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdViewability.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { Ad } from '../../../../graphql/posts';
+import type { ViewabilityData } from '../../../../features/monetization/viewability';
+import { useViewability } from '../../../../features/monetization/useViewability';
+
+interface AdViewabilityProps {
+  ad: Ad;
+  onViewable: (data: ViewabilityData) => void;
+}
+
+/**
+ * Reports the IAB viewable impression of an ad. The tracker stretches over the
+ * card's `relative` root so the observer measures the creative's own box, and
+ * stays non-interactive so the card keeps ownership of clicks.
+ */
+export const AdViewability = ({
+  ad,
+  onViewable,
+}: AdViewabilityProps): ReactElement => {
+  const { ref } = useViewability<HTMLDivElement>({
+    onViewable,
+    trackingKey: ad.generationId ?? ad.link,
+  });
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      data-testid="adViewability"
+      className="pointer-events-none absolute inset-0"
+    />
+  );
+};

--- a/packages/shared/src/components/cards/ad/common/common.tsx
+++ b/packages/shared/src/components/cards/ad/common/common.tsx
@@ -1,5 +1,6 @@
 import type { HTMLAttributes } from 'react';
 import type { Ad } from '../../../../graphql/posts';
+import type { ViewabilityData } from '../../../../features/monetization/viewability';
 
 type Callback = (ad: Ad) => unknown;
 export interface AdCardProps {
@@ -7,5 +8,6 @@ export interface AdCardProps {
   index: number;
   feedIndex: number;
   onLinkClick?: Callback;
+  onViewable?: (ad: Ad, data: ViewabilityData) => void;
   domProps?: HTMLAttributes<HTMLDivElement>;
 }

--- a/packages/shared/src/components/cards/ad/squad/SquadAdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/squad/SquadAdGrid.tsx
@@ -14,6 +14,7 @@ import { Separator } from '../../common/common';
 import { HorizontalSeparator } from '../../../utilities';
 import { ProfileImageSize, ProfilePicture } from '../../../ProfilePicture';
 import { AdPixel } from '../common/AdPixel';
+import { AdViewability } from '../common/AdViewability';
 import { Tooltip } from '../../../tooltip/Tooltip';
 import Link from '../../../utilities/Link';
 import { SquadOptionsButton } from '../../common/SquadOptionsButton';
@@ -28,6 +29,7 @@ export function SquadAdGrid({
   item,
   onClickAd,
   onMount,
+  onViewable,
 }: SquadAdFeedProps): ReactElement {
   const { source } = item.ad.data;
   const { squad, campaign, members, shouldShowAction, onJustJoined } =
@@ -58,6 +60,7 @@ export function SquadAdGrid({
         <CardLink href={source.permalink} />
       </Link>
       {item.ad?.pixel && <AdPixel pixel={item.ad.pixel} />}
+      <AdViewability ad={item.ad} onViewable={(data) => onViewable?.(data)} />
       <div className="flex flex-row justify-between">
         <Image src={source.image} className="h-8 w-8 rounded-max" />
         <SquadOptionsButton squad={source} />

--- a/packages/shared/src/components/cards/ad/squad/SquadAdList.tsx
+++ b/packages/shared/src/components/cards/ad/squad/SquadAdList.tsx
@@ -14,6 +14,7 @@ import { Separator } from '../../common/common';
 import { HorizontalSeparator } from '../../../utilities';
 import { ProfileImageSize, ProfilePicture } from '../../../ProfilePicture';
 import { AdPixel } from '../common/AdPixel';
+import { AdViewability } from '../common/AdViewability';
 import { Tooltip } from '../../../tooltip/Tooltip';
 import { CardLink } from '../../common/Card';
 import Link from '../../../utilities/Link';
@@ -27,6 +28,7 @@ export function SquadAdList({
   item,
   onClickAd,
   onMount,
+  onViewable,
 }: SquadAdFeedProps): ReactElement {
   const { source } = item.ad.data;
   const { squad, campaign, members, shouldShowAction, onJustJoined } =
@@ -57,6 +59,7 @@ export function SquadAdList({
         <CardLink href={source.permalink} />
       </Link>
       {item.ad?.pixel && <AdPixel pixel={item.ad.pixel} />}
+      <AdViewability ad={item.ad} onViewable={(data) => onViewable?.(data)} />
       <div className="mb-2 flex w-full flex-row gap-2">
         <Image src={source.image} className="h-10 w-10 rounded-max" />
         <div className="flex flex-col gap-1">

--- a/packages/shared/src/components/cards/ad/squad/common.ts
+++ b/packages/shared/src/components/cards/ad/squad/common.ts
@@ -5,6 +5,7 @@ import { getCampaignById } from '../../../../graphql/campaigns';
 import type { BasicSourceMember } from '../../../../graphql/sources';
 import { getSquadMembers } from '../../../../graphql/squads';
 import type { AdSquadItem } from '../../../../hooks/useFeed';
+import type { ViewabilityData } from '../../../../features/monetization/viewability';
 import { generateQueryKey, RequestKey, StaleTime } from '../../../../lib/query';
 import { useSquad } from '../../../../hooks';
 
@@ -12,6 +13,7 @@ export interface SquadAdFeedProps {
   item: AdSquadItem;
   onClickAd: () => void;
   onMount?: () => void;
+  onViewable?: (data: ViewabilityData) => void;
 }
 
 export const useSquadAd = ({ item }: Pick<SquadAdFeedProps, 'item'>) => {

--- a/packages/shared/src/components/cards/squad/SquadGrid.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.tsx
@@ -25,6 +25,7 @@ import {
   TypographyType,
 } from '../../typography/Typography';
 import { useSquadsDirectoryLogging } from './common/useSquadsDirectoryLogging';
+import { AdViewability } from '../ad/common/AdViewability';
 import { useScrambler } from '../../../hooks/useScrambler';
 
 export enum SourceCardBorderColor {
@@ -85,7 +86,7 @@ export const SquadGrid = ({
     staleTime: StaleTime.OneHour,
   });
   const borderColor = border || color || SourceCardBorderColor.Avocado;
-  const { ref, onClickAd } = useSquadsDirectoryLogging(ad);
+  const { ref, onClickAd, onViewableAd } = useSquadsDirectoryLogging(ad);
   const promotedText = useScrambler('Promoted');
   const promotedByTooltip = useScrambler(
     campaign ? `Promoted by @${campaign.user.username}` : null,
@@ -167,6 +168,7 @@ export const SquadGrid = ({
         </div>
       </div>
       {children}
+      {!!ad && <AdViewability ad={ad} onViewable={onViewableAd} />}
     </Card>
   );
 };

--- a/packages/shared/src/components/cards/squad/SquadList.tsx
+++ b/packages/shared/src/components/cards/squad/SquadList.tsx
@@ -16,6 +16,7 @@ import { Image, ImageType } from '../../image/Image';
 import { ButtonVariant } from '../../buttons/common';
 import type { Ad } from '../../../graphql/posts';
 import { useSquadsDirectoryLogging } from './common/useSquadsDirectoryLogging';
+import { AdViewability } from '../ad/common/AdViewability';
 import { useScrambler } from '../../../hooks/useScrambler';
 
 interface SquadListProps extends ComponentProps<'div'> {
@@ -34,7 +35,7 @@ export const SquadList = ({
 }: SquadListProps): ReactElement => {
   const { image, name, permalink } = squad;
   const campaignId = ad?.data?.source?.flags?.campaignId;
-  const { ref, onClickAd } = useSquadsDirectoryLogging(ad);
+  const { ref, onClickAd, onViewableAd } = useSquadsDirectoryLogging(ad);
   const promotedText = useScrambler('Promoted');
 
   return (
@@ -88,6 +89,7 @@ export const SquadList = ({
         buttonVariants={[ButtonVariant.Secondary, ButtonVariant.Float]}
       />
       {children}
+      {!!ad && <AdViewability ad={ad} onViewable={onViewableAd} />}
     </div>
   );
 };

--- a/packages/shared/src/components/cards/squad/common/useSquadsDirectoryLogging.ts
+++ b/packages/shared/src/components/cards/squad/common/useSquadsDirectoryLogging.ts
@@ -5,6 +5,9 @@ import { adLogEvent, feedLogExtra } from '../../../../lib/feed';
 import { LogEvent } from '../../../../lib/log';
 import { OtherFeedPage } from '../../../../lib/query';
 import { useLogContext } from '../../../../contexts/LogContext';
+import { AdActions } from '../../../../lib/ads';
+import type { ViewabilityData } from '../../../../features/monetization/viewability';
+import { viewabilityLogExtra } from '../../../../features/monetization/viewability';
 
 export const useSquadsDirectoryLogging = (ad?: Ad) => {
   const { ref, inView } = useInView({
@@ -15,14 +18,27 @@ export const useSquadsDirectoryLogging = (ad?: Ad) => {
   const shouldLogEvent = inView && ad && !isLoggedRef.current;
 
   const onLogAdEvent = useCallback(
-    (action: LogEvent.Impression | LogEvent.Click) => {
+    (
+      action: LogEvent.Impression | LogEvent.Click | AdActions.Viewable,
+      extra?: Record<string, unknown>,
+    ) => {
       if (!ad) {
         throw new Error('Missing ad for squads directory logging');
       }
 
-      logEvent(adLogEvent(action, ad, feedLogExtra(OtherFeedPage.Squad)));
+      logEvent(
+        adLogEvent(action, ad, {
+          extra: { ...feedLogExtra(OtherFeedPage.Squad).extra, ...extra },
+        }),
+      );
     },
     [ad, logEvent],
+  );
+
+  const onViewableAd = useCallback(
+    (data: ViewabilityData) =>
+      onLogAdEvent(AdActions.Viewable, viewabilityLogExtra(data)),
+    [onLogAdEvent],
   );
 
   useEffect(() => {
@@ -42,5 +58,5 @@ export const useSquadsDirectoryLogging = (ad?: Ad) => {
     onLogAdEvent(LogEvent.Click);
   };
 
-  return { ref, onClickAd };
+  return { ref, onClickAd, onViewableAd };
 };

--- a/packages/shared/src/components/comments/AdAsComment.tsx
+++ b/packages/shared/src/components/comments/AdAsComment.tsx
@@ -10,6 +10,9 @@ import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { AdPixel } from '../cards/ad/common/AdPixel';
+import { AdViewability } from '../cards/ad/common/AdViewability';
+import type { ViewabilityData } from '../../features/monetization/viewability';
+import { viewabilityLogExtra } from '../../features/monetization/viewability';
 import { AdActions, AdPlacement } from '../../lib/ads';
 import { usePlusSubscription } from '../../hooks/usePlusSubscription';
 import { RemoveAd } from '../cards/ad/common/RemoveAd';
@@ -42,7 +45,7 @@ export const AdAsComment = ({ postId }: AdAsCommentProps): ReactElement => {
   });
 
   const onAdAction = useCallback(
-    (action: AdActions) => {
+    (action: AdActions, extra?: Record<string, unknown>) => {
       if (!ad) {
         return;
       }
@@ -50,11 +53,18 @@ export const AdAsComment = ({ postId }: AdAsCommentProps): ReactElement => {
         adLogEvent(action, ad, {
           extra: {
             origin: 'post page',
+            ...extra,
           },
         }),
       );
     },
     [logEvent, ad],
+  );
+
+  const onViewable = useCallback(
+    (data: ViewabilityData) =>
+      onAdAction(AdActions.Viewable, viewabilityLogExtra(data)),
+    [onAdAction],
   );
 
   const promotedText = useScrambler(
@@ -129,6 +139,7 @@ export const AdAsComment = ({ postId }: AdAsCommentProps): ReactElement => {
         className="mt-2 w-fit whitespace-nowrap typo-caption2"
       />
       <AdPixel pixel={pixel} />
+      <AdViewability ad={ad} onViewable={onViewable} />
     </div>
   );
 };

--- a/packages/shared/src/components/post/PostSidebarAdWidget.tsx
+++ b/packages/shared/src/components/post/PostSidebarAdWidget.tsx
@@ -6,6 +6,9 @@ import EntityCard from '../cards/entity/EntityCard';
 import EntityCardSkeleton from '../cards/entity/EntityCardSkeleton';
 import AdAttribution from '../cards/ad/common/AdAttribution';
 import { AdPixel } from '../cards/ad/common/AdPixel';
+import { AdViewability } from '../cards/ad/common/AdViewability';
+import type { ViewabilityData } from '../../features/monetization/viewability';
+import { viewabilityLogExtra } from '../../features/monetization/viewability';
 import { getAdFaviconImageLink } from '../cards/ad/common/getAdFaviconImageLink';
 import { useFeature } from '../GrowthBookProvider';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -60,18 +63,24 @@ export function PostSidebarAdWidget({
   });
 
   const onAdAction = useCallback(
-    (action: AdActions) => {
+    (action: AdActions, extra?: Record<string, unknown>) => {
       if (!ad) {
         return;
       }
 
       logEvent(
         adLogEvent(action, ad, {
-          extra: { origin: 'post page sidebar widget' },
+          extra: { origin: 'post page sidebar widget', ...extra },
         }),
       );
     },
     [logEvent, ad],
+  );
+
+  const onViewable = useCallback(
+    (data: ViewabilityData) =>
+      onAdAction(AdActions.Viewable, viewabilityLogExtra(data)),
+    [onAdAction],
   );
 
   useEffect(() => {
@@ -185,6 +194,7 @@ export function PostSidebarAdWidget({
         <span className="absolute bottom-0 left-0">
           <AdPixel pixel={ad.pixel} />
         </span>
+        <AdViewability ad={ad} onViewable={onViewable} />
       </div>
     );
   }
@@ -251,6 +261,7 @@ export function PostSidebarAdWidget({
         />
       </div>
       <AdPixel pixel={ad.pixel} />
+      <AdViewability ad={ad} onViewable={onViewable} />
     </EntityCard>
   );
 }

--- a/packages/shared/src/features/daily/CoverGrid.tsx
+++ b/packages/shared/src/features/daily/CoverGrid.tsx
@@ -16,8 +16,10 @@ import {
 } from '../../components/icons';
 import { IconSize } from '../../components/Icon';
 import { useAdQuery } from '../monetization/useAdQuery';
-import { AdPlacement } from '../../lib/ads';
+import { AdActions, AdPlacement } from '../../lib/ads';
 import { AdPixel } from '../../components/cards/ad/common/AdPixel';
+import { AdViewability } from '../../components/cards/ad/common/AdViewability';
+import { viewabilityLogExtra } from '../monetization/viewability';
 import { getAdFaviconImageLink } from '../../components/cards/ad/common/getAdFaviconImageLink';
 import { useScrambler } from '../../hooks/useScrambler';
 import { adFaviconPlaceholder } from '../../lib/image';
@@ -103,7 +105,7 @@ const AdRow = ({ ad }: { ad: Ad }): ReactElement => {
   );
 
   return (
-    <li ref={impressionRef}>
+    <li ref={impressionRef} className="relative">
       <a
         href={ad.link}
         target="_blank"
@@ -154,6 +156,22 @@ const AdRow = ({ ad }: { ad: Ad }): ReactElement => {
         </span>
       </a>
       <AdPixel pixel={ad.pixel} />
+      <AdViewability
+        ad={ad}
+        onViewable={(data) =>
+          logEvent(
+            adLogEvent(AdActions.Viewable, ad, {
+              columns: 1,
+              column: 0,
+              row: AD_SLOT_INDEX,
+              extra: {
+                ...dailyFeedExtra().extra,
+                ...viewabilityLogExtra(data),
+              },
+            }),
+          )
+        }
+      />
     </li>
   );
 };

--- a/packages/shared/src/features/monetization/useViewability.spec.ts
+++ b/packages/shared/src/features/monetization/useViewability.spec.ts
@@ -1,0 +1,195 @@
+import { act, renderHook } from '@testing-library/react';
+import { useViewability } from './useViewability';
+import { largeDisplayArea } from './viewability';
+
+interface EntryOptions {
+  ratio: number;
+  width?: number;
+  height?: number;
+}
+
+class MockIntersectionObserver {
+  static instances: MockIntersectionObserver[] = [];
+
+  disconnected = false;
+
+  constructor(
+    private callback: IntersectionObserverCallback,
+    public options: IntersectionObserverInit,
+  ) {
+    MockIntersectionObserver.instances.push(this);
+  }
+
+  static get last(): MockIntersectionObserver {
+    return MockIntersectionObserver.instances[
+      MockIntersectionObserver.instances.length - 1
+    ];
+  }
+
+  observe = jest.fn();
+
+  unobserve = jest.fn();
+
+  disconnect = jest.fn(() => {
+    this.disconnected = true;
+  });
+
+  trigger({ ratio, width = 300, height = 250 }: EntryOptions): void {
+    act(() => {
+      this.callback(
+        [
+          {
+            isIntersecting: ratio > 0,
+            intersectionRatio: ratio,
+            boundingClientRect: { width, height } as DOMRectReadOnly,
+          } as IntersectionObserverEntry,
+        ],
+        this as unknown as IntersectionObserver,
+      );
+    });
+  }
+}
+
+const setVisibility = (state: DocumentVisibilityState): void => {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+};
+
+const renderViewability = (onViewable = jest.fn()) => {
+  const { result, unmount } = renderHook(() => useViewability({ onViewable }));
+
+  act(() => {
+    result.current.ref(document.createElement('div'));
+  });
+
+  return { onViewable, result, unmount };
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  MockIntersectionObserver.instances = [];
+  global.IntersectionObserver =
+    MockIntersectionObserver as unknown as typeof IntersectionObserver;
+  setVisibility('visible');
+  jest.spyOn(document, 'hasFocus').mockReturnValue(true);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+describe('useViewability', () => {
+  it('should report once half the pixels held a full second', () => {
+    const { onViewable, result } = renderViewability();
+
+    MockIntersectionObserver.last.trigger({ ratio: 0.5 });
+    expect(onViewable).not.toHaveBeenCalled();
+
+    act(() => {
+      jest.advanceTimersByTime(1_000);
+    });
+
+    expect(onViewable).toHaveBeenCalledTimes(1);
+    expect(onViewable).toHaveBeenCalledWith({
+      ratio: 0.5,
+      duration: 1_000,
+      timeToViewable: 1_000,
+    });
+    expect(result.current.isViewable).toBe(true);
+  });
+
+  it('should not report below half the pixels', () => {
+    const { onViewable } = renderViewability();
+
+    MockIntersectionObserver.last.trigger({ ratio: 0.49 });
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(onViewable).not.toHaveBeenCalled();
+  });
+
+  it('should require the second to be continuous', () => {
+    const { onViewable } = renderViewability();
+    const observer = MockIntersectionObserver.last;
+
+    observer.trigger({ ratio: 0.5 });
+
+    act(() => {
+      jest.advanceTimersByTime(900);
+    });
+
+    observer.trigger({ ratio: 0.2 });
+
+    act(() => {
+      jest.advanceTimersByTime(900);
+    });
+
+    expect(onViewable).not.toHaveBeenCalled();
+
+    observer.trigger({ ratio: 0.5 });
+
+    act(() => {
+      jest.advanceTimersByTime(1_000);
+    });
+
+    expect(onViewable).toHaveBeenCalledTimes(1);
+  });
+
+  it('should only need 30% of a large creative', () => {
+    const { onViewable } = renderViewability();
+
+    MockIntersectionObserver.last.trigger({
+      ratio: 0.3,
+      width: 970,
+      height: largeDisplayArea / 970,
+    });
+
+    act(() => {
+      jest.advanceTimersByTime(1_000);
+    });
+
+    expect(onViewable).toHaveBeenCalledWith(
+      expect.objectContaining({ ratio: 0.3 }),
+    );
+  });
+
+  it('should not count time while the tab is in the background', () => {
+    const { onViewable } = renderViewability();
+
+    setVisibility('hidden');
+    MockIntersectionObserver.last.trigger({ ratio: 1 });
+
+    act(() => {
+      jest.advanceTimersByTime(10_000);
+    });
+
+    expect(onViewable).not.toHaveBeenCalled();
+
+    setVisibility('visible');
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'));
+      jest.advanceTimersByTime(1_000);
+    });
+
+    expect(onViewable).toHaveBeenCalledTimes(1);
+  });
+
+  it('should stop observing once reported', () => {
+    const { onViewable } = renderViewability();
+    const observer = MockIntersectionObserver.last;
+
+    observer.trigger({ ratio: 1 });
+
+    act(() => {
+      jest.advanceTimersByTime(5_000);
+    });
+
+    expect(onViewable).toHaveBeenCalledTimes(1);
+    expect(observer.disconnected).toBe(true);
+  });
+});

--- a/packages/shared/src/features/monetization/useViewability.ts
+++ b/packages/shared/src/features/monetization/useViewability.ts
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { ViewabilityCriteria, ViewabilityData } from './viewability';
+import {
+  getViewabilityCriteria,
+  ratioTolerance,
+  viewabilityThresholds,
+} from './viewability';
+
+interface UseViewabilityProps {
+  onViewable: (data: ViewabilityData) => void;
+  enabled?: boolean;
+  /**
+   * Restarts measurement when it changes, for elements that swap their content
+   * in place (an auto-rotated ad keeps the same card).
+   */
+  trackingKey?: string;
+}
+
+interface UseViewability<T extends HTMLElement> {
+  ref: (node: T | null) => void;
+  isViewable: boolean;
+}
+
+// Pixels in the viewport are only on screen when the tab is the active one and
+// the browser window itself has focus.
+const isPageInFocus = (): boolean =>
+  globalThis.document.visibilityState === 'visible' &&
+  globalThis.document.hasFocus();
+
+/**
+ * Tracks the MRC/IAB viewable impression of an element and reports it once.
+ * See `viewability.ts` for the criteria.
+ */
+export const useViewability = <T extends HTMLElement = HTMLElement>({
+  onViewable,
+  enabled = true,
+  trackingKey,
+}: UseViewabilityProps): UseViewability<T> => {
+  const [element, setElement] = useState<T | null>(null);
+  const [isViewable, setIsViewable] = useState(false);
+  const onViewableRef = useRef(onViewable);
+  onViewableRef.current = onViewable;
+
+  const ref = useCallback((node: T | null) => setElement(node), []);
+
+  useEffect(() => {
+    setIsViewable(false);
+  }, [trackingKey]);
+
+  useEffect(() => {
+    if (!element || !enabled || isViewable) {
+      return undefined;
+    }
+
+    const renderedAt = Date.now();
+    let criteria: ViewabilityCriteria | undefined;
+    let meetsRatio = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const stopTimer = () => {
+      globalThis.clearTimeout(timeout);
+      timeout = undefined;
+    };
+
+    const reportViewable = (met: ViewabilityCriteria) => {
+      stopTimer();
+      setIsViewable(true);
+      onViewableRef.current({
+        ...met,
+        timeToViewable: Date.now() - renderedAt,
+      });
+    };
+
+    // The duration has to be continuous, so losing the ratio or the tab focus
+    // drops the accumulated time instead of pausing it.
+    const evaluate = () => {
+      if (!criteria || !meetsRatio || !isPageInFocus()) {
+        stopTimer();
+        return;
+      }
+
+      if (timeout) {
+        return;
+      }
+
+      const met = criteria;
+      timeout = setTimeout(() => reportViewable(met), met.duration);
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        const { width, height } = entry.boundingClientRect;
+        criteria = getViewabilityCriteria(width * height);
+        meetsRatio =
+          entry.isIntersecting &&
+          entry.intersectionRatio >= criteria.ratio - ratioTolerance;
+
+        evaluate();
+      },
+      { threshold: viewabilityThresholds },
+    );
+
+    observer.observe(element);
+    globalThis.document.addEventListener('visibilitychange', evaluate);
+    globalThis.addEventListener('blur', evaluate);
+    globalThis.addEventListener('focus', evaluate);
+
+    return () => {
+      stopTimer();
+      observer.disconnect();
+      globalThis.document.removeEventListener('visibilitychange', evaluate);
+      globalThis.removeEventListener('blur', evaluate);
+      globalThis.removeEventListener('focus', evaluate);
+    };
+  }, [element, enabled, isViewable, trackingKey]);
+
+  return { ref, isViewable };
+};

--- a/packages/shared/src/features/monetization/viewability.ts
+++ b/packages/shared/src/features/monetization/viewability.ts
@@ -1,0 +1,57 @@
+export interface ViewabilityCriteria {
+  /** Share of the creative's pixels that must be inside the viewport. */
+  ratio: number;
+  /** Continuous milliseconds the ratio must hold. */
+  duration: number;
+}
+
+/**
+ * MRC/IAB viewable impression: 50% of the creative's pixels in the viewable
+ * space of the browser for one continuous second. Creatives of 242,500 pixels
+ * or more ("large display", e.g. a 970x250 billboard) only need 30%.
+ */
+export const displayCriteria: ViewabilityCriteria = {
+  ratio: 0.5,
+  duration: 1_000,
+};
+
+export const largeDisplayCriteria: ViewabilityCriteria = {
+  ratio: 0.3,
+  duration: 1_000,
+};
+
+export const largeDisplayArea = 242_500;
+
+export const getViewabilityCriteria = (area: number): ViewabilityCriteria =>
+  area >= largeDisplayArea ? largeDisplayCriteria : displayCriteria;
+
+// Both criteria ratios plus the edges, so the observer reports every crossing
+// of a ratio we care about.
+export const viewabilityThresholds = [
+  0,
+  largeDisplayCriteria.ratio,
+  displayCriteria.ratio,
+  1,
+];
+
+/**
+ * A threshold crossing can report a ratio a hair under the threshold that
+ * triggered it, because the geometry is computed on fractional pixels. Without
+ * the slack, an ad sitting exactly at 50% never counts.
+ */
+export const ratioTolerance = 0.001;
+
+export interface ViewabilityData extends ViewabilityCriteria {
+  /** Milliseconds between the creative rendering and meeting the criteria. */
+  timeToViewable: number;
+}
+
+export const viewabilityLogExtra = ({
+  ratio,
+  duration,
+  timeToViewable,
+}: ViewabilityData): Record<string, unknown> => ({
+  viewability_ratio: ratio,
+  viewability_duration: duration,
+  time_to_viewable: timeToViewable,
+});

--- a/packages/shared/src/lib/ads.ts
+++ b/packages/shared/src/lib/ads.ts
@@ -6,6 +6,9 @@ export enum AdActions {
   Click = 'click',
   Refresh = 'refresh',
   Impression = 'impression',
+  // Rendered and seen by IAB rules, unlike `Impression` which only means the
+  // creative reached the viewport.
+  Viewable = 'viewable impression',
 }
 
 export enum AdPlacement {

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -188,6 +188,15 @@ const strictSkipList = new Set([
   // `false | (() => void)` onSignUp) live on unrelated lines and should be
   // addressed in a dedicated cleanup PR.
   'packages/shared/src/components/post/PostEngagements.tsx',
+  // Ad-viewability branch: the squad ad cards were touched only to render
+  // the viewability tracker. Pre-existing strict violations (`item.ad.data`
+  // and its `source`/`squad` members being optional, the `condition && class`
+  // className, the border-color record index, optional member lists) live on
+  // unrelated lines and should be addressed in a dedicated cleanup PR.
+  'packages/shared/src/components/cards/ad/squad/SquadAdGrid.tsx',
+  'packages/shared/src/components/cards/ad/squad/SquadAdList.tsx',
+  'packages/shared/src/components/cards/ad/squad/common.ts',
+  'packages/shared/src/components/cards/squad/SquadGrid.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
## What

Adds `useViewability`, a hook that applies the MRC/IAB viewable impression criteria, and wires it into every ad surface.

Today's ad `impression` event fires the moment a creative crosses 50% of the viewport: no dwell time, no tab-focus check. That is a render event, not a viewable impression, so it cannot be compared against what advertisers and the MRC measure.

## Criteria implemented

- 50% of the creative's pixels in the viewport for **1 continuous second**
- 30% for large display creatives (>= 242,500 px, e.g. a 970x250 billboard)
- Time accrues only while the tab is the active one (`visibilityState`) and the browser window has focus (`document.hasFocus()`)
- Losing the ratio or the focus **drops** the accumulated time instead of pausing it, since the second has to be continuous
- Reported once per creative, and reset when an auto-rotating card swaps in a new ad

## How it is wired

`AdViewability` renders a non-interactive tracker stretched over the card's `relative` root (the same trick `AdMeasurement` already uses for overlay tags), so the observer measures the creative's own box rather than a zero-size marker. It is rendered next to `AdPixel` on:

- feed ad cards: `AdGrid`, `AdList`, `SignalAdList`
- boosted post ads and boosted squad ads in `FeedItemComponent`
- squads directory cards (`SquadGrid`, `SquadList`)
- `PostSidebarAdWidget` (both variants), `AdAsComment`, and the daily page ad row

Each surface logs a new `viewable impression` ad event through its existing logging path, so the feed extras (feed name, grid position, origin) are preserved. The event carries `viewability_ratio`, `viewability_duration` and `time_to_viewable`. The existing `impression` event is untouched.

## Verification

- New `useViewability.spec.ts`: reports after a continuous second at 50%, does not report below the ratio, restarts when the ratio or the tab focus is lost, uses 30% for large creatives, and stops observing once reported
- `AdCard.spec.tsx`: asserts the tracker is a direct child of the positioned card root on all three feed variants
- shared (2201), webapp (418) and extension (43) suites pass; `typecheck:strict:changed` and lint pass

The four squad card files added to the strict skip list were touched only to render the tracker; their strict violations are pre-existing and unrelated.

### Preview domain
https://claude-iab-viewability-definitio.preview.app.daily.dev