### PR TITLE
fix(profile): keep the world toggle flush, and desktop only

### DIFF
--- a/packages/shared/src/components/profile/ProfileHeader.tsx
+++ b/packages/shared/src/components/profile/ProfileHeader.tsx
@@ -81,8 +81,12 @@ const ProfileHeader = ({
         className="absolute left-6 top-16 h-[7.5rem] w-[7.5rem] rounded-16 object-cover"
       />
       <div className="flex flex-col gap-3 px-6">
+        {/* Edit leads and `actions` trails, because edit is only hidden, not
+            removed: it holds its width so the row keeps its height for a
+            visitor. Trailing, that reserved width sat between the actions and
+            the right edge and left them looking short of it; leading, it falls
+            on the inside and whatever trails stays flush either way. */}
         <div className="mb-4 ml-auto mt-2 flex items-center gap-2">
-          {actions}
           <Link passHref href={`${webappUrl}settings/profile`}>
             <Button
               className={classNames(
@@ -96,6 +100,7 @@ const ProfileHeader = ({
               aria-label="Edit profile"
             />
           </Link>
+          {actions}
         </div>
         <div className="flex items-center gap-1">
           <Typography type={TypographyType.Title2} bold>

--- a/packages/webapp/__tests__/ProfileSideToggle.spec.tsx
+++ b/packages/webapp/__tests__/ProfileSideToggle.spec.tsx
@@ -48,14 +48,23 @@ describe('ProfileSideToggle', () => {
   it('offers both sides, with the world a link away', () => {
     renderToggle(new QueryClient());
 
-    // "side" is its own element so it can drop on a phone, so the labels are
-    // read off the group rather than out of a single node.
     const group = screen.getByRole('group', { name: 'Profile sides' });
-    expect(group).toHaveTextContent(/Professional side/);
-    expect(group).toHaveTextContent(/Fun side/);
+    expect(group).toHaveTextContent('Professional side');
+    expect(group).toHaveTextContent('Fun side');
 
     const fun = screen.getByRole('link', { name: /Fun side/ });
     expect(fun).toHaveAttribute('href', '/world/ido');
+  });
+
+  it('is offered from laptop up, where the world is worth opening', () => {
+    renderToggle(new QueryClient());
+
+    /* Asserted on the class because that is where the rule lives: hiding this
+       in CSS rather than on a measured viewport is what keeps it in the first
+       paint on a desktop. jsdom applies no stylesheet, so there is nothing
+       computed to read instead. */
+    const group = screen.getByRole('group', { name: 'Profile sides' });
+    expect(group).toHaveClass('hidden', 'laptop:flex');
   });
 
   it('falls back to the id for a reader with no username', () => {

--- a/packages/webapp/components/profile/ProfileSideToggle.tsx
+++ b/packages/webapp/components/profile/ProfileSideToggle.tsx
@@ -45,6 +45,12 @@ interface ProfileSideToggleProps {
  * "Fun side" navigates rather than swapping in place: the world is a
  * full-screen WebGL scene with no room for the profile's chrome, and it already
  * owns a route that knows how to get back here.
+ *
+ * Laptop and up only. The world it opens into is a better place on a big
+ * screen — a phone gets the lite renderer, no rail, no scrubber and no bench —
+ * so the door is offered where the room behind it is worth walking into. Hidden
+ * in CSS rather than by measuring the viewport, so it is in the first paint on
+ * a desktop instead of popping in once a hook has resolved.
  */
 export function ProfileSideToggle({
   user,
@@ -74,20 +80,15 @@ export function ProfileSideToggle({
       role="group"
       aria-label="Profile sides"
       className={classNames(
-        'flex items-center gap-0.5 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-0.5',
+        'hidden items-center gap-0.5 rounded-16 border border-border-subtlest-tertiary bg-background-subtle p-0.5 laptop:flex',
         className,
       )}
     >
-      {/* "side" is dropped on a phone rather than the labels being shortened:
-          the row also carries the edit button inside the header's padding, and
-          the pair still has to read as one switch at 320px. Each width gets its
-          own whole label — splitting one would put the flex gap mid-phrase. */}
       <span
         aria-current="page"
         className={classNames(segment, 'bg-surface-float text-text-primary')}
       >
-        <span className="tablet:hidden">Professional</span>
-        <span className="hidden tablet:inline">Professional side</span>
+        Professional side
       </span>
       <Link href={worldHref} passHref>
         {/* href is set here as well as by Link, so the anchor reads as one to
@@ -109,8 +110,7 @@ export function ProfileSideToggle({
           }
         >
           <WorldIcon size={IconSize.Size16} />
-          <span className="tablet:hidden">Fun</span>
-          <span className="hidden tablet:inline">Fun side</span>
+          Fun side
         </a>
       </Link>
     </div>


### PR DESCRIPTION
Two follow-ups to #6443, both on screens it was not looked at on.

## Swap the toggle and the edit button

The edit button is only *hidden* for a visitor, not removed, so it holds its width and the row keeps its height. With the toggle leading, that reserved 40px sat between the toggle and the right edge, leaving it visibly short of it on every profile except your own.

Since the row is `ml-auto`, putting edit first and `actions` last means the reserved width falls on the inside and whatever trails is flush in both cases.

Verified on my own profile (edit visible) and via `?preview=true` (edit invisible, i.e. the visitor layout).

## Toggle is laptop and up

The world it opens into is a better place on a big screen: a phone gets the lite renderer, no rail, no scrubber and no bench. So the door is offered where the room behind it is worth walking into.

Hidden in CSS (`hidden … laptop:flex`) rather than on a measured viewport, so it stays in the first paint on a desktop instead of popping in once a hook resolves. That is the same pattern `ProfilePreviewToggle` already uses.

This also retires the short labels the toggle carried below `tablet` ("Professional" / "Fun"). Nothing renders it at that width any more, so they were dead.

## Testing

shared 2218, webapp 437, lint and `typecheck:strict:changed` clean.

I still cannot get a real mobile viewport out of the browser tooling, so rather than eyeball it I confirmed the rule resolves by reading the stylesheet on the live page: `.hidden` applies unconditionally, `.laptop\:flex` only inside `@media (min-width: 1020px)` and later in the sheet. Computed `display` is `flex` at 1920px, and `none` is the only rule that can apply below 1020px. There is a test asserting the classes, with a comment on why it asserts a class rather than a computed style.

https://claude.ai/code/session_01YTH2aMrEfccxg3xPaJHV6L


### Preview domain
https://fix-profile-toggle-order.preview.app.daily.dev