### PR TITLE
feat(world): level progress on the plates, and events for the loop

### DIFF
--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -372,6 +372,15 @@ export enum LogEvent {
   ShareLog = 'share log',
   ShareWorld = 'share world',
   // End Share
+  /* Start World
+     `world view` is the denominator and fires whatever happens next, so the
+     boot it precedes can be measured as a rate against it: every open resolves
+     to exactly one `world ready` or one `world boot failed`. */
+  WorldView = 'world view',
+  WorldReady = 'world ready',
+  WorldBootFailed = 'world boot failed',
+  WorldCustomize = 'world customize',
+  // End World
   // Navigation
   NavigatePrevious = 'navigate previous',
   NavigateNext = 'navigate next',

--- a/packages/webapp/__tests__/ladder.spec.ts
+++ b/packages/webapp/__tests__/ladder.spec.ts
@@ -1,0 +1,141 @@
+import {
+  LEVELS,
+  levelOf,
+  levelProgress,
+  MAX_LEVEL,
+  nearestLevelUp,
+  REALM_DIV,
+  realmLevelOf,
+} from '../components/world/ladder';
+
+const row = (name: string, reads: number) => ({ key: name, name, reads });
+
+describe('levelOf', () => {
+  it('gives untouched ground no level at all', () => {
+    expect(levelOf(0)).toEqual(0);
+    expect(levelOf(-1)).toEqual(0);
+  });
+
+  it('lands exactly on every rung', () => {
+    LEVELS.forEach((level, index) => {
+      expect(levelOf(level.reads)).toEqual(index + 1);
+    });
+  });
+
+  it('holds the rung until the next threshold is reached', () => {
+    // 3 is CAMP and 5 is HOLD, so 4 is still a camp.
+    expect(levelOf(4)).toEqual(3);
+    expect(levelOf(1279)).toEqual(MAX_LEVEL - 1);
+  });
+
+  it('does not run off the top of the ladder', () => {
+    expect(levelOf(LEVELS[MAX_LEVEL - 1].reads * 10)).toEqual(MAX_LEVEL);
+  });
+});
+
+describe('levelProgress', () => {
+  it('counts the articles left to the next rung', () => {
+    // SANCTUM is 20.
+    expect(levelProgress(18)).toMatchObject({ level: 5, toNext: 2 });
+  });
+
+  it('places the district across the rung it is on', () => {
+    // Half way from ATELIER (10) to SANCTUM (20).
+    expect(levelProgress(15).fraction).toEqual(0.5);
+  });
+
+  it('has nothing above the top rung', () => {
+    expect(levelProgress(2000)).toEqual({
+      level: MAX_LEVEL,
+      toNext: 0,
+      fraction: 1,
+    });
+  });
+});
+
+describe('realmLevelOf', () => {
+  it('leaves a realm nobody has read at no level', () => {
+    expect(realmLevelOf(0)).toEqual(0);
+  });
+
+  it('floors a realm that has been read at all to L1', () => {
+    // 1/8 of an article is below the first rung, but the realm is not absent.
+    expect(realmLevelOf(1)).toEqual(1);
+  });
+
+  it('moves the rungs out by the divisor', () => {
+    expect(realmLevelOf(LEVELS[1].reads * REALM_DIV)).toEqual(2);
+    expect(realmLevelOf(LEVELS[1].reads * REALM_DIV - 1)).toEqual(1);
+  });
+});
+
+describe('levelProgress on the realm ladder', () => {
+  it('counts what is left in articles, not in eighths', () => {
+    // 3,372 articles sits on realm L10 (320 x 8); L11 is 640 x 8 = 5,120.
+    expect(levelProgress(3372, REALM_DIV)).toMatchObject({
+      level: 10,
+      toNext: 5120 - 3372,
+    });
+  });
+
+  it('never puts a floored L1 realm behind the start of its own bar', () => {
+    // The rung's own threshold is 8 articles, but realmLevelOf floors at L1, so
+    // a realm holding 1 would otherwise report a negative fraction.
+    const progress = levelProgress(1, REALM_DIV);
+
+    expect(progress.level).toEqual(1);
+    expect(progress.fraction).toEqual(0);
+    expect(progress.toNext).toEqual(LEVELS[1].reads * REALM_DIV - 1);
+  });
+
+  it('places a realm across the rung it is on', () => {
+    // Half way from 8 to 16.
+    expect(levelProgress(12, REALM_DIV).fraction).toEqual(0.5);
+  });
+
+  it('rounds a part-article up, because rungs are crossed by reading one', () => {
+    expect(levelProgress(3.5, REALM_DIV).toNext).toEqual(13);
+  });
+
+  it('leaves the district ladder alone by default', () => {
+    expect(levelProgress(18)).toMatchObject({ level: 5, toNext: 2 });
+  });
+});
+
+describe('nearestLevelUp', () => {
+  it('has nothing to point at in an empty world', () => {
+    expect(nearestLevelUp([])).toBeNull();
+    expect(nearestLevelUp(undefined)).toBeNull();
+  });
+
+  it('picks the closest district, not the biggest', () => {
+    // The 318 district is 2 off ARCANUM; the 400 one is 240 off CITADEL.
+    const nearest = nearestLevelUp([row('LLMs', 400), row('CSS & UI', 318)]);
+
+    expect(nearest).toMatchObject({ name: 'CSS & UI', toNext: 2 });
+  });
+
+  it('ignores districts that have topped out', () => {
+    const nearest = nearestLevelUp([row('LLMs', 1280), row('Rust', 30)]);
+
+    expect(nearest).toMatchObject({ name: 'Rust', toNext: 10 });
+  });
+
+  it('is null when every district has topped out', () => {
+    expect(nearestLevelUp([row('LLMs', 1280), row('Agents', 4000)])).toBeNull();
+  });
+
+  it('breaks a tie towards the district further along', () => {
+    // Both one article out, from CAIRN and from SKY COURT respectively.
+    const nearest = nearestLevelUp([row('PHP', 1), row('LLMs', 1279)]);
+
+    expect(nearest).toMatchObject({ name: 'LLMs', toNext: 1 });
+  });
+
+  it('carries the rung it is walking towards', () => {
+    expect(nearestLevelUp([row('Go', 39)])?.next).toMatchObject({
+      n: 'CONCLAVE',
+      reads: 40,
+    });
+  });
+});

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -17,6 +17,7 @@ import { WorldTimeline } from './WorldTimeline';
 import type { WorldEngine, WorldState } from './worldState';
 import type { UserWorldResult } from './useUserWorld';
 import { useWorldDraft } from './useWorldDraft';
+import { useWorldLog } from './useWorldLog';
 import { RIDE_MUTED_KEY, useWorldMusic } from './useWorldMusic';
 import { useWorldPlate } from './useWorldPlate';
 import { buildWorld } from './engine/buildWorld';
@@ -240,6 +241,13 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     engineRef.current?.setSky(resolveSky(applied));
   }, [applied]);
 
