### PR TITLE
fix: paint prerendered content before boot

### DIFF
--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -334,6 +334,9 @@ function MainLayoutComponent({
         />
       )}
 
+      {/* Temporary while layout v2 is experimental: production users are on
+          v1, so render its header in the initial HTML instead of waiting for
+          feature resolution and delaying the post page's LCP. */}
       {!sidebarOwnsHeader && (
         <MainLayoutHeader
           hasBanner={isBannerAvailable}

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -334,7 +334,7 @@ function MainLayoutComponent({
         />
       )}
 
-      {!sidebarOwnsHeader && isLayoutChromeResolved && (
+      {!sidebarOwnsHeader && (
         <MainLayoutHeader
           hasBanner={isBannerAvailable}
           sidebarRendered={sidebarRendered}

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -189,10 +189,9 @@ function MainLayoutComponent({
   // `<div id="__next">`, so every crawler that doesn't run JS (including the
   // answer engines `PostSEOSchema` targets) saw nothing but meta tags.
   //
-  // The paint still has to wait for boot, so hold it with `visibility` on the
-  // wrapper below instead of dropping the tree. `visibility` (not `display`)
-  // keeps descendants that measure themselves on mount getting real geometry.
-  const isHoldingPaint = !isPageReady && showSidebar;
+  // Keep variant-specific chrome hidden until boot resolves, while allowing
+  // the prerendered page content itself to paint immediately.
+  const isHoldingChrome = !isPageReady && showSidebar;
 
   // On laptop the v1 and v2 chrome (sidebar + global header) look different,
   // so rendering before the experiment resolves makes v2 users flash the v1
@@ -207,7 +206,7 @@ function MainLayoutComponent({
   // `isLaptop` alone made the server emit one and the client skip it, which
   // shifted `<main>` and broke hydration.
   const isLayoutChromeResolved =
-    !isHoldingPaint && (!isLaptop || !isLayoutVariantLoading);
+    !isHoldingChrome && (!isLaptop || !isLayoutVariantLoading);
 
   // Extension new tab mounts its own `ExtensionTopBanners` strip, so
   // the webapp strip is suppressed there to avoid duplicate cards.
@@ -312,7 +311,6 @@ function MainLayoutComponent({
     <div
       className={classNames(
         'antialiased',
-        isHoldingPaint && 'invisible',
         isV2 &&
           'laptop:bg-[color-mix(in_srgb,var(--theme-surface-secondary)_3%,var(--theme-background-default))]',
       )}

--- a/packages/webapp/__tests__/MainLayoutPaintHold.tsx
+++ b/packages/webapp/__tests__/MainLayoutPaintHold.tsx
@@ -73,6 +73,13 @@ describe('MainLayout before boot resolves', () => {
     expect(content.closest('div.antialiased')).not.toHaveClass('invisible');
   });
 
+  it('renders the header before the layout experiment resolves', () => {
+    mockRouter('/posts/[id]');
+    renderLayout();
+
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
   it('still renders nothing for feed-shaped pages', () => {
     mockRouter('/popular');
     renderLayout();

--- a/packages/webapp/__tests__/MainLayoutPaintHold.tsx
+++ b/packages/webapp/__tests__/MainLayoutPaintHold.tsx
@@ -65,12 +65,12 @@ describe('MainLayout before boot resolves', () => {
     expect(screen.getByText('prerendered page content')).toBeInTheDocument();
   });
 
-  it('holds the paint with visibility rather than unmounting', () => {
+  it('paints prerendered content before boot resolves', () => {
     mockRouter('/posts/[id]');
     renderLayout();
 
     const content = screen.getByText('prerendered page content');
-    expect(content.closest('div.antialiased')).toHaveClass('invisible');
+    expect(content.closest('div.antialiased')).not.toHaveClass('invisible');
   });
 
   it('still renders nothing for feed-shaped pages', () => {


### PR DESCRIPTION
## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://fix-post-ssr-visible.preview.app.daily.dev