### PR TITLE
fix(seo): render prerendered content instead of an empty document

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -180,13 +180,34 @@ function MainLayoutComponent({
     ? contentTransitionsEnabled
     : layoutSettled;
 
+  const isPageReady =
+    (growthbook?.ready && router?.isReady && isAuthReady) || isTesting;
+
+  // Everything that isn't feed-shaped (post, tag, source, profile) prerenders
+  // real data through `getStaticProps`, but `isPageReady` can never be true on
+  // the server. Unmounting the layout until boot therefore shipped an empty
+  // `<div id="__next">`, so every crawler that doesn't run JS (including the
+  // answer engines `PostSEOSchema` targets) saw nothing but meta tags.
+  //
+  // The paint still has to wait for boot, so hold it with `visibility` on the
+  // wrapper below instead of dropping the tree. `visibility` (not `display`)
+  // keeps descendants that measure themselves on mount getting real geometry.
+  const isHoldingPaint = !isPageReady && showSidebar;
+
   // On laptop the v1 and v2 chrome (sidebar + global header) look different,
   // so rendering before the experiment resolves makes v2 users flash the v1
   // layout and then swap. Hold the variant-specific chrome until the flag has
   // resolved so the correct layout paints once. Below laptop there is no v2
   // chrome and `isLayoutVariantLoading` never resolves (the flag isn't
   // evaluated there), so treat non-laptop as always resolved.
-  const isLayoutChromeResolved = !isLaptop || !isLayoutVariantLoading;
+  //
+  // The held render must also stay viewport-independent: `useMedia` seeds its
+  // state from `window.matchMedia`, so the first client render already knows
+  // the real breakpoint while the server assumed mobile. Leaving the header to
+  // `isLaptop` alone made the server emit one and the client skip it, which
+  // shifted `<main>` and broke hydration.
+  const isLayoutChromeResolved =
+    !isHoldingPaint && (!isLaptop || !isLayoutVariantLoading);
 
   // Extension new tab mounts its own `ExtensionTopBanners` strip, so
   // the webapp strip is suppressed there to avoid duplicate cards.
@@ -218,8 +239,6 @@ function MainLayoutComponent({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isNotificationsReady, unreadCount, hasLoggedImpression]);
 
-  const isPageReady =
-    (growthbook?.ready && router?.isReady && isAuthReady) || isTesting;
   // Feed-shaped pages hold their paint until boot so the resolved chrome
   // renders once. Broader than the onboarding gate below on purpose: this is
   // about layout stability, not about forcing onboarding.
@@ -279,17 +298,10 @@ function MainLayoutComponent({
     });
   }, [shouldShowLogin, showLogin]);
 
