### PR TITLE
feat(profile): a toggle from the professional side to the world

### DIFF
--- a/packages/shared/src/components/icons/World/filled.svg
+++ b/packages/shared/src/components/icons/World/filled.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="World">
+<path id="Ring" fill-rule="evenodd" clip-rule="evenodd" transform="rotate(-22 12 12)" d="M0.6 12a11.4 3.7 0 1 0 22.8 0a11.4 3.7 0 1 0 -22.8 0ZM2.2 12a9.8 2.1 0 1 0 19.6 0a9.8 2.1 0 1 0 -19.6 0Z" fill="#FFFFFF"/>
+<circle id="Orb" cx="12" cy="12" r="6.6" fill="#FFFFFF"/>
+</g>
+</svg>

--- a/packages/shared/src/components/icons/World/index.tsx
+++ b/packages/shared/src/components/icons/World/index.tsx
@@ -1,0 +1,25 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { IconProps } from '../../Icon';
+import Icon from '../../Icon';
+import FilledIcon from './filled.svg';
+
+/**
+ * A world seen from outside: an orb with a ring tilted across it.
+ *
+ * Two primitives on purpose. Drawing the place literally — the floating island
+ * the renderer actually builds — does not survive this icon's size: a plateau
+ * over a tapering keel is the Tesla mark, a spire added to break that symmetry
+ * resolves into a four-pointed star, and enough parts to say "island" at all
+ * closes into a blob by 16px, which is where this is read in the profile
+ * toggle. The ring keeps the same silhouette at every size.
+ *
+ * One glyph rather than an outlined/filled pair, on the same reasoning the
+ * world's own crest charges are drawn solid (`engine/crest.js`: "deliberately
+ * blunt… interior detail is a smudge"). The orb is a separate element from the
+ * ring so it fills the ring's hole where they overlap — that is what reads as
+ * the ring passing behind — and so no even-odd rule spans both.
+ */
+export const WorldIcon = (props: IconProps): ReactElement => (
+  <Icon {...props} IconPrimary={FilledIcon} IconSecondary={FilledIcon} />
+);

--- a/packages/shared/src/components/icons/index.ts
+++ b/packages/shared/src/components/icons/index.ts
@@ -183,5 +183,6 @@ export * from './Volume';
 export * from './VolumeOff';
 export * from './Warning';
 export * from './Whatsapp';
+export * from './World';
 export * from './YearInReview';
 export * from './Youtube';

--- a/packages/shared/src/components/profile/ProfileHeader.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import React from 'react';
 import dynamic from 'next/dynamic';
 import classNames from 'classnames';