+  /* Unlike the look and the crest, this one is the VIEWER's: how far a plot is
+     through its level is the owner's own business, and on a stranger's world it
+     is a number about somebody else's reading on a plate the size of a stamp. */
+  useEffect(() => {
+    engineRef.current?.setLevelProgress(isOwn);
+  }, [isOwn]);
+
   /* The share card is composed server-side around a render only this machine
      can cheaply make. Reads the STORED settings, not the draft: a plate is what
      the world looks like to everyone, not what the owner is trying on. */
@@ -327,6 +335,19 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     [isMuted, setIsMuted],
   );
   useWorldMusic({ isRiding, isMuted });
+
+  useWorldLog({
+    userId: user.id,
+    isOwn,
+    isLite,
+    isSettled: !isPending,
+    isPrivate,
+    isUnbuilt,
+    isReady: isStanding,
+    failure,
+    state,
+    districts,
+  });
 
   /* The bench is the owner's only, and the rail's only: below laptop there is
      no room to dress a world and look at it at the same time, so a phone shows

--- a/packages/webapp/components/world/engine/styles.js
+++ b/packages/webapp/components/world/engine/styles.js
@@ -58,6 +58,14 @@ export const WORLD_CSS = `
   white-space:nowrap;margin-top:2px}
 .world-root .lb .sb{font-size:8.5px;letter-spacing:.06em;font-weight:700;margin-top:3px;
   white-space:nowrap;opacity:.9}
+/* How far through its current level a plot is, on its owner's own world only.
+   Hidden by default and shown from JS, because the tier that hides a plate's
+   count hides this with it and an inline display would beat the class doing it.
+   currentColor is the district's or realm's own accent, already on the label. */
+.world-root .lb .pg{display:none;height:2px;margin-top:5px;border-radius:2px;
+  background:rgba(168,179,206,.26);overflow:hidden}
+.world-root .lb .pg i{display:block;height:100%;border-radius:2px;
+  background:currentColor;transition:width .2s linear}
 .world-root .lb .stem,.world-root .lb .pin{display:none}
 /* Tier 1 is a bare name over the world — no plate, nothing hidden behind it. */
 .world-root .lb.t1 .box{background:none;border-color:transparent;box-shadow:none;padding:0}

--- a/packages/webapp/components/world/engine/taxonomy.js
+++ b/packages/webapp/components/world/engine/taxonomy.js
@@ -10,70 +10,12 @@ import * as THREE from 'three';
  * palettes and their light are the concept art from `concept-lab.html`.
  */
 
-/* ------------------------------------------------------------------ ladder */
-/* Calibrated 2026-08-02 against the FULL export — 10,404,383 districts over
-   1,325,633 users — not against a sample. That matters, because the previous
-   ladder (1/3/8/16/30/55/100/180/300/550/1000/2000) was tuned on a world
-   labelled "p50" that measures p93.9 across the real userbase, so every rung
-   sat about two percentile-decades too high:
+/* The rungs themselves live in `../ladder`, which imports nothing: a feed nudge
+   that wants to say "two more articles" should not have to load the renderer to
+   find out. Re-exported here so the engine still has one place to ask. */
+import { LEVELS, levelOf, realmLevelOf } from '../ladder';
 
