### PR TITLE
feat(ads): move the ad_only card links into an options menu on the glass card

### DIFF
--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -23,7 +23,7 @@ import { businessWebsiteUrl } from '../../../lib/constants';
 import { useFeature } from '../../GrowthBookProvider';
 import { AdLabelVariant, featureAdLabel } from '../../../lib/featureManagement';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
-import { LogEvent, TargetType } from '../../../lib/log';
+import { LogEvent, TargetId } from '../../../lib/log';
 
 jest.mock('../../../hooks/useFeedCardGlassActions');
 
@@ -42,6 +42,8 @@ const mockAdLabelVariant = (variant: AdLabelVariant): void => {
   mockUseFeature.mockImplementation(((feature: { id: string }) =>
     feature?.id === featureAdLabel.id ? variant : undefined) as never);
 };
+
+const plusUser = { id: 'u1', isPlus: true } as never;
 
 const defaultProps: AdCardProps = {
   ad,
@@ -88,11 +90,12 @@ const getNormalizedText = (element?: Element | null): string =>
 
 const renderGridComponent = (
   props: Partial<AdCardProps> = {},
+  boot: Partial<React.ComponentProps<typeof TestBootProvider>> = {},
 ): RenderResult => {
   const client = new QueryClient();
 
   return render(
-    <TestBootProvider client={client}>
+    <TestBootProvider client={client} {...boot}>
       <ActiveFeedContext.Provider value={{ items: [], queryKey: ['test'] }}>
         <AdGrid {...defaultProps} {...props} />
       </ActiveFeedContext.Provider>
@@ -321,7 +324,7 @@ describe('ad_label experiment', () => {
 describe('ad_only options menu on the glass card', () => {
   const optionsLabel = 'Ad options';
 
-  it('should move the advertise and remove links into the menu', async () => {
+  it('should move the remove control into the menu', async () => {
     mockUseGlassActions.mockReturnValue(true);
     mockAdLabelVariant(AdLabelVariant.AdOnly);
     renderGridComponent();
@@ -330,14 +333,11 @@ describe('ad_only options menu on the glass card', () => {
       await screen.findByRole('button', { name: optionsLabel }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole('link', { name: 'Advertise here' }),
-    ).not.toBeInTheDocument();
-    expect(
       screen.queryByRole('link', { name: 'Remove' }),
     ).not.toBeInTheDocument();
   });
 
-  it('should offer both actions once the menu is open', async () => {
+  it('should offer remove ads, and not the advertise link the arm removes', async () => {
     mockUseGlassActions.mockReturnValue(true);
     mockAdLabelVariant(AdLabelVariant.AdOnly);
     renderGridComponent();
@@ -347,29 +347,44 @@ describe('ad_only options menu on the glass card', () => {
     // path opens the same menu.
     fireEvent.keyDown(trigger, { key: 'Enter' });
 
-    expect(await screen.findByText('Advertise with us')).toBeInTheDocument();
     expect(await screen.findByText('Remove ads')).toBeInTheDocument();
+    expect(screen.queryByText('Advertise with us')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Advertise here' }),
+    ).not.toBeInTheDocument();
   });
 
-  it('should log the advertise impression once, on the first open', async () => {
+  it('should log the upgrade against the same funnel RemoveAd feeds', async () => {
     mockUseGlassActions.mockReturnValue(true);
     mockAdLabelVariant(AdLabelVariant.AdOnly);
     renderGridComponent();
 
     const trigger = await screen.findByRole('button', { name: optionsLabel });
     fireEvent.keyDown(trigger, { key: 'Enter' });
-    await screen.findByText('Advertise with us');
-    fireEvent.keyDown(trigger, { key: 'Escape' });
-    fireEvent.keyDown(trigger, { key: 'Enter' });
-    await screen.findByText('Advertise with us');
+    const item = await screen.findByText('Remove ads');
+    fireEvent.click(item);
 
     const logEvent = jest.mocked(defaultLogContextData.logEvent);
-    const impressions = logEvent.mock.calls.filter(
-      ([event]) =>
-        event.event_name === LogEvent.Impression &&
-        event.target_type === TargetType.AdvertiseHereCta,
+    expect(logEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.UpgradeSubscription,
+        target_id: TargetId.Ads,
+      }),
     );
-    expect(impressions).toHaveLength(1);
+  });
+
+  it('should not render the menu for a Plus subscriber', async () => {
+    mockUseGlassActions.mockReturnValue(true);
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderGridComponent({}, { auth: { user: plusUser } });
+
+    await screen.findByTestId('adItem');
+    expect(
+      screen.queryByRole('button', { name: optionsLabel }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Remove' }),
+    ).not.toBeInTheDocument();
   });
 
   it('should keep the links inline on the classic card', async () => {

--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -1,7 +1,13 @@
 /* eslint-disable no-template-curly-in-string -- literal macro token in measurement fixture */
 import React from 'react';
 import type { RenderResult } from '@testing-library/react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import ad from '../../../../__tests__/fixture/ad';
 import { AdGrid } from './AdGrid';
@@ -13,6 +19,9 @@ import { ActiveFeedContext } from '../../../contexts';
 import { businessWebsiteUrl } from '../../../lib/constants';
 import { useFeature } from '../../GrowthBookProvider';
 import { AdLabelVariant, featureAdLabel } from '../../../lib/featureManagement';
+import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
+
+jest.mock('../../../hooks/useFeedCardGlassActions');
 
 jest.mock('../../GrowthBookProvider', () => ({
   ...(jest.requireActual('../../GrowthBookProvider') as Record<
@@ -23,6 +32,7 @@ jest.mock('../../GrowthBookProvider', () => ({
 }));
 
 const mockUseFeature = jest.mocked(useFeature);
+const mockUseGlassActions = jest.mocked(useFeedCardGlassActions);
 
 const mockAdLabelVariant = (variant: AdLabelVariant): void => {
   mockUseFeature.mockImplementation(((feature: { id: string }) =>
@@ -40,6 +50,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   // clearAllMocks keeps implementations, so reset the arm for every test.
   mockAdLabelVariant(AdLabelVariant.Control);
+  mockUseGlassActions.mockReturnValue(false);
 });
 
 const renderListComponent = (
@@ -300,6 +311,67 @@ describe('ad_label experiment', () => {
     expect(
       screen.getByRole('link', { name: 'Advertise here' }),
     ).toBeInTheDocument();
+  });
+});
+
+describe('ad_only options menu on the glass card', () => {
+  const optionsLabel = 'Ad options';
+
+  it('should move the advertise and remove links into the menu', async () => {
+    mockUseGlassActions.mockReturnValue(true);
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderGridComponent();
+
+    expect(
+      await screen.findByRole('button', { name: optionsLabel }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Advertise here' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: 'Remove' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should offer both actions once the menu is open', async () => {
+    mockUseGlassActions.mockReturnValue(true);
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderGridComponent();
+
+    const trigger = await screen.findByRole('button', { name: optionsLabel });
+    // Radix opens on pointerdown, which jsdom has no event for; the keyboard
+    // path opens the same menu.
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(await screen.findByText('Advertise with us')).toBeInTheDocument();
+    expect(await screen.findByText('Remove ads')).toBeInTheDocument();
+  });
+
+  it('should keep the links inline on the classic card', async () => {
+    mockUseGlassActions.mockReturnValue(false);
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderGridComponent();
+
+    await screen.findByTestId('adItem');
+    expect(
+      screen.queryByRole('button', { name: optionsLabel }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Remove' })).toBeInTheDocument();
+  });
+
+  it('should keep the links inline on the other arms', async () => {
+    mockUseGlassActions.mockReturnValue(true);
+    mockAdLabelVariant(AdLabelVariant.Ad);
+    renderGridComponent();
+
+    await screen.findByTestId('adItem');
+    expect(
+      screen.queryByRole('button', { name: optionsLabel }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'Advertise here' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Remove' })).toBeInTheDocument();
   });
 });
 

--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -23,7 +23,7 @@ import { businessWebsiteUrl } from '../../../lib/constants';
 import { useFeature } from '../../GrowthBookProvider';
 import { AdLabelVariant, featureAdLabel } from '../../../lib/featureManagement';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
-import { LogEvent, TargetId } from '../../../lib/log';
+import { LogEvent, TargetId, TargetType } from '../../../lib/log';
 
 jest.mock('../../../hooks/useFeedCardGlassActions');
 
@@ -324,7 +324,7 @@ describe('ad_label experiment', () => {
 describe('ad_only options menu on the glass card', () => {
   const optionsLabel = 'Ad options';
 
-  it('should move the remove control into the menu', async () => {
+  it('should move both links into the menu', async () => {
     mockUseGlassActions.mockReturnValue(true);
     mockAdLabelVariant(AdLabelVariant.AdOnly);
     renderGridComponent();
@@ -333,11 +333,14 @@ describe('ad_only options menu on the glass card', () => {
       await screen.findByRole('button', { name: optionsLabel }),
     ).toBeInTheDocument();
     expect(
+      screen.queryByRole('link', { name: 'Advertise here' }),
+    ).not.toBeInTheDocument();
+    expect(
       screen.queryByRole('link', { name: 'Remove' }),
     ).not.toBeInTheDocument();
   });
 
-  it('should offer remove ads, and not the advertise link the arm removes', async () => {
+  it('should offer both actions once the menu is open', async () => {
     mockUseGlassActions.mockReturnValue(true);
     mockAdLabelVariant(AdLabelVariant.AdOnly);
     renderGridComponent();
@@ -347,11 +350,24 @@ describe('ad_only options menu on the glass card', () => {
     // path opens the same menu.
     fireEvent.keyDown(trigger, { key: 'Enter' });
 
+    expect(await screen.findByText('Advertise with us')).toBeInTheDocument();
     expect(await screen.findByText('Remove ads')).toBeInTheDocument();
-    expect(screen.queryByText('Advertise with us')).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'Advertise here' }),
-    ).not.toBeInTheDocument();
+  });
+
+  it('should log the advertise impression on mount, like the inline link', async () => {
+    mockUseGlassActions.mockReturnValue(true);
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderGridComponent();
+
+    await screen.findByRole('button', { name: optionsLabel });
+
+    const logEvent = jest.mocked(defaultLogContextData.logEvent);
+    const impressions = logEvent.mock.calls.filter(
+      ([event]) =>
+        event.event_name === LogEvent.Impression &&
+        event.target_type === TargetType.AdvertiseHereCta,
+    );
+    expect(impressions).toHaveLength(1);
   });
 
   it('should log the upgrade against the same funnel RemoveAd feeds', async () => {
@@ -361,8 +377,7 @@ describe('ad_only options menu on the glass card', () => {
 
     const trigger = await screen.findByRole('button', { name: optionsLabel });
     fireEvent.keyDown(trigger, { key: 'Enter' });
-    const item = await screen.findByText('Remove ads');
-    fireEvent.click(item);
+    fireEvent.click(await screen.findByText('Remove ads'));
 
     const logEvent = jest.mocked(defaultLogContextData.logEvent);
     expect(logEvent).toHaveBeenCalledWith(
@@ -373,18 +388,16 @@ describe('ad_only options menu on the glass card', () => {
     );
   });
 
-  it('should not render the menu for a Plus subscriber', async () => {
+  it('should offer a Plus subscriber the advertise link only', async () => {
     mockUseGlassActions.mockReturnValue(true);
     mockAdLabelVariant(AdLabelVariant.AdOnly);
     renderGridComponent({}, { auth: { user: plusUser } });
 
-    await screen.findByTestId('adItem');
-    expect(
-      screen.queryByRole('button', { name: optionsLabel }),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('link', { name: 'Remove' }),
-    ).not.toBeInTheDocument();
+    const trigger = await screen.findByRole('button', { name: optionsLabel });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+
+    expect(await screen.findByText('Advertise with us')).toBeInTheDocument();
+    expect(screen.queryByText('Remove ads')).not.toBeInTheDocument();
   });
 
   it('should keep the links inline on the classic card', async () => {

--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -14,12 +14,16 @@ import { AdGrid } from './AdGrid';
 import { AdList } from './AdList';
 import { SignalAdList } from './SignalAdList';
 import type { AdCardProps } from './common/common';
-import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import {
+  defaultLogContextData,
+  TestBootProvider,
+} from '../../../../__tests__/helpers/boot';
 import { ActiveFeedContext } from '../../../contexts';
 import { businessWebsiteUrl } from '../../../lib/constants';
 import { useFeature } from '../../GrowthBookProvider';
 import { AdLabelVariant, featureAdLabel } from '../../../lib/featureManagement';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
+import { LogEvent, TargetType } from '../../../lib/log';
 
 jest.mock('../../../hooks/useFeedCardGlassActions');
 
@@ -345,6 +349,27 @@ describe('ad_only options menu on the glass card', () => {
 
     expect(await screen.findByText('Advertise with us')).toBeInTheDocument();
     expect(await screen.findByText('Remove ads')).toBeInTheDocument();
+  });
+
+  it('should log the advertise impression once, on the first open', async () => {
+    mockUseGlassActions.mockReturnValue(true);
+    mockAdLabelVariant(AdLabelVariant.AdOnly);
+    renderGridComponent();
+
+    const trigger = await screen.findByRole('button', { name: optionsLabel });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    await screen.findByText('Advertise with us');
+    fireEvent.keyDown(trigger, { key: 'Escape' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+    await screen.findByText('Advertise with us');
+
+    const logEvent = jest.mocked(defaultLogContextData.logEvent);
+    const impressions = logEvent.mock.calls.filter(
+      ([event]) =>
+        event.event_name === LogEvent.Impression &&
+        event.target_type === TargetType.AdvertiseHereCta,
+    );
+    expect(impressions).toHaveLength(1);
   });
 
   it('should keep the links inline on the classic card', async () => {

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -44,8 +44,9 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   const { showAdvertiseLink, isAdOnly } = useAdLabel();
   // Only the glass card takes the options menu: it is the layout with the
   // floating action bar, where a text row under the creative reads as clutter.
-  // The classic card keeps both links inline, unchanged.
-  const useOptionsMenu = useGlass && isAdOnly;
+  // The classic card keeps its links inline, unchanged. Plus subscribers have
+  // nothing to put in the menu, so they never get the trigger.
+  const useOptionsMenu = useGlass && isAdOnly && !isPlus;
   const showInlineActions = !useOptionsMenu;
   const { ref } = useAutoRotatingAds(
     ad,
@@ -67,7 +68,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
     >
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <AdFavicon ad={ad} className="mx-4">
-        {useOptionsMenu && <AdOptionsButton targetId={TargetId.AdCard} />}
+        {useOptionsMenu && <AdOptionsButton />}
       </AdFavicon>
       <CardTextContainer className="flex-1">
         <CardTitle className="typo-title3">{ad.description}</CardTitle>

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -44,9 +44,8 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   const { showAdvertiseLink, isAdOnly } = useAdLabel();
   // Only the glass card takes the options menu: it is the layout with the
   // floating action bar, where a text row under the creative reads as clutter.
-  // The classic card keeps its links inline, unchanged. Plus subscribers have
-  // nothing to put in the menu, so they never get the trigger.
-  const useOptionsMenu = useGlass && isAdOnly && !isPlus;
+  // The classic card keeps its links inline, unchanged.
+  const useOptionsMenu = useGlass && isAdOnly;
   const showInlineActions = !useOptionsMenu;
   const { ref } = useAutoRotatingAds(
     ad,
@@ -68,7 +67,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
     >
       <AdLink ad={ad} onLinkClick={onLinkClick} />
       <AdFavicon ad={ad} className="mx-4">
-        {useOptionsMenu && <AdOptionsButton />}
+        {useOptionsMenu && <AdOptionsButton targetId={TargetId.AdCard} />}
       </AdFavicon>
       <CardTextContainer className="flex-1">
         <CardTitle className="typo-title3">{ad.description}</CardTitle>

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -45,6 +45,12 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   // Only the glass card takes the options menu: it is the layout with the
   // floating action bar, where a text row under the creative reads as clutter.
   // The classic card keeps its links inline, unchanged.
+  //
+  // The menu carries "Advertise with us" even though `showAdvertiseLink` is
+  // false in this arm. That is deliberate: the arm removes the link from the
+  // card face, and the product call is to keep it reachable from the menu. It
+  // does mean the arm's advertise-click metric has to be segmented by the
+  // glass flag, since the classic half of the arm cannot reach the link at all.
   const useOptionsMenu = useGlass && isAdOnly;
   const showInlineActions = !useOptionsMenu;
   const { ref } = useAutoRotatingAds(

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { forwardRef } from 'react';
+import classNames from 'classnames';
 
 import {
   Card,
@@ -31,6 +32,7 @@ import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
 import { useFeedCardGlassActions } from '../../../hooks/useFeedCardGlassActions';
 import { useAdLabel } from '../../../features/monetization/useAdLabel';
+import { AdOptionsButton } from './common/AdOptionsButton';
 
 export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   { ad, onLinkClick, onViewable, domProps, index, feedIndex },
@@ -39,7 +41,12 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   const { isPlus } = usePlusSubscription();
   const adImprovementsV3 = useFeature(adImprovementsV3Feature);
   const useGlass = useFeedCardGlassActions();
-  const { showAdvertiseLink } = useAdLabel();
+  const { showAdvertiseLink, isAdOnly } = useAdLabel();
+  // Only the glass card takes the options menu: it is the layout with the
+  // floating action bar, where a text row under the creative reads as clutter.
+  // The classic card keeps both links inline, unchanged.
+  const useOptionsMenu = useGlass && isAdOnly;
+  const showInlineActions = !useOptionsMenu;
   const { ref } = useAutoRotatingAds(
     ad,
     index,
@@ -50,9 +57,18 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   const clickUrl = useAdClickUrl(ad);
 
   return (
-    <Card {...domProps} data-testid="adItem" ref={ref}>
+    <Card
+      {...domProps}
+      // `group` only ships with the options menu, so every other arm keeps the
+      // card's original class list.
+      className={classNames(useOptionsMenu && 'group', domProps?.className)}
+      data-testid="adItem"
+      ref={ref}
+    >
       <AdLink ad={ad} onLinkClick={onLinkClick} />
-      <AdFavicon ad={ad} className="mx-4" />
+      <AdFavicon ad={ad} className="mx-4">
+        {useOptionsMenu && <AdOptionsButton targetId={TargetId.AdCard} />}
+      </AdFavicon>
       <CardTextContainer className="flex-1">
         <CardTitle className="typo-title3">{ad.description}</CardTitle>
         <CardSpace />
@@ -67,40 +83,44 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
       {!useGlass && (
         <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />
       )}
-      <CardTextContainer className="!mx-1 my-1">
-        <div className="flex items-center">
-          {!!ad.callToAction && (
-            <Button
-              tag="a"
-              href={clickUrl}
-              target="_blank"
-              rel="noopener"
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Small}
-              className="z-1"
-              {...combinedClicks(() => onLinkClick?.(ad))}
-            >
-              {ad.callToAction}
-            </Button>
-          )}
-          {showAdvertiseLink && (
-            <AdvertiseLink
-              targetId={TargetId.AdCard}
-              buttonStyle
-              size={ButtonSize.Small}
-            />
-          )}
-          <div className="ml-auto flex items-center gap-2">
-            {!isPlus && (
-              <RemoveAd
-                variant={ButtonVariant.Tertiary}
+      {(showInlineActions || !!ad.callToAction) && (
+        <CardTextContainer className="!mx-1 my-1">
+          <div className="flex items-center">
+            {!!ad.callToAction && (
+              <Button
+                tag="a"
+                href={clickUrl}
+                target="_blank"
+                rel="noopener"
+                variant={ButtonVariant.Primary}
                 size={ButtonSize.Small}
-                className="!font-normal typo-footnote"
+                className="z-1"
+                {...combinedClicks(() => onLinkClick?.(ad))}
+              >
+                {ad.callToAction}
+              </Button>
+            )}
+            {showInlineActions && showAdvertiseLink && (
+              <AdvertiseLink
+                targetId={TargetId.AdCard}
+                buttonStyle
+                size={ButtonSize.Small}
               />
             )}
+            {showInlineActions && (
+              <div className="ml-auto flex items-center gap-2">
+                {!isPlus && (
+                  <RemoveAd
+                    variant={ButtonVariant.Tertiary}
+                    size={ButtonSize.Small}
+                    className="!font-normal typo-footnote"
+                  />
+                )}
+              </div>
+            )}
           </div>
-        </div>
-      </CardTextContainer>
+        </CardTextContainer>
+      )}
       {useGlass && (
         <AdImage
           className="!mx-0 !mb-0 !rounded-b-16 !rounded-t-none [&_img]:!rounded-none"

--- a/packages/shared/src/components/cards/ad/common/AdFavicon.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdFavicon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { ProfileImageSize, ProfilePicture } from '../../../ProfilePicture';
 import { CardHeader } from '../../common/Card';
 import type { Ad } from '../../../../graphql/posts';
@@ -11,8 +11,14 @@ import { getAdFaviconImageLink } from './getAdFaviconImageLink';
 type AdFaviconProps = {
   ad: Ad;
   className?: string;
+  /** Rendered next to the favicon, on the same header row. */
+  children?: ReactNode;
 };
-export const AdFavicon = ({ ad, className }: AdFaviconProps): ReactElement => {
+export const AdFavicon = ({
+  ad,
+  className,
+  children,
+}: AdFaviconProps): ReactElement => {
   const adImprovementsV3 = useFeature(adImprovementsV3Feature);
   const imageLink = getAdFaviconImageLink({
     ad,
@@ -32,6 +38,7 @@ export const AdFavicon = ({ ad, className }: AdFaviconProps): ReactElement => {
         }}
         nativeLazyLoading
       />
+      {children}
     </CardHeader>
   );
 };

--- a/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useCallback, useMemo, useRef, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import classNames from 'classnames';
 import {
   DropdownMenu,
@@ -8,77 +8,35 @@ import {
   DropdownMenuTrigger,
 } from '../../../dropdown/DropdownMenu';
 import type { MenuItemProps } from '../../../dropdown/common';
-import { DevPlusIcon, MegaphoneIcon, MenuIcon } from '../../../icons';
+import { DevPlusIcon, MenuIcon } from '../../../icons';
 import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
-import { useLogContext } from '../../../../contexts/LogContext';
 import { usePlusSubscription } from '../../../../hooks/usePlusSubscription';
-import { businessWebsiteUrl, plusUrl } from '../../../../lib/constants';
-import { LogEvent, TargetId, TargetType } from '../../../../lib/log';
-import { anchorDefaultRel } from '../../../../lib/strings';
+import { plusUrl } from '../../../../lib/constants';
+import { LogEvent, TargetId } from '../../../../lib/log';
 import { visibleOnGroupHover } from '../../common/common';
 
 interface AdOptionsButtonProps {
-  targetId: TargetId;
   className?: string;
 }
 
 /**
- * The ad card's own links (advertise with us, remove ads) collapsed into the
- * post card's options menu, so the creative keeps the card to itself.
+ * The ad card's remove-ads link collapsed into the post card's options menu,
+ * so the creative keeps the card to itself.
  *
- * The advertise-here impression fires the first time the menu opens rather
- * than on mount: inside a menu the link is not on screen until then. It fires
- * once per card, not once per open, so the guardrail click rate stays
- * comparable with the arms that render the link inline.
+ * Deliberately not a home for "Advertise here": the arm that shows this menu
+ * is the one whose whole definition is that the advertise link is gone, and
+ * putting it back in a menu would leave the arm meaning two different things
+ * depending on an unrelated layout flag.
  */
 export function AdOptionsButton({
-  targetId,
   className,
 }: AdOptionsButtonProps): ReactElement {
   const [open, setOpen] = useState(false);
-  const impressionLogged = useRef(false);
-  const { logEvent } = useLogContext();
-  const { isPlus, logSubscriptionEvent } = usePlusSubscription();
+  const { logSubscriptionEvent } = usePlusSubscription();
 
-  const onOpenChange = useCallback(
-    (isOpen: boolean) => {
-      setOpen(isOpen);
-
-      if (!isOpen || impressionLogged.current) {
-        return;
-      }
-
-      impressionLogged.current = true;
-      logEvent({
-        event_name: LogEvent.Impression,
-        target_type: TargetType.AdvertiseHereCta,
-        target_id: targetId,
-      });
-    },
-    [logEvent, targetId],
-  );
-
-  const options = useMemo(() => {
-    const list: MenuItemProps[] = [
+  const options = useMemo(
+    (): MenuItemProps[] => [
       {
-        label: 'Advertise with us',
-        icon: <MegaphoneIcon />,
-        anchorProps: {
-          href: businessWebsiteUrl,
-          target: '_blank',
-          rel: anchorDefaultRel,
-        },
-        action: () =>
-          logEvent({
-            event_name: LogEvent.Click,
-            target_type: TargetType.AdvertiseHereCta,
-            target_id: targetId,
-          }),
-      },
-    ];
-
-    if (!isPlus) {
-      list.push({
         label: 'Remove ads',
         icon: <DevPlusIcon />,
         anchorProps: { href: plusUrl },
@@ -89,25 +47,26 @@ export function AdOptionsButton({
             event_name: LogEvent.UpgradeSubscription,
             target_id: TargetId.Ads,
           }),
-      });
-    }
+      },
+    ],
+    [logSubscriptionEvent],
+  );
 
-    return list;
-  }, [isPlus, logEvent, logSubscriptionEvent, targetId]);
-
-  // Mirrors the post card's header actions: a span carries the hover reveal and
-  // the `ml-auto`, because `.header > button` in Card.module.css would override
-  // a margin set on the button itself and pin it next to the favicon.
   return (
     <span
       className={classNames(
         'ml-auto flex flex-row',
         visibleOnGroupHover,
+        // The trigger is the only route to the menu's actions, so it also has
+        // to appear for a keyboard reader: `visibleOnGroupHover` is
+        // `visibility: hidden`, which takes it out of the tab order until
+        // something inside the card holds focus.
+        'laptop:mouse:group-focus-within:!visible',
         open && 'laptop:mouse:!visible',
         className,
       )}
     >
-      <DropdownMenu open={open} onOpenChange={onOpenChange}>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
         <DropdownMenuTrigger tooltip={{ content: 'Options' }} asChild>
           <Button
             aria-label="Ad options"

--- a/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
@@ -1,0 +1,119 @@
+import type { ReactElement } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
+import classNames from 'classnames';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuOptions,
+  DropdownMenuTrigger,
+} from '../../../dropdown/DropdownMenu';
+import type { MenuItemProps } from '../../../dropdown/common';
+import { DevPlusIcon, MegaphoneIcon, MenuIcon } from '../../../icons';
+import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
+import { useLogContext } from '../../../../contexts/LogContext';
+import { usePlusSubscription } from '../../../../hooks/usePlusSubscription';
+import { businessWebsiteUrl, plusUrl } from '../../../../lib/constants';
+import type { TargetId } from '../../../../lib/log';
+import { LogEvent, TargetType } from '../../../../lib/log';
+import { anchorDefaultRel } from '../../../../lib/strings';
+import { visibleOnGroupHover } from '../../common/common';
+
+interface AdOptionsButtonProps {
+  targetId: TargetId;
+  className?: string;
+}
+
+/**
+ * The ad card's own links (advertise with us, remove ads) collapsed into the
+ * post card's options menu, so the creative keeps the card to itself. The
+ * advertise-here impression fires when the menu opens rather than on mount:
+ * inside a menu the link is not on screen until then, and the guardrail metric
+ * is a click rate over impressions.
+ */
+export function AdOptionsButton({
+  targetId,
+  className,
+}: AdOptionsButtonProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const { logEvent } = useLogContext();
+  const { isPlus, logSubscriptionEvent } = usePlusSubscription();
+
+  const onOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setOpen(isOpen);
+
+      if (isOpen) {
+        logEvent({
+          event_name: LogEvent.Impression,
+          target_type: TargetType.AdvertiseHereCta,
+          target_id: targetId,
+        });
+      }
+    },
+    [logEvent, targetId],
+  );
+
+  const options = useMemo(() => {
+    const list: MenuItemProps[] = [
+      {
+        label: 'Advertise with us',
+        icon: <MegaphoneIcon />,
+        anchorProps: {
+          href: businessWebsiteUrl,
+          target: '_blank',
+          rel: anchorDefaultRel,
+        },
+        action: () =>
+          logEvent({
+            event_name: LogEvent.Click,
+            target_type: TargetType.AdvertiseHereCta,
+            target_id: targetId,
+          }),
+      },
+    ];
+
+    if (!isPlus) {
+      list.push({
+        label: 'Remove ads',
+        icon: <DevPlusIcon />,
+        anchorProps: { href: plusUrl },
+        action: () =>
+          logSubscriptionEvent({
+            event_name: LogEvent.UpgradeSubscription,
+            target_id: targetId,
+          }),
+      });
+    }
+
+    return list;
+  }, [isPlus, logEvent, logSubscriptionEvent, targetId]);
+
+  // Mirrors the post card's header actions: a span carries the hover reveal and
+  // the `ml-auto`, because `.header > button` in Card.module.css would override
+  // a margin set on the button itself and pin it next to the favicon.
+  return (
+    <span
+      className={classNames(
+        'ml-auto flex flex-row',
+        visibleOnGroupHover,
+        open && 'laptop:mouse:!visible',
+        className,
+      )}
+    >
+      <DropdownMenu open={open} onOpenChange={onOpenChange}>
+        <DropdownMenuTrigger tooltip={{ content: 'Options' }} asChild>
+          <Button
+            aria-label="Ad options"
+            variant={ButtonVariant.Tertiary}
+            icon={<MenuIcon />}
+            size={ButtonSize.Small}
+            className="z-1"
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuOptions options={options} />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </span>
+  );
+}

--- a/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import {
   DropdownMenu,
@@ -13,8 +13,7 @@ import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
 import { useLogContext } from '../../../../contexts/LogContext';
 import { usePlusSubscription } from '../../../../hooks/usePlusSubscription';
 import { businessWebsiteUrl, plusUrl } from '../../../../lib/constants';
-import type { TargetId } from '../../../../lib/log';
-import { LogEvent, TargetType } from '../../../../lib/log';
+import { LogEvent, TargetId, TargetType } from '../../../../lib/log';
 import { anchorDefaultRel } from '../../../../lib/strings';
 import { visibleOnGroupHover } from '../../common/common';
 
@@ -25,16 +24,19 @@ interface AdOptionsButtonProps {
 
 /**
  * The ad card's own links (advertise with us, remove ads) collapsed into the
- * post card's options menu, so the creative keeps the card to itself. The
- * advertise-here impression fires when the menu opens rather than on mount:
- * inside a menu the link is not on screen until then, and the guardrail metric
- * is a click rate over impressions.
+ * post card's options menu, so the creative keeps the card to itself.
+ *
+ * The advertise-here impression fires the first time the menu opens rather
+ * than on mount: inside a menu the link is not on screen until then. It fires
+ * once per card, not once per open, so the guardrail click rate stays
+ * comparable with the arms that render the link inline.
  */
 export function AdOptionsButton({
   targetId,
   className,
 }: AdOptionsButtonProps): ReactElement {
   const [open, setOpen] = useState(false);
+  const impressionLogged = useRef(false);
   const { logEvent } = useLogContext();
   const { isPlus, logSubscriptionEvent } = usePlusSubscription();
 
@@ -42,13 +44,16 @@ export function AdOptionsButton({
     (isOpen: boolean) => {
       setOpen(isOpen);
 
-      if (isOpen) {
-        logEvent({
-          event_name: LogEvent.Impression,
-          target_type: TargetType.AdvertiseHereCta,
-          target_id: targetId,
-        });
+      if (!isOpen || impressionLogged.current) {
+        return;
       }
+
+      impressionLogged.current = true;
+      logEvent({
+        event_name: LogEvent.Impression,
+        target_type: TargetType.AdvertiseHereCta,
+        target_id: targetId,
+      });
     },
     [logEvent, targetId],
   );
@@ -77,10 +82,12 @@ export function AdOptionsButton({
         label: 'Remove ads',
         icon: <DevPlusIcon />,
         anchorProps: { href: plusUrl },
+        // TargetId.Ads, not the card's own target: this is the same upgrade
+        // funnel RemoveAd feeds, and the two have to stay comparable.
         action: () =>
           logSubscriptionEvent({
             event_name: LogEvent.UpgradeSubscription,
-            target_id: targetId,
+            target_id: TargetId.Ads,
           }),
       });
     }

--- a/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdOptionsButton.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import {
   DropdownMenu,
@@ -8,35 +8,65 @@ import {
   DropdownMenuTrigger,
 } from '../../../dropdown/DropdownMenu';
 import type { MenuItemProps } from '../../../dropdown/common';
-import { DevPlusIcon, MenuIcon } from '../../../icons';
+import { DevPlusIcon, MegaphoneIcon, MenuIcon } from '../../../icons';
 import { Button, ButtonSize, ButtonVariant } from '../../../buttons/Button';
+import { useLogContext } from '../../../../contexts/LogContext';
 import { usePlusSubscription } from '../../../../hooks/usePlusSubscription';
-import { plusUrl } from '../../../../lib/constants';
-import { LogEvent, TargetId } from '../../../../lib/log';
+import { businessWebsiteUrl, plusUrl } from '../../../../lib/constants';
+import { LogEvent, TargetId, TargetType } from '../../../../lib/log';
+import { anchorDefaultRel } from '../../../../lib/strings';
 import { visibleOnGroupHover } from '../../common/common';
 
 interface AdOptionsButtonProps {
+  targetId: TargetId;
   className?: string;
 }
 
 /**
- * The ad card's remove-ads link collapsed into the post card's options menu,
- * so the creative keeps the card to itself.
- *
- * Deliberately not a home for "Advertise here": the arm that shows this menu
- * is the one whose whole definition is that the advertise link is gone, and
- * putting it back in a menu would leave the arm meaning two different things
- * depending on an unrelated layout flag.
+ * The ad card's own links (advertise with us, remove ads) collapsed into the
+ * post card's options menu, so the creative keeps the card to itself.
  */
 export function AdOptionsButton({
+  targetId,
   className,
 }: AdOptionsButtonProps): ReactElement {
   const [open, setOpen] = useState(false);
-  const { logSubscriptionEvent } = usePlusSubscription();
+  const { logEvent } = useLogContext();
+  const { isPlus, logSubscriptionEvent } = usePlusSubscription();
 
-  const options = useMemo(
-    (): MenuItemProps[] => [
+  // Counted on mount, exactly like the inline `AdvertiseLink`: one impression
+  // per rendered ad card, whether or not the menu is opened. Counting opens
+  // instead would divide the same clicks by a far smaller denominator and read
+  // as a large lift in the guardrail rate that is purely instrumentation.
+  useEffect(() => {
+    logEvent({
+      event_name: LogEvent.Impression,
+      target_type: TargetType.AdvertiseHereCta,
+      target_id: targetId,
+    });
+  }, [logEvent, targetId]);
+
+  const options = useMemo(() => {
+    const list: MenuItemProps[] = [
       {
+        label: 'Advertise with us',
+        icon: <MegaphoneIcon />,
+        anchorProps: {
+          href: businessWebsiteUrl,
+          target: '_blank',
+          rel: anchorDefaultRel,
+        },
+        action: () =>
+          logEvent({
+            event_name: LogEvent.Click,
+            target_type: TargetType.AdvertiseHereCta,
+            target_id: targetId,
+          }),
+      },
+    ];
+
+    if (!isPlus) {
+      list.push({
         label: 'Remove ads',
         icon: <DevPlusIcon />,
         anchorProps: { href: plusUrl },
@@ -47,10 +77,11 @@ export function AdOptionsButton({
             event_name: LogEvent.UpgradeSubscription,
             target_id: TargetId.Ads,
           }),
-      },
-    ],
-    [logSubscriptionEvent],
-  );
+      });
+    }
+
+    return list;
+  }, [isPlus, logEvent, logSubscriptionEvent, targetId]);
 
   return (
     <span

--- a/packages/shared/src/components/dropdown/DropdownMenu.tsx
+++ b/packages/shared/src/components/dropdown/DropdownMenu.tsx
@@ -200,7 +200,11 @@ export const DropdownMenuOptions = ({
                     role="menuitem"
                     {...anchorProps}
                   >
-                    <a className={className} target={anchorProps?.target}>
+                    <a
+                      className={className}
+                      target={anchorProps?.target}
+                      rel={anchorProps?.rel}
+                    >
                       {icon} {label}
                     </a>
                   </Link>

--- a/packages/shared/src/features/monetization/useAdLabel.ts
+++ b/packages/shared/src/features/monetization/useAdLabel.ts
@@ -5,6 +5,12 @@ interface UseAdLabel {
   /** Treatments disclose with a plain "Ad" instead of naming the advertiser. */
   hideAdvertiser: boolean;
   showAdvertiseLink: boolean;
+  /**
+   * The strictest arm keeps the card's own links but moves them off the card,
+   * into an options menu. Only the glass card has the header room for it, so
+   * the card pairs this with its own layout check.
+   */
+  isAdOnly: boolean;
 }
 
 export const useAdLabel = (): UseAdLabel => {
@@ -13,5 +19,6 @@ export const useAdLabel = (): UseAdLabel => {
   return {
     hideAdvertiser: !!variant && variant !== AdLabelVariant.Control,
     showAdvertiseLink: variant !== AdLabelVariant.AdOnly,
+    isAdOnly: variant === AdLabelVariant.AdOnly,
   };
 };


### PR DESCRIPTION
Follow-up to #6379.

The `ad_only` arm drops "Advertise here" from the ad card and leaves "Remove ads" sitting under the creative. On the glass card, where the cover image runs full-bleed to the bottom edge, that leftover text row is the only thing between the copy and the image.

**Both links move into a three-dots menu in the card header**, in the same spot a post card puts its options button. Neither action is removed; the card just stops carrying a row of text links under the creative.

| | Attribution | Advertise with us | Remove ads |
| --- | --- | --- | --- |
| `control` | Promoted by {advertiser} | inline | inline |
| `ad` | Ad | inline | inline |
| `ad_only`, classic card | Ad | not shown (unchanged) | inline (unchanged) |
| `ad_only`, glass card | Ad | in the options menu | in the options menu |
| `ad_only`, glass card, Plus | Ad | in the options menu | not shown (they have no ads) |

## Experiment note, please read before merge

This is a deliberate product decision and it does change what `ad_only` means on part of its population. The arm was defined by "Advertise here" is gone; on the glass card it now comes back inside the menu. So:

- **The advertise-click metric for `ad_label` has to be segmented by `feed_card_glass_actions`.** Users in `ad_only` + glass can reach the link; users in `ad_only` + classic cannot.
- `feed_card_glass_actions` correspondingly becomes a change to ad disclosure surface for that slice, not only a layout change.

An earlier revision of this PR dropped the advertise link from the menu to preserve the arm; the product call is to keep both links, with the segmentation above. Raising it here so the trade is on the record rather than discovered at analysis time.

## Everything is behind the flag

- **Only the `ad_only` arm.** Control and `ad` keep both links inline in both layouts.
- **Only the glass card** (`feed_card_glass_actions`). The classic grid card and the list card, which is what every feed below laptop renders, are untouched in every arm.
- The `group` class the hover reveal needs ships with the menu, so a card outside the arm keeps its original class list. With `ad_label` at `control` the rendered card is identical to main.

## Instrumentation

- The advertise-here impression fires **from a mount effect, once per rendered ad card** — exactly how the inline `AdvertiseLink` counts it. Logging it on menu open instead would divide the same clicks by a denominator orders of magnitude smaller and read as a large lift in the guardrail rate that is pure instrumentation.
- The remove item logs `UpgradeSubscription` with `TargetId.Ads`, the same id `RemoveAd` sends, so both feed one comparable Plus funnel.

## Accessibility

The options container is the same `span` with the same `visibleOnGroupHover` class the post card's header actions use, so it sits at the right edge and reveals on hover. Because the menu is the only route to both links in this arm, it also reveals on `laptop:mouse:group-focus-within`, so focus anywhere in the card brings the trigger into the tab order.

## Also in this PR

`DropdownMenuOptions` dropped `rel` on its way to the anchor it renders, so every external menu item in the repo shipped `target="_blank"` with no `rel` — two callers in `LiveRoomLobby`, one in `SquadMemberMenu`. Fixed at the source.

## Test plan

Seven cases in `AdCard.spec.tsx` covering this change: both links in the menu and neither inline, both actions present once open, the advertise impression logged once on mount, the upgrade logged against `TargetId.Ads`, the Plus subscriber getting the advertise link only, the classic card keeping its links inline, and the other arms keeping theirs.

32 tests in the ad card spec, 2243 across the shared package, 485 webapp, 43 extension. eslint and the changed-file strict typecheck clean.

The Storybook page this was reviewed on lives in #6463, which stacks on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-ad-options-menu-glass-car.preview.app.daily.dev