### PR TITLE
feat(ads): re-fire our own pixel with viewed=true

### DIFF
--- a/packages/shared/src/components/cards/ad/common/AdPixel.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdPixel.tsx
@@ -6,17 +6,31 @@ import { isTesting } from '../../../../lib/constants';
 import { substituteMacros } from '../../../../features/monetization/adMacros';
 import { useAdMacroContext } from '../../../../features/monetization/useAdMacroContext';
 
-export const AdPixel = ({ pixel }: Pick<Ad, 'pixel'>): ReactElement => {
+interface AdPixelProps extends Pick<Ad, 'pixel'> {
+  /**
+   * Skips the viewport gate, for pixels that are only rendered once the ad is
+   * known to be on screen. Without it the pixel would wait for this span's own
+   * corner to scroll in, which can be well after the creative itself is up.
+   */
+  fireOnMount?: boolean;
+}
+
+export const AdPixel = ({
+  pixel,
+  fireOnMount = false,
+}: AdPixelProps): ReactElement => {
   const { ref, inView } = useInView({
     triggerOnce: true,
     initialInView: isTesting, // interection observer in tests
     fallbackInView: true, // for old browsers missing intersection observer
+    skip: fireOnMount,
   });
+  const shouldFire = fireOnMount || inView;
 
   // Fill cachebuster/consent macros before firing. Waiting for a resolved
   // context avoids firing an impression twice (once with empty consent, once
   // filled), which would double-count.
-  const ctx = useAdMacroContext(inView && !!pixel?.length);
+  const ctx = useAdMacroContext(shouldFire && !!pixel?.length);
 
   // Memoized so re-renders keep the same cachebuster — a new value would change
   // `src` and make the browser refetch, counting the impression again.
@@ -28,7 +42,7 @@ export const AdPixel = ({ pixel }: Pick<Ad, 'pixel'>): ReactElement => {
 
   return (
     <span ref={ref} className="size-0">
-      {inView &&
+      {shouldFire &&
         sources?.map(({ key, src }) => (
           <img
             src={src}

--- a/packages/shared/src/components/cards/ad/common/AdViewability.spec.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdViewability.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import ad from '../../../../../__tests__/fixture/ad';
+import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
+import { AdViewability } from './AdViewability';
+
+const ownPixel = 'https://api.daily.dev/a/imp';
+const thirdPartyPixel = 'https://ads.example.com/imp';
+
+let observerCallback: IntersectionObserverCallback;
+
+const mockObserver = (): void => {
+  global.IntersectionObserver = jest.fn().mockImplementation((callback) => {
+    observerCallback = callback;
+
+    return {
+      observe: jest.fn(),
+      unobserve: jest.fn(),
+      disconnect: jest.fn(),
+    };
+  }) as unknown as typeof IntersectionObserver;
+};
+
+const becomeViewable = (): void => {
+  act(() => {
+    observerCallback(
+      [
+        {
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+          boundingClientRect: { width: 300, height: 250 } as DOMRectReadOnly,
+        } as IntersectionObserverEntry,
+      ],
+      null as unknown as IntersectionObserver,
+    );
+  });
+
+  act(() => {
+    jest.advanceTimersByTime(1_000);
+  });
+};
+
+const renderComponent = (pixel?: string[]): void => {
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <AdViewability ad={{ ...ad, pixel }} onViewable={jest.fn()} />
+    </TestBootProvider>,
+  );
+};
+
+const getPixelSources = (): string[] =>
+  screen.queryAllByTestId('pixel').map((el) => el.getAttribute('src') ?? '');
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockObserver();
+  jest.spyOn(document, 'hasFocus').mockReturnValue(true);
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+  jest.restoreAllMocks();
+});
+
+it('should re-fire our own pixel as viewed once the ad is viewable', () => {
+  renderComponent([ownPixel]);
+
+  expect(getPixelSources()).toHaveLength(0);
+
+  becomeViewable();
+
+  expect(getPixelSources()).toEqual([`${ownPixel}?viewed=true`]);
+});
+
+it('should not re-fire third party pixels', () => {
+  renderComponent([thirdPartyPixel, ownPixel]);
+
+  becomeViewable();
+
+  expect(getPixelSources()).toEqual([`${ownPixel}?viewed=true`]);
+});
+
+it('should not fire anything before the ad is viewable', () => {
+  renderComponent([ownPixel]);
+
+  act(() => {
+    observerCallback(
+      [
+        {
+          isIntersecting: true,
+          intersectionRatio: 0.5,
+          boundingClientRect: { width: 300, height: 250 } as DOMRectReadOnly,
+        } as IntersectionObserverEntry,
+      ],
+      null as unknown as IntersectionObserver,
+    );
+  });
+
+  act(() => {
+    jest.advanceTimersByTime(900);
+  });
+
+  expect(getPixelSources()).toHaveLength(0);
+});

--- a/packages/shared/src/components/cards/ad/common/AdViewability.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdViewability.tsx
@@ -1,8 +1,10 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import type { Ad } from '../../../../graphql/posts';
 import type { ViewabilityData } from '../../../../features/monetization/viewability';
 import { useViewability } from '../../../../features/monetization/useViewability';
+import { AdPixel } from './AdPixel';
+import { getViewedPixels } from './getViewedPixels';
 
 interface AdViewabilityProps {
   ad: Ad;
@@ -13,22 +15,33 @@ interface AdViewabilityProps {
  * Reports the IAB viewable impression of an ad. The tracker stretches over the
  * card's `relative` root so the observer measures the creative's own box, and
  * stays non-interactive so the card keeps ownership of clicks.
+ *
+ * Our own pixels fire a second time with `viewed=true` once the criteria are
+ * met, so the ad server counts the viewable impression from the same tracker
+ * it already counts the render with.
  */
 export const AdViewability = ({
   ad,
   onViewable,
 }: AdViewabilityProps): ReactElement => {
-  const { ref } = useViewability<HTMLDivElement>({
+  const { ref, isViewable } = useViewability<HTMLDivElement>({
     onViewable,
     trackingKey: ad.generationId ?? ad.link,
   });
+  const viewedPixels = useMemo(() => getViewedPixels(ad.pixel), [ad.pixel]);
 
+  // The viewed pixel rides inside the tracker so it stays out of flow: cards
+  // that space their children with `gap-*` would otherwise grow by one gap.
   return (
     <div
       ref={ref}
       aria-hidden
       data-testid="adViewability"
       className="pointer-events-none absolute inset-0"
-    />
+    >
+      {isViewable && !!viewedPixels.length && (
+        <AdPixel pixel={viewedPixels} fireOnMount />
+      )}
+    </div>
   );
 };

--- a/packages/shared/src/components/cards/ad/common/getViewedPixels.spec.ts
+++ b/packages/shared/src/components/cards/ad/common/getViewedPixels.spec.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-template-curly-in-string -- literal macro tokens */
+import { getViewedPixels } from './getViewedPixels';
+
+describe('getViewedPixels', () => {
+  it('should mark our own pixels as viewed', () => {
+    expect(getViewedPixels(['https://api.daily.dev/a/imp'])).toEqual([
+      'https://api.daily.dev/a/imp?viewed=true',
+    ]);
+  });
+
+  it('should keep an existing query string', () => {
+    expect(getViewedPixels(['https://api.daily.dev/a/imp?id=1'])).toEqual([
+      'https://api.daily.dev/a/imp?id=1&viewed=true',
+    ]);
+  });
+
+  it('should leave macro tokens untouched', () => {
+    expect(
+      getViewedPixels(['https://api.daily.dev/a/imp?ord=[timestamp]']),
+    ).toEqual(['https://api.daily.dev/a/imp?ord=[timestamp]&viewed=true']);
+    expect(
+      getViewedPixels(['https://api.daily.dev/a/imp?cb=${CACHEBUSTER}']),
+    ).toEqual(['https://api.daily.dev/a/imp?cb=${CACHEBUSTER}&viewed=true']);
+  });
+
+  it('should skip third party pixels', () => {
+    expect(
+      getViewedPixels([
+        'https://ads.example.com/imp',
+        'https://api.daily.dev.evil.com/imp',
+        'https://daily.dev/imp',
+        'not a url',
+      ]),
+    ).toEqual([]);
+  });
+
+  it('should handle an ad without pixels', () => {
+    expect(getViewedPixels()).toEqual([]);
+    expect(getViewedPixels([])).toEqual([]);
+  });
+});

--- a/packages/shared/src/components/cards/ad/common/getViewedPixels.ts
+++ b/packages/shared/src/components/cards/ad/common/getViewedPixels.ts
@@ -1,0 +1,21 @@
+// Only our own ad server understands the viewed signal. Third party pixels are
+// contracted to fire once per impression, so re-firing them would double count.
+const ownPixelHost = 'api.daily.dev';
+
+const isOwnPixel = (url: string): boolean => {
+  try {
+    return new URL(url).hostname === ownPixelHost;
+  } catch {
+    // A tracker we cannot parse is not ours to re-fire.
+    return false;
+  }
+};
+
+// Appended by hand rather than through `URL`, whose serializer percent-encodes
+// the macro tokens (`[timestamp]`, `${CACHEBUSTER}`) and would leave nothing
+// for `substituteMacros` to match.
+const appendViewed = (url: string): string =>
+  `${url}${url.includes('?') ? '&' : '?'}viewed=true`;
+
+export const getViewedPixels = (pixel?: string[]): string[] =>
+  pixel?.filter(isOwnPixel).map(appendViewed) ?? [];


### PR DESCRIPTION
Follow-up to #6441.

## What

Once an ad meets the IAB viewability criteria, its impression pixel fires a second time with a `viewed=true` query param, so the ad server counts the viewable impression from the same tracker it already counts the render with.

**Only pixels served from `api.daily.dev` are repeated.** Third party trackers are contracted to fire once per impression, so re-firing them would double count.

## Details worth a look

- The param is appended by hand rather than through `URL`. Its serializer percent-encodes the macro tokens (`[timestamp]`, `${CACHEBUSTER}`) into `%5Btimestamp%5D`, which would leave nothing for `substituteMacros` to match and would ship a literal macro to the server.
- The viewed pixel renders **inside** the viewability tracker, which is already `absolute inset-0`. Rendered as a sibling it would be an in-flow zero-size span, and cards that space children with `gap-*` (e.g. `SquadAdGrid`'s `gap-3`) would grow by one gap.
- New `fireOnMount` prop on `AdPixel` skips the viewport gate. At this point the ad is known to be on screen, and waiting for the pixel span's own corner to scroll into view could delay the call well past the moment it describes. Existing consumers keep their exact DOM and behaviour.
- Each call gets a fresh cachebuster, since `substituteMacros` generates one per call, so the two requests are distinct.

## Tests

- `getViewedPixels.spec.ts`: our host only, existing query strings preserved, macro tokens left intact, third party and lookalike hosts (`api.daily.dev.evil.com`) skipped, missing pixels handled
- `AdViewability.spec.tsx`: drives a controllable IntersectionObserver, asserts nothing fires before the continuous second elapses and that only our pixel is re-fired after it

shared (2215) and webapp (418) suites pass; strict typecheck and lint clean.

## Note

The host check is a literal `api.daily.dev`, as specified, so viewed pixels will not fire against staging or local API hosts. Say the word if you would rather match the configured API host instead, it is a one-line change.

### Preview domain
https://claude-ad-viewed-pixel.preview.app.daily.dev