-       61.6% of all districts came out L1, 84% were L1-L2, and the top four
-       rungs between them described 0.14% of the map. Half of all users owned
-       nothing above a WAYSTONE — a whole world of lodestones on bare rock.
-
-   The distribution the ladder actually has to survive is brutally long-tailed:
-   45.6% of districts hold exactly ONE article, p50=2, p75=4, p90=12, p99=87,
-   and the largest district on the platform holds 8,615. No ladder can split
-   the 45.6% — one article is one article — so L1 is a floor we accept.
-
-   The trap here, and the first recalibration walked straight into it, is that
-   the ladder has TWO jobs and only one of them is visible in that histogram:
-
-     1. GLOBAL — separate districts across the userbase. Optimising this alone
-        means equal population per rung, and since the population is dominated
-        by the singletons it drags every rung DOWN.
-     2. INTRA-WORLD — separate one user's districts from EACH OTHER. This is
-        the one you actually look at, because you look at one world at a time.
-
-   Tuning purely for (1) put 19 of a four-year reader's 40 districts on the same
-   rung: a world where everything is the same size, which is precisely the
-   saturation the twelve-step ladder exists to prevent. So the rungs DOUBLE from
-   L4 up — one rung per doubling of attention, which is scale-free and therefore
-   spreads any world's districts the same way wherever that world sits. Measured
-   over the whole export: L1 45.6% (was 61.6%), L3-L10 27.7% (was 15.6%), and a
-   four-year reader now uses 8 rungs with 40% on the modal one instead of 7 and
-   48%.
-
-   Two honest limits. With twelve rungs the bottom and the top compete: every
-   rung spent separating 1-from-2-from-3 articles is a rung not available to a
-   veteran, and a 14-rung ladder would get that reader to 9 rungs / 28% without
-   giving anything back at the bottom. And the modal pile-up is not all ladder —
-   that reader genuinely has 16 districts sitting between 320 and 640 articles,
-   which no choice of thresholds can pull apart.
-
-   SKY COURT stays endgame on purpose: 0.005% of districts, and the biggest
-   district still sits 6.7x above the top rung so there is headroom left in the
-   tail. A ladder whose ceiling is reachable stops being a ceiling.
-
-   `reads` is the only field that reaches a reader, as "L7". The names and the
-   descriptions are for whoever edits the geometry: they say what each rung is
-   supposed to BUILD, next to the threshold that triggers it. Twelve invented
-   names is a second vocabulary to learn before a level means anything, so the
-   UI counts instead of naming, and nothing here should be rendered. */
-export const LEVELS = [
-  { n:'WAYSTONE',  reads:1,    d:'A single lodestone on bare rock. One article is a real thing that happened — it gets land, however little.' },
-  { n:'CAIRN',     reads:2,    d:'Somebody stacked stones and planted the first crystal sprout. Still wild, no longer untouched.' },
-  { n:'CAMP',      reads:3,    d:'A tended camp: lantern, path, the district\'s signature motif appears — identity arrives early, before size does.' },
-  { n:'HOLD',      reads:5,    d:'Ground is cut into two terraces and the first roof goes up. The plot starts reading as built, not found.' },
-  { n:'ATELIER',   reads:10,   d:'A working hamlet with a pool at its heart. Gardens, hedges, the first real greenery.' },
-  { n:'SANCTUM',   reads:20,   d:'Three terraces, a dome, and the first spire. Birds arrive — the place is worth circling.' },
-  { n:'CONCLAVE',  reads:40,   d:'Water spills off the rim as a falls. Lamps line the paths. Density picks up faster than the land does.' },
-  { n:'SPIRE',     reads:80,   d:'Ground runs out before the reading does: cantilever decks brace out past the cliff on struts. The silhouette stops being a lump.' },
-  { n:'ACADEMY',   reads:160,  d:'Four terraces, a spire cluster, and sky bridges strung between the towers. Legible from across the map.' },
-  { n:'ARCANUM',   reads:320,  d:'Lanterns and hanging gardens spill over the terrace lips, a second hall opens, and the district starts growing downward as well as out.' },
-  { n:'CITADEL',   reads:640,  d:'The Great Spire goes up — one landmark that owns the skyline — over a full upper tier of decks and bridges.' },
-  { n:'SKY COURT', reads:1280, d:'The endgame plot. Everything lit, everything tended, everything moving. A capital of one subject.' },
-];
+export { LEVELS, levelOf, realmLevelOf };
 
 /* ------------------------------------------------------- realms & districts
    Six realms, forty districts — the whole taxonomy from world-procedural.html.
@@ -367,25 +309,6 @@ export function paletteOf(realm,niche){
   return P;
 }
 
-/* Level from a lifetime article count, on the twelve-step ladder. */
-export function levelOf(articles){
-  if(articles<=0)return 0;
-  let L=1; for(let i=0;i<LEVELS.length;i++) if(articles>=LEVELS[i].reads) L=i+1;
-  return L;
-}
-/* A REALM is scored on the same ladder with the thresholds moved out 8x. The
-   divisor tracks the ladder: on the recalibrated rungs 4x puts a four-year
-   reader at L12 / L12 / L11 / L11 / L11 / L10, which is the saturation the
-   twelve-step ladder exists to prevent, one scale up. 8x lands the same reader
-   on L11 / L11 / L11 / L11 / L10 / L10 and holds L11+L12 to 0.006% of realms.
-
-   No divisor rescues the middle of this axis, and it is honest to say so: a
-   user reads a handful of niches inside one or two realms, so 82% of realm
-   instances are a single-digit article count and score L1 whatever we do. The
-   realm ladder separates the top of the userbase; it is not a progress bar for
-   the median. Floored at 1: a realm you have read once is small, not absent. */
-const REALM_DIV=8;
-export const realmLevelOf=a=>a<=0?0:Math.max(1,levelOf(a/REALM_DIV));
 
 export const NICHE_OF={}, REALM_OF={};
 REALMS.forEach(r=>r.niches.forEach(n=>{ NICHE_OF[n.id]=n; REALM_OF[n.id]=r; }));

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -5,6 +5,7 @@ import { ShaderPass }     from 'three/addons/postprocessing/ShaderPass.js';
 import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { WORLD_CSS } from './styles';
+import { levelProgress, REALM_DIV } from '../ladder';
 import { drawCrest } from './crest';
 import { DEFAULT_LOOK_ID, lookFromPreset } from './look';
 import { DEFAULT_SKY, skyHourOf, skyPalOf } from './sky';
