### PR TITLE
feat(cookies): style iubenda TCF banner like the in-house cookie banner

### DIFF
--- a/packages/shared/src/styles/components.css
+++ b/packages/shared/src/styles/components.css
@@ -1,5 +1,6 @@
 @import './components/buttons.css';
 @import './components/buttons-v2.css';
 @import './components/feedCardGlassActions.css';
+@import './components/iubenda.css';
 @import './components/radix.css';
 @import './components/swipe-onboarding.css';

--- a/packages/shared/src/styles/components/iubenda.css
+++ b/packages/shared/src/styles/components/iubenda.css
@@ -1,0 +1,121 @@
+/*
+ * Restyles the iubenda TCF banner (webapp only) to match the in-house
+ * CookieBanner card. iubenda's stylesheet uses `!important` behind
+ * `#iubenda-cs-banner.<theme>` selectors, so the doubled id keeps these
+ * rules winning no matter which theme class it applies. The banner
+ * background is written inline with `!important` by iubenda itself and
+ * therefore comes from the config in `Iubenda.tsx`, not from here.
+ */
+
+#iubenda-cs-banner#iubenda-cs-banner {
+  inset: auto 0 0 0 !important;
+  transform: none !important;
+  width: 100% !important;
+  height: auto !important;
+  max-height: calc(100vh - 3rem) !important;
+  font-family: inherit !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-container {
+  width: 100% !important;
+  max-width: none !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-content {
+  border: 0 solid var(--theme-border-subtlest-secondary) !important;
+  border-top-width: 1px !important;
+  border-radius: 0 !important;
+  padding: 1rem !important;
+  font-family: inherit !important;
+  font-size: 0.8125rem !important;
+  line-height: 1.125rem !important;
+  color: var(--theme-text-secondary) !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-rationale {
+  max-height: 16.25rem !important;
+  overflow-y: auto !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-banner-content {
+  margin: 0 !important;
+  padding: 0 !important;
+  font-size: inherit !important;
+  line-height: inherit !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-banner-content h2 {
+  margin: 0 0 0.5rem !important;
+  background: transparent !important;
+  color: var(--theme-text-primary) !important;
+  font-family: inherit !important;
+  font-size: 0.9375rem !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-banner-content a {
+  color: var(--theme-text-primary) !important;
+  text-decoration: underline !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-opt-group {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 0.5rem !important;
+  margin: 1rem 0 0 !important;
+  float: none !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-opt-group > div {
+  display: flex !important;
+  gap: 0.5rem !important;
+  margin: 0 !important;
+  float: none !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-opt-group button {
+  flex: 1 !important;
+  min-height: 2rem !important;
+  margin: 0 !important;
+  padding: 0.25rem 0.75rem !important;
+  border: none !important;
+  border-radius: 0.75rem !important;
+  font-family: inherit !important;
+  font-size: 0.8125rem !important;
+  font-weight: 700 !important;
+}
+
+/* Accept and Reject stay visually identical: TCF equal prominence. */
+#iubenda-cs-banner#iubenda-cs-banner
+  .iubenda-cs-opt-group
+  button.iubenda-cs-btn-primary {
+  background: var(--theme-text-primary) !important;
+  color: var(--theme-background-default) !important;
+}
+
+#iubenda-cs-banner#iubenda-cs-banner
+  .iubenda-cs-opt-group
+  button.iubenda-cs-customize-btn {
+  background: transparent !important;
+  color: var(--theme-text-secondary) !important;
+  font-weight: 400 !important;
+  text-decoration: underline;
+}
+
+@media (min-width: 1020px) {
+  #iubenda-cs-banner#iubenda-cs-banner {
+    inset: auto 1.5rem 1.5rem auto !important;
+    width: auto !important;
+  }
+
+  /* matches CookieBanner's laptop:w-64 card */
+  #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-container {
+    width: 16rem !important;
+  }
+
+  #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-content {
+    border-width: 1px !important;
+    border-radius: 1rem !important;
+  }
+}

--- a/packages/shared/src/styles/components/iubenda.css
+++ b/packages/shared/src/styles/components/iubenda.css
@@ -21,15 +21,22 @@
   max-width: none !important;
 }
 
+/* radius steps mirror CookieBanner's rounded-10 tablet:rounded-0 laptop:rounded-16 */
 #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-content {
   border: 0 solid var(--theme-border-subtlest-secondary) !important;
   border-top-width: 1px !important;
-  border-radius: 0 !important;
+  border-radius: 0.625rem !important;
   padding: 1rem !important;
   font-family: inherit !important;
   font-size: 0.8125rem !important;
   line-height: 1.125rem !important;
   color: var(--theme-text-secondary) !important;
+}
+
+@media (min-width: 656px) {
+  #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-content {
+    border-radius: 0 !important;
+  }
 }
 
 #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-rationale {

--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -78,6 +78,7 @@ export const Iubenda = (): ReactElement | null => {
     injectedRef.current = true;
 
     win._iub = win._iub || {};
+    const tokens = getComputedStyle(document.documentElement);
     // Aligned with the marketing homepage's embed (same siteId/cookiePolicyId,
     // countryDetection, LGPD/USPR) so both surfaces treat consent the same.
     // Deliberate differences: enableTcf + ACM (the point of this integration)
@@ -102,13 +103,16 @@ export const Iubenda = (): ReactElement | null => {
       floatingPreferencesButtonDisplay: false,
       banner: {
         position: 'float-bottom-right',
-        // iubenda writes this inline with !important, so unlike the rest
-        // of the card (styles/components/iubenda.css) it can't come from
-        // the stylesheet; read the token so it follows the active theme
+        // iubenda writes these three inline with !important, so unlike the
+        // rest of the card (styles/components/iubenda.css) they can't come
+        // from the stylesheet; read the tokens so they follow the active
+        // theme
         backgroundColor:
-          getComputedStyle(document.documentElement)
-            .getPropertyValue('--theme-accent-pepper-subtlest')
-            .trim() || '#161921',
+          tokens.getPropertyValue('--theme-accent-pepper-subtlest').trim() ||
+          '#161921',
+        textColor:
+          tokens.getPropertyValue('--theme-text-secondary').trim() || '#CDD4E4',
+        fontSize: '13px',
         acceptButtonDisplay: true,
         rejectButtonDisplay: true,
         customizeButtonDisplay: true,

--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -101,7 +101,14 @@ export const Iubenda = (): ReactElement | null => {
       localConsentDomain: process.env.NEXT_PUBLIC_DOMAIN,
       floatingPreferencesButtonDisplay: false,
       banner: {
-        position: 'float-bottom-center',
+        position: 'float-bottom-right',
+        // iubenda writes this inline with !important, so unlike the rest
+        // of the card (styles/components/iubenda.css) it can't come from
+        // the stylesheet; read the token so it follows the active theme
+        backgroundColor:
+          getComputedStyle(document.documentElement)
+            .getPropertyValue('--theme-accent-pepper-subtlest')
+            .trim() || '#161921',
         acceptButtonDisplay: true,
         rejectButtonDisplay: true,
         customizeButtonDisplay: true,


### PR DESCRIPTION
## Changes

Restyles the iubenda TCF consent banner (shown to users in GDPR/TCF regions) to match the in-house `CookieBanner` card instead of iubenda's stock black theme.

- **Mobile (<1020px):** full-width bottom sheet with a top border, same as the in-house banner.
- **Laptop+:** 256px floating card at bottom-right with `rounded-16`, matching the in-house `laptop:w-64` card.
- Design-system tokens throughout (`--theme-accent-pepper-subtlest` surface, `--theme-text-secondary` copy, footnote type scale), so light mode follows automatically.
- **Accept and Reject stay visually identical** (both primary), preserving TCF equal-prominence; "Learn more and customize" becomes a quiet underlined link.
- Notice text scrolls inside a capped area instead of stretching the card.

## Implementation notes

- iubenda writes the banner background as an inline `!important` style, which no stylesheet rule can override — so that one color is passed through `banner.backgroundColor` in `Iubenda.tsx`, read from the CSS variable at injection time. Everything else lives in `packages/shared/src/styles/components/iubenda.css`.
- The doubled-id selector (`#iubenda-cs-banner#iubenda-cs-banner`) is deliberate: iubenda's own rules are `!important` behind `#id.theme-class` selectors, and doubling the id outranks them regardless of which theme class it applies.
- Banner position config changes `float-bottom-center` → `float-bottom-right` so the default matches the CSS if the stylesheet ever fails to load.

## Testing

- Verified live against production DOM at desktop (1512px) and mobile (600px) widths with the exact shipped CSS.
- Strict typecheck, ESLint, and Prettier pass on changed files.

## Screenshots

Desktop card (bottom-right, both buttons primary) and mobile bottom sheet verified in-browser.

### Preview domain
https://feat-iubenda-banner-inhouse-styl.preview.app.daily.dev