### PR TITLE
fix: show gift messages in the wallet transaction row

### DIFF
--- a/packages/shared/src/components/cores/TransactionItem.spec.tsx
+++ b/packages/shared/src/components/cores/TransactionItem.spec.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { TransactionItemProps } from './TransactionItem';
+import { TransactionItem } from './TransactionItem';
+import { author } from '../../../__tests__/fixture/loggedUser';
+import { defaultQueryClientTestingConfig } from '../../../__tests__/helpers/tanstack-query';
+
+const renderComponent = (props: Partial<TransactionItemProps> = {}) =>
+  render(
+    <QueryClientProvider
+      client={new QueryClient(defaultQueryClientTestingConfig)}
+    >
+      <TransactionItem
+        type="receive"
+        user={author}
+        date={new Date('2026-01-01')}
+        amount={100}
+        label="Award"
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+
+it('should render the note under the label', () => {
+  renderComponent({ note: 'Thanks for the help!' });
+
+  expect(screen.getByText('Thanks for the help!')).toBeInTheDocument();
+});
+
+it('should keep long notes clamped instead of slicing them', () => {
+  const note = 'a'.repeat(400);
+  renderComponent({ note });
+
+  expect(screen.getByText(note)).toHaveClass('line-clamp-2');
+});
+
+it('should not render a note when there is none', () => {
+  renderComponent();
+
+  expect(screen.getByText('Award')).toBeInTheDocument();
+  expect(screen.queryByText('Thanks for the help!')).not.toBeInTheDocument();
+});

--- a/packages/shared/src/components/cores/TransactionItem.tsx
+++ b/packages/shared/src/components/cores/TransactionItem.tsx
@@ -28,6 +28,7 @@ export type TransactionItemProps = {
   amount: number;
   label: ReactNode;
   extraLabel?: ReactNode;
+  note?: ReactNode;
 };
 
 const TransactionTypeToIcon: Record<
@@ -63,6 +64,7 @@ export const TransactionItem = ({
   amount,
   label,
   extraLabel,
+  note,
 }: TransactionItemProps): ReactElement => {
   return (
     <li className="flex">
@@ -93,6 +95,15 @@ export const TransactionItem = ({
                 <DateFormat date={date} type={TimeFormatType.Transaction} />
               </div>
             </div>
+            {!!note && (
+              <Typography
+                className="line-clamp-2 max-w-[200px] tablet:max-w-[360px]"
+                type={TypographyType.Footnote}
+                color={TypographyColor.Tertiary}
+              >
+                {note}
+              </Typography>
+            )}
           </div>
         </div>
       </div>

--- a/packages/shared/src/graphql/njord.ts
+++ b/packages/shared/src/graphql/njord.ts
@@ -146,6 +146,7 @@ export const getProductsQueryOptions = () => {
 
 export enum UserTransactionType {
   PostBoost = 'post_boost',
+  User = 'user',
 }
 
 export enum UserTransactionStatus {

--- a/packages/shared/src/lib/transaction.spec.tsx
+++ b/packages/shared/src/lib/transaction.spec.tsx
@@ -1,0 +1,113 @@
+import type { UserTransaction } from '../graphql/njord';
+import { ProductType, UserTransactionType } from '../graphql/njord';
+import { getTransactionLabel, getTransactionNote } from './transaction';
+import loggedUser, { author } from '../../__tests__/fixture/loggedUser';
+
+const baseTransaction: UserTransaction = {
+  id: 't1',
+  status: 0,
+  receiver: author,
+  sender: { ...author, id: 'u2' },
+  value: 100,
+  valueIncFees: 100,
+  flags: {},
+  balance: { amount: 0 },
+  createdAt: new Date(),
+  product: {
+    id: 'p1',
+    name: 'Award',
+    image: 'https://daily.dev/award.jpg',
+    type: ProductType.Award,
+    value: 100,
+  },
+};
+
+describe('getTransactionNote', () => {
+  it('returns the note for a user award', () => {
+    expect(
+      getTransactionNote({
+        transaction: {
+          ...baseTransaction,
+          referenceType: UserTransactionType.User,
+          flags: { note: 'Thanks for the help!' },
+        },
+      }),
+    ).toEqual('Thanks for the help!');
+  });
+
+  it('returns undefined for a user award without a note', () => {
+    expect(
+      getTransactionNote({
+        transaction: {
+          ...baseTransaction,
+          referenceType: UserTransactionType.User,
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores the system note on a post boost', () => {
+    expect(
+      getTransactionNote({
+        transaction: {
+          ...baseTransaction,
+          referenceType: UserTransactionType.PostBoost,
+          flags: { note: 'Boosting my post' },
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it('ignores the system note on a streak restore', () => {
+    expect(
+      getTransactionNote({
+        transaction: { ...baseTransaction, flags: { note: 'Streak restore' } },
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe('getTransactionLabel', () => {
+  const getLabel = (transaction: UserTransaction) =>
+    getTransactionLabel({ transaction, user: loggedUser });
+
+  it('keeps the system note as the label for a post boost', () => {
+    expect(
+      getLabel({
+        ...baseTransaction,
+        referenceType: UserTransactionType.PostBoost,
+        flags: { note: 'Boosting my post' },
+      }),
+    ).toEqual('Boosting my post');
+  });
+
+  it('keeps the system note as the label for a quest reward', () => {
+    expect(
+      getLabel({
+        ...baseTransaction,
+        referenceType: 'quest_reward:streak' as UserTransactionType,
+        flags: { note: 'Streak quest completed' },
+      }),
+    ).toEqual('Streak quest completed');
+  });
+
+  it('keeps the streak restore label', () => {
+    expect(
+      getLabel({
+        ...baseTransaction,
+        product: undefined,
+        flags: { note: 'Streak restore' },
+      }),
+    ).toEqual('Streak restore');
+  });
+
+  it('does not use the note as the label for a user award', () => {
+    expect(
+      getLabel({
+        ...baseTransaction,
+        referenceType: UserTransactionType.User,
+        flags: { note: 'Thanks for the help!' },
+      }),
+    ).not.toEqual('Thanks for the help!');
+  });
+});

--- a/packages/shared/src/lib/transaction.tsx
+++ b/packages/shared/src/lib/transaction.tsx
@@ -102,4 +102,13 @@ export const getTransactionLabel = ({
   return type.toUpperCase();
 };
 
+export const getTransactionNote = ({
+  transaction,
+}: {
+  transaction: UserTransaction;
+}): string | undefined =>
+  transaction.referenceType === UserTransactionType.User
+    ? transaction.flags.note
+    : undefined;
+
 export const coreApproxValueUSD = 100;

--- a/packages/webapp/pages/wallet.tsx
+++ b/packages/webapp/pages/wallet.tsx
@@ -41,6 +41,7 @@ import { formatCoresCurrency } from '@dailydotdev/shared/src/lib/utils';
 import {
   getTransactionType,
   getTransactionLabel,
+  getTransactionNote,
 } from '@dailydotdev/shared/src/lib/transaction';
 import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import {
@@ -323,6 +324,7 @@ const Wallet = (): ReactElement | null => {
                                     ? `${transaction.sourceName} Squad`
                                     : undefined
                                 }
+                                note={getTransactionNote({ transaction })}
                               />
                             );
                           });


### PR DESCRIPTION
Notes sent with a Cores gift were fetched but never rendered. `TRANSACTION_FRAGMENT` already selects `flags { note error }`, but `getTransactionLabel` only returned the note for post boosts and quest rewards, so gift messages were discarded client-side.

## Changes

- `getTransactionNote` in `lib/transaction.tsx` returns `flags.note` for user awards.
- `TransactionItem` gained an optional `note` slot rendered under the label row.
- `wallet.tsx` passes it through.

## Key decisions

- **Scoped to `referenceType === user`.** `flags.note` is overloaded — it also carries the system labels for streak restores, post boosts and quest rewards. A blanket "render `flags.note`" change would silently rewrite those existing wallet labels, so `getTransactionLabel` is left structurally untouched and covered by regression tests.
- **Truncation is visual, not destructive.** Long notes reuse the existing `line-clamp-2 max-w-[200px] tablet:max-w-[360px]` treatment rather than being sliced, so the full text stays in the DOM for screen readers and a future expand affordance is a pure frontend change.
- **New DOM is gated on the prop**, so existing consumers keep their original markup.
- **No backfill needed.** Notes are already persisted on historic rows, so existing gifts start showing their message as soon as this ships.

## Tests

Unit tests cover branch selection in `getTransactionNote` and guard the post-boost / quest-reward / streak-restore label branches; RTL tests cover rendering and the clamp treatment. All 480 webapp tests pass, plus lint and the strict-changed typecheck.

## Related

The API side (notification description + vordr screening of user-award notes) ships separately in `dailydotdev/daily-api`. The GraphQL contract already exists, so neither blocks the other.

Closes ENG-1936

---
Created by Huginn 🐦‍⬛


### Preview domain
https://eng-1936-feedback-bug-report-gif.preview.app.daily.dev