@@ -169,6 +170,14 @@ const FX={vc:true,bevel:true,env:true,noise:true,air:true,water:true,
    the plot borders and the ambient motion all read these live, so the
    controller can offer them later without anything else moving. */
 const VIEW={border:true,labels:true,life:true,sky:true};
+
+/* Whether the plates carry how far through its rung each plot is. OFF by
+   default, and turned on only for a reader looking at their OWN world: on
+   somebody else's it is a stranger's homework, and the plate is already
+   carrying a name, a subject and a count on a box the size of a stamp.
+   Read live by the label pass, which runs every frame, so flipping it needs
+   nothing rebuilt. */
+let LVLPROG=false;
 
 /* ------------------------------------------------------------ the engine DOM
    Only the layers that have to be placed by projecting a world point to a pixel
@@ -8657,6 +8666,29 @@ function placeOut(px,py,rx,ry,up,w,h,boxes,ox,oy,discs,self,bias=0){
   return fall;
 }
 
+/* The rung a plate carries on its owner's own world: how far through its current
+   level the plot is, as a bar, plus how many articles are left of it. `div`
+   stretches the ladder for a realm (see REALM_DIV in ../ladder).
+
+   The count goes ON the existing line rather than on a line of its own because
+   the solver that places these plates works from fixed box sizes: every element
+   that comes and goes is another size it has to be told about, and the two
+   callers already have to widen their boxes for the text this returns.
+
+   Returns the suffix and sets the bar, because the two are the same fact and
+   splitting them across two calls is two chances to show one without the other.
+   Empty and hidden when there is nothing to say: a stranger's world, bare
+   ground, or a plot with nothing read into it yet. */
+function rung(x,shown,div){
+  if(!LVLPROG||W.unbuilt||shown<=0){ x.elPg.style.display='none'; return ''; }
+  const p=levelProgress(shown,div);
+  x.elPg.style.display='block';
+  x.elPgI.style.width=(clamp(p.fraction,0,1)*100).toFixed(1)+'%';
+  /* Nothing above L12: the bar sits full and the line says no more than the
+     count it is already carrying. */
+  return p.next?' · '+fmt(p.toNext)+' to L'+(p.level+1):'';
+}
+
 function buildLabels(){
   labelBox.querySelectorAll('.lb').forEach(e=>e.remove());
   leadBox.innerHTML='';
@@ -8664,26 +8696,29 @@ function buildLabels(){
     const e=document.createElement('div');
     e.className='lb t1'; e.style.color=hexs(d.niche.accent);
     e.innerHTML='<div class="box"><div class="nm"></div><div class="mt"></div>'
-               +'<div class="sb"></div></div><div class="stem"></div><div class="pin"></div>';
+               +'<div class="sb"></div><div class="pg"><i></i></div></div>'
+               +'<div class="stem"></div><div class="pin"></div>';
     e.onclick=()=>{ select(d.i); flyTo(d); };
     e.onmouseenter=()=>{ hovered=d; paintBorders(); };
     e.onmouseleave=()=>{ hovered=null; paintBorders(); };
     labelBox.appendChild(e);
     d.el=e; d.elNm=e.querySelector('.nm'); d.elMt=e.querySelector('.mt');
-    d.elBn=e.querySelector('.sb'); d.lead=makeLead(hexs(d.niche.accent));
+    d.elBn=e.querySelector('.sb'); d.elPg=e.querySelector('.pg');
+    d.elPgI=e.querySelector('.pg i'); d.lead=makeLead(hexs(d.niche.accent));
   }
   for(const g of W.quarters){
     const e=document.createElement('div');
     e.className='lb rl t2'; e.style.color=hexs(g.realm.accent);
     e.innerHTML=`<div class="box"><div class="nm">${g.realm.name}</div>`
                +`<div class="sb">${g.realm.theme}</div>`
-               +`<div class="mt"></div></div>`
+               +`<div class="mt"></div><div class="pg"><i></i></div></div>`
                +`<div class="stem"></div><div class="pin"></div>`;
     e.onclick=()=>enterRealm(g);
     e.onmouseenter=()=>{ if(!OPEN)hovered=g; };
     e.onmouseleave=()=>{ if(!OPEN)hovered=null; };
     labelBox.appendChild(e);
-    g.el=e; g.elS=e.querySelector('.mt'); g.lead=makeLead(hexs(g.realm.accent));
+    g.el=e; g.elS=e.querySelector('.mt'); g.elPg=e.querySelector('.pg');
+    g.elPgI=e.querySelector('.pg i'); g.lead=makeLead(hexs(g.realm.accent));
   }
 }
 const _v=new THREE.Vector3();
@@ -8734,7 +8769,11 @@ function layoutLabels(){
        falls back to "least bad", which is six names in a heap. The narrow
        plates are the same component one size down; the CSS follows. */
     const wide=VW>=700;
-    const boxes0=[], w0=wide?250:150, h0=wide?72:56;
+    /* The rung line lengthens the count and adds a bar under it, and the solver
+       works from fixed sizes rather than from measuring the DOM, so the box has
+       to be told. Under-reserving here is plates overlapping the thing they name. */
+    const rungOn=LVLPROG&&!W.unbuilt;
+    const boxes0=[], w0=(wide?250:150)+(rungOn?54:0), h0=(wide?72:56)+(rungOn?7:0);
     const live0=[...W.quarters].filter(q=>q.shown>0).sort((a,b)=>b.shown-a.shown);
     /* The realms' own footprints, so the solver can see the ground it is about
        to cover. Without this the district fix reached the realm labels as a
@@ -8767,7 +8806,7 @@ function layoutLabels(){
       /* Name and subject, and no third line: an unbuilt realm has no count to
          show, and six labels all repeating the same instruction is the
          instruction shouted six times. The page asks once, on the world. */
-      const txt=W.unbuilt?'':arts(g.shown);
+      const txt=W.unbuilt?'':arts(g.shown)+rung(g,g.shown,REALM_DIV);
       if(g.elS.textContent!==txt) g.elS.textContent=txt;
     }
     return;
@@ -8813,7 +8852,10 @@ function layoutLabels(){
        had selected — that is gone with the rest of the pointer states, so size
        is now purely a function of how big the district is on screen. */
     const t=dpx<190?1:2;
-    const w=t>=2?168:104, h=t>=2?58:32;
+    /* Same reservation the realm plates make, one scale down. Only the second
+       tier carries a count, so only it grows. */
+    const rungOn=LVLPROG&&!W.unbuilt&&t>=2;
+    const w=t>=2?168+(rungOn?46:0):104, h=t>=2?58+(rungOn?7:0):32;
     /* Clear the LAND, not the territory. terrR is the district's plot — its
        island plus the verge the border and the open ground live in — and
        clearing that put every plate a further four world-units out, over the
@@ -8835,8 +8877,12 @@ function layoutLabels(){
     const nm=nameOf(d);
     if(d.elNm.textContent!==nm) d.elNm.textContent=nm;
     if(t>=2){
-      const mt=arts(d.shown);
+      const mt=arts(d.shown)+rung(d,d.shown,1);
       if(d.elMt.textContent!==mt) d.elMt.textContent=mt;
+    }else{
+      /* A bare name over the world hides its count in CSS, and the bar has to go
+         with it — but `rung` writes display inline, and inline beats the class. */
+      d.elPg.style.display='none';
     }
     /* The banner line only ever appeared on the third tier, which was the
        selected district's plate — so it goes with it. A district's heraldry is
@@ -10733,6 +10779,10 @@ return {
   setLook: lookSet,
   setCrest: crestSet,
   setSky: skySet,
+  /* The rung lines are the owner's own business, so unlike the look and the
+     crest this one IS about the viewer. Read live by the label pass, which runs
+     every frame, so there is nothing to rebuild and nothing to invalidate. */
+  setLevelProgress: on=>{ LVLPROG=!!on; },
   setViewFlags: v=>{ Object.assign(VIEW,v);
     if(W){ paintBorders();
            clouds.visible=VIEW.sky;

--- a/packages/webapp/components/world/ladder.ts
+++ b/packages/webapp/components/world/ladder.ts
@@ -1,0 +1,255 @@
+/**
+ * The twelve-step ladder, and everything derived from a district's position on
+ * it.
+ *
+ * Split out of `engine/taxonomy.js` rather than left there because taxonomy
+ * imports `three` on its first line. Anything outside the world page that wants
+ * to say how far a district is from its next rung (a feed nudge, a post-read
+ * card) would drag most of a megabyte of renderer in behind one integer
+ * comparison. Nothing here knows what a district looks like, so nothing here
+ * needs the renderer.
+ *
+ * `taxonomy.js` re-exports `LEVELS` and `levelOf` so the engine still has one
+ * source of truth for the rungs.
+ */
+
+export interface WorldLevel {
+  /** Build name, for whoever edits the geometry. See the note below. */
+  n: string;
+  /** Lifetime article count at which this rung is reached. */
+  reads: number;
+  /** What this rung is supposed to BUILD. */
+  d: string;
+}
+
+/* Twelve rungs, doubling from L4 up: one rung per doubling of attention. That
+   is scale-free, so it spreads any world's districts the same way wherever that
+   world sits, which is the property that matters here — you look at one world
+   at a time, and the job is to separate ONE reader's districts from each other.
+
+   Tuning instead for an even spread across everybody drags every rung down,
+   because the population is dominated by districts holding a single article.
+   What comes out is a world where everything is the same size, which is exactly
+   the saturation this ladder exists to prevent.
+
+   Two limits worth knowing. The bottom and the top compete: every rung spent
+   separating one article from two is a rung not available to a long-time
+   reader. And nothing can split the districts holding exactly one article, so
+   L1 is a floor we accept rather than a rung anybody earns.
+
+   SKY COURT stays out of reach on purpose. A ladder whose ceiling is reachable
+   stops being a ceiling.
+
+   `reads` is the only field that has ever reached a reader, as "L7". The names
+   and the descriptions are for whoever edits the geometry: they say what each
+   rung is supposed to BUILD, next to the threshold that triggers it. Twelve
+   invented names is a second vocabulary to learn before a level means anything,
+   so the UI counts instead of naming. */
+export const LEVELS: WorldLevel[] = [
+  {
+    n: 'WAYSTONE',
+    reads: 1,
+    d: 'A single lodestone on bare rock. One article is a real thing that happened — it gets land, however little.',
+  },
+  {
+    n: 'CAIRN',
+    reads: 2,
+    d: 'Somebody stacked stones and planted the first crystal sprout. Still wild, no longer untouched.',
+  },
+  {
+    n: 'CAMP',
+    reads: 3,
+    d: "A tended camp: lantern, path, the district's signature motif appears — identity arrives early, before size does.",
+  },
+  {
+    n: 'HOLD',
+    reads: 5,
+    d: 'Ground is cut into two terraces and the first roof goes up. The plot starts reading as built, not found.',
+  },
+  {
+    n: 'ATELIER',
+    reads: 10,
+    d: 'A working hamlet with a pool at its heart. Gardens, hedges, the first real greenery.',
+  },
+  {
+    n: 'SANCTUM',
+    reads: 20,
+    d: 'Three terraces, a dome, and the first spire. Birds arrive — the place is worth circling.',
+  },
+  {
+    n: 'CONCLAVE',
+    reads: 40,
+    d: 'Water spills off the rim as a falls. Lamps line the paths. Density picks up faster than the land does.',
+  },
+  {
+    n: 'SPIRE',
+    reads: 80,
+    d: 'Ground runs out before the reading does: cantilever decks brace out past the cliff on struts. The silhouette stops being a lump.',
+  },
+  {
+    n: 'ACADEMY',
+    reads: 160,
+    d: 'Four terraces, a spire cluster, and sky bridges strung between the towers. Legible from across the map.',
+  },
+  {
+    n: 'ARCANUM',
+    reads: 320,
+    d: 'Lanterns and hanging gardens spill over the terrace lips, a second hall opens, and the district starts growing downward as well as out.',
+  },
+  {
+    n: 'CITADEL',
+    reads: 640,
+    d: 'The Great Spire goes up — one landmark that owns the skyline — over a full upper tier of decks and bridges.',
+  },
+  {
+    n: 'SKY COURT',
+    reads: 1280,
+    d: 'The endgame plot. Everything lit, everything tended, everything moving. A capital of one subject.',
+  },
+];
+
+export const MAX_LEVEL = LEVELS.length;
+
+/**
+ * Level from a lifetime article count, on the twelve-step ladder.
+ *
+ * The engine calls this once per district per day of history, so it stays a
+ * plain scan over twelve entries rather than anything that allocates.
+ */
+export function levelOf(articles: number): number {
+  if (articles <= 0) {
+    return 0;
+  }
+  let level = 1;
+  for (let i = 0; i < LEVELS.length; i += 1) {
+    if (articles >= LEVELS[i].reads) {
+      level = i + 1;
+    }
+  }
+  return level;
+}
+
+/** The minimum a district needs to sit on `level`, and 0 for untouched ground. */
+export const floorOf = (level: number): number =>
+  level <= 0 ? 0 : LEVELS[level - 1].reads;
+
+/* A REALM is scored on the same ladder with its thresholds moved out, because a
+   realm collects many districts and would otherwise top out long before the
+   districts inside it do. A divisor too small saturates the top of the range,
+   which is the same flattening the twelve-step ladder exists to prevent, one
+   scale up.
+
+   No divisor rescues the middle of this axis, and it is honest to say so: a
+   reader covers a handful of niches inside one or two realms, so most realms
+   sit on the first rung whatever we pick. This ladder separates the top of the
+   range; it is not a progress bar for the median. Floored at 1: a realm you
+   have read once is small, not absent. */
+export const REALM_DIV = 8;
+
+export const realmLevelOf = (articles: number): number =>
+  articles <= 0 ? 0 : Math.max(1, levelOf(articles / REALM_DIV));
+
+export interface LevelProgress {
+  level: number;
+  /** Articles still to read for the next rung. 0 once the ladder is topped out. */
+  toNext: number;
+  /** 0 to 1 across the current rung. 1 at L12, which has nothing above it. */
+  fraction: number;
+  /** Null at L12. */
+  next?: WorldLevel;
+}
+
+/**
+ * Where a district stands between the rung it is on and the one above it.
+ *
+ * `div` scales the whole ladder for things scored on a stretched copy of it:
+ * pass `REALM_DIV` for a realm, nothing for a district. It is the divisor rather
+ * than pre-divided reads because every number that comes back out is in
+ * ARTICLES, and "read 28 more" has to be a count of articles a reader can go and
+ * read, not a count of eighths.
+ *
+ * The rungs double, so `fraction` is a within-rung position and NOT comparable
+ * between districts: half way from L11 to L12 is 320 articles, half way from L1
+ * to L2 is not quite one. Anything that ranks districts against each other has
+ * to rank on `toNext`.
+ */
+export const levelProgress = (reads: number, div = 1): LevelProgress => {
+  const level = div === 1 ? levelOf(reads) : realmLevelOf(reads);
+  if (level >= MAX_LEVEL) {
+    return { level, toNext: 0, fraction: 1 };
+  }
+
+  const ceiling = LEVELS[level].reads * div;
+  /* `realmLevelOf` floors at L1, so a realm sitting on its first rung can hold
+     fewer articles than that rung's own threshold. Clamping the floor to what
+     has actually been read keeps such a realm at the START of the bar instead
+     of behind it. A district cannot reach L1 below the threshold, so this is
+     the identity for everything else. */
+  const floor = Math.min(floorOf(level) * div, reads);
+
+  return {
+    level,
+    /* Ceiled: the ladder is walked in whole articles, and a realm 0.4 of an
+       article short still needs one more read to cross. */
+    toNext: Math.ceil(ceiling - reads),
+    fraction: (reads - floor) / (ceiling - floor),
+    next: LEVELS[level],
+  };
+};
+
+/** The least a district has to carry to be worth pointing at. */
+export interface LadderRow {
+  key: string;
+  name: string;
+  reads: number;
+}
+
+export interface NearestLevelUp extends LevelProgress {
+  key: string;
+  name: string;
+  reads: number;
+  /** Present, so callers never have to re-test `level >= MAX_LEVEL`. */
+  next: WorldLevel;
+}
+
+/**
+ * The district closest to its next rung, anywhere in the world.
+ *
+ * This is the whole mechanic, and picking the nearest rather than the biggest is
+ * what makes it usable. The ladder doubles, so a reader's strongest district is
+ * usually their FURTHEST from levelling: a district at L11 needs 640 more
+ * articles, and putting that number in front of someone is a reason to stop, not
+ * to read. Their seventh district is typically one or two away.
+ *
+ * It also means the target moves as they read, which is the only variability in
+ * the mechanic that we do not have to invent.
+ *
+ * Ties break towards the district with more reads: of two districts one article
+ * from a rung, the one further along is the one they are actually reading.
+ */
+export const nearestLevelUp = (
+  rows: readonly LadderRow[] | undefined,
+): NearestLevelUp | null => {
+  if (!rows?.length) {
+    return null;
+  }
+
+  let best: NearestLevelUp | null = null;
+  rows.forEach((row) => {
+    const progress = levelProgress(row.reads);
+    // Topped out: there is no next rung to walk towards.
+    if (!progress.next) {
+      return;
+    }
+    if (
+      best &&
+      (progress.toNext > best.toNext ||
+        (progress.toNext === best.toNext && row.reads <= best.reads))
+    ) {
+      return;
+    }
+    best = { ...row, ...progress, next: progress.next };
+  });
+
+  return best;
+};

--- a/packages/webapp/components/world/useWorldDraft.ts
+++ b/packages/webapp/components/world/useWorldDraft.ts
@@ -1,6 +1,9 @@
 import { useCallback, useMemo, useState } from 'react';
 import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
 import type { WorldSettings } from '../../graphql/world';
+import { isWorldCustomised } from './worldCustomization';
 import type { WorldSettingsPatch } from './useWorldSettings';
 import { useUpdateWorldSettings } from './useWorldSettings';
 
@@ -88,6 +91,7 @@ export const useWorldDraft = (
 ): WorldDraft => {
   const [settings, setSettings] = useState<WorldDraftSettings | null>(null);
   const { save: persist, isSaving, error } = useUpdateWorldSettings(userId);
+  const { logEvent } = useLogContext();
 
   const open = useCallback(() => setSettings(toDraft(saved)), [saved]);
   const cancel = useCallback(() => setSettings(null), []);
@@ -106,9 +110,22 @@ export const useWorldDraft = (
         // open so nothing typed is lost.
         return;
       }
+      /* The patch rather than the draft, so this says what was CHANGED and not
+         what happens to be set. `is_first` is the one that matters: whether
+         somebody who has now put something of their own into a world comes back
+         to it is the whole question, and it can only be asked of the save that
+         turned an undressed world into a dressed one. */
+      logEvent({
+        event_name: LogEvent.WorldCustomize,
+        target_id: userId,
+        extra: JSON.stringify({
+          fields: Object.keys(patch),
+          is_first: !isWorldCustomised(saved),
+        }),
+      });
     }
     setSettings(null);
-  }, [persist, saved, settings]);
+  }, [logEvent, persist, saved, settings, userId]);
 
   /* The draft while the bench is open, stored settings the moment it closes —
      what makes Cancel put the place back the way it was found. */