@@ -47,9 +48,13 @@ const ProfileActions = dynamic(
 
 type ProfileHeaderProps = {
   user: PublicProfile;
-  userStats: Omit<UserStatsProps['stats'], 'reputation'>;
+  /** Optional for the same reason the profile's static props are: the counts
+      arrive with the user, and there is no user on the not-found path. */
+  userStats?: Omit<UserStatsProps['stats'], 'reputation'>;
   isSameUser?: boolean;
   isPreviewMode?: boolean;
+  /** Rendered in the top row, left of the edit button. */
+  actions?: ReactNode;
 };
 
 const ProfileHeader = ({
@@ -57,6 +62,7 @@ const ProfileHeader = ({
   userStats,
   isSameUser: propIsSameUser,
   isPreviewMode,
+  actions,
 }: ProfileHeaderProps) => {
   const { name, username, bio, image, cover, isPlus } = user;
   const { user: loggedUser } = useAuthContext();
@@ -75,19 +81,22 @@ const ProfileHeader = ({
         className="absolute left-6 top-16 h-[7.5rem] w-[7.5rem] rounded-16 object-cover"
       />
       <div className="flex flex-col gap-3 px-6">
-        <Link passHref href={`${webappUrl}settings/profile`}>
-          <Button
-            className={classNames(
-              'mb-4 ml-auto mt-2 text-text-secondary',
-              !isSameUser && 'invisible',
-            )}
-            tag="a"
-            disabled={!isSameUser}
-            variant={ButtonVariant.Float}
-            icon={<EditIcon />}
-            aria-label="Edit profile"
-          />
-        </Link>
+        <div className="mb-4 ml-auto mt-2 flex items-center gap-2">
+          {actions}
+          <Link passHref href={`${webappUrl}settings/profile`}>
+            <Button
+              className={classNames(
+                'text-text-secondary',
+                !isSameUser && 'invisible',
+              )}
+              tag="a"
+              disabled={!isSameUser}
+              variant={ButtonVariant.Float}
+              icon={<EditIcon />}
+              aria-label="Edit profile"
+            />
+          </Link>
+        </div>
         <div className="flex items-center gap-1">
           <Typography type={TypographyType.Title2} bold>
             {name}
@@ -144,7 +153,15 @@ const ProfileHeader = ({
           )}
           <UserStats
             userId={user.id}
-            stats={{ ...userStats, reputation: user.reputation }}
+            // The zeros are what UserStats already rendered for a missing
+            // count (`stat?.amount || 0`), stated here instead of implied.
+            stats={{
+              upvotes: 0,
+              numFollowers: 0,
+              numFollowing: 0,
+              ...userStats,
+              reputation: user.reputation,
+            }}
           />
         </div>
       </div>

--- a/packages/shared/src/features/profile/components/ProfileWidgets/ProfileWidgets.tsx
+++ b/packages/shared/src/features/profile/components/ProfileWidgets/ProfileWidgets.tsx
@@ -45,7 +45,16 @@ const AchievementTrackingWidget = dynamic(() =>
   ),
 );
 
-export interface ProfileWidgetsProps extends ProfileV2 {
+/**
+ * Both of the extras are optional because this reads neither as a requirement:
+ * `userStats` is not touched at all, and `sources` is already handled empty. A
+ * profile's static props carry them as optional (the not-found path has no user
+ * to fetch them for), so demanding them here only moved that fact to the caller.
+ */
+export interface ProfileWidgetsProps
+  extends Omit<ProfileV2, 'userStats' | 'sources'> {
+  userStats?: ProfileV2['userStats'];
+  sources?: ProfileV2['sources'];
   className?: string;
   enableSticky?: boolean;
 }

--- a/packages/shared/src/features/profile/hooks/useGear.ts
+++ b/packages/shared/src/features/profile/hooks/useGear.ts
@@ -1,48 +1,34 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import type { PublicProfile } from '../../../lib/user';
 import type {
   AddGearInput,
   ReorderGearInput,
 } from '../../../graphql/user/gear';
-import {
-  getGear,
-  addGear,
-  deleteGear,
-  reorderGear,
-} from '../../../graphql/user/gear';
-import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import { addGear, deleteGear, reorderGear } from '../../../graphql/user/gear';
+import type { ProfileShowcase } from '../../../graphql/user/profileShowcase';
+import { useProfileShowcase } from './useProfileShowcase';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 
+const selectGear = (data: ProfileShowcase) => data.gear;
+
 export function useGear(user: PublicProfile | null) {
-  const queryClient = useQueryClient();
   const { user: loggedUser } = useAuthContext();
   const { logEvent } = useLogContext();
   const isOwner = loggedUser?.id === user?.id;
 
-  const queryKey = generateQueryKey(
-    RequestKey.Gear,
-    user ?? undefined,
-    'profile',
-  );
-
-  const query = useQuery({
+  const {
     queryKey,
-    queryFn: () => getGear(user?.id as string),
-    staleTime: StaleTime.Default,
-    enabled: !!user?.id,
-  });
+    invalidate: invalidateQuery,
+    ...query
+  } = useProfileShowcase(user, selectGear);
 
   const gearItems = useMemo(
     () => query.data?.edges?.map(({ node }) => node) ?? [],
     [query.data],
   );
-
-  const invalidateQuery = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey });
-  }, [queryClient, queryKey]);
 
   const addMutation = useMutation({
     mutationFn: (input: AddGearInput) => addGear(input),

--- a/packages/shared/src/features/profile/hooks/useHotTakes.ts
+++ b/packages/shared/src/features/profile/hooks/useHotTakes.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import type { PublicProfile } from '../../../lib/user';
 import type {
   AddHotTakeInput,
@@ -7,13 +7,13 @@ import type {
   ReorderHotTakeInput,
 } from '../../../graphql/user/userHotTake';
 import {
-  getHotTakes,
   addHotTake,
   updateHotTake,
   deleteHotTake,
   reorderHotTakes,
 } from '../../../graphql/user/userHotTake';
-import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import type { ProfileShowcase } from '../../../graphql/user/profileShowcase';
+import { useProfileShowcase } from './useProfileShowcase';
 import { useProfilePreview } from '../../../hooks/profile/useProfilePreview';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
@@ -21,23 +21,17 @@ import { LogEvent } from '../../../lib/log';
 export const MAX_HOT_TAKES = 5;
 export const HOT_TAKE_LIMIT_REACHED_MESSAGE = `You already have all ${MAX_HOT_TAKES} hot takes. Remove one to add a new one.`;
 
+const selectHotTakes = (data: ProfileShowcase) => data.hotTakes;
+
 export const useHotTakes = (user: PublicProfile | null) => {
-  const queryClient = useQueryClient();
   const { isOwner } = useProfilePreview(user);
   const { logEvent } = useLogContext();
 
-  const queryKey = generateQueryKey(
-    RequestKey.UserHotTakes,
-    user ?? undefined,
-    'profile',
-  );
-
-  const query = useQuery({
+  const {
     queryKey,
-    queryFn: () => getHotTakes(user?.id as string),
-    staleTime: StaleTime.Default,
-    enabled: !!user?.id,
-  });
+    invalidate: invalidateQuery,
+    ...query
+  } = useProfileShowcase(user, selectHotTakes);
 
   const hotTakes = useMemo(
     () => query.data?.edges?.map(({ node }) => node) ?? [],
@@ -45,10 +39,6 @@ export const useHotTakes = (user: PublicProfile | null) => {
   );
 
   const canAddMore = hotTakes.length < MAX_HOT_TAKES;
-
-  const invalidateQuery = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey });
-  }, [queryClient, queryKey]);
 
   const addMutation = useMutation({
     mutationFn: (input: AddHotTakeInput) => addHotTake(input),

--- a/packages/shared/src/features/profile/hooks/useProfileShowcase.spec.tsx
+++ b/packages/shared/src/features/profile/hooks/useProfileShowcase.spec.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { gqlClient } from '../../../graphql/common';
+import type { PublicProfile } from '../../../lib/user';
+import { useUserStack } from './useUserStack';
+import { useHotTakes } from './useHotTakes';
+import { useUserWorkspacePhotos } from './useUserWorkspacePhotos';
+import { useGear } from './useGear';
+
+jest.mock('../../../graphql/common', () => ({
+  ...jest.requireActual('../../../graphql/common'),
+  gqlClient: { request: jest.fn() },
+}));
+
+jest.mock('../../../hooks/profile/useProfilePreview', () => ({
+  useProfilePreview: () => ({ isOwner: false }),
+}));
+
+jest.mock('../../../contexts/AuthContext', () => ({
+  useAuthContext: () => ({ user: null }),
+}));
+
+jest.mock('../../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+const request = gqlClient.request as jest.Mock;
+
+const user = { id: 'u1' } as PublicProfile;
+
+const connection = <T,>(nodes: T[]) => ({
+  edges: nodes.map((node) => ({ node })),
+  pageInfo: { hasNextPage: false, endCursor: null },
+});
+
+const showcase = {
+  userStack: connection([{ id: 's1', section: 'editor', position: 0 }]),
+  hotTakes: connection([{ id: 'h1', title: 'Tabs' }]),
+  userWorkspacePhotos: connection([{ id: 'p1', image: 'a.png' }]),
+  gear: connection([{ id: 'g1', position: 0 }]),
+};
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider
+    client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+  >
+    {children}
+  </QueryClientProvider>
+);
+
+beforeEach(() => {
+  request.mockReset();
+});
+
+describe('the profile showcase sections', () => {
+  it('take one round trip between the four of them', async () => {
+    request.mockResolvedValue(showcase);
+
+    const { result } = renderHook(
+      () => ({
+        stack: useUserStack(user),
+        hotTakes: useHotTakes(user),
+        photos: useUserWorkspacePhotos(user),
+        gear: useGear(user),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.stack.stackItems).toHaveLength(1),
+    );
+
+    // The whole point: four sections that used to be four requests.
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
+  it('each hand back only their own slice', async () => {
+    request.mockResolvedValue(showcase);
+
+    const { result } = renderHook(
+      () => ({
+        stack: useUserStack(user),
+        hotTakes: useHotTakes(user),
+        photos: useUserWorkspacePhotos(user),
+        gear: useGear(user),
+      }),
+      { wrapper },
+    );
+
+    await waitFor(() =>
+      expect(result.current.stack.stackItems).toHaveLength(1),
+    );
+    expect(result.current.stack.stackItems[0].id).toBe('s1');
+    expect(result.current.hotTakes.hotTakes[0].id).toBe('h1');
+    expect(result.current.photos.photos[0].id).toBe('p1');
+    expect(result.current.gear.gearItems[0].id).toBe('g1');
+  });
+
+  it('ask for nothing without a reader', () => {
+    renderHook(() => useUserStack(null), { wrapper });
+
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/features/profile/hooks/useProfileShowcase.ts
+++ b/packages/shared/src/features/profile/hooks/useProfileShowcase.ts
@@ -1,0 +1,55 @@
+import type { QueryKey, UseQueryResult } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import type { PublicProfile } from '../../../lib/user';
+import type { ProfileShowcase } from '../../../graphql/user/profileShowcase';
+import { getProfileShowcase } from '../../../graphql/user/profileShowcase';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+
+type ShowcaseUser = Pick<PublicProfile, 'id'> | null | undefined;
+
+export type UseProfileShowcase<TSlice> = UseQueryResult<TSlice> & {
+  queryKey: QueryKey;
+  invalidate: () => void;
+};
+
+/**
+ * One request behind the stack, hot takes, workspace photos and gear hooks.
+ *
+ * Each caller passes the selector for its own slice, so a hook still hands back
+ * the connection it always did — but four of them mounting together now share a
+ * single query key, and React Query collapses that into one round trip.
+ *
+ * `select` has to be referentially stable or React Query re-runs it on every
+ * render, so callers pass a module-level function rather than an inline arrow.
+ */
+export function useProfileShowcase<TSlice>(
+  user: ShowcaseUser,
+  select: (data: ProfileShowcase) => TSlice,
+): UseProfileShowcase<TSlice> {
+  const queryClient = useQueryClient();
+  const userId = user?.id;
+  const queryKey = useMemo(
+    () =>
+      generateQueryKey(
+        RequestKey.ProfileShowcase,
+        userId ? { id: userId } : undefined,
+        'profile',
+      ),
+    [userId],
+  );
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => getProfileShowcase(userId as string),
+    select,
+    enabled: !!userId,
+    staleTime: StaleTime.Default,
+  });
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey });
+  }, [queryClient, queryKey]);
+
+  return { ...query, queryKey, invalidate };
+}

--- a/packages/shared/src/features/profile/hooks/useUserStack.ts
+++ b/packages/shared/src/features/profile/hooks/useUserStack.ts
@@ -1,5 +1,5 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import type { PublicProfile } from '../../../lib/user';
 import type {
   UserStack,
@@ -9,34 +9,28 @@ import type {
 } from '../../../graphql/user/userStack';
 import {
   MAX_STACK_ITEMS,
-  getUserStack,
   addUserStack,
   updateUserStack,
   deleteUserStack,
   reorderUserStack,
 } from '../../../graphql/user/userStack';
-import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import type { ProfileShowcase } from '../../../graphql/user/profileShowcase';
+import { useProfileShowcase } from './useProfileShowcase';
 import { useProfilePreview } from '../../../hooks/profile/useProfilePreview';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 
+const selectStack = (data: ProfileShowcase) => data.userStack;
+
 export function useUserStack(user: PublicProfile | null) {
-  const queryClient = useQueryClient();
   const { isOwner } = useProfilePreview(user);
   const { logEvent } = useLogContext();
 
-  const queryKey = generateQueryKey(
-    RequestKey.UserStack,
-    user ?? undefined,
-    'profile',
-  );
-
-  const query = useQuery({
+  const {
     queryKey,
-    queryFn: () => getUserStack(user?.id as string),
-    staleTime: StaleTime.Default,
-    enabled: !!user?.id,
-  });
+    invalidate: invalidateQuery,
+    ...query
+  } = useProfileShowcase(user, selectStack);
 
   const stackItems = useMemo(
     () => query.data?.edges?.map(({ node }) => node) ?? [],
@@ -55,10 +49,6 @@ export function useUserStack(user: PublicProfile | null) {
     });
     return groups;
   }, [stackItems]);
-
-  const invalidateQuery = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey });
-  }, [queryClient, queryKey]);
 
   const addMutation = useMutation({
     mutationFn: (input: AddUserStackInput) => addUserStack(input),

--- a/packages/shared/src/features/profile/hooks/useUserWorkspacePhotos.ts
+++ b/packages/shared/src/features/profile/hooks/useUserWorkspacePhotos.ts
@@ -1,40 +1,34 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo, useCallback } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useMemo } from 'react';
 import type { PublicProfile } from '../../../lib/user';
 import type {
   AddUserWorkspacePhotoInput,
   ReorderUserWorkspacePhotoInput,
 } from '../../../graphql/user/userWorkspacePhoto';
 import {
-  getUserWorkspacePhotos,
   addUserWorkspacePhoto,
   deleteUserWorkspacePhoto,
   reorderUserWorkspacePhotos,
 } from '../../../graphql/user/userWorkspacePhoto';
-import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import type { ProfileShowcase } from '../../../graphql/user/profileShowcase';
+import { useProfileShowcase } from './useProfileShowcase';
 import { useProfilePreview } from '../../../hooks/profile/useProfilePreview';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 
 export const MAX_WORKSPACE_PHOTOS = 5;
 
+const selectPhotos = (data: ProfileShowcase) => data.userWorkspacePhotos;
+
 export function useUserWorkspacePhotos(user: PublicProfile | null) {
-  const queryClient = useQueryClient();
   const { isOwner } = useProfilePreview(user);
   const { logEvent } = useLogContext();
 
-  const queryKey = generateQueryKey(
-    RequestKey.UserWorkspacePhotos,
-    user ?? undefined,
-    'profile',
-  );
-
-  const query = useQuery({
+  const {
     queryKey,
-    queryFn: () => getUserWorkspacePhotos(user?.id as string),
-    staleTime: StaleTime.Default,
-    enabled: !!user?.id,
-  });
+    invalidate: invalidateQuery,
+    ...query
+  } = useProfileShowcase(user, selectPhotos);
 
   const photos = useMemo(
     () => query.data?.edges?.map(({ node }) => node) ?? [],
@@ -42,10 +36,6 @@ export function useUserWorkspacePhotos(user: PublicProfile | null) {
   );
 
   const canAddMore = photos.length < MAX_WORKSPACE_PHOTOS;
-
-  const invalidateQuery = useCallback(() => {
-    queryClient.invalidateQueries({ queryKey });
-  }, [queryClient, queryKey]);
 
   const addMutation = useMutation({
     mutationFn: (input: AddUserWorkspacePhotoInput) =>

--- a/packages/shared/src/graphql/user/gear.ts
+++ b/packages/shared/src/graphql/user/gear.ts
@@ -1,6 +1,5 @@
 import type { ComponentType } from 'react';
 import { gql } from 'graphql-request';
-import type { Connection } from '../common';
 import { gqlClient } from '../common';
 import type { IconProps } from '../../components/Icon';
 import { TerminalIcon } from '../../components/icons/Terminal';
@@ -124,7 +123,7 @@ export interface ReorderGearInput {
   position: number;
 }
 
-const GEAR_FRAGMENT = gql`
+export const GEAR_FRAGMENT = gql`
   fragment GearFragment on Gear {
     id
     position
@@ -134,23 +133,6 @@ const GEAR_FRAGMENT = gql`
       category
     }
   }
-`;
-
-const GEAR_QUERY = gql`
-  query Gear($userId: ID!, $first: Int, $after: String) {
-    gear(userId: $userId, first: $first, after: $after) {
-      edges {
-        node {
-          ...GearFragment
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-  ${GEAR_FRAGMENT}
 `;
 
 const AUTOCOMPLETE_GEAR_QUERY = gql`
@@ -187,16 +169,6 @@ const REORDER_GEAR_MUTATION = gql`
   }
   ${GEAR_FRAGMENT}
 `;
-
-export const getGear = async (
-  userId: string,
-  first = 50,
-): Promise<Connection<Gear>> => {
-  const result = await gqlClient.request<{
-    gear: Connection<Gear>;
-  }>(GEAR_QUERY, { userId, first });
-  return result.gear;
-};
 
 export const searchGear = async (query: string): Promise<DatasetGear[]> => {
   const result = await gqlClient.request<{

--- a/packages/shared/src/graphql/user/profileShowcase.ts
+++ b/packages/shared/src/graphql/user/profileShowcase.ts
@@ -1,0 +1,86 @@
+import { gql } from 'graphql-request';
+import type { Connection } from '../common';
+import { gqlClient } from '../common';
+import type { UserStack } from './userStack';
+import { MAX_STACK_ITEMS, USER_STACK_FRAGMENT } from './userStack';
+import type { HotTake } from './userHotTake';
+import { HOT_TAKE_FRAGMENT } from './userHotTake';
+import type { UserWorkspacePhoto } from './userWorkspacePhoto';
+import { USER_WORKSPACE_PHOTO_FRAGMENT } from './userWorkspacePhoto';
+import type { Gear } from './gear';
+import { GEAR_FRAGMENT } from './gear';
+
+export interface ProfileShowcase {
+  userStack: Connection<UserStack>;
+  hotTakes: Connection<HotTake>;
+  userWorkspacePhotos: Connection<UserWorkspacePhoto>;
+  gear: Connection<Gear>;
+}
+
+/**
+ * The four lists the profile's main column always renders, in one document.
+ *
+ * They were four separate requests, all keyed on the same user, all mounting in
+ * the same paint. Nothing here paginates in practice — the caps are low enough
+ * that the first page is the whole list — so there is no lifecycle to keep them
+ * apart, only four round trips where one does.
+ */
+const PROFILE_SHOWCASE_QUERY = gql`
+  query ProfileShowcase($userId: ID!, $stackFirst: Int, $first: Int) {
+    userStack(userId: $userId, first: $stackFirst) {
+      edges {
+        node {
+          ...UserStackFragment
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+    hotTakes(userId: $userId, first: $first) {
+      edges {
+        node {
+          ...HotTakeFragment
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+    userWorkspacePhotos(userId: $userId, first: $first) {
+      edges {
+        node {
+          ...UserWorkspacePhotoFragment
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+    gear(userId: $userId, first: $first) {
+      edges {
+        node {
+          ...GearFragment
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+  ${USER_STACK_FRAGMENT}
+  ${HOT_TAKE_FRAGMENT}
+  ${USER_WORKSPACE_PHOTO_FRAGMENT}
+  ${GEAR_FRAGMENT}
+`;
+
+export const getProfileShowcase = (userId: string): Promise<ProfileShowcase> =>
+  gqlClient.request<ProfileShowcase>(PROFILE_SHOWCASE_QUERY, {
+    userId,
+    stackFirst: MAX_STACK_ITEMS,
+    first: 50,
+  });

--- a/packages/shared/src/graphql/user/userHotTake.ts
+++ b/packages/shared/src/graphql/user/userHotTake.ts
@@ -1,5 +1,4 @@
 import { gql } from 'graphql-request';
-import type { Connection } from '../common';
 import { gqlClient } from '../common';
 import { USER_SHORT_INFO_FRAGMENT } from '../fragments';
 import type { UserShortProfile } from '../../lib/user';
@@ -33,7 +32,7 @@ export interface ReorderHotTakeInput {
   position: number;
 }
 
-const HOT_TAKE_FRAGMENT = gql`
+export const HOT_TAKE_FRAGMENT = gql`
   fragment HotTakeFragment on HotTake {
     id
     emoji
@@ -44,23 +43,6 @@ const HOT_TAKE_FRAGMENT = gql`
     upvotes
     upvoted
   }
-`;
-
-const HOT_TAKES_QUERY = gql`
-  query HotTakes($userId: ID!, $first: Int, $after: String) {
-    hotTakes(userId: $userId, first: $first, after: $after) {
-      edges {
-        node {
-          ...HotTakeFragment
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-  ${HOT_TAKE_FRAGMENT}
 `;
 
 const ADD_HOT_TAKE_MUTATION = gql`
@@ -97,16 +79,6 @@ const REORDER_HOT_TAKES_MUTATION = gql`
   }
   ${HOT_TAKE_FRAGMENT}
 `;
-
-export const getHotTakes = async (
-  userId: string,
-  first = 50,
-): Promise<Connection<HotTake>> => {
-  const result = await gqlClient.request<{
-    hotTakes: Connection<HotTake>;
-  }>(HOT_TAKES_QUERY, { userId, first });
-  return result.hotTakes;
-};
 
 export const addHotTake = async (input: AddHotTakeInput): Promise<HotTake> => {
   const result = await gqlClient.request<{

--- a/packages/shared/src/graphql/user/userStack.ts
+++ b/packages/shared/src/graphql/user/userStack.ts
@@ -48,7 +48,7 @@ export interface ReorderUserStackInput {
   section?: string;
 }
 
-const USER_STACK_FRAGMENT = gql`
+export const USER_STACK_FRAGMENT = gql`
   fragment UserStackFragment on UserStack {
     id
     section

--- a/packages/shared/src/graphql/user/userWorkspacePhoto.ts
+++ b/packages/shared/src/graphql/user/userWorkspacePhoto.ts
@@ -1,5 +1,4 @@
 import { gql } from 'graphql-request';
-import type { Connection } from '../common';
 import { gqlClient } from '../common';
 
 export interface UserWorkspacePhoto {
@@ -18,30 +17,13 @@ export interface ReorderUserWorkspacePhotoInput {
   position: number;
 }
 
-const USER_WORKSPACE_PHOTO_FRAGMENT = gql`
+export const USER_WORKSPACE_PHOTO_FRAGMENT = gql`
   fragment UserWorkspacePhotoFragment on UserWorkspacePhoto {
     id
     image
     position
     createdAt
   }
-`;
-
-const USER_WORKSPACE_PHOTOS_QUERY = gql`
-  query UserWorkspacePhotos($userId: ID!, $first: Int, $after: String) {
-    userWorkspacePhotos(userId: $userId, first: $first, after: $after) {
-      edges {
-        node {
-          ...UserWorkspacePhotoFragment
-        }
-      }
-      pageInfo {
-        hasNextPage
-        endCursor
-      }
-    }
-  }
-  ${USER_WORKSPACE_PHOTO_FRAGMENT}
 `;
 
 const ADD_USER_WORKSPACE_PHOTO_MUTATION = gql`
@@ -71,16 +53,6 @@ const REORDER_USER_WORKSPACE_PHOTOS_MUTATION = gql`
   }
   ${USER_WORKSPACE_PHOTO_FRAGMENT}
 `;
-
-export const getUserWorkspacePhotos = async (
-  userId: string,
-  first = 50,
-): Promise<Connection<UserWorkspacePhoto>> => {
-  const result = await gqlClient.request<{
-    userWorkspacePhotos: Connection<UserWorkspacePhoto>;
-  }>(USER_WORKSPACE_PHOTOS_QUERY, { userId, first });
-  return result.userWorkspacePhotos;
-};
 
 export const addUserWorkspacePhoto = async (
   input: AddUserWorkspacePhotoInput,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -370,6 +370,7 @@ export enum LogEvent {
   SharePost = 'share post',
   ShareComment = 'share comment',
   ShareLog = 'share log',
+  ShareWorld = 'share world',
   // End Share
   // Navigation
   NavigatePrevious = 'navigate previous',
@@ -603,6 +604,7 @@ export enum TargetType {
   HighlightsCard = 'highlights card',
   AdvertiseHereCta = 'advertise here cta',
   ExtensionPromo = 'extension promo',
+  ProfileWorldToggle = 'profile world toggle',
 }
 
 export enum TargetId {

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -260,6 +260,7 @@ export enum RequestKey {
   Autocomplete = 'autocomplete',
   UserExperience = 'user_experience',
   UserStack = 'user_stack',
+  ProfileShowcase = 'profile_showcase',
   SourceStack = 'source_stack',
   StackSearch = 'stack_search',
   UserHotTakes = 'user_hot_takes',

--- a/packages/webapp/__tests__/ProfileSideToggle.spec.tsx
+++ b/packages/webapp/__tests__/ProfileSideToggle.spec.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { ProfileSideToggle } from '../components/profile/ProfileSideToggle';
+import { userWorldQueryKey } from '../components/world/useUserWorld';
+
+const mockLogEvent = jest.fn();
+
+jest.mock('@dailydotdev/shared/src/graphql/common', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/graphql/common'),
+  gqlClient: { request: jest.fn() },
+}));
+
+jest.mock('@dailydotdev/shared/src/contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: mockLogEvent }),
+}));
+
+// The renderer is most of a megabyte of three.js and a WebGL context; the
+// warm-up only has to be observed, never actually run.
+jest.mock('../components/world/WorldView', () => ({ WorldView: () => null }));
+
+const request = gqlClient.request as jest.Mock;
+
+const user = {
+  id: 'u1',
+  username: 'ido',
+  name: 'Ido',
+} as PublicProfile;
+
+const renderToggle = (
+  queryClient: QueryClient,
+  profile: PublicProfile = user,
+) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProfileSideToggle user={profile} />
+    </QueryClientProvider>,
+  );
+
+beforeEach(() => {
+  request.mockReset();
+  mockLogEvent.mockReset();
+});
+
+describe('ProfileSideToggle', () => {
+  it('offers both sides, with the world a link away', () => {
+    renderToggle(new QueryClient());
+
+    // "side" is its own element so it can drop on a phone, so the labels are
+    // read off the group rather than out of a single node.
+    const group = screen.getByRole('group', { name: 'Profile sides' });
+    expect(group).toHaveTextContent(/Professional side/);
+    expect(group).toHaveTextContent(/Fun side/);
+
+    const fun = screen.getByRole('link', { name: /Fun side/ });
+    expect(fun).toHaveAttribute('href', '/world/ido');
+  });
+
+  it('falls back to the id for a reader with no username', () => {
+    renderToggle(new QueryClient(), { ...user, username: undefined });
+
+    expect(screen.getByRole('link', { name: /Fun side/ })).toHaveAttribute(
+      'href',
+      '/world/u1',
+    );
+  });
+
+  it('warms the world on intent, so the click is not the start of the wait', async () => {
+    const districts = [{ niche: { slug: 'ai_llm' } }];
+    request.mockResolvedValue({
+      userWorld: districts,
+      userWorldSettings: null,
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    renderToggle(queryClient);
+
+    expect(request).not.toHaveBeenCalled();
+
+    fireEvent.mouseEnter(screen.getByRole('link', { name: /Fun side/ }));
+
+    // The entry the world page will read on arrival, under the key it reads it
+    // by — a prefetch into a different key would be a wasted request.
+    await waitFor(() =>
+      expect(queryClient.getQueryData(userWorldQueryKey('u1'))).toEqual({
+        districts,
+        settings: null,
+      }),
+    );
+  });
+
+  it('warms the world once, however often it is hovered', async () => {
+    request.mockResolvedValue({ userWorld: [], userWorldSettings: null });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    renderToggle(queryClient);
+    const fun = screen.getByRole('link', { name: /Fun side/ });
+
+    fireEvent.mouseEnter(fun);
+    await waitFor(() => expect(request).toHaveBeenCalledTimes(1));
+
+    fireEvent.mouseEnter(fun);
+    fireEvent.focus(fun);
+
+    // Fresh data is fresh: re-hovering must not re-ask.
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/webapp/__tests__/WorldShare.spec.tsx
+++ b/packages/webapp/__tests__/WorldShare.spec.tsx
@@ -1,0 +1,104 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
+import { WorldShare } from '../components/world/WorldShare';
+
+const mockShareOrCopy = jest.fn();
+const mockUseShareOrCopyLink = jest.fn();
+
+jest.mock('@dailydotdev/shared/src/hooks/useShareOrCopyLink', () => ({
+  useShareOrCopyLink: (props: unknown) => mockUseShareOrCopyLink(props),
+}));
+
+const user = {
+  id: 'u1',
+  username: 'ido',
+  name: 'Ido',
+} as PublicProfile;
+
+interface ShareArgs {
+  link: string;
+  text: string;
+  logObject: (provider: ShareProvider) => Record<string, unknown>;
+}
+
+const argsOf = (): ShareArgs =>
+  mockUseShareOrCopyLink.mock.calls[0][0] as ShareArgs;
+
+// Tooltip reads the request protocol off a query client.
+const render = (ui: ReactElement) =>
+  rtlRender(
+    <QueryClientProvider client={new QueryClient()}>{ui}</QueryClientProvider>,
+  );
+
+beforeEach(() => {
+  mockShareOrCopy.mockReset();
+  mockUseShareOrCopyLink.mockReset();
+  mockUseShareOrCopyLink.mockReturnValue([false, mockShareOrCopy]);
+});
+
+describe('WorldShare', () => {
+  it('hands out an absolute link to the world', () => {
+    render(<WorldShare user={user} isOwn={false} />);
+
+    // Absolute on purpose: the whole point is a link that survives the tab.
+    expect(argsOf().link).toBe(
+      `${process.env.NEXT_PUBLIC_WEBAPP_URL}world/ido`,
+    );
+  });
+
+  it('falls back to the id for a reader with no username', () => {
+    render(
+      <WorldShare user={{ ...user, username: undefined }} isOwn={false} />,
+    );
+
+    expect(argsOf().link).toBe(`${process.env.NEXT_PUBLIC_WEBAPP_URL}world/u1`);
+  });
+
+  it('names the owner when the world belongs to somebody else', () => {
+    render(<WorldShare user={user} isOwn={false} />);
+
+    expect(argsOf().text).toBe("Check out Ido's world on daily.dev");
+  });
+
+  it('speaks in the first person on your own world', () => {
+    render(<WorldShare user={user} isOwn />);
+
+    expect(argsOf().text).toBe('Check out my world on daily.dev');
+  });
+
+  it('leads with the name its owner gave the place', () => {
+    render(<WorldShare user={user} worldName="Shamunia" isOwn />);
+
+    expect(argsOf().text).toBe('Check out Shamunia, my world on daily.dev');
+  });
+
+  it('logs the world it shared and how it was shared', () => {
+    render(<WorldShare user={user} isOwn={false} />);
+
+    expect(argsOf().logObject(ShareProvider.Native)).toEqual({
+      event_name: LogEvent.ShareWorld,
+      target_id: 'u1',
+      extra: JSON.stringify({ provider: ShareProvider.Native }),
+    });
+  });
+
+  it('shares on click', () => {
+    render(<WorldShare user={user} isOwn={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Share this world' }));
+
+    expect(mockShareOrCopy).toHaveBeenCalled();
+  });
+
+  it('says so once the link is on the clipboard', () => {
+    mockUseShareOrCopyLink.mockReturnValue([true, mockShareOrCopy]);
+    render(<WorldShare user={user} isOwn={false} />);
+
+    expect(screen.getByRole('button', { name: 'Copied!' })).toBeInTheDocument();
+  });
+});

--- a/packages/webapp/__tests__/profileWorld.spec.ts
+++ b/packages/webapp/__tests__/profileWorld.spec.ts
@@ -1,0 +1,62 @@
+import { hasPublicWorld } from '../components/world/profileWorld';
+
+const fetchMock = jest.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
+});
+
+const respond = (body: unknown) =>
+  fetchMock.mockResolvedValue({ json: async () => body });
+
+describe('hasPublicWorld', () => {
+  it('opens the door once there is somewhere to walk into', async () => {
+    respond({ data: { userWorld: [{ niche: { slug: 'ai_llm' } }] } });
+
+    await expect(hasPublicWorld('u1')).resolves.toBe(true);
+  });
+
+  it('keeps it shut for a reader who has read nothing yet', async () => {
+    respond({ data: { userWorld: [] } });
+
+    await expect(hasPublicWorld('u1')).resolves.toBe(false);
+  });
+
+  it('keeps it shut for a world its owner has hidden', async () => {
+    // Privacy is applied by the resolver, so a hidden world is indistinguishable
+    // from an empty one here — which is exactly the answer a visitor should get.
+    respond({ data: { userWorld: [] } });
+
+    await expect(hasPublicWorld('u1')).resolves.toBe(false);
+  });
+
+  it('does not take the profile down with it', async () => {
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    await expect(hasPublicWorld('u1')).resolves.toBe(false);
+  });
+
+  it('gives up rather than holding the profile open', async () => {
+    jest.useFakeTimers();
+    // A request that never settles — the profile's own render is awaiting this.
+    fetchMock.mockImplementation(
+      (_url: string, { signal }: { signal: AbortSignal }) =>
+        new Promise((_, reject) =>
+          signal.addEventListener('abort', () => reject(new Error('aborted'))),
+        ),
+    );
+
+    const pending = hasPublicWorld('u1');
+    jest.advanceTimersByTime(2000);
+
+    await expect(pending).resolves.toBe(false);
+    jest.useRealTimers();
+  });
+
+  it('survives an API that predates worlds', async () => {
+    respond({ errors: [{ message: 'Cannot query field "userWorld"' }] });
+
+    await expect(hasPublicWorld('u1')).resolves.toBe(false);
+  });
+});

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -34,6 +34,7 @@ import { getPageSeoTitles } from '../utils';
 import { getAppOrigin } from '../../../lib/seo';
 import { ProfileWidgets } from '../../../../shared/src/features/profile/components/ProfileWidgets/ProfileWidgets';
 import { useProfileSidebarCollapse } from '../../../hooks/useProfileSidebarCollapse';
+import { hasPublicWorld } from '../../world/profileWorld';
 
 const Custom404 = dynamic(
   () => import(/* webpackChunkName: "404" */ '../../../pages/404'),
@@ -46,6 +47,8 @@ export interface ProfileLayoutProps extends Partial<ProfileV2> {
   // v2: title shown in the shared page-header strip at the top of the
   // floating card, above the profile sidebar + main + aside row.
   pageHeaderTitle?: string;
+  /** Whether this reader has a world a visitor is allowed to walk into. */
+  hasWorld?: boolean;
 }
 
 export const getOGImageUrl = (userId: string): string => {
@@ -215,12 +218,17 @@ export async function getStaticProps({
         revalidate: 60,
       };
     }
-    const data = await getProfileV2Extra(user.id);
+    // Both only need the resolved id, so neither has to wait on the other.
+    const [data, hasWorld] = await Promise.all([
+      getProfileV2Extra(user.id),
+      hasPublicWorld(user.id),
+    ]);
 
     return {
       props: {
         user,
         ...data,
+        hasWorld,
         noindex: !!user.noindex,
       },
       revalidate: 60,

--- a/packages/webapp/components/profile/ProfileSideToggle.tsx
+++ b/packages/webapp/components/profile/ProfileSideToggle.tsx
@@ -1,0 +1,118 @@
+import type { ReactElement } from 'react';
+import React, { useCallback } from 'react';
+import classNames from 'classnames';
+import { useQueryClient } from '@tanstack/react-query';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { WorldIcon } from '@dailydotdev/shared/src/components/icons';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import { StaleTime } from '@dailydotdev/shared/src/lib/query';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { LogEvent, TargetType } from '@dailydotdev/shared/src/lib/log';
+import { fetchUserWorld, userWorldQueryKey } from '../world/useUserWorld';
+
+/** The renderer is fetched once per session at most, however often this is hovered. */
+let rendererWarmed = false;
+
+const warmRenderer = () => {
+  if (rendererWarmed) {
+    return;
+  }
+  rendererWarmed = true;
+  // Same chunk name the world page's next/dynamic uses, so this IS that chunk:
+  // by the time the route mounts, the import it makes is already resolved.
+  import(/* webpackChunkName: "worldView" */ '../world/WorldView').catch(() => {
+    // A failed warm-up is not a failure: the route will ask for it again.
+    rendererWarmed = false;
+  });
+};
+
+const segment =
+  'flex items-center gap-1.5 rounded-12 px-3 py-1.5 typo-footnote font-bold transition-colors duration-100';
+
+interface ProfileSideToggleProps {
+  user: PublicProfile;
+  className?: string;
+}
+
+/**
+ * The two sides of a reader: the profile they wrote, and the world they read
+ * into being. Rendered as one control rather than a link in a menu because the
+ * point is that the second one EXISTS — most people arriving at a profile have
+ * never seen a world, and a segmented switch is the shape that says there is
+ * something on the other side of it.
+ *
+ * "Fun side" navigates rather than swapping in place: the world is a
+ * full-screen WebGL scene with no room for the profile's chrome, and it already
+ * owns a route that knows how to get back here.
+ */
+export function ProfileSideToggle({
+  user,
+  className,
+}: ProfileSideToggleProps): ReactElement {
+  const queryClient = useQueryClient();
+  const { logEvent } = useLogContext();
+  const worldHref = `/world/${user.username || user.id}`;
+
+  /* Both halves of the wait, started on intent rather than on click: the ~700KB
+     renderer and the districts it needs to raise anything. Hovering the segment
+     is a good enough signal, and the two race each other instead of queueing.
+     Deliberately hover and focus only — a touchstart also fires when a finger
+     lands here on its way to scrolling past, and that is not worth most of a
+     megabyte of somebody's data. */
+  const onIntent = useCallback(() => {
+    warmRenderer();
+    queryClient.prefetchQuery({
+      queryKey: userWorldQueryKey(user.id),
+      queryFn: () => fetchUserWorld(user.id),
+      staleTime: StaleTime.Default,
+    });
+  }, [queryClient, user.id]);
+
+  return (
+    <div
+      role="group"
+      aria-label="Profile sides"
+      className={classNames(
+        'flex items-center gap-0.5 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-0.5',
+        className,
+      )}
+    >
+      {/* "side" is dropped on a phone rather than the labels being shortened:
+          the row also carries the edit button inside the header's padding, and
+          the pair still has to read as one switch at 320px. Each width gets its
+          own whole label — splitting one would put the flex gap mid-phrase. */}
+      <span
+        aria-current="page"
+        className={classNames(segment, 'bg-surface-float text-text-primary')}
+      >
+        <span className="tablet:hidden">Professional</span>
+        <span className="hidden tablet:inline">Professional side</span>
+      </span>
+      <Link href={worldHref} passHref>
+        {/* href is set here as well as by Link, so the anchor reads as one to
+            a11y tooling and still resolves with JS off. */}
+        <a
+          href={worldHref}
+          className={classNames(
+            segment,
+            'text-text-tertiary hover:bg-surface-hover hover:text-text-primary',
+          )}
+          onMouseEnter={onIntent}
+          onFocus={onIntent}
+          onClick={() =>
+            logEvent({
+              event_name: LogEvent.Click,
+              target_type: TargetType.ProfileWorldToggle,
+              target_id: user.id,
+            })
+          }
+        >
+          <WorldIcon size={IconSize.Size16} />
+          <span className="tablet:hidden">Fun</span>
+          <span className="hidden tablet:inline">Fun side</span>
+        </a>
+      </Link>
+    </div>
+  );
+}

--- a/packages/webapp/components/world/WorldBack.tsx
+++ b/packages/webapp/components/world/WorldBack.tsx
@@ -8,11 +8,17 @@ import {
   ButtonSize,
   ButtonVariant,
 } from '@dailydotdev/shared/src/components/buttons/Button';
+import { WorldShare } from './WorldShare';
 
 interface WorldBackProps {
   user: PublicProfile;
   /** Inside a realm the way out is one level up, not off the world entirely. */
   isInRealm: boolean;
+  /** What the owner calls the place, if they have named it. */
+  worldName?: string;
+  isOwn: boolean;
+  /** False on a world its owner has hidden: the link would open on a wall. */
+  canShare: boolean;
   onLeaveRealm: () => void;
 }
 
@@ -23,13 +29,19 @@ interface WorldBackProps {
  * more than it needs anything written over it: the ranking, the stats, the name
  * and the counters are all things you read for a while, and the strip a phone
  * can spare makes them unreadable and the world smaller at the same time. So
- * the only thing left is the one control you cannot do without, standing in a
- * corner opposite the mark — the same plate, the same height, so the two read
- * as one line across the top of the world rather than as two stray buttons.
+ * what is left is the way out and the way to pass it on, standing in a corner
+ * opposite the mark — the same plate, the same height, so the two read as one
+ * line across the top of the world rather than as stray buttons.
+ *
+ * Share earns the second slot because a phone is where it is worth most: it is
+ * the one control here that opens the native sheet rather than a clipboard.
  */
 export function WorldBack({
   user,
   isInRealm,
+  worldName,
+  isOwn,
+  canShare,
   onLeaveRealm,
 }: WorldBackProps): ReactElement {
   const props = {
@@ -54,6 +66,9 @@ export function WorldBack({
         <Link href={`/${user.username || user.id}`} passHref>
           <Button {...props} tag="a" aria-label="Back to profile" />
         </Link>
+      )}
+      {canShare && (
+        <WorldShare user={user} worldName={worldName} isOwn={isOwn} />
       )}
     </div>
   );

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -37,6 +37,7 @@ import type { Author } from '@dailydotdev/shared/src/graphql/comments';
 import type { WorldDistrict } from '../../graphql/world';
 import { WorldCustomizeRail } from './WorldCustomize';
 import { WorldImmersiveToggle } from './WorldMark';
+import { WorldShare } from './WorldShare';
 import { WorldNudge } from './WorldNudge';
 import { WorldSignupCta } from './WorldSignupCta';
 import { WorldViewerAction } from './WorldViewerAction';
@@ -113,6 +114,8 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
   user,
   worldName,
   isImmersive,
+  isOwn,
+  canShare,
   onToggleImmersive,
   onCustomize,
 }: {
@@ -120,6 +123,9 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
   /** What the owner calls the place, or nothing if they never named it. */
   worldName?: string;
   isImmersive: boolean;
+  isOwn: boolean;
+  /** False on a world its owner has hidden: the link would open on a wall. */
+  canShare: boolean;
   onToggleImmersive: () => void;
   /** Only on your own world: nobody else's place is yours to dress. */
   onCustomize?: () => void;
@@ -152,6 +158,9 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
           </Button>
         </Link>
         <div className="flex flex-none items-center">
+          {canShare && (
+            <WorldShare user={user} worldName={worldName} isOwn={isOwn} />
+          )}
           {!!onCustomize && (
             <Tooltip content="Make it yours">
               <Button
@@ -223,6 +232,9 @@ interface WorldPanelProps {
   unbuilt?: boolean;
   isImmersive: boolean;
   worldName?: string;
+  isOwn: boolean;
+  /** False on a world its owner has hidden: the link would open on a wall. */
+  canShare: boolean;
   /** Open on your own world, and only there. */
   draft?: WorldDraft;
   districts?: WorldDistrict[];
@@ -248,6 +260,8 @@ export function WorldPanel({
   unbuilt,
   isImmersive,
   worldName,
+  isOwn,
+  canShare,
   draft,
   districts,
   showNudge,
@@ -275,6 +289,8 @@ export function WorldPanel({
         user={user}
         worldName={worldName}
         isImmersive={isImmersive}
+        isOwn={isOwn}
+        canShare={canShare}
         onToggleImmersive={onToggleImmersive}
         onCustomize={draft?.open}
       />

--- a/packages/webapp/components/world/WorldShare.tsx
+++ b/packages/webapp/components/world/WorldShare.tsx
@@ -1,0 +1,70 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { ShareIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
+import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
+import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import type { ShareProvider } from '@dailydotdev/shared/src/lib/share';
+
+interface WorldShareProps {
+  user: PublicProfile;
+  /** What the owner calls the place, if they have named it. */
+  worldName?: string;
+  /** Whether the viewer is looking at their own world. */
+  isOwn: boolean;
+  className?: string;
+}
+
+/**
+ * Hands out the link to this world. The same button in both places the world
+ * keeps chrome: beside the immersive toggle in the rail, beside the way out on
+ * a phone.
+ *
+ * `useShareOrCopyLink` is what makes one button right for both. On a phone it
+ * opens the native sheet, which is where a world is most likely to be passed
+ * on; anywhere else it copies and toasts. That is also why the tooltip talks
+ * about copying — it only ever appears on the pointer that does the copying.
+ *
+ * Absolute rather than the router's path: the whole point of the button is a
+ * link that survives leaving the tab.
+ */
+export function WorldShare({
+  user,
+  worldName,
+  isOwn,
+  className,
+}: WorldShareProps): ReactElement {
+  const whose = isOwn ? 'my' : `${user.name}'s`;
+  const [copying, onShareOrCopy] = useShareOrCopyLink({
+    link: `${webappUrl}world/${user.username || user.id}`,
+    text: worldName
+      ? `Check out ${worldName}, ${whose} world on daily.dev`
+      : `Check out ${whose} world on daily.dev`,
+    logObject: (provider: ShareProvider) => ({
+      event_name: LogEvent.ShareWorld,
+      target_id: user.id,
+      extra: JSON.stringify({ provider }),
+    }),
+  });
+
+  return (
+    <Tooltip content={copying ? 'Copied!' : 'Copy link'}>
+      <Button
+        type="button"
+        aria-label={copying ? 'Copied!' : 'Share this world'}
+        variant={ButtonVariant.Tertiary}
+        size={ButtonSize.Small}
+        icon={<ShareIcon secondary={copying} />}
+        onClick={() => onShareOrCopy()}
+        className={className}
+      />
+    </Tooltip>
+  );
+}

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -2,6 +2,8 @@ import type { ReactElement } from 'react';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import { useViewSize, ViewSize } from '@dailydotdev/shared/src/hooks';
+import Toast from '@dailydotdev/shared/src/components/notifications/Toast';
+import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { WorldBack } from './WorldBack';
 import { WorldBoot } from './WorldBoot';
 import { useIsOwnWorld, WorldInvite } from './WorldInvite';
@@ -78,6 +80,7 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
   const [failed, setFailed] = useState<string | null>(null);
   const [isImmersive, setIsImmersive] = useState(false);
   const isLaptop = useViewSize(ViewSize.Laptop);
+  const { autoDismissNotifications } = useSettingsContext();
   /* Answered before the engine is built and never asked again: it decides how
      the renderer is configured, and a WebGL context cannot be reconfigured
      without being replaced. */
@@ -316,6 +319,12 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
      the place and a laptop is where it is made yours. */
   const ownerDraft = isOwn ? draft : undefined;
   const worldName = applied?.name ?? undefined;
+  /* Reads the STORED setting rather than the draft: what a visitor following
+     the link will hit is what has been saved, not what the bench is previewing.
+     A visitor never gets here with a hidden world at all — that returns above —
+     so this only ever takes the button off the owner's own hidden world, where
+     the link it would hand out opens on WorldPrivate for everyone else. */
+  const canShare = !settings?.private;
   /* Never on an unbuilt world: WorldInvite already makes the one ask there,
      and it makes it nowhere else. */
   const showNudge = isOwn && !isUnbuilt && !isWorldCustomised(applied);
@@ -347,6 +356,8 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
               unbuilt={isUnbuilt}
               isImmersive={isImmersive}
               worldName={worldName}
+              isOwn={isOwn}
+              canShare={canShare}
               draft={ownerDraft}
               districts={districts}
               showNudge={showNudge}
@@ -358,6 +369,9 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
             <WorldBack
               user={user}
               isInRealm={!!state.open}
+              worldName={worldName}
+              isOwn={isOwn}
+              canShare={canShare}
               onLeaveRealm={onLeaveRealm}
             />
           )}
@@ -416,6 +430,12 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
             message={state.progress > 0 ? state.message : undefined}
           />
         ))}
+
+      {/* The app mounts this in MainLayout, which this page deliberately has
+          none of, so every toast raised here would be written to a renderer
+          that is not on screen — including the one that confirms a copied
+          link, which is the whole of the share button's feedback on a pointer. */}
+      <Toast autoDismissNotifications={autoDismissNotifications} />
     </div>
   );
 }

--- a/packages/webapp/components/world/profileWorld.ts
+++ b/packages/webapp/components/world/profileWorld.ts
@@ -1,0 +1,54 @@
+import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
+
+/**
+ * The profile's own render is what waits on this, so it is allowed to be late
+ * exactly once. Past this the answer is "no world", which costs the page a
+ * button; without it a stalled API costs the page.
+ */
+const TIMEOUT_MS = 2000;
+
+/**
+ * Whether this reader's world is worth putting a door to on their profile.
+ *
+ * Answered at build time so the toggle is in the first paint: it is a mode
+ * switch for the whole page, and one that appears a beat late reads as the page
+ * still settling.
+ *
+ * `userWorld` is the right question to ask rather than `userWorldSettings`. It
+ * already applies privacy — a hidden world comes back as an empty list to
+ * anyone but its owner, and static props have no session, so they are always
+ * anyone. Settings would answer the wrong question twice over: it throws for a
+ * hidden world, and returns null both for a reader who has never dressed a
+ * perfectly good world and for one who has no world at all.
+ *
+ * Only `niche { slug }` is selected. Nothing here reads a district; the count
+ * is the whole answer.
+ */
+export const hasPublicWorld = async (userId: string): Promise<boolean> => {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  try {
+    const res = await fetch(graphqlUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        query: `query ProfileHasWorld($id: ID!) {
+          userWorld(id: $id) { niche { slug } }
+        }`,
+        variables: { id: userId },
+      }),
+      signal: controller.signal,
+    });
+    const body = await res.json();
+
+    return !!body?.data?.userWorld?.length;
+  } catch {
+    // A profile that renders without its door beats one that does not render.
+    return false;
+  } finally {
+    // Otherwise the pending timer holds the render open for its full length,
+    // which is the thing this was added to prevent.
+    clearTimeout(timer);
+  }
+};

--- a/packages/webapp/components/world/useUserWorld.ts
+++ b/packages/webapp/components/world/useUserWorld.ts
@@ -46,6 +46,22 @@ export const userWorldQueryKey = (userId?: string): unknown[] =>
     userId ? { id: userId } : undefined,
   ) as unknown[];
 
+export interface UserWorldEntry {
+  districts: WorldDistrict[];
+  settings: WorldSettings | null;
+}
+
+/** Shared with the profile's prefetch, so a warmed cache is the same entry. */
+export const fetchUserWorld = async (
+  userId: string,
+): Promise<UserWorldEntry> => {
+  const res = await gqlClient.request<UserWorldData>(USER_WORLD_QUERY, {
+    id: userId,
+  });
+
+  return { districts: res.userWorld, settings: res.userWorldSettings ?? null };
+};
+
 /**
  * Districts+settings in one blocking round trip; the heavy growth log loads
  * behind the standing world and may fail without taking it down.
@@ -60,15 +76,7 @@ export const useUserWorld = (userId?: string): UserWorldResult => {
   const [withHistory] = useState(() => !isHandheld());
   const world = useQuery({
     queryKey: userWorldQueryKey(userId),
-    queryFn: async () => {
-      const res = await gqlClient.request<UserWorldData>(USER_WORLD_QUERY, {
-        id: userId,
-      });
-      return {
-        districts: res.userWorld,
-        settings: res.userWorldSettings ?? null,
-      };
-    },
+    queryFn: () => fetchUserWorld(userId as string),
     enabled: !!userId,
     staleTime: StaleTime.Default,
     // A refused world stays refused, so FORBIDDEN skips the usual retries.

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -36,6 +36,7 @@ import {
   getStaticProps as getProfileStaticProps,
 } from '../../components/layouts/ProfileLayout';
 import type { ProfileLayoutProps } from '../../components/layouts/ProfileLayout';
+import { ProfileSideToggle } from '../../components/profile/ProfileSideToggle';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const ProfilePage = ({
@@ -43,6 +44,7 @@ const ProfilePage = ({
   noindex,
   userStats,
   sources,
+  hasWorld,
 }: ProfileLayoutProps): ReactElement => {
   useJoinReferral();
   const router = useRouter();
@@ -97,6 +99,13 @@ const ProfilePage = ({
         userStats={userStats}
         isSameUser={isSameUser}
         isPreviewMode={isPreviewMode}
+        actions={
+          /* The owner always gets the door, even before their world has
+             anything in it — the empty world is the invitation to build one.
+             Everyone else gets it only once there is something to walk into,
+             which the static props already answered without a session. */
+          (hasWorld || isSameUser) && <ProfileSideToggle user={user} />
+        }
       />
       <div className="flex flex-col divide-y divide-border-subtlest-tertiary p-6">
         {shouldShowBanner && (


### PR DESCRIPTION
A toggle in the profile header for anyone with a public world. "Professional side" is the profile you wrote; "Fun side" opens the world your reading built.


## The toggle

Most people arriving at a profile have never seen a world. A segmented switch is the shape that says there is another side to this, rather than a link buried in a menu.

**Who sees it:** anyone, once the owner has a world worth walking into; the owner always, so an empty world reads as an invitation to build one.

"Fun side" navigates to the existing `/world/:user` rather than swapping in place. The world is a full-screen WebGL scene with no room for the profile's chrome, and it already owns a route that knows how to get back.

## Critical path

- **Availability is answered in `getStaticProps`**, so the control is in the first paint. A mode switch for the whole page that appears a beat late reads as the page still settling.
- `userWorld` is the right question, not `userWorldSettings`. It already applies privacy, so a hidden world comes back empty to the anonymous build. Settings would answer the wrong question twice: it *throws* for a hidden world, and returns `null` both for someone who never dressed a perfectly good world and for someone with no world at all.
- It runs in `Promise.all` with `getProfileV2Extra` (those were sequential), selects one field, and **aborts after 2s** so a stalled API costs a button rather than the page.
- **Prefetch on intent:** hovering warms the districts query *and* the ~700KB renderer chunk under the same `webpackChunkName` the route's own dynamic import resolves. Hover and focus only, no `touchstart`, since that also fires when a finger lands on the way to scrolling past.

## Batching (2nd commit)

The stack, hot takes, workspace photos and gear were **four round trips**, same user, same paint, and none of them paginates in practice. Now one `ProfileShowcase` document behind `useProfileShowcase`, each hook selecting its slice. **4 requests → 1**, asserted in a test. Every hook keeps its previous shape, so no consumer changed.

Achievements are deliberately left alone: that hook has seven consumers with independent lifetimes, and folding it in would pull the batch onto surfaces that do not want it.

## The icon (`WorldIcon`)

Drawing the place literally does not survive 16px, which is where this ships. A plateau over a tapering keel *is* the Tesla mark; a spire added to break that symmetry resolves into a four-pointed star; and enough parts to actually say "island" close into a blob. An orb with a ring keeps its silhouette at every size. Solid rather than an outlined/filled pair, following `Sparkle` and the world's own crest idiom ("deliberately blunt... interior detail is a smudge at 22px").

## Share button (3rd commit)

One button in both places the world keeps chrome: beside the immersive toggle in the rail, beside the way out on a phone. `useShareOrCopyLink` opens the native sheet on a phone and copies elsewhere.

Two things surfaced while wiring it:
- **`Toast` had no renderer on the world page.** It is mounted in `MainLayout`, which this page deliberately has none of, so every toast raised here was written to a renderer that was not on screen, including the one confirming a copied link. Now mounted in `WorldView`.
- **Hidden worlds get no button**, read off the stored setting rather than the draft. Only ever affects the owner's own hidden world, where the link would open on `WorldPrivate` for everyone else.

## Also

`ProfileHeader` and `ProfileWidgets` now take their extras as optional, which is what they always were: static props carry them that way because the not-found path has no user, `ProfileWidgets` never reads `userStats` at all, and `UserStats` already rendered a missing count as zero. Required types only moved that fact to the caller, where it failed `typecheck:strict:changed` once these files were touched.

## Testing

Local: shared 2201, webapp 436, extension 43, all passing. `lint_shared`, `typecheck:strict:changed` and `build_extension` all run clean.

Verified in the browser end to end: profile → Fun side → the world, and back. Confirmed the batched document is accepted by the real API with all four sections rendering live data, and that the share button copies and toasts.

**Not verified:** the mobile layouts. The browser tooling would not give me a real mobile viewport, so the narrow-screen toggle labels and the phone placement of the share button are code-verified only and worth a look on a device.

https://claude.ai/code/session_01YTH2aMrEfccxg3xPaJHV6L


### Preview domain
https://feat-profile-world-toggle.preview.app.daily.dev
