### PR TITLE
feat(world): count a visit to someone else's world towards the tour

### DIFF
--- a/packages/shared/src/components/quest/questDestinations.ts
+++ b/packages/shared/src/components/quest/questDestinations.ts
@@ -62,6 +62,10 @@ export const getQuestDestination = (
       return { label: 'Later', path: '/bookmarks/later' };
     case 'visit_watercooler_feed':
       return { label: 'Watercooler', path: '/watercooler' };
+    // Worlds have no index of their own: each one is reached from its owner's
+    // profile, so the leaderboards are where a tour starts.
+    case 'visit_user_world':
+      return { label: 'Profiles', path: '/users' };
     case 'feedback_submit':
       return { label: 'Feedback', path: '/settings/feedback' };
     case 'squad_join':

--- a/packages/shared/src/graphql/quests.ts
+++ b/packages/shared/src/graphql/quests.ts
@@ -93,6 +93,7 @@ export enum ClientQuestEventType {
   VisitDiscussionsPage = 'visit_discussions_page',
   VisitReadItLaterPage = 'visit_read_it_later_page',
   VisitWatercoolerFeed = 'visit_watercooler_feed',
+  VisitUserWorld = 'visit_user_world',
   ViewUserProfile = 'view_user_profile',
 }
 

--- a/packages/webapp/__tests__/WorldQuestVisit.spec.tsx
+++ b/packages/webapp/__tests__/WorldQuestVisit.spec.tsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import {
+  ClientQuestEventType,
+  trackQuestClientEvent,
+} from '@dailydotdev/shared/src/graphql/quests';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import ProfileWorldPage from '../pages/world/[userId]';
+import { useUserWorld } from '../components/world/useUserWorld';
+import type { UserWorldResult } from '../components/world/useUserWorld';
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({ isFallback: false }),
+}));
+
+jest.mock('@dailydotdev/shared/src/contexts/AuthContext', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/contexts/AuthContext'),
+  useAuthContext: jest.fn(),
+}));
+
+jest.mock('@dailydotdev/shared/src/graphql/quests', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/graphql/quests'),
+  trackQuestClientEvent: jest.fn(),
+}));
+
+jest.mock('../components/world/useUserWorld', () => ({
+  ...jest.requireActual('../components/world/useUserWorld'),
+  useUserWorld: jest.fn(),
+}));
+
+jest.mock('../components/world/WorldView', () => ({ WorldView: () => null }));
+
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<
+  typeof useAuthContext
+>;
+const mockUseUserWorld = useUserWorld as jest.MockedFunction<
+  typeof useUserWorld
+>;
+const mockTrack = trackQuestClientEvent as jest.MockedFunction<
+  typeof trackQuestClientEvent
+>;
+
+const owner = {
+  id: 'owner',
+  username: 'ido',
+  name: 'Ido',
+} as PublicProfile;
+
+const standing: UserWorldResult = {
+  districts: [],
+  isPending: false,
+  isHistoryPending: false,
+  isEmpty: true,
+  isPrivate: false,
+};
+
+const setViewer = (id: string | null) =>
+  mockUseAuthContext.mockReturnValue({
+    user: id ? { id } : null,
+  } as unknown as ReturnType<typeof useAuthContext>);
+
+// The boot fallback the dynamic renderer shows first reads the shared query
+// cache, so the page needs a client even with the renderer itself stubbed out.
+const renderWorld = (user: PublicProfile = owner) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ProfileWorldPage user={user} noindex={false} />
+    </QueryClientProvider>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseUserWorld.mockReturnValue(standing);
+  mockTrack.mockResolvedValue(undefined);
+  setViewer('visitor');
+});
+
+describe('visiting a world that is not yours', () => {
+  it('counts towards the tour', async () => {
+    renderWorld();
+
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith(
+        ClientQuestEventType.VisitUserWorld,
+      ),
+    );
+  });
+
+  it('does not count a visit to your own world', () => {
+    setViewer(owner.id);
+
+    renderWorld();
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('does not count a logged out visit', () => {
+    setViewer(null);
+
+    renderWorld();
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('does not count a world that has not stood up yet', () => {
+    mockUseUserWorld.mockReturnValue({ ...standing, isPending: true });
+
+    renderWorld();
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('does not count a world its owner has hidden', () => {
+    mockUseUserWorld.mockReturnValue({ ...standing, isPrivate: true });
+
+    renderWorld();
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+
+  it('does not count a world that failed to load', () => {
+    mockUseUserWorld.mockReturnValue({
+      ...standing,
+      error: new Error('nope'),
+    });
+
+    renderWorld();
+
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+});

--- a/packages/webapp/pages/world/[userId].tsx
+++ b/packages/webapp/pages/world/[userId].tsx
@@ -8,6 +8,9 @@ import type { ParsedUrlQuery } from 'querystring';
 import { useRouter } from 'next/router';
 import Custom404 from '@dailydotdev/shared/src/components/Custom404';
 import { graphqlUrl } from '@dailydotdev/shared/src/lib/config';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { useTrackQuestClientEvent } from '@dailydotdev/shared/src/hooks/useTrackQuestClientEvent';
+import { ClientQuestEventType } from '@dailydotdev/shared/src/graphql/quests';
 import type { ProfileLayoutProps } from '../../components/layouts/ProfileLayout';
 import {
   getProfileSeoDefaults,
@@ -178,6 +181,21 @@ const ProfileWorldPage = ({
      page's first render they run against the download instead, and the world is
      usually raisable by the time there is anything to raise it with. */
   const world = useUserWorld(user?.id);
+  const { user: viewer } = useAuthContext();
+  /* Counted once the world has actually stood up for this viewer. A hidden one
+     never does, and landing on the door of a place you cannot enter is not a
+     visit to it. */
+  useTrackQuestClientEvent({
+    eventType: ClientQuestEventType.VisitUserWorld,
+    enabled:
+      !!user &&
+      !!viewer?.id &&
+      viewer.id !== user.id &&
+      !world.isPending &&
+      !world.isPrivate &&
+      !world.error,
+    eventKey: user ? `world:${user.id}` : undefined,
+  });
 
   if (!isFallback && !user) {
     return <Custom404 />;


### PR DESCRIPTION
daily-api [#4054](https://github.com/dailydotdev/daily-api/pull/4054) added the **Grand tour** daily quest (visit 3 other users' worlds) behind the client-trackable `visit_user_world` event. Only the client can report that one, so this is the app side of it.

- `ClientQuestEventType.VisitUserWorld` added to the enum the `trackQuestEvent` mutation is typed against.
- `/world/[userId]` reports the visit once the world has actually stood up for this viewer: not the owner, not pending, not private, not errored. Keyed `world:<ownerId>`, so the three the quest asks for are three different people's worlds rather than three returns to the same one.
- The quest card points at `/users`. Worlds have no index of their own; each is reached from its owner's profile.

The other half of #4054, the **Terraformer** achievement, is awarded server-side when the world settings mutation lands and needs nothing here.

## Test plan

New `packages/webapp/__tests__/WorldQuestVisit.spec.tsx` covers the gate: counted for a signed-in visitor on a standing world, not counted for your own world, logged out, still loading, private, or failed.

https://claude.ai/code/session_011zqv1ekz2S8jeUyt2SAby9

### Preview domain
https://feat-visit-user-world-quest.preview.app.daily.dev