--- a/packages/webapp/components/world/useWorldLog.ts
+++ b/packages/webapp/components/world/useWorldLog.ts
@@ -1,0 +1,186 @@
+import { useEffect, useRef } from 'react';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import type { WorldDistrict } from '../../graphql/world';
+import { levelOf, nearestLevelUp } from './ladder';
+import type { WorldState } from './worldState';
+
+/**
+ * Where a visit came from, as far as a client can honestly tell.
+ *
+ * Referrer only, and deliberately coarse. `external` is the question worth
+ * answering, because it is the one thing no other event can see: a link that has
+ * left the product and come back with somebody on it. Navigation inside the app
+ * is already attributed by the click that caused it (`ProfileWorldToggle`), so
+ * this does not try to beat `document.referrer`'s known blind spot, which is
+ * that a soft navigation leaves it describing whatever last hard-loaded.
+ */
+const worldSource = (): 'direct' | 'internal' | 'external' => {
+  const { referrer } = globalThis.document ?? {};
+  if (!referrer) {
+    return 'direct';
+  }
+
+  try {
+    return new URL(referrer).origin === globalThis.location.origin
+      ? 'internal'
+      : 'external';
+  } catch {
+    // A referrer we cannot parse is not a referrer we can attribute.
+    return 'direct';
+  }
+};
+
+interface UseWorldLogProps {
+  userId: string;
+  isOwn: boolean;
+  /** The handheld renderer tier, which is a different product and a different boot. */
+  isLite: boolean;
+  /** Districts and settings have settled, so we know whether this world is refused. */
+  isSettled: boolean;
+  isPrivate: boolean;
+  /** Six realms of bare ground. Still a world, and still worth counting as one. */
+  isUnbuilt: boolean;
+  /** The engine has this reader's world standing. */
+  isReady: boolean;
+  /** Why the boot died, if it did. */
+  failure?: string;
+  state: WorldState;
+  districts?: WorldDistrict[];
+}
+
+/**
+ * The world's own funnel: one `world view` per visit, resolving to exactly one
+ * `world ready` or one `world boot failed`.
+ *
+ * Kept as three events rather than one with an outcome field because the view is
+ * knowable long before the outcome is, and a single event would have to wait for
+ * the slowest boot on the worst connection to report the visit at all. Which is
+ * exactly the population that never reports.
+ *
+ * A hidden world is the one visit with no outcome: nothing is raised, so nothing
+ * succeeds or fails. It is still a view, and `is_private` is what separates it
+ * from a boot that never came back.
+ *
+ * Every guard is keyed by reader rather than by mount: a soft navigation from one
+ * world to another keeps this component, its engine and its refs, and the second
+ * world is a second visit.
+ */
+export const useWorldLog = ({
+  userId,
+  isOwn,
+  isLite,
+  isSettled,
+  isPrivate,
+  isUnbuilt,
+  isReady,
+  failure,
+  state,
+  districts,
+}: UseWorldLogProps): void => {
+  const { logEvent } = useLogContext();
+  const viewedFor = useRef<string | null>(null);
+  const settledFor = useRef<string | null>(null);
+  const startedAt = useRef(0);
+
+  /* Read through a ref so the effects below depend on the reader and the one
+     fact that moved them, and not on a render-scoped `logEvent` or on a `state`
+     the engine replaces sixty times a second while the replay runs. */
+  const latest = useRef({
+    logEvent,
+    isOwn,
+    isLite,
+    isPrivate,
+    state,
+    districts,
+  });
+  latest.current = { logEvent, isOwn, isLite, isPrivate, state, districts };
+
+  useEffect(() => {
+    if (!isSettled || viewedFor.current === userId) {
+      return;
+    }
+    viewedFor.current = userId;
+    settledFor.current = null;
+    startedAt.current = globalThis.performance?.now() ?? 0;
+
+    const { current } = latest;
+    current.logEvent({
+      event_name: LogEvent.WorldView,
+      target_id: userId,
+      extra: JSON.stringify({
+        source: worldSource(),
+        is_own: current.isOwn,
+        is_private: current.isPrivate,
+        is_lite: current.isLite,
+      }),
+    });
+  }, [isSettled, userId]);
+
+  useEffect(() => {
+    if (viewedFor.current !== userId || settledFor.current === userId) {
+      return;
+    }
+    if (!isReady && !failure) {
+      return;
+    }
+    settledFor.current = userId;
+
+    const { current } = latest;
+    /* Measured from the view, so it covers the districts query and the engine
+       raising the world. It does NOT cover the renderer chunk: this hook only
+       exists once that has landed, and the wait before it is the thing the
+       profile's prefetch is already trying to spend. */
+    const bootMs = Math.round(
+      (globalThis.performance?.now() ?? 0) - startedAt.current,
+    );
+
+    if (failure) {
+      current.logEvent({
+        event_name: LogEvent.WorldBootFailed,
+        target_id: userId,
+        extra: JSON.stringify({
+          is_own: current.isOwn,
+          is_lite: current.isLite,
+          boot_ms: bootMs,
+          reason: failure,
+        }),
+      });
+      return;
+    }
+
+    /* Off the districts, not off `state.rank`, which holds REALMS at the top
+       level and is scored on the realm ladder. The level anyone is ever shown is
+       a district's. */
+    const rows = current.districts ?? [];
+    const nearest = nearestLevelUp(
+      rows.map(({ niche, reads }) => ({
+        key: niche.slug,
+        name: niche.slug,
+        reads,
+      })),
+    );
+
+    current.logEvent({
+      event_name: LogEvent.WorldReady,
+      target_id: userId,
+      extra: JSON.stringify({
+        is_own: current.isOwn,
+        is_lite: current.isLite,
+        is_unbuilt: isUnbuilt,
+        boot_ms: bootMs,
+        articles: current.state.articles ?? 0,
+        districts: current.state.districts ?? 0,
+        realms: current.state.realms ?? 0,
+        top_level: rows.reduce(
+          (top, { reads }) => Math.max(top, levelOf(reads)),
+          0,
+        ),
+        /* The baseline the level-up nudge would be built on: how far the closest
+           district is from its next rung, at the moment somebody looked. Null
+           when every district has topped out, which is nobody yet. */
+        nearest_gap: nearest?.toNext ?? null,
+      }),
+    });
+  }, [failure, isReady, isUnbuilt, userId]);
+};