-  // Pages that render the app chrome (sidebar layout) wait for boot before
-  // painting — the same `isPageReady` gate the feeds already use. The v1/v2
-  // chrome differs structurally and the variant only resolves after boot, so
-  // rendering early makes v2 users paint the v1 layout and then snap. Holding
-  // until boot lets the resolved layout paint once. The gate is
-  // breakpoint-independent (false on both server and first client render until
-  // ready), so it stays free of hydration mismatches.
-  if (
-    (!isPageReady && (isFeedShapedPage || showSidebar)) ||
-    shouldRedirectOnboarding
-  ) {
+  // Feed-shaped pages have nothing prerendered worth showing (the feed is
+  // fetched on the client) and anonymous visitors may still bounce to
+  // onboarding, so they keep bailing out entirely.
+  if (shouldRedirectOnboarding || (!isPageReady && isFeedShapedPage)) {
     return null;
   }
 
@@ -300,6 +312,7 @@ function MainLayoutComponent({
     <div
       className={classNames(
         'antialiased',
+        isHoldingPaint && 'invisible',
         isV2 &&
           'laptop:bg-[color-mix(in_srgb,var(--theme-surface-secondary)_3%,var(--theme-background-default))]',
       )}

--- a/packages/webapp/__tests__/MainLayoutPaintHold.tsx
+++ b/packages/webapp/__tests__/MainLayoutPaintHold.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import * as hooks from '@dailydotdev/shared/src/hooks/useViewSize';
+import * as layoutVariant from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
+import MainLayout from '../components/layouts/MainLayout';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+// `isPageReady` is forced true under jest, which is exactly the condition that
+// never holds on the server. Unmocking it is what makes this file reproduce a
+// server render at all.
+jest.mock('@dailydotdev/shared/src/lib/constants', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/lib/constants'),
+  isTesting: false,
+}));
+
+const mockRouter = (route: string) => {
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        route,
+        pathname: route,
+        asPath: route,
+        query: {},
+        isReady: false,
+        push: jest.fn(),
+        replace: jest.fn(),
+        events: { on: jest.fn(), off: jest.fn() },
+      } as unknown as NextRouter),
+  );
+};
+
+describe('MainLayout before boot resolves', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(hooks, 'useViewSize').mockImplementation(() => true);
+    jest
+      .spyOn(layoutVariant, 'useLayoutVariant')
+      .mockReturnValue({ isV2: false, isLoading: true });
+  });
+
+  const renderLayout = (): RenderResult =>
+    render(
+      <TestBootProvider
+        client={new QueryClient()}
+        auth={{ isAuthReady: false, isLoggedIn: false, user: undefined }}
+      >
+        <MainLayout>
+          <p>prerendered page content</p>
+        </MainLayout>
+      </TestBootProvider>,
+    );
+
+  it('keeps prerendered content in the markup so crawlers can read it', () => {
+    mockRouter('/posts/[id]');
+    renderLayout();
+
+    expect(screen.getByText('prerendered page content')).toBeInTheDocument();
+  });
+
+  it('holds the paint with visibility rather than unmounting', () => {
+    mockRouter('/posts/[id]');
+    renderLayout();
+
+    const content = screen.getByText('prerendered page content');
+    expect(content.closest('div.antialiased')).toHaveClass('invisible');
+  });
+
+  it('still renders nothing for feed-shaped pages', () => {
+    mockRouter('/popular');
+    renderLayout();
+
+    expect(
+      screen.queryByText('prerendered page content'),
+    ).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Problem

Every page that renders the sidebar chrome prerenders an empty `<div id="__next">`. `MainLayout` unmounts itself until `isPageReady` (growthbook + router + auth), and none of those can ever be true during a server render.

The data is already there. Post pages fetch through `getStaticProps` and ship it in `__NEXT_DATA__`, but nothing renders it into markup, so any crawler that doesn't execute JS sees meta tags and nothing else.

That also silently swallowed `PostSEOSchema`: the `TechArticle`, `BreadcrumbList` and `FAQPage` structured data added in #6451 and #6452 never actually reached an answer engine. The only JSON-LD in the document today is the global Organization/WebSite block from `_app`.

Against production right now, characters of rendered text in the body:

```
/posts/[id]     1
/tags/[tag]     1
/sources/[id]   1
/[userId]       1
```

The `showSidebar` clause landed in #6083 for the layout-v2 experiment. The chrome it guards is already gated separately by `isLayoutChromeResolved` and `isAuthReady`, so the top-level bail was broader than it needed to be.

## Fix

Hold the paint with `visibility` instead of dropping the tree. The markup ships, and the chrome still appears in one shot once boot resolves, so users see the same blank-then-paint sequence as before.

Feed-shaped pages keep bailing out entirely: their feed loads on the client, so there is nothing prerendered to show, and anonymous visitors may still bounce to onboarding.

The held render also has to stay viewport-independent. `useMedia` seeds its state from `window.matchMedia`, so the first client render already knows the real breakpoint while the server assumed mobile. Gating the global header on `isLaptop` alone made the server emit one and the client skip it, which shifted `<main>` and broke hydration.

## Verification

Against the local ISR server, characters of rendered text:

| route | before | after |
|---|---|---|
| `/posts/[id]` | 1 | 1427, plus TechArticle + BreadcrumbList + WebPage JSON-LD |
| `/tags/[tag]` | 1 | 1875 |
| `/sources/[id]` | 1 | 1178 |
| `/[userId]` | 1 | 509 |
| `/popular`, `/` | 1 | unchanged, still bails out |

Checked in the browser for hydration errors. `MainLayoutPaintHold.tsx` covers all three behaviours and fails on `main` without this change.

`pnpm --filter webapp test` (479) and `pnpm --filter @dailydotdev/shared test` (2223) pass. Full `webapp` tsc has the same 20 pre-existing errors as `main`, none in the touched files.

## Follow-up, not in this PR

`useMedia` reads `window.matchMedia` in its `useState` initialiser, so every breakpoint branch renders differently on the server than on the first client render. React recovers by discarding the prerendered DOM and re-rendering, which is hidden behind the paint hold and costs no UX, but it does mean the prerendered markup is not actually reused.

Fixing it properly means `useSyncExternalStore` with a server snapshot, which changes breakpoint behaviour for 158 files across webapp and extension. That wants its own regression pass, so it is deliberately excluded here. This PR delivers the crawler fix either way.

https://claude.ai/code/session_01YZb1sNQww4Ud2Vdw39rhWP