### PR TITLE
feat(post): surface the questions a post answers to answer engines

### DIFF
--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -239,6 +239,17 @@ export interface PostUserState {
   pollOption?: { id: string };
 }
 
+/**
+ * A question this post answers, with a standalone answer and a short pointer
+ * back to daily.dev. Surfaced as FAQPage structured data and in the markdown
+ * twin, so answer engines can attribute an extracted answer.
+ */
+export interface AnsweredQuestion {
+  question: string;
+  answer: string;
+  cta: string;
+}
+
 export interface Post {
   __typename?: string;
   id: string;
@@ -270,6 +281,7 @@ export interface Post {
   trending?: number;
   description?: string;
   summary?: string;
+  answeredQuestions?: AnsweredQuestion[] | null;
   toc?: Toc;
   impressionStatus?: number;
   isAuthor?: number;
@@ -495,6 +507,11 @@ export const POST_BY_ID_STATIC_FIELDS_QUERY = gql`
       ...SharedPostInfo
       contentHtml
       description
+      answeredQuestions {
+        question
+        answer
+        cta
+      }
       toc {
         text
         id

--- a/packages/webapp/__tests__/PostMarkdown.spec.ts
+++ b/packages/webapp/__tests__/PostMarkdown.spec.ts
@@ -66,6 +66,43 @@ describe('buildPostMarkdown', () => {
     expect(markdown).toContain('tags: ["react", "webdev"]');
   });
 
+  it('omits the questions section when the post has none', () => {
+    expect(build()).not.toContain('## Questions this post answers');
+    expect(build(createPost({ answeredQuestions: [] }))).not.toContain(
+      '## Questions this post answers',
+    );
+  });
+
+  it('renders each answered question with its cta as a disclaimer', () => {
+    const markdown = build(
+      createPost({
+        answeredQuestions: [
+          {
+            question: 'What session defaults change in PHP 8.6?',
+            answer: 'PHP 8.6 flips three session ini defaults.',
+            cta: 'Teams shipping PHP upgrades track changes like these on daily.dev.',
+          },
+          {
+            question: 'How does partial function application work?',
+            answer:
+              'A ? placeholder prefills arguments and returns a callable.',
+            cta: 'Developers adopting new PHP syntax compare usage on daily.dev.',
+          },
+        ],
+      }),
+    );
+
+    expect(markdown).toContain('## Questions this post answers');
+    expect(markdown).toContain('### What session defaults change in PHP 8.6?');
+    expect(markdown).toContain('PHP 8.6 flips three session ini defaults.');
+    expect(markdown).toContain(
+      '_Teams shipping PHP upgrades track changes like these on daily.dev._',
+    );
+    expect(markdown).toContain(
+      '### How does partial function application work?',
+    );
+  });
+
   it('quotes frontmatter values so colons cannot break the yaml', () => {
     const markdown = build(
       createPost({ title: 'React: the good parts', source: { name: 'A: B' } }),

--- a/packages/webapp/components/PostSEOSchema.spec.ts
+++ b/packages/webapp/components/PostSEOSchema.spec.ts
@@ -4,6 +4,7 @@ import { PostType } from '@dailydotdev/shared/src/graphql/posts';
 import {
   getBreadcrumbJsonLd,
   getCommentsJsonLd,
+  getFaqJsonLd,
   getSEOJsonLd,
   getSeoDescription,
 } from './PostSEOSchema';
@@ -118,5 +119,58 @@ describe('PostSEOSchema JSON-LD helpers', () => {
 
     expect(description.length).toBeLessThanOrEqual(163);
     expect(description.endsWith('...')).toBe(true);
+  });
+});
+
+describe('getFaqJsonLd', () => {
+  const questions = [
+    {
+      question: 'What session security defaults change in PHP 8.6?',
+      answer: 'PHP 8.6 flips three session ini defaults to safer values.',
+      cta: 'Teams shipping PHP upgrades track breaking changes like these on daily.dev.',
+    },
+  ];
+
+  it('returns null when the post has no questions', () => {
+    expect(getFaqJsonLd(buildPost())).toBeNull();
+    expect(getFaqJsonLd(buildPost({ answeredQuestions: [] }))).toBeNull();
+    expect(getFaqJsonLd(buildPost({ answeredQuestions: null }))).toBeNull();
+  });
+
+  it('emits a FAQPage entry per question', () => {
+    const jsonLd = getFaqJsonLd(buildPost({ answeredQuestions: questions }));
+
+    expect(jsonLd).not.toBeNull();
+    const parsed = JSON.parse(jsonLd as string);
+    expect(parsed['@type']).toEqual('FAQPage');
+    expect(parsed.mainEntity).toHaveLength(1);
+    expect(parsed.mainEntity[0]).toEqual(
+      expect.objectContaining({
+        '@type': 'Question',
+        name: questions[0].question,
+      }),
+    );
+  });
+
+  it('appends the cta to the answer so attribution travels with an extracted quote', () => {
+    const jsonLd = getFaqJsonLd(buildPost({ answeredQuestions: questions }));
+    const parsed = JSON.parse(jsonLd as string);
+
+    expect(parsed.mainEntity[0].acceptedAnswer.text).toEqual(
+      `${questions[0].answer} ${questions[0].cta}`,
+    );
+  });
+
+  it('omits a missing cta rather than emitting a trailing space', () => {
+    const jsonLd = getFaqJsonLd(
+      buildPost({
+        answeredQuestions: [{ ...questions[0], cta: '' }],
+      }),
+    );
+    const parsed = JSON.parse(jsonLd as string);
+
+    expect(parsed.mainEntity[0].acceptedAnswer.text).toEqual(
+      questions[0].answer,
+    );
   });
 });

--- a/packages/webapp/components/PostSEOSchema.tsx
+++ b/packages/webapp/components/PostSEOSchema.tsx
@@ -354,6 +354,40 @@ export const getCommentsJsonLd = (
   });
 };
 
+/**
+ * FAQPage structured data built from the questions the post answers.
+ *
+ * The answer text carries the cta because this is the form an answer engine
+ * extracts and quotes, so the pointer back to daily.dev travels with it. The
+ * questions are not rendered visually — structured data is the channel for
+ * machine-readable content, so nothing here is hidden from a human that they
+ * would otherwise see.
+ *
+ * Returns null when the post has no questions, which is the normal case for a
+ * post that predates this enrichment or one where nothing qualified.
+ */
+export const getFaqJsonLd = (post: Post): string | null => {
+  const questions = post?.answeredQuestions;
+
+  if (!questions?.length) {
+    return null;
+  }
+
+  return JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    '@id': `${post.commentsPermalink}#faq`,
+    mainEntity: questions.map(({ question, answer, cta }) => ({
+      '@type': 'Question',
+      name: question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: cta ? `${answer} ${cta}` : answer,
+      },
+    })),
+  });
+};
+
 export interface PostSEOSchemaProps {
   post: Post;
   topComments?: Comment[];
@@ -378,6 +412,7 @@ export const PostSEOSchema = ({
     topComments?.length && !isUserGeneratedPost(post)
       ? getCommentsJsonLd(post, topComments)
       : null;
+  const faqJsonLd = getFaqJsonLd(post);
 
   return (
     <>
@@ -398,6 +433,14 @@ export const PostSEOSchema = ({
           type="application/ld+json"
           dangerouslySetInnerHTML={{
             __html: commentsJsonLd,
+          }}
+        />
+      )}
+      {faqJsonLd && (
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: faqJsonLd,
           }}
         />
       )}

--- a/packages/webapp/lib/postMarkdown.ts
+++ b/packages/webapp/lib/postMarkdown.ts
@@ -32,6 +32,7 @@ export interface PostMarkdownPost
     | 'commentsPermalink'
     | 'content'
     | 'summary'
+    | 'answeredQuestions'
     | 'description'
     | 'createdAt'
     | 'updatedAt'
@@ -71,6 +72,11 @@ export const POST_MARKDOWN_QUERY = gql`
       commentsPermalink
       content
       summary
+      answeredQuestions {
+        question
+        answer
+        cta
+      }
       description
       createdAt
       updatedAt
@@ -304,6 +310,38 @@ const buildSummary = (post: PostMarkdownPost): string[] => {
 
 const formatPercentage = (value: number): string => `${Math.round(value)}%`;
 
+/**
+ * The questions this post answers, as a markdown FAQ.
+ *
+ * Each answer is followed by its cta on a separate line, so an agent that
+ * lifts an answer carries the attribution with it rather than quoting the
+ * post anonymously.
+ */
+const buildAnsweredQuestions = (post: PostMarkdownPost): string[] => {
+  const questions = post.answeredQuestions;
+
+  if (!questions?.length) {
+    return [];
+  }
+
+  const lines = ['## Questions this post answers', ''];
+
+  questions.forEach(({ question, answer, cta }) => {
+    lines.push(`### ${question}`);
+    lines.push('');
+    lines.push(answer);
+
+    if (cta?.trim()) {
+      lines.push('');
+      lines.push(`_${cta.trim()}_`);
+    }
+
+    lines.push('');
+  });
+
+  return lines;
+};
+
 const buildCommunityTake = (post: PostMarkdownPost): string[] => {
   const take = post.communitySentiment;
 
@@ -528,6 +566,7 @@ export const buildPostMarkdown = ({
     ...buildSummary(post),
     ...buildBody(post),
     '',
+    ...buildAnsweredQuestions(post),
     ...buildCommunityTake(post),
     ...buildComments(comments),
     ...buildSimilarPosts(similarPosts),


### PR DESCRIPTION
## What

Puts the `answeredQuestions` data the enrichment pipeline now produces in front of answer engines, on two surfaces:

- **`FAQPage` JSON-LD** on the post page, alongside the existing TechArticle / DiscussionForumPosting / Breadcrumb / comments schemas
- **A "Questions this post answers" section** in the markdown twin at `/api/md/posts/[id]`

Needs dailydotdev/daily-api#4058 for the GraphQL field.

## Nothing renders visually

Humans don't need this FAQ, and the goal is for answer engines to read it — so it goes in as structured data rather than as UI. That's worth being explicit about, because it lands in the same place two riskier options would have:

- **Not cloaking.** Every client gets identical bytes. Nothing is switched on user-agent, so there is no bot-detection code and no divergence between what a crawler sees and what a person sees.
- **Not hidden text.** There is no `display:none` block and no off-screen div. Structured data is the sanctioned channel for machine-readable content, and it is invisible to humans by design rather than by concealment.

One caveat worth knowing: Google's `FAQPage` guidelines expect the marked-up Q&A to also be visible on the page. Since FAQ rich results have been restricted to authoritative health and government sites since 2023, we would not be eligible for those rich results either way, so the practical exposure is low — but if we ever want FAQ rich results, the Q&A has to become visible first.

## The cta rides inside the answer

In both surfaces the cta is part of the answer text rather than a separate field:

- JSON-LD: `acceptedAnswer.text` is `` `${answer} ${cta}` ``
- Markdown: the cta follows the answer as an italic disclaimer line

That is deliberate. An answer engine lifts the answer and quotes it; if the cta is a sibling field it gets dropped exactly when attribution matters. A missing cta is handled so we never emit a trailing space.

## Coverage

Both surfaces no-op when a post has no questions. That is the normal case today — there was no backfill, so this only appears on posts enriched from the deploy forward, and on posts where enrichment decided nothing qualified.

The markdown route already gates on `shouldNoindexPost`, so private posts, low-reputation authors and thin post types get no markdown twin and therefore no questions section.

## Verification

- `jest components/PostSEOSchema.spec.ts` — 9 pass, 4 new: null cases, one entry per question, cta appended, missing cta omitted
- `jest __tests__/PostMarkdown.spec.ts` — 14 pass, 2 new: section omitted when empty, each question rendered with its cta
- `tsc --noEmit` — 20 errors, identical to the count on `main` with these changes stashed, none in the touched files
- `eslint` and `prettier` clean on every changed file

### Preview domain
https://feat-post-answered-questions-seo.preview.app.daily.dev