--- a/packages/webapp/components/world/worldState.ts
+++ b/packages/webapp/components/world/worldState.ts
@@ -107,6 +107,8 @@ export interface WorldEngine {
   setCrest: (crest: WorldCrest | null) => void;
   /** Palette and hour. Repaints the environment, so it is key-guarded inside. */
   setSky: (sky: WorldSky) => void;
+  /** Whether the plates carry how far through its rung each plot is. Owner only. */
+  setLevelProgress: (on: boolean) => void;
   setViewFlags: (flags: Partial<Record<string, boolean>>) => void;
   /**
    * A bare render of the whole world as a JPEG data URL, for the share card to


### PR DESCRIPTION
## Level progress on the plates

On your own world, every realm and district plate now carries how far through its current level the plot is: the articles left of the rung, plus a bar in the plot's own accent. The count line reads `<n> articles · <n> to L<n>`.

Owner only. On somebody else's world the plates are unchanged, because it would be a number about a stranger's reading on a box the size of a stamp. Gated by `setLevelProgress(isOwn)`, read live by the label pass that already runs every frame, so flipping it rebuilds nothing.

A topped-out plot shows the count and a full bar with no chase number: there is nothing above it to promise. The bare-name tier keeps its bar hidden along with its count.

Note the plate solver works from fixed box sizes rather than measuring the DOM, so the reserved boxes grow by the extra line's worth when progress is on. Under-reserving there is plates overlapping the islands they name.

## The ladder moves out of the renderer

`LEVELS`, `levelOf`, `realmLevelOf` and `REALM_DIV` now live in `components/world/ladder.ts`, which imports nothing. `engine/taxonomy.js` pulls in `three` on its first line, so anything outside the world page that wants to say "two more articles" would have dragged most of a megabyte of renderer in behind one integer comparison. Taxonomy re-exports them, so the engine still has one source of truth.

`levelProgress` takes the realm divisor, so a realm's remaining count comes back in articles a reader can go and read rather than in eighths.

## Four events

The world had two events (`share world`, `profile world toggle`), which is not enough to answer whether anyone ever comes back to one.

| event | carries |
|---|---|
| `world view` | `source`, `is_own`, `is_private`, `is_lite` |
| `world ready` | `boot_ms`, `articles`, `districts`, `realms`, `top_level`, `nearest_gap` |
| `world boot failed` | `boot_ms`, `reason` |
| `world customize` | `fields`, `is_first` |

`world view` is the denominator and fires whatever happens next, so the other two resolve it as a rate rather than as a sample of the boots that survived. A hidden world is the one visit with no outcome, and `is_private` is what separates it from a boot that never came back.

`world customize` carries `is_first` because whether a reader who has put something of their own into a world comes back to it is the question, and it can only be asked of the save that turned an undressed world into a dressed one.

`source` is referrer-based and deliberately coarse. `external` is the case no other event can see. In-app navigation is already attributed by the click that caused it, so this does not try to beat `document.referrer`'s soft-navigation blind spot.

## Open question, not blocking

The realm figures get large on a well-read world, because the realm ladder pushes its thresholds out and a realm collects many districts. The comment on `REALM_DIV` says it plainly: that ladder separates the top of the range and is not a progress bar for the median. The district numbers read well; the realm ones can read as a wall. Options are dropping the number on realms and keeping the bar, restricting the whole thing to districts, or accepting realms as a status readout. Happy to change it either way.

## A note on the comments

This PR also strips the calibration figures out of the ladder's comments, including the block that was already in `engine/taxonomy.js`. The reasoning is worth keeping and is all still there; the platform-wide counts and distributions behind it are not something a public repo needs to carry.

## Verification

Checked against a real world on staging: realm plates, district plates inside a realm, a topped-out district, and a second user's world for the gate. 95 tests pass across 10 world suites, lint clean, and full webapp `tsc` shows the same pre-existing errors as `main` with none in world.

https://claude.ai/code/session_01UUMb3WtmKvBMWNsKZD93ir
