### PR TITLE
feat(world): make the rail back button step out of a realm first

### DIFF
--- a/packages/webapp/components/world/WorldBack.tsx
+++ b/packages/webapp/components/world/WorldBack.tsx
@@ -59,7 +59,7 @@ export function WorldBack({
         <Button
           {...props}
           type="button"
-          aria-label="Back to the world"
+          aria-label="Back to world view"
           onClick={onLeaveRealm}
         />
       ) : (

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -114,21 +114,26 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
   user,
   worldName,
   isImmersive,
+  isInRealm,
   isOwn,
   canShare,
   onToggleImmersive,
   onCustomize,
+  onLeaveRealm,
 }: {
   user: PublicProfile;
   /** What the owner calls the place, or nothing if they never named it. */
   worldName?: string;
   isImmersive: boolean;
+  /** Inside a realm the way out is one level up, not off the world entirely. */
+  isInRealm: boolean;
   isOwn: boolean;
   /** False on a world its owner has hidden: the link would open on a wall. */
   canShare: boolean;
   onToggleImmersive: () => void;
   /** Only on your own world: nobody else's place is yours to dress. */
   onCustomize?: () => void;
+  onLeaveRealm: () => void;
 }): ReactElement {
   /* A profile carries everything a comment author does, but types its handle as
      optional, and the comment components do not. One that has no handle has no
@@ -147,16 +152,28 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
           button's own padding is what lines its label up with the content under
           it, and the icon-only one has none to give. */}
       <div className="-mx-1 flex items-center justify-between gap-2">
-        <Link href={`/${user.username || user.id}`} passHref>
+        {isInRealm ? (
           <Button
-            tag="a"
+            type="button"
             variant={ButtonVariant.Tertiary}
             size={ButtonSize.Small}
             icon={<ArrowIcon className="-rotate-90" />}
+            onClick={onLeaveRealm}
           >
-            Back to profile
+            Back to world view
           </Button>
-        </Link>
+        ) : (
+          <Link href={`/${user.username || user.id}`} passHref>
+            <Button
+              tag="a"
+              variant={ButtonVariant.Tertiary}
+              size={ButtonSize.Small}
+              icon={<ArrowIcon className="-rotate-90" />}
+            >
+              Back to profile
+            </Button>
+          </Link>
+        )}
         <div className="flex flex-none items-center">
           {canShare && (
             <WorldShare user={user} worldName={worldName} isOwn={isOwn} />
@@ -289,10 +306,12 @@ export function WorldPanel({
         user={user}
         worldName={worldName}
         isImmersive={isImmersive}
+        isInRealm={!!open}
         isOwn={isOwn}
         canShare={canShare}
         onToggleImmersive={onToggleImmersive}
         onCustomize={draft?.open}
+        onLeaveRealm={onLeaveRealm}
       />
 
       {!!showNudge && !!draft && <WorldNudge onCustomize={draft.open} />}
@@ -320,26 +339,14 @@ export function WorldPanel({
       {/* Natural height, not flex-1: the rail scrolls as a whole, and a ranking
           that grew to fill it left the signup card underneath the list. */}
       <section className="flex flex-col gap-2">
-        <div className="flex items-center justify-between gap-2">
-          <Typography
-            tag={TypographyTag.H2}
-            type={TypographyType.Footnote}
-            color={TypographyColor.Tertiary}
-            bold
-          >
-            {open ? 'Districts' : 'Realms'}
-          </Typography>
-          {!!open && (
-            <Button
-              variant={ButtonVariant.Tertiary}
-              size={ButtonSize.XSmall}
-              icon={<ArrowIcon className="-rotate-90" />}
-              onClick={onLeaveRealm}
-            >
-              Back to the world
-            </Button>
-          )}
-        </div>
+        <Typography
+          tag={TypographyTag.H2}
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+          bold
+        >
+          {open ? 'Districts' : 'Realms'}
+        </Typography>
         {!!open && (
           <Typography
             type={TypographyType.Caption1}


### PR DESCRIPTION
Inside a realm, the rail's top-left button still said **Back to profile**, so the only way up one level was the small button next to the Districts heading. The phone chrome already stepped out of the realm instead of off the world, so desktop was the odd one out.

- The header button now becomes **Back to world view** while a realm is open, wired to `onLeaveRealm`. At world level it stays the profile link.
- Dropped the duplicate back button beside the Districts heading: with the header doing the job it was the same affordance twice on one panel.
- The phone button's `aria-label` moved from "Back to the world" to "Back to world view" so both surfaces read the same.

`isInRealm` is passed as a boolean so the memo boundary on `WorldPanelHeader` still holds while the replay pushes a new state every frame.

From inside a realm it now takes two presses to reach the profile, which is the same as mobile has always been.

https://claude.ai/code/session_012M5PUc6yr6KGXgiGFHKxaN

### Preview domain
https://feat-world-back-to-world-view.preview.app.daily.dev