### PR TITLE
feat(wallet): link transaction counterparts to their profile

### DIFF
--- a/packages/shared/src/components/cores/TransactionItem.tsx
+++ b/packages/shared/src/components/cores/TransactionItem.tsx
@@ -20,10 +20,14 @@ import { TimeFormatType } from '../../lib/dateFormat';
 import { IconSize } from '../Icon';
 import type { TransactionItemType } from '../../lib/transaction';
 import { formatCoresCurrency } from '../../lib/utils';
+import type { UserShortProfile } from '../../lib/user';
+import { ProfileLink } from '../profile/ProfileLink';
+import { ProfileTooltip } from '../profile/ProfileTooltip';
 
 export type TransactionItemProps = {
   type: TransactionItemType;
   user: UserImageProps;
+  profileUser?: UserShortProfile;
   date: Date;
   amount: number;
   label: ReactNode;
@@ -59,20 +63,39 @@ const TransactionTypeToIcon: Record<
 export const TransactionItem = ({
   type,
   user,
+  profileUser,
   date,
   amount,
   label,
   extraLabel,
 }: TransactionItemProps): ReactElement => {
+  const linkToProfile = (children: ReactElement): ReactElement => {
+    if (!profileUser) {
+      return children;
+    }
+
+    return (
+      <ProfileTooltip userId={profileUser.id} initialUser={profileUser}>
+        <ProfileLink className="w-fit" href={profileUser.permalink}>
+          {children}
+        </ProfileLink>
+      </ProfileTooltip>
+    );
+  };
+
   return (
     <li className="flex">
       <div className="flex flex-1 items-center gap-2">
         {TransactionTypeToIcon[type]}
-        <ProfilePicture size={ProfileImageSize.Medium} user={user} />{' '}
+        {linkToProfile(
+          <ProfilePicture size={ProfileImageSize.Medium} user={user} />,
+        )}{' '}
         <div className="flex flex-col gap-1">
-          <Typography type={TypographyType.Subhead} bold>
-            {user.name}
-          </Typography>
+          {linkToProfile(
+            <Typography type={TypographyType.Subhead} bold>
+              {user.name}
+            </Typography>,
+          )}
           <div className="flex flex-col flex-wrap">
             <Typography
               className="line-clamp-2 max-w-[200px] tablet:max-w-[360px]"

--- a/packages/shared/src/graphql/njord.ts
+++ b/packages/shared/src/graphql/njord.ts
@@ -3,7 +3,7 @@ import { gql } from 'graphql-request';
 import type { Connection, Edge } from './common';
 import { gqlClient } from './common';
 import type { AwardTypes } from '../contexts/GiveAwardModalContext';
-import type { LoggedUser } from '../lib/user';
+import type { LoggedUser, UserShortProfile } from '../lib/user';
 import {
   FEATURED_AWARD_FRAGMENT,
   PRODUCT_FRAGMENT,
@@ -162,8 +162,8 @@ export type UserTransaction = {
   id: string;
   product?: Product;
   status: number;
-  receiver: Author;
-  sender?: Author;
+  receiver: UserShortProfile;
+  sender?: UserShortProfile;
   value: number;
   valueIncFees: number;
   flags: Partial<{

--- a/packages/webapp/__tests__/WalletPage.spec.tsx
+++ b/packages/webapp/__tests__/WalletPage.spec.tsx
@@ -1,0 +1,251 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import nock from 'nock';
+import { QueryClient } from '@tanstack/react-query';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import type { UserTransaction } from '@dailydotdev/shared/src/graphql/njord';
+import {
+  ProductType,
+  TRANSACTION_SUMMARY_QUERY,
+  TRANSACTIONS_QUERY,
+  UserTransactionStatus,
+  UserTransactionType,
+} from '@dailydotdev/shared/src/graphql/njord';
+import type {
+  LoggedUser,
+  UserShortProfile,
+} from '@dailydotdev/shared/src/lib/user';
+import { CoresRole } from '@dailydotdev/shared/src/lib/user';
+import defaultUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
+import { mockGraphQL } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import WalletPage from '../pages/wallet';
+
+const walletUser: LoggedUser = {
+  ...defaultUser,
+  coresRole: CoresRole.User,
+  balance: { amount: 1000 },
+};
+
+const toShortProfile = (
+  user: Pick<
+    UserShortProfile,
+    'id' | 'name' | 'username' | 'image' | 'permalink'
+  >,
+): UserShortProfile => ({
+  ...user,
+  createdAt: '2023-01-01T00:00:00.000Z',
+  reputation: 10,
+});
+
+const me = toShortProfile(walletUser);
+
+const gifter = toShortProfile({
+  id: 'gifter',
+  name: 'Gifty McGift',
+  username: 'gifty',
+  image: 'https://daily.dev/gifty.png',
+  permalink: 'https://app.daily.dev/gifty',
+});
+
+const recipient = toShortProfile({
+  id: 'recipient',
+  name: 'Recipient Rita',
+  username: 'rita',
+  image: 'https://daily.dev/rita.png',
+  permalink: 'https://app.daily.dev/rita',
+});
+
+const system = toShortProfile({
+  id: 'system',
+  name: 'daily.dev',
+  username: 'system',
+  image: 'https://daily.dev/system.png',
+  permalink: 'https://app.daily.dev/system',
+});
+
+const award = {
+  id: 'award-1',
+  type: ProductType.Award,
+  name: 'Medal',
+  image: 'https://daily.dev/medal.png',
+  value: 42,
+};
+
+const createdAt = new Date('2024-03-05T10:20:00.000Z');
+
+const baseTransaction = {
+  status: UserTransactionStatus.Success,
+  flags: {},
+  balance: { amount: 1000 },
+  createdAt,
+};
+
+const receivedAward: UserTransaction = {
+  ...baseTransaction,
+  id: 't-received',
+  product: award,
+  sender: gifter,
+  receiver: me,
+  value: 42,
+  valueIncFees: 42,
+  sourceName: 'Web',
+};
+
+const sentAward: UserTransaction = {
+  ...baseTransaction,
+  id: 't-sent',
+  product: award,
+  sender: me,
+  receiver: recipient,
+  value: 20,
+  valueIncFees: 20,
+};
+
+const boost: UserTransaction = {
+  ...baseTransaction,
+  id: 't-boost',
+  sender: system,
+  receiver: me,
+  value: 100,
+  valueIncFees: 100,
+  flags: { note: 'Post boost refund' },
+  referenceType: UserTransactionType.PostBoost,
+};
+
+const purchase: UserTransaction = {
+  ...baseTransaction,
+  id: 't-purchase',
+  receiver: me,
+  value: 500,
+  valueIncFees: 500,
+};
+
+const freeAward: UserTransaction = {
+  ...baseTransaction,
+  id: 't-free',
+  product: { ...award, value: 0 },
+  sender: gifter,
+  receiver: me,
+  value: 0,
+  valueIncFees: 0,
+};
+
+const allTransactions = [receivedAward, sentAward, boost, purchase, freeAward];
+
+const getWalletRows = async (): Promise<HTMLElement[]> => {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  mockGraphQL({
+    request: { query: TRANSACTION_SUMMARY_QUERY },
+    result: {
+      data: { transactionSummary: { purchased: 1, received: 2, spent: 3 } },
+    },
+  });
+  mockGraphQL({
+    request: { query: TRANSACTIONS_QUERY, variables: { first: 20, after: '' } },
+    result: {
+      data: {
+        transactions: {
+          pageInfo: { endCursor: 'cursor', hasNextPage: false },
+          edges: allTransactions.map((node) => ({ node })),
+        },
+      },
+    },
+  });
+
+  render(
+    <TestBootProvider client={client} auth={{ user: walletUser }}>
+      <WalletPage />
+    </TestBootProvider>,
+  );
+
+  return screen.findAllByRole('listitem');
+};
+
+const getRowLinks = (row: HTMLElement): HTMLAnchorElement[] =>
+  within(row).getAllByRole('link') as HTMLAnchorElement[];
+
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+  jest.mocked(useRouter).mockImplementation(
+    () =>
+      ({
+        isReady: true,
+        pathname: '/wallet',
+        asPath: '/wallet',
+        query: {},
+        push: jest.fn(),
+        replace: jest.fn(),
+      } as unknown as NextRouter),
+  );
+});
+
+describe('wallet transaction history', () => {
+  it('links a received award to the sender profile', async () => {
+    const [row] = await getWalletRows();
+    const links = getRowLinks(row);
+
+    expect(links).toHaveLength(2);
+    links.forEach((link) =>
+      expect(link).toHaveAttribute('href', gifter.permalink),
+    );
+    expect(within(links[1]).getByText(gifter.name)).toBeInTheDocument();
+  });
+
+  it('links a sent award to the receiver profile', async () => {
+    const rows = await getWalletRows();
+    const links = getRowLinks(rows[1]);
+
+    links.forEach((link) =>
+      expect(link).toHaveAttribute('href', recipient.permalink),
+    );
+    expect(within(links[1]).getByText(recipient.name)).toBeInTheDocument();
+  });
+
+  it('links a boost row to the system profile', async () => {
+    const rows = await getWalletRows();
+    const links = getRowLinks(rows[2]);
+
+    links.forEach((link) =>
+      expect(link).toHaveAttribute('href', system.permalink),
+    );
+    expect(within(links[1]).getByText(system.name)).toBeInTheDocument();
+  });
+
+  it('links a purchase row to your own profile', async () => {
+    const rows = await getWalletRows();
+    const links = getRowLinks(rows[3]);
+
+    links.forEach((link) => expect(link).toHaveAttribute('href', me.permalink));
+    expect(within(links[1]).getByText(me.name)).toBeInTheDocument();
+  });
+
+  it('keeps amounts, labels and dates outside of the profile link', async () => {
+    const rows = await getWalletRows();
+
+    expect(within(rows[0]).getByText('+42')).toBeInTheDocument();
+    expect(within(rows[0]).getByText('Award')).toBeInTheDocument();
+    expect(within(rows[0]).getByText('Web Squad')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('-20')).toBeInTheDocument();
+    expect(within(rows[2]).getByText('Post boost refund')).toBeInTheDocument();
+    expect(within(rows[3]).getByText('Purchased')).toBeInTheDocument();
+    expect(within(rows[4]).getByText('Free')).toBeInTheDocument();
+
+    rows.forEach((row) => {
+      expect(
+        within(row).getByText(/Mar 05, 2024 \d{2}:\d{2}/),
+      ).toBeInTheDocument();
+
+      getRowLinks(row).forEach((link) => {
+        expect(
+          within(link).queryByText(/Mar 05, 2024/),
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/packages/webapp/pages/wallet.tsx
+++ b/packages/webapp/pages/wallet.tsx
@@ -308,6 +308,7 @@ const Wallet = (): ReactElement | null => {
                                 key={transaction.id}
                                 type={type}
                                 user={transactionUser}
+                                profileUser={transactionUser}
                                 amount={
                                   type === 'send'
                                     ? -transaction.value


### PR DESCRIPTION
## Changes

Every row in the Core wallet transaction history now renders the counterpart's **avatar and name as a profile link**, with the standard user hover card on desktop. Gift/award senders were previously a dead end — you could see who sent you Cores but had no way to reach them.

- `TransactionItem` (shared) gains an optional `profileUser` prop. When it's absent the rendered DOM is byte-identical to before, so the shared component stays safe for future consumers.
- `ProfileTooltip` receives `initialUser` with the object we already hold, so hovering a row fires **no** `getUserShortInfo` request.
- Retyped `UserTransaction.sender/receiver` from `Author` to `UserShortProfile` — that's what `TRANSACTION_FRAGMENT` already fetches. No consumer relied on `Author`-only fields.
- Uses the payload's `permalink` rather than concatenating `${webappUrl}${senderId}`: canonical, username-based, and consistent with every other profile link in the app.
- Links are **unconditional** — boosts, quest rewards, streak restores and founding/giveback rewards point at the `system` user, purchases point at you, and all of those profiles resolve. One code path, no allow/deny list to keep in sync as new transaction types land.

### Key decisions

- **Tooltip wiring:** used the `CommentAuthor` pattern (`ProfileTooltip` wrapping `ProfileLink`) instead of `ProfileTooltip`'s `link` prop. The `link` prop combined with `ProfileLink` nests two Next `<Link>`s around a single anchor; this way one wrapper gives both the hover card and click-through, and tippy stays lazily loaded.
- **Hit area:** added `w-fit` to the link so the name anchor hugs its text instead of stretching the full column width. Only the avatar and name are interactive — the type icon, label, `extraLabel`, date and amount are untouched and stay outside the anchor.
- **No feature flag:** cosmetic, low risk, trivially revertible.
- **Out of scope:** the profile page's "Badges & Awards" widget. It renders `userProductSummary` (per-award image + count), which carries no sender data, so senders there would need a new API query.

### Tests

New `packages/webapp/__tests__/WalletPage.spec.tsx` (no wallet test existed) covering one row per case: award received from another user, award sent to another user, a boost row with the `system` counterpart, and a purchase row where the counterpart is you — each asserting the anchor's `href` and the name rendered inside it. Plus a regression case for amounts (`+42` / `-20` / `Free`), labels, `extraLabel` and dates. `getShouldLoadTooltip()` is `!isTouchDevice() && !isTesting`, so tippy content never mounts under Jest — the specs assert the link, not the hover-card body.

Playwright E2E deliberately skipped: it runs against live production with a shared account, so asserting a link inside a real, changing transaction history would be flaky.

Verified: `pnpm --filter shared test` (337 suites / 2225 tests) and `pnpm --filter webapp test` (63 suites / 485 tests) both green, `node ./scripts/typecheck-strict-changed.js` passes, eslint clean on all changed files.

## Events

No new tracking events. `ProfileTooltip` already logs `LogEvent.HoverUserCard`.

## Experiment

No.

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

Still worth a human pass on: desktop hover (card renders, no network request in devtools), mobile tap (navigates, no tooltip), dark + light theme, and a very long display name at ~390px width (long names should still truncate and the amount stay right-aligned).

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension? — n/a, `/wallet` is webapp-only
- [ ] Does this not break anything in companion? — n/a

Closes ENG-1937

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1937-feedback-feature-reques.preview.app.daily.dev