### PR TITLE
fix(profile): 404 unknown profiles instead of 200

### DIFF
--- a/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
+++ b/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
@@ -1,0 +1,99 @@
+import type { GetStaticPropsContext } from 'next';
+import type { ParsedUrlQuery } from 'querystring';
+import { getProfile, getProfileV2Extra } from '@dailydotdev/shared/src/lib/user';
+import {
+  getStaticPaths,
+  getStaticProps,
+} from '../components/layouts/ProfileLayout';
+import { hasPublicWorld } from '../components/world/profileWorld';
+
+jest.mock('@dailydotdev/shared/src/lib/user', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/lib/user'),
+  getProfile: jest.fn(),
+  getProfileV2Extra: jest.fn(),
+}));
+
+jest.mock('../components/world/profileWorld', () => ({
+  hasPublicWorld: jest.fn(),
+}));
+
+const mockedGetProfile = getProfile as jest.Mock;
+const mockedGetProfileV2Extra = getProfileV2Extra as jest.Mock;
+const mockedHasPublicWorld = hasPublicWorld as jest.Mock;
+
+const context = (userId?: string) =>
+  ({ params: { userId } } as unknown as GetStaticPropsContext<ParsedUrlQuery>);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// `pages/[userId]` is a ROOT-LEVEL dynamic route, so it claims every
+// single-segment path on the apex. If it answers 200 for handles that do
+// not exist, every unknown URL on daily.dev becomes a soft 404 —
+// `/plus.md`, `/llms-full.txt` and `/definitely-not-a-user` all looked
+// like real pages to crawlers and agents, which read the status code.
+describe('profile getStaticPaths', () => {
+  it('blocks on the first request instead of serving a 200 shell', async () => {
+    // `fallback: true` answers unknown paths with a loading shell under
+    // HTTP 200 before getStaticProps runs, which makes the `notFound`
+    // below unreachable on the request that matters.
+    await expect(getStaticPaths()).resolves.toEqual({
+      paths: [],
+      fallback: 'blocking',
+    });
+  });
+});
+
+describe('profile getStaticProps', () => {
+  it('returns notFound when the handle does not resolve to a user', async () => {
+    mockedGetProfile.mockResolvedValue(null);
+
+    await expect(getStaticProps(context('definitely-not-a-user'))).resolves.toEqual(
+      { notFound: true, revalidate: 60 },
+    );
+  });
+
+  it('returns notFound when no handle was supplied', async () => {
+    await expect(getStaticProps(context(undefined))).resolves.toEqual({
+      notFound: true,
+      revalidate: 60,
+    });
+    expect(mockedGetProfile).not.toHaveBeenCalled();
+  });
+
+  it('returns notFound when the profile is forbidden, without confirming it exists', async () => {
+    mockedGetProfile.mockRejectedValue({
+      response: { errors: [{ extensions: { code: 'FORBIDDEN' } }] },
+    });
+
+    await expect(getStaticProps(context('blocked-user'))).resolves.toEqual({
+      notFound: true,
+      revalidate: 60,
+    });
+  });
+
+  it('still serves a real profile', async () => {
+    const user = { id: 'u1', username: 'kramer', noindex: false };
+    mockedGetProfile.mockResolvedValue(user);
+    mockedGetProfileV2Extra.mockResolvedValue({ userStats: { numPosts: 1 } });
+    mockedHasPublicWorld.mockResolvedValue(true);
+
+    await expect(getStaticProps(context('kramer'))).resolves.toEqual({
+      props: {
+        user,
+        userStats: { numPosts: 1 },
+        hasWorld: true,
+        noindex: false,
+      },
+      revalidate: 60,
+    });
+  });
+
+  it('rethrows unexpected errors rather than hiding them as a 404', async () => {
+    const boom = { response: { errors: [{ extensions: { code: 'BOOM' } }] } };
+    mockedGetProfile.mockRejectedValue(boom);
+
+    await expect(getStaticProps(context('kramer'))).rejects.toEqual(boom);
+  });
+});

