### PR TITLE
feat(post): show the answered questions FAQ to anonymous readers

### DIFF
--- a/packages/shared/src/components/post/BasePostContent.tsx
+++ b/packages/shared/src/components/post/BasePostContent.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import PostEngagements from './PostEngagements';
 import type { BasePostContentProps } from './common';
 import { PostHeaderActions } from './PostHeaderActions';
+import { PostAnsweredQuestions } from './PostAnsweredQuestions';
 import { ButtonSize } from '../buttons/common';
 
 const Custom404 = dynamic(
@@ -62,6 +63,7 @@ export function BasePostContent({
         </GoBackHeaderMobile>
       )}
       {children}
+      {isPostPage && <PostAnsweredQuestions post={post} className="mt-6" />}
       {!!engagementProps && (
         <PostEngagements
           post={post}

--- a/packages/shared/src/components/post/PostAnsweredQuestions.spec.tsx
+++ b/packages/shared/src/components/post/PostAnsweredQuestions.spec.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PostAnsweredQuestions } from './PostAnsweredQuestions';
+import { useAuthContext } from '../../contexts/AuthContext';
+import type { Post } from '../../graphql/posts';
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuthContext: jest.fn(),
+}));
+
+const answeredQuestions = [
+  {
+    question: 'What session defaults change in PHP 8.6?',
+    answer: 'PHP 8.6 flips three session ini defaults to safer values.',
+    cta: 'Teams shipping PHP upgrades track changes like these on daily.dev.',
+  },
+  {
+    question: 'How does partial function application work?',
+    answer: 'A ? placeholder prefills arguments and returns a callable.',
+    cta: 'Developers adopting new PHP syntax compare usage on daily.dev.',
+  },
+];
+
+const buildPost = (props: Partial<Post> = {}): Post =>
+  ({ id: 'p1', answeredQuestions, ...props } as Post);
+
+const mockAuth = (isLoggedIn: boolean) =>
+  jest.mocked(useAuthContext).mockReturnValue({ isLoggedIn } as never);
+
+describe('PostAnsweredQuestions', () => {
+  it('renders a collapsed entry per question for anonymous users', () => {
+    mockAuth(false);
+
+    render(<PostAnsweredQuestions post={buildPost()} />);
+
+    expect(screen.getByText('Questions this post answers')).toBeInTheDocument();
+    const entries = screen.getAllByRole('group');
+    expect(entries).toHaveLength(answeredQuestions.length);
+    entries.forEach((entry) => expect(entry).not.toHaveAttribute('open'));
+  });
+
+  it('keeps the answers in the markup while collapsed so crawlers read them', () => {
+    mockAuth(false);
+
+    render(<PostAnsweredQuestions post={buildPost()} />);
+
+    answeredQuestions.forEach(({ question, answer, cta }) => {
+      expect(screen.getByText(question)).toBeInTheDocument();
+      expect(screen.getByText(`${answer} ${cta}`)).toBeInTheDocument();
+    });
+  });
+
+  it('omits a missing cta rather than rendering a trailing space', () => {
+    mockAuth(false);
+
+    render(
+      <PostAnsweredQuestions
+        post={buildPost({
+          answeredQuestions: [{ ...answeredQuestions[0], cta: '' }],
+        })}
+      />,
+    );
+
+    expect(screen.getByText(answeredQuestions[0].answer)).toBeInTheDocument();
+  });
+
+  it('renders nothing for logged in users', () => {
+    mockAuth(true);
+
+    const { container } = render(<PostAnsweredQuestions post={buildPost()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing when the post has no questions', () => {
+    mockAuth(false);
+
+    const { container, rerender } = render(
+      <PostAnsweredQuestions post={buildPost({ answeredQuestions: null })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+
+    rerender(
+      <PostAnsweredQuestions post={buildPost({ answeredQuestions: [] })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/shared/src/components/post/PostAnsweredQuestions.tsx
+++ b/packages/shared/src/components/post/PostAnsweredQuestions.tsx
@@ -1,0 +1,63 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../graphql/posts';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { Summary, SummaryArrow } from '../utilities/common';
+import { widgetClasses } from '../widgets/common';
+import { Typography, TypographyType } from '../typography/Typography';
+
+interface PostAnsweredQuestionsProps {
+  post: Post;
+  className?: string;
+}
+
+/**
+ * The visible twin of the FAQPage structured data. Anonymous visitors land here
+ * from a search or an answer engine, so the questions that brought them are
+ * worth answering on the page; logged-in readers came for the post itself and
+ * get the feed's own surfaces instead.
+ *
+ * Built on `<details>` rather than the Radix accordion because Radix unmounts
+ * collapsed panels, which would keep every answer out of the HTML a crawler
+ * reads. The answer text carries its cta exactly as getFaqJsonLd builds it, so
+ * the visible copy and the structured data stay identical.
+ */
+export const PostAnsweredQuestions = ({
+  post,
+  className,
+}: PostAnsweredQuestionsProps): ReactElement | null => {
+  const { isLoggedIn } = useAuthContext();
+  const questions = post?.answeredQuestions;
+
+  if (isLoggedIn || !questions?.length) {
+    return null;
+  }
+
+  return (
+    <section className={classNames('flex w-full flex-col gap-3', className)}>
+      <Typography type={TypographyType.Body} bold>
+        Questions this post answers
+      </Typography>
+      {questions.map(({ question, answer, cta }) => (
+        <details
+          key={question}
+          className={classNames(
+            'select-none overflow-hidden px-4 py-0',
+            widgetClasses,
+          )}
+        >
+          <Summary className="-mx-4 px-4 py-3 hover:bg-surface-hover">
+            <div className="flex items-center gap-4 font-bold text-text-primary typo-callout">
+              {question}
+              <SummaryArrow />
+            </div>
+          </Summary>
+          <p className="select-text pb-3 text-text-secondary typo-callout">
+            {cta ? `${answer} ${cta}` : answer}
+          </p>
+        </details>
+      ))}
+    </section>
+  );
+};

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -53,6 +53,7 @@ import { FollowButton } from '../../contentPreference/FollowButton';
 import { ContentPreferenceType } from '../../../graphql/contentPreference';
 import { PostSidebarAdWidget } from '../PostSidebarAdWidget';
 import { PostMenuOptions } from '../PostMenuOptions';
+import { PostAnsweredQuestions } from '../PostAnsweredQuestions';
 import { FocusCardActionBar } from './FocusCardActionBar';
 import { PostDiscussionPanel } from './PostDiscussionPanel';
 import { CollectionSources } from './CollectionSources';
@@ -591,6 +592,8 @@ export const PostFocusCard = ({
             // read as too large here).
             className="-mt-2"
           />
+
+          {!onClose && <PostAnsweredQuestions post={article} />}
 
           <div ref={discussionRef} className="scroll-mt-16">
             <PostDiscussionPanel

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -418,6 +418,11 @@ export const POST_BY_ID_QUERY = gql`
       }
       description
       summary
+      answeredQuestions {
+        question
+        answer
+        cta
+      }
       toc {
         text
         id

--- a/packages/webapp/components/PostSEOSchema.tsx
+++ b/packages/webapp/components/PostSEOSchema.tsx
@@ -359,9 +359,9 @@ export const getCommentsJsonLd = (
  *
  * The answer text carries the cta because this is the form an answer engine
  * extracts and quotes, so the pointer back to daily.dev travels with it. The
- * questions are not rendered visually — structured data is the channel for
- * machine-readable content, so nothing here is hidden from a human that they
- * would otherwise see.
+ * questions themselves are also rendered for anonymous visitors by
+ * PostAnsweredQuestions, which builds the same answer text so the visible copy
+ * and the structured data match.
  *
  * Returns null when the post has no questions, which is the normal case for a
  * post that predates this enrichment or one where nothing qualified.


### PR DESCRIPTION
Follow-up to #6451, which surfaced the questions a post answers as FAQPage structured data only. This renders them on the page as well, for logged out visitors: they arrive from a search or an answer engine with one of these questions in hand, while logged in readers came for the post itself and have the feed's own surfaces.

The section sits between the post body and the engagement bar on the classic layout, and above the discussion panel on the `post_redesign` focus card. It self-hides when the post has no questions, which is the normal case for anything predating the enrichment.

Two things worth calling out:

- Each entry is a native `<details>` rather than the Radix accordion. Radix unmounts collapsed panels, so every answer would have been absent from the HTML a crawler reads, which defeats the point. `<details>` also matches `PostToc`, the existing collapsible inside the post body.
- The visible answer text is built exactly as `getFaqJsonLd` builds it, cta included, so the copy on the page and the structured data cannot drift apart.

`POST_BY_ID_QUERY` gains the field too. Without it the client refetch replaced the statically generated post with one that had no questions, and the section vanished a moment after hydration.

https://claude.ai/code/session_01Jq9LmQN5XnaR7kGMQfBeHN