--- a/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
+++ b/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
@@ -1,6 +1,9 @@
 import type { GetStaticPropsContext } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
-import { getProfile, getProfileV2Extra } from '@dailydotdev/shared/src/lib/user';
+import {
+  getProfile,
+  getProfileV2Extra,
+} from '@dailydotdev/shared/src/lib/user';
 import {
   getStaticPaths,
   getStaticProps,
@@ -21,8 +24,15 @@ const mockedGetProfile = getProfile as jest.Mock;
 const mockedGetProfileV2Extra = getProfileV2Extra as jest.Mock;
 const mockedHasPublicWorld = hasPublicWorld as jest.Mock;
 
+// Mirrors the (unexported) ProfileParams in ProfileLayout. Typing the
+// helper as GetStaticPropsContext<ParsedUrlQuery> compiles under the
+// default config but fails `typecheck:strict:changed`.
+interface ProfileParams extends ParsedUrlQuery {
+  userId: string;
+}
+
 const context = (userId?: string) =>
-  ({ params: { userId } } as unknown as GetStaticPropsContext<ParsedUrlQuery>);
+  ({ params: { userId } } as unknown as GetStaticPropsContext<ProfileParams>);
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -49,9 +59,9 @@ describe('profile getStaticProps', () => {
   it('returns notFound when the handle does not resolve to a user', async () => {
     mockedGetProfile.mockResolvedValue(null);
 
-    await expect(getStaticProps(context('definitely-not-a-user'))).resolves.toEqual(
-      { notFound: true, revalidate: 60 },
-    );
+    await expect(
+      getStaticProps(context('definitely-not-a-user')),
+    ).resolves.toEqual({ notFound: true, revalidate: 60 });
   });
 
   it('returns notFound when no handle was supplied', async () => {

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -194,9 +194,32 @@ interface ProfileParams extends ParsedUrlQuery {
   userId: string;
 }
 
+// `blocking`, not `true`. `pages/[userId]` is a ROOT-LEVEL dynamic
+// route, so it claims every single-segment path on the apex — and with
+// `fallback: true` Next answers all of them with a loading shell under
+// HTTP 200 before `getStaticProps` ever runs. That made `daily.dev/`
+// plus any unknown segment indistinguishable from a real profile:
+// `/definitely-not-a-user-xyz123` and `/kramer` both returned the same
+// 10,549-byte body. Crawlers and agents read the status code, so every
+// missing page looked like a hit. `blocking` resolves the profile
+// first, which is what lets the `notFound` below produce a real 404.
 export async function getStaticPaths(): Promise<GetStaticPathsResult> {
-  return { paths: [], fallback: true };
+  return { paths: [], fallback: 'blocking' };
 }
+
+// A missing profile is a 404, not a 200 with `noindex`.
+//
+// The layout has always rendered the right thing for this case —
+// `if (!isFallback && !user) return <Custom404 />` — it just served it
+// under a success status, and `noindex` suppressed the search-engine
+// symptom rather than fixing the response. `notFound: true` renders
+// the same `pages/404.tsx` with the status to match, and keeps
+// `revalidate` so a profile created later starts resolving within the
+// window instead of being cached as missing forever.
+const profileNotFound = {
+  notFound: true,
+  revalidate: 60,
+} as const;
 
 export async function getStaticProps({
   params,
@@ -205,18 +228,12 @@ export async function getStaticProps({
 > {
   const userId = params?.userId;
   if (!userId) {
-    return {
-      props: { noindex: true },
-      revalidate: 60,
-    };
+    return profileNotFound;
   }
   try {
     const user = await getProfile(userId);
     if (!user) {
-      return {
-        props: { noindex: true },
-        revalidate: 60,
-      };
+      return profileNotFound;
     }
     // Both only need the resolved id, so neither has to wait on the other.
     const [data, hasWorld] = await Promise.all([
@@ -236,10 +253,10 @@ export async function getStaticProps({
   } catch (err) {
     const clientError = err as ClientError;
     if (clientError?.response?.errors?.[0]?.extensions?.code === 'FORBIDDEN') {
-      return {
-        props: { noindex: true },
-        revalidate: 60,
-      };
+      // Same answer as a missing profile, deliberately: the viewer
+      // cannot see it, and 404 avoids confirming that the handle
+      // exists. This path already rendered `<Custom404 />` too.
+      return profileNotFound;
     }
     throw err;
   }


### PR DESCRIPTION
`pages/[userId]` is a **root-level** dynamic route, so it claims every single-segment path on the apex — and it answered `200` for all of them.

```
GET /kramer                        200  10,549 B   (a real profile)
GET /definitely-not-a-user-xyz123  200  10,549 B   (nobody)
```

Byte-identical. Crawlers and agents read the status code, so every missing page on daily.dev currently looks like a hit.

This is also the reason `/plus.md`, `/jobs.md`, `/highlights.md` and `/llms-full.txt` return HTML under a `200` — they were never special, just unknown usernames. It surfaced while auditing `llms.txt` for agent-readiness ([recruiter-landing#415](https://github.com/dailydotdev/recruiter-landing/pull/415)): every `.md` URL we advertise is unverifiable while a miss and a hit are indistinguishable.

## Two causes, both in `ProfileLayout`

**1. `fallback: true`** — Next serves a loading shell with HTTP `200` *before* `getStaticProps` runs, so nothing the resolver decides can reach the response that matters. Changed to `blocking`.

**2. A missing profile returned props, not `notFound`:**

```ts
const user = await getProfile(userId);
if (!user) {
  return { props: { noindex: true }, revalidate: 60 };
}
```

The layout already rendered the right thing for this case:

```tsx
if (!isFallback && !user) {
  return <Custom404 />;   // correct UI, wrong status
}
```

So the UI was already a 404 and only the status disagreed. `noindex` hid the symptom from search engines; agents don't read it. Now `notFound: true`.

`FORBIDDEN` gets the same answer, deliberately — the viewer can't see the profile, 404 avoids confirming the handle exists, and that path already rendered `Custom404` too.

`revalidate` is kept on the `notFound` results so a handle registered later starts resolving within the window instead of being cached as missing.

## Scope

Covers every `/[userId]/*` sub-page (posts, upvoted, replies, work, education, achievements, …) and `/world/[userId]` — they all re-export this resolver.

## Tradeoff

The first uncached request for a profile now waits on the API instead of painting a skeleton. That's the cost of a correct status code, and it applies once per profile per `revalidate` window (60s). Flagging it explicitly since profiles are a high-traffic page type — if that's not acceptable, the alternative is keeping `fallback: true` and accepting that cold URLs stay `200`, which is exactly the case agents and crawlers hit.

## Verification

New `__tests__/ProfileLayoutStaticProps.tsx`. The four tests that assert the fix **fail on the previous behaviour** and pass with it:

```
✕ blocks on the first request instead of serving a 200 shell
✕ returns notFound when the handle does not resolve to a user
✕ returns notFound when no handle was supplied
✕ returns notFound when the profile is forbidden, without confirming it exists
✓ still serves a real profile
✓ rethrows unexpected errors rather than hiding them as a 404
```

With the fix: 6/6 pass. `eslint` clean on the changed file. `tsc` error count unchanged at 24 before and after (all pre-existing, in `__tests__` and `shared`; none in `ProfileLayout`).

## Not fixed here

- `pages/backoffice/keywords/[value].tsx` has the same `fallback: true`, but it's auth-gated and not root-level.
- `pages/agents/[entityId].tsx` 307-redirects any unknown entity id to `/highlights/vibes` rather than 404ing — same "swallow unknown input" shape, different mechanism. Worth a separate look.

### Preview domain
https://fix-profile-soft-404.preview.app.daily.dev