### PR TITLE
feat(storybook): ad card review pages, plus two ad card fixes they surfaced

### DIFF
--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -321,6 +321,10 @@ describe('ad_label experiment', () => {
   });
 });
 
+// These assert the class list, not the rendered gap: jsdom has no stylesheet to
+// compute against. They catch the class being dropped, not a parent rule
+// beating it, which is the failure Storybook's Ad Card Fixes page is the real
+// check for.
 describe('ad card spacing and controls', () => {
   it('should keep the disclosure off the ad copy on the grid card', async () => {
     renderGridComponent();

--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -321,6 +321,30 @@ describe('ad_label experiment', () => {
   });
 });
 
+describe('ad card spacing and controls', () => {
+  it('should keep the disclosure off the ad copy on the grid card', async () => {
+    renderGridComponent();
+
+    const attribution = await screen.findByTestId('adAttribution');
+    expect(attribution).toHaveClass('mt-3');
+  });
+
+  it('should keep the disclosure off the ad copy on the list card', async () => {
+    renderListComponent();
+
+    const attribution = await screen.findByTestId('adAttribution');
+    expect(attribution).toHaveClass('mt-3');
+  });
+
+  it('should render the list remove control flat, like the grid card', async () => {
+    renderListComponent();
+
+    const remove = await screen.findByRole('link', { name: 'Remove' });
+    expect(remove).toHaveClass('btn-tertiary-bacon');
+    expect(remove).not.toHaveClass('btn-tertiaryFloat-bacon');
+  });
+});
+
 describe('ad_only options menu on the glass card', () => {
   const optionsLabel = 'Ad options';
 

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -11,7 +11,7 @@ import {
 } from '../common/Card';
 import AdLink from './common/AdLink';
 import { combinedClicks } from '../../../lib/click';
-import AdAttribution from './common/AdAttribution';
+import AdAttribution, { adAttributionSpacing } from './common/AdAttribution';
 import { AdImage } from './common/AdImage';
 import { AdPixel } from './common/AdPixel';
 import { AdMeasurement } from './common/AdMeasurement';
@@ -84,7 +84,10 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
             className="!items-end"
           />
         ) : null}
-        <AdAttribution ad={ad} className={{ main: 'font-normal' }} />
+        <AdAttribution
+          ad={ad}
+          className={{ main: `${adAttributionSpacing} font-normal` }}
+        />
       </CardTextContainer>
       {!useGlass && (
         <AdImage className="mx-1 mb-0" ad={ad} ImageComponent={CardImage} />

--- a/packages/shared/src/components/cards/ad/AdList.tsx
+++ b/packages/shared/src/components/cards/ad/AdList.tsx
@@ -22,7 +22,6 @@ import type { InViewRef } from '../../../hooks/feed/useAutoRotatingAds';
 import { useAutoRotatingAds } from '../../../hooks/feed/useAutoRotatingAds';
 import { Button } from '../../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
-import AdAttribution from './common/AdAttribution';
 import { AdFavicon } from './common/AdFavicon';
 import PostTags from '../common/PostTags';
 import { useFeature } from '../../GrowthBookProvider';
@@ -30,6 +29,7 @@ import { adImprovementsV3Feature } from '../../../lib/featureManagement';
 import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
 import { useAdLabel } from '../../../features/monetization/useAdLabel';
+import AdAttribution, { adAttributionSpacing } from './common/AdAttribution';
 
 const getLinkProps = ({
   ad,
@@ -87,7 +87,7 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
           ) : null}
           <AdAttribution
             ad={ad}
-            className={{ main: 'mt-2 block font-normal' }}
+            className={{ main: `${adAttributionSpacing} block font-normal` }}
           />
         </CardTextContainer>
         <AdImage ad={ad} ImageComponent={CardImage} />
@@ -117,6 +117,7 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
         <div className="ml-auto">
           {!isPlus && (
             <RemoveAd
+              variant={ButtonVariant.Tertiary}
               size={ButtonSize.Small}
               className="!font-normal typo-footnote"
             />

--- a/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
@@ -5,6 +5,13 @@ import type { Ad } from '../../../../graphql/posts';
 import { useScrambler } from '../../../../hooks/useScrambler';
 import { useAdLabel } from '../../../../features/monetization/useAdLabel';
 
+/**
+ * Minimum room between the ad copy and the disclosure line. The grid card
+ * pushes the disclosure down with a flex spacer, which collapses to nothing on
+ * a long creative and leaves the line touching the title.
+ */
+export const adAttributionSpacing = 'mt-3';
+
 interface AdClassName {
   main?: string;
   typo?: string;
@@ -38,6 +45,7 @@ export default function AdAttribution({
         target="_blank"
         rel="noopener"
         className={elementClass}
+        data-testid="adAttribution"
         suppressHydrationWarning
       >
         {promotedText}
@@ -46,7 +54,11 @@ export default function AdAttribution({
   }
 
   return (
-    <div className={elementClass} suppressHydrationWarning>
+    <div
+      className={elementClass}
+      data-testid="adAttribution"
+      suppressHydrationWarning
+    >
       {promotedText}
     </div>
   );

--- a/packages/storybook/stories/components/cards/AdCardFixes.stories.tsx
+++ b/packages/storybook/stories/components/cards/AdCardFixes.stories.tsx
@@ -51,27 +51,28 @@ const beforeStyles = `
 // flex spacer behave the way it does in the feed.
 const glassRowHeight = { height: '21.5rem' };
 
-// List mode caps the feed at 42.5rem (FeedPageLayoutList). Inline rather than an
-// arbitrary Tailwind width for the same JIT reason as the before-state rules.
-const listWidth = { width: '42.5rem' };
+// A grid card is 20rem in the feed and a list card is capped at 42.5rem
+// (FeedPageLayoutList). Inline rather than arbitrary Tailwind widths for the
+// same JIT reason as the before-state rules.
+const gridWidth = '20rem';
+const listWidth = '42.5rem';
 
 const Column = ({
   title,
   note,
   tone = 'before',
   feedRow,
+  width = gridWidth,
   children,
 }: {
   title: string;
   note: string;
   tone?: 'before' | 'after';
   feedRow?: boolean;
+  width?: string;
   children: ReactNode;
 }): ReactElement => (
-  <div
-    className="flex shrink-0 flex-col gap-2"
-    style={{ width: 'fit-content', minWidth: '20rem' }}
-  >
+  <div className="flex shrink-0 flex-col gap-2" style={{ width }}>
     <span
       className={
         tone === 'after'
@@ -181,9 +182,10 @@ const ListSection = (): ReactElement => (
       <Row>
         <Column
           title="Before"
+          width={listWidth}
           note="8px above the disclosure. Only the spacing is reverted here: the remove control's old treatment is the pair below, since a class swap cannot be undone with CSS."
         >
-          <div className={beforeListSpacing} style={listWidth}>
+          <div className={beforeListSpacing}>
             <AdList ad={shortCopyAd} {...adProps} />
           </div>
         </Column>
@@ -191,12 +193,11 @@ const ListSection = (): ReactElement => (
       <Row>
         <Column
           title="After"
+          width={listWidth}
           note="12px above the disclosure, and the remove control flat like the grid card"
           tone="after"
         >
-          <div style={listWidth}>
-            <AdList ad={shortCopyAd} {...adProps} />
-          </div>
+          <AdList ad={shortCopyAd} {...adProps} />
         </Column>
       </Row>
     </div>

--- a/packages/storybook/stories/components/cards/AdCardFixes.stories.tsx
+++ b/packages/storybook/stories/components/cards/AdCardFixes.stories.tsx
@@ -1,0 +1,286 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AdGrid } from '@dailydotdev/shared/src/components/cards/ad/AdGrid';
+import { AdList } from '@dailydotdev/shared/src/components/cards/ad/AdList';
+import { RemoveAd } from '@dailydotdev/shared/src/components/cards/ad/common/RemoveAd';
+import {
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { featureFeedCardGlassActions } from '@dailydotdev/shared/src/lib/featureManagement';
+
+import { AdProviders, Page, Section } from '../../experiments/adLabel.mocks';
+import {
+  adProps,
+  longCopyAd,
+  shortCopyAd,
+  withFlags,
+} from './adPlacements.mocks';
+
+// ---------------------------------------------------------------------------
+// Two fixes found while reviewing the ad placements against the post cards.
+//
+// 1. The list card kept RemoveAd's own Float default, so "Remove ads" sat on a
+//    filled surface while the grid card rendered it flat.
+// 2. The disclosure line ("Promoted by ...") is pushed down by a flex spacer
+//    that collapses on a long creative, leaving it touching the ad copy.
+//
+// "Before" columns are the same components with the old value forced back, so
+// the comparison is the real card, not a mock-up of it.
+// ---------------------------------------------------------------------------
+
+/**
+ * The grid card had no margin above the disclosure; the list card had 8px.
+ * Plain CSS rather than an arbitrary Tailwind variant: the JIT only scans class
+ * names it has seen, and a value that exists nowhere else in the app would
+ * silently produce no rule.
+ */
+const beforeGridSpacing = 'ad-fix-before-grid';
+const beforeListSpacing = 'ad-fix-before-list';
+
+const beforeStyles = `
+  .${beforeGridSpacing} [data-testid='adAttribution'] { margin-top: 0 !important; }
+  .${beforeListSpacing} [data-testid='adAttribution'] { margin-top: 0.5rem !important; }
+`;
+
+// Feed rows are as tall as the tallest card in them, and a grid ad card has no
+// floor of its own, so it stretches to whatever the post cards next to it set:
+// min-h-cardGlass on a glass row. Locking that height here is what makes the
+// flex spacer behave the way it does in the feed.
+const glassRowHeight = { height: '21.5rem' };
+
+// List mode caps the feed at 42.5rem (FeedPageLayoutList). Inline rather than an
+// arbitrary Tailwind width for the same JIT reason as the before-state rules.
+const listWidth = { width: '42.5rem' };
+
+const Column = ({
+  title,
+  note,
+  tone = 'before',
+  feedRow,
+  children,
+}: {
+  title: string;
+  note: string;
+  tone?: 'before' | 'after';
+  feedRow?: boolean;
+  children: ReactNode;
+}): ReactElement => (
+  <div
+    className="flex shrink-0 flex-col gap-2"
+    style={{ width: 'fit-content', minWidth: '20rem' }}
+  >
+    <span
+      className={
+        tone === 'after'
+          ? 'font-bold text-action-upvote-default typo-footnote'
+          : 'font-bold text-accent-ketchup-default typo-footnote'
+      }
+    >
+      {title}
+    </span>
+    <span className="min-h-8 text-text-tertiary typo-caption1">{note}</span>
+    {feedRow ? (
+      <div className="flex" style={glassRowHeight}>
+        {children}
+      </div>
+    ) : (
+      children
+    )}
+  </div>
+);
+
+const Row = ({ children }: { children: ReactNode }): ReactElement => (
+  <div className="flex flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
+    {children}
+  </div>
+);
+
+const glassOn = { [featureFeedCardGlassActions.id]: true };
+
+const SpacingSection = (): ReactElement => (
+  <Section
+    title="Space between the ad copy and the disclosure"
+    description="The disclosure is pushed to the bottom of the card by a flex spacer. Whenever that spacer has nothing to give, the line lands right under the ad copy and reads as part of it. A minimum margin fixes the collapsed case and is absorbed in the roomy one, so nothing moves where it already looked right."
+    note="Before columns force the old margin back on the same card, so exactly one property differs between the pair."
+  >
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <span className="font-bold text-text-primary typo-callout">
+          Card at its own height, which is the reported case
+        </span>
+        <Row>
+          <Column
+            title="Before, long copy"
+            note="Disclosure flush against the ad copy"
+          >
+            <div className={beforeGridSpacing}>
+              {withFlags(glassOn, <AdGrid ad={longCopyAd} {...adProps} />)}
+            </div>
+          </Column>
+          <Column
+            title="After, long copy"
+            note="12px of its own, so the line reads as metadata"
+            tone="after"
+          >
+            {withFlags(glassOn, <AdGrid ad={longCopyAd} {...adProps} />)}
+          </Column>
+          <Column
+            title="Before, short copy"
+            note="Same problem: a short creative does not give the spacer room either"
+          >
+            <div className={beforeGridSpacing}>
+              {withFlags(glassOn, <AdGrid ad={shortCopyAd} {...adProps} />)}
+            </div>
+          </Column>
+          <Column
+            title="After, short copy"
+            note="Same 12px, so both creatives read the same"
+            tone="after"
+          >
+            {withFlags(glassOn, <AdGrid ad={shortCopyAd} {...adProps} />)}
+          </Column>
+        </Row>
+      </div>
+      <div className="flex flex-col gap-3">
+        <span className="font-bold text-text-primary typo-callout">
+          Card stretched by a taller row, where the spacer already had room
+        </span>
+        <Row>
+          <Column
+            title="Before"
+            note="Spacer pushes the disclosure to the bottom"
+            feedRow
+          >
+            <div className={beforeGridSpacing}>
+              {withFlags(glassOn, <AdGrid ad={shortCopyAd} {...adProps} />)}
+            </div>
+          </Column>
+          <Column
+            title="After"
+            note="Identical: the margin only eats into the flexible space"
+            tone="after"
+            feedRow
+          >
+            {withFlags(glassOn, <AdGrid ad={shortCopyAd} {...adProps} />)}
+          </Column>
+        </Row>
+      </div>
+    </div>
+  </Section>
+);
+
+const ListSection = (): ReactElement => (
+  <Section
+    title="List card: disclosure spacing and the remove control"
+    description="The list card had 8px above the disclosure and rendered Remove ads on a filled surface, because it never passed a variant and RemoveAd defaults itself to Float. Both now match the grid card."
+  >
+    <div className="flex flex-col gap-6">
+      <Row>
+        <Column
+          title="Before"
+          note="8px above the disclosure. Only the spacing is reverted here: the remove control's old treatment is the pair below, since a class swap cannot be undone with CSS."
+        >
+          <div className={beforeListSpacing} style={listWidth}>
+            <AdList ad={shortCopyAd} {...adProps} />
+          </div>
+        </Column>
+      </Row>
+      <Row>
+        <Column
+          title="After"
+          note="12px above the disclosure, and the remove control flat like the grid card"
+          tone="after"
+        >
+          <div style={listWidth}>
+            <AdList ad={shortCopyAd} {...adProps} />
+          </div>
+        </Column>
+      </Row>
+    </div>
+  </Section>
+);
+
+const RemoveControlSection = (): ReactElement => (
+  <Section
+    title="The remove control on its own"
+    description="The same RemoveAd component with the variant each card used. The grid card always passed Tertiary; the list card passed nothing and inherited Float."
+  >
+    <Row>
+      <Column title="Before, list card" note="ButtonVariant.Float (inherited)">
+        <div className="flex rounded-12 border border-border-subtlest-tertiary p-4">
+          <RemoveAd variant={ButtonVariant.Float} size={ButtonSize.Small} />
+        </div>
+      </Column>
+      <Column
+        title="After, list card"
+        note="ButtonVariant.Tertiary, same as the grid card"
+        tone="after"
+      >
+        <div className="flex rounded-12 border border-border-subtlest-tertiary p-4">
+          <RemoveAd variant={ButtonVariant.Tertiary} size={ButtonSize.Small} />
+        </div>
+      </Column>
+    </Row>
+  </Section>
+);
+
+const AdCardFixesPage = (): ReactElement => (
+  <AdProviders>
+    <Page>
+      <style>{beforeStyles}</style>
+      <SpacingSection />
+      <ListSection />
+      <RemoveControlSection />
+    </Page>
+  </AdProviders>
+);
+
+const meta: Meta = {
+  title: 'Components/Cards/Ad Card Fixes',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          'Before and after for two ad card fixes: the disclosure line touching the ad copy on a long creative, and the list card rendering the remove control on a filled surface while the grid card renders it flat.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const BeforeAndAfter: Story = {
+  render: () => <AdCardFixesPage />,
+  name: 'Before and after',
+};
+
+export const Spacing: Story = {
+  render: () => (
+    <AdProviders>
+      <Page>
+        <style>{beforeStyles}</style>
+        <SpacingSection />
+      </Page>
+    </AdProviders>
+  ),
+  name: 'Disclosure spacing only',
+};
+
+export const RemoveControl: Story = {
+  render: () => (
+    <AdProviders>
+      <Page>
+        <style>{beforeStyles}</style>
+        <ListSection />
+        <RemoveControlSection />
+      </Page>
+    </AdProviders>
+  ),
+  name: 'Remove control only',
+};

--- a/packages/storybook/stories/components/cards/AdPlacementConsistency.stories.tsx
+++ b/packages/storybook/stories/components/cards/AdPlacementConsistency.stories.tsx
@@ -414,15 +414,15 @@ const optionsMenuAnatomy: AnatomyRow[] = [
     element: 'Three-dots button',
     left: 'Never rendered',
     right:
-      'ad_only only. Top right of the header row, hover-revealed on pointer devices, always visible while the menu is open',
+      'ad_only only. Top right of the header row, hover-revealed on pointer devices, revealed by keyboard focus inside the card, always visible while the menu is open',
     aligned: false,
   },
   {
     element: 'Advertise-here impression',
-    left: 'Logged when the card mounts, since the link is on screen',
+    left: 'Logged when the card mounts, once per rendered ad',
     right:
-      'Logged when the menu opens, since that is when the link is actually shown',
-    aligned: false,
+      'Same: logged from a mount effect, not on menu open, so clicks over impressions stays comparable across arms',
+    aligned: true,
   },
   {
     element: 'Plus subscribers',
@@ -715,7 +715,7 @@ const ArmsPage = (): ReactElement => {
       <Section
         title="Glass card: the ad_only arm moves both links into the options menu"
         description="Hover the ad_only card and the three-dots button appears top right, next to the advertiser favicon, exactly where a post card puts it. The menu holds Advertise with us and Remove ads, so nothing is taken away, it just stops competing with the creative."
-        note="Only the ad_only arm and only the glass card change. Control and ad keep both links in a row above the image."
+        note="Only the ad_only arm and only the glass card change. Control and ad keep both links in a row above the image. Note that this hands the advertise link back to the slice of ad_only that also landed in feed_card_glass_actions, so the arm's advertise-click metric has to be segmented by that flag."
       >
         <div className="flex flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
           {arms.map((arm) => (

--- a/packages/storybook/stories/components/cards/AdPlacementConsistency.stories.tsx
+++ b/packages/storybook/stories/components/cards/AdPlacementConsistency.stories.tsx
@@ -1,0 +1,1010 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { AdGrid } from '@dailydotdev/shared/src/components/cards/ad/AdGrid';
+import { AdList } from '@dailydotdev/shared/src/components/cards/ad/AdList';
+import { SignalAdList } from '@dailydotdev/shared/src/components/cards/ad/SignalAdList';
+import { PostSidebarAdWidget } from '@dailydotdev/shared/src/components/post/PostSidebarAdWidget';
+import { AdAsComment } from '@dailydotdev/shared/src/components/comments/AdAsComment';
+
+import { ArticleGrid } from '@dailydotdev/shared/src/components/cards/article/ArticleGrid';
+import { ShareGrid } from '@dailydotdev/shared/src/components/cards/share/ShareGrid';
+import { CollectionGrid } from '@dailydotdev/shared/src/components/cards/collection/CollectionGrid';
+import { FreeformGrid } from '@dailydotdev/shared/src/components/cards/Freeform/FreeformGrid';
+import PollGrid from '@dailydotdev/shared/src/components/cards/poll/PollGrid';
+
+import { ArticleList } from '@dailydotdev/shared/src/components/cards/article/ArticleList';
+import { ShareList } from '@dailydotdev/shared/src/components/cards/share/ShareList';
+import { CollectionList } from '@dailydotdev/shared/src/components/cards/collection/CollectionList';
+import { FreeformList } from '@dailydotdev/shared/src/components/cards/Freeform/FreeformList';
+import { PollList } from '@dailydotdev/shared/src/components/cards/poll/PollList';
+import { SignalList } from '@dailydotdev/shared/src/components/cards/common/list/SignalList';
+
+import {
+  adImprovementsV3Feature,
+  AdLabelVariant,
+  featureAdLabel,
+  featureFeedCardGlassActions,
+} from '@dailydotdev/shared/src/lib/featureManagement';
+
+import {
+  AdProviders,
+  baseAd,
+  COMMENT_POST_ID,
+  Page,
+  Section,
+  SIDEBAR_POST_ID,
+} from '../../experiments/adLabel.mocks';
+import type { Slot } from './adPlacements.mocks';
+import {
+  actionHandlers,
+  adProps,
+  articlePost,
+  collectionPost,
+  defaultToolbar,
+  DeviceFrame,
+  isEmbedded,
+  freeformPost,
+  longCopyAd,
+  networkAd,
+  pollPost,
+  shortCopyAd,
+  SlotGrid,
+  SlotStack,
+  sharePost,
+  taggedAd,
+  Toolbar,
+  videoPost,
+  withFlags,
+} from './adPlacements.mocks';
+
+// ---------------------------------------------------------------------------
+// Every placement an ad can take, lined up against the post-type cards it sits
+// between in the same feed. The point of the page is the seam: source image,
+// title, tags, metadata line, cover image and the bottom action row should read
+// as one card family whichever slot they land in, and a row of cards should
+// resolve to one height.
+// ---------------------------------------------------------------------------
+
+const gridSlots = (v3Tags: boolean): Slot[] => [
+  {
+    key: 'grid-article',
+    label: 'Article',
+    node: <ArticleGrid post={articlePost} {...actionHandlers} />,
+  },
+  {
+    key: 'grid-ad',
+    label: 'Ad (AdGrid)',
+    isAd: true,
+    node: <AdGrid ad={v3Tags ? taggedAd : shortCopyAd} {...adProps} />,
+  },
+  {
+    key: 'grid-share',
+    label: 'Share',
+    node: <ShareGrid post={sharePost} {...actionHandlers} />,
+  },
+  {
+    key: 'grid-collection',
+    label: 'Collection',
+    node: <CollectionGrid post={collectionPost} {...actionHandlers} />,
+  },
+  {
+    key: 'grid-ad-long',
+    label: 'Ad, long copy',
+    isAd: true,
+    node: <AdGrid ad={longCopyAd} {...adProps} />,
+  },
+  {
+    key: 'grid-freeform',
+    label: 'Freeform',
+    node: <FreeformGrid post={freeformPost} {...actionHandlers} />,
+  },
+  {
+    key: 'grid-video',
+    label: 'Video',
+    node: <ArticleGrid post={videoPost} {...actionHandlers} />,
+  },
+  {
+    key: 'grid-ad-network',
+    label: 'Ad, network creative',
+    isAd: true,
+    node: <AdGrid ad={networkAd} {...adProps} />,
+  },
+  {
+    key: 'grid-poll',
+    label: 'Poll',
+    node: <PollGrid post={pollPost} {...actionHandlers} />,
+  },
+];
+
+const listSlots = (v3Tags: boolean): Slot[] => [
+  {
+    key: 'list-article',
+    label: 'Article',
+    node: <ArticleList post={articlePost} {...actionHandlers} />,
+  },
+  {
+    key: 'list-ad',
+    label: 'Ad (AdList)',
+    isAd: true,
+    node: <AdList ad={v3Tags ? taggedAd : shortCopyAd} {...adProps} />,
+  },
+  {
+    key: 'list-share',
+    label: 'Share',
+    node: <ShareList post={sharePost} {...actionHandlers} />,
+  },
+  {
+    key: 'list-collection',
+    label: 'Collection',
+    node: <CollectionList post={collectionPost} {...actionHandlers} />,
+  },
+  {
+    key: 'list-ad-long',
+    label: 'Ad, long copy',
+    isAd: true,
+    node: <AdList ad={longCopyAd} {...adProps} />,
+  },
+  {
+    key: 'list-freeform',
+    label: 'Freeform',
+    node: <FreeformList post={freeformPost} {...actionHandlers} />,
+  },
+  {
+    key: 'list-poll',
+    label: 'Poll',
+    node: <PollList post={pollPost} {...actionHandlers} />,
+  },
+];
+
+const signalSlots = (v3Tags: boolean): Slot[] => [
+  {
+    key: 'signal-article',
+    label: 'Article',
+    node: <SignalList post={articlePost} {...actionHandlers} />,
+  },
+  {
+    key: 'signal-ad',
+    label: 'Ad (SignalAdList)',
+    isAd: true,
+    node: <SignalAdList ad={v3Tags ? taggedAd : shortCopyAd} {...adProps} />,
+  },
+  {
+    key: 'signal-share',
+    label: 'Share',
+    node: <SignalList post={sharePost} {...actionHandlers} />,
+  },
+];
+
+const postPageSlots: Slot[] = [
+  {
+    key: 'sidebar-card',
+    label: 'Ad, post sidebar (card)',
+    isAd: true,
+    width: '22rem',
+    node: <PostSidebarAdWidget postId={SIDEBAR_POST_ID} />,
+  },
+  {
+    key: 'sidebar-inline',
+    label: 'Ad, post sidebar (inline)',
+    isAd: true,
+    width: '26rem',
+    node: <PostSidebarAdWidget postId={SIDEBAR_POST_ID} variant="inline" />,
+  },
+  {
+    key: 'comment',
+    label: 'Ad, as a comment',
+    isAd: true,
+    width: '36rem',
+    node: <AdAsComment postId={COMMENT_POST_ID} />,
+  },
+];
+
+interface AnatomyRow {
+  element: string;
+  left: string;
+  right: string;
+  aligned: boolean;
+}
+
+const gridAnatomy: AnatomyRow[] = [
+  {
+    element: 'Source image',
+    left: 'AuthorSourceStack: 32px author square in front, 32px source circle behind, opens on hover',
+    right:
+      'AdFavicon: one 32px circle (advertiser favicon), no stack, no hover card',
+    aligned: false,
+  },
+  {
+    element: 'Header inset',
+    left: 'Avatar lines up with the title (mx-1.5 cancels the header -mx-1.5)',
+    right:
+      'Favicon gets mx-4 on the header itself, so its left edge depends on which margin utility wins',
+    aligned: false,
+  },
+  {
+    element: 'Header actions',
+    left: 'Read post button plus the options menu, revealed on hover',
+    right: 'None',
+    aligned: false,
+  },
+  {
+    element: 'Title',
+    left: 'CardTitle, typo-title3, bold, line-clamp-3',
+    right:
+      'CardTitle, typo-title3, bold, line-clamp-3 (renders ad.description)',
+    aligned: true,
+  },
+  {
+    element: 'Tags row',
+    left: 'PostTags, always rendered',
+    right: 'PostTags on matchingTags, only while ad_improvements_v3 is on',
+    aligned: false,
+  },
+  {
+    element: 'Metadata line',
+    left: 'PostMetadata: date, separator, read time',
+    right:
+      'AdAttribution: "Promoted by {advertiser}" (or "Ad" in the ad_label treatments)',
+    aligned: false,
+  },
+  {
+    element: 'Cover image',
+    left: 'CardCover, h-40, rounded-12, px-1 side inset',
+    right: 'AdImage on the same CardImage: h-40, rounded-12, mx-1 side inset',
+    aligned: true,
+  },
+  {
+    element: 'Bottom row',
+    left: 'ActionButtons: upvote, comment, bookmark, copy link',
+    right:
+      '"Advertise here" and "Remove ads". The card can also render a primary CTA button, but served creatives carry no callToAction, so it never appears',
+    aligned: false,
+  },
+  {
+    element: 'Card height floor',
+    left: 'min-h-card (24rem), min-h-cardGlass (21.5rem) in the glass variant',
+    right:
+      'No minimum: the ad card is only as tall as its content, so it can be the short one in a row',
+    aligned: false,
+  },
+];
+
+const glassAnatomy: AnatomyRow[] = [
+  {
+    element: 'Cover image position',
+    left: 'Full-bleed at the bottom of the card, top corners square, bottom corners rounded-16',
+    right:
+      'Same treatment: the image moves below the CTA row and goes full-bleed',
+    aligned: true,
+  },
+  {
+    element: 'Floating action bar',
+    left: 'FeedCardGlassActions pill floats over the bottom of the cover image',
+    right:
+      'No pill. The CTA and "Remove ads" stay in a normal row above the image',
+    aligned: false,
+  },
+  {
+    element: 'Space under the image',
+    left: 'The cover reserves room for the pill (pb-12 on the share cover)',
+    right:
+      'Nothing floats over the image, so the ad image runs to the card edge',
+    aligned: false,
+  },
+];
+
+const placementAnatomy: AnatomyRow[] = [
+  {
+    element: 'Source image',
+    left: 'Feed ad card and post sidebar widget both resolve it through getAdFaviconImageLink',
+    right:
+      'Ad as a comment uses the creative (ad.image) as its avatar, so the same ad shows a different source image on the post page',
+    aligned: false,
+  },
+  {
+    element: 'Title line',
+    left: 'Sidebar widget leads with the company name, then the tagline in bold and the description',
+    right:
+      'Ad as a comment leads with the company, then repeats tagline plus description as one paragraph',
+    aligned: true,
+  },
+  {
+    element: 'Attribution',
+    left: 'Sidebar widget shares AdAttribution, so the ad_label arms swap the wording',
+    right:
+      'Ad as a comment builds its own "Promoted by {advertiser}" string and ignores the flag',
+    aligned: false,
+  },
+  {
+    element: 'Call to action',
+    left: 'Sidebar widget ships a "Visit" button',
+    right: 'Ad as a comment has no button at all, only the whole-card link',
+    aligned: false,
+  },
+];
+
+const mobileAnatomy: AnatomyRow[] = [
+  {
+    element: 'Layout below laptop',
+    left: 'Every post type falls back to its list card (useFeedLayout returns the mobile list layout under 1020px)',
+    right:
+      'The ad falls back to AdList too, so grid and list are the only two ad card layouts to review',
+    aligned: true,
+  },
+  {
+    element: 'Cover image',
+    left: 'Stacks under the text and goes full width until mobileXL (500px), then sits on the right at w-40 / w-56',
+    right:
+      'AdImage uses the same list CardImage, so it follows the same stack-then-sidecar rule',
+    aligned: true,
+  },
+  {
+    element: 'Action row',
+    left: 'ActionButtons move below the content on mobile (isMobile branch in ArticleList)',
+    right:
+      'The advertise and remove links stay in one row under the content at every width',
+    aligned: false,
+  },
+  {
+    element: 'Source line',
+    left: '40px source avatar, source name and read time on their own line above the title',
+    right:
+      '32px favicon inline in the title block, no advertiser name line, attribution below the title',
+    aligned: false,
+  },
+  {
+    element: 'Glass floating bar',
+    left: 'Grid cards only. List cards keep the classic action row at every width',
+    right: 'Same: AdGrid has the glass variant, AdList does not',
+    aligned: true,
+  },
+];
+
+const removeAdAnatomy: AnatomyRow[] = [
+  {
+    element: 'Grid ad card',
+    left: 'AdGrid passes variant=Tertiary, size Small',
+    right: 'btn-tertiary-bacon: flat label on a transparent background',
+    aligned: true,
+  },
+  {
+    element: 'List ad card',
+    left: 'AdList passes no variant, so RemoveAd falls back to its own Float default',
+    right:
+      'btn-tertiaryFloat-bacon: the same label sitting on an 8% filled surface, so it reads as a boxed button next to the flat grid one',
+    aligned: false,
+  },
+  {
+    element: 'Signal ad card',
+    left: 'SignalAdList passes variant=Tertiary, icon only',
+    right: 'Flat close icon, no label',
+    aligned: true,
+  },
+  {
+    element: 'Ad as a comment',
+    left: 'AdAsComment passes variant=Tertiary, icon only',
+    right: 'Flat close icon, no label',
+    aligned: true,
+  },
+];
+
+const optionsMenuAnatomy: AnatomyRow[] = [
+  {
+    element: 'control arm',
+    left: 'Advertise here and Remove ads inline, above the image',
+    right: 'Same, inline',
+    aligned: true,
+  },
+  {
+    element: 'ad arm',
+    left: 'Advertise here and Remove ads inline',
+    right: 'Same, inline',
+    aligned: true,
+  },
+  {
+    element: 'ad_only arm',
+    left: 'Advertise here dropped, Remove ads stays inline (unchanged behaviour)',
+    right:
+      'Both move into the three-dots menu in the card header, revealed on hover',
+    aligned: false,
+  },
+  {
+    element: 'Three-dots button',
+    left: 'Never rendered',
+    right:
+      'ad_only only. Top right of the header row, hover-revealed on pointer devices, always visible while the menu is open',
+    aligned: false,
+  },
+  {
+    element: 'Advertise-here impression',
+    left: 'Logged when the card mounts, since the link is on screen',
+    right:
+      'Logged when the menu opens, since that is when the link is actually shown',
+    aligned: false,
+  },
+  {
+    element: 'Plus subscribers',
+    left: 'No Remove ads link, they already have no ads',
+    right: 'Menu holds Advertise with us only',
+    aligned: true,
+  },
+];
+
+const AnatomyTable = ({
+  caption,
+  rows,
+  headers = ['Post card', 'Ad card'],
+}: {
+  caption: string;
+  rows: AnatomyRow[];
+  headers?: [string, string];
+}): ReactElement => (
+  <div className="w-full overflow-x-auto">
+    <table className="w-full min-w-[52rem] border-collapse text-left typo-footnote">
+      <caption className="mb-2 text-left font-bold text-text-primary typo-callout">
+        {caption}
+      </caption>
+      <thead>
+        <tr className="text-text-tertiary">
+          <th className="w-40 border-b border-border-subtlest-tertiary py-2 pr-4 font-normal">
+            Element
+          </th>
+          <th className="border-b border-border-subtlest-tertiary py-2 pr-4 font-normal">
+            {headers[0]}
+          </th>
+          <th className="border-b border-border-subtlest-tertiary py-2 pr-4 font-normal">
+            {headers[1]}
+          </th>
+          <th className="w-24 border-b border-border-subtlest-tertiary py-2 font-normal">
+            Match
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row) => (
+          <tr key={row.element} className="align-top">
+            <td className="border-b border-border-subtlest-tertiary py-2 pr-4 font-bold text-text-primary">
+              {row.element}
+            </td>
+            <td className="border-b border-border-subtlest-tertiary py-2 pr-4 text-text-tertiary">
+              {row.left}
+            </td>
+            <td className="border-b border-border-subtlest-tertiary py-2 pr-4 text-text-tertiary">
+              {row.right}
+            </td>
+            <td
+              className={
+                row.aligned
+                  ? 'border-b border-border-subtlest-tertiary py-2 text-action-upvote-default'
+                  : 'border-b border-border-subtlest-tertiary py-2 text-accent-ketchup-default'
+              }
+            >
+              {row.aligned ? 'consistent' : 'differs'}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+const useToolbar = () => {
+  const [state, setState] = useState(defaultToolbar);
+
+  return {
+    state,
+    toolbar: isEmbedded() ? null : (
+      <Toolbar state={state} onChange={setState} />
+    ),
+  };
+};
+
+const StoryPage = ({ children }: { children: ReactNode }): ReactElement => (
+  <AdProviders>
+    <Page>{children}</Page>
+  </AdProviders>
+);
+
+const GridFeedPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section
+        title="Grid feed: classic action row"
+        description="The ad card sits in the same CSS grid as every post type, so a row resolves to one height. Read down the cards: source image, title, tags, metadata line, cover image, bottom row."
+        note="Post cards carry a min-h-card floor; the ad card has none, so in a sparse row it is the card that decides how short the row can get."
+      >
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotGrid
+            slots={gridSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="Anatomy">
+        <AnatomyTable
+          caption="Grid card, element by element"
+          rows={gridAnatomy}
+        />
+      </Section>
+    </StoryPage>
+  );
+};
+
+const GlassFeedPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section
+        title="Grid feed: glass variant, image at the bottom"
+        description="With feed_card_glass_actions on, the cover image moves to the bottom of the card and goes full-bleed. Post cards float the glass action pill over that image; the ad card moves its image the same way but leaves the image bare and keeps its advertise and remove links in a text row above it."
+        note="Compare the bottom edge: the post cards end on an image with the pill over it, the ad card ends on a bare image with no bar at all. The image crop, radius and full-bleed inset should match."
+      >
+        {withFlags(
+          {
+            [featureFeedCardGlassActions.id]: true,
+            [adImprovementsV3Feature.id]: state.v3Tags,
+          },
+          <SlotGrid
+            slots={gridSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="Anatomy">
+        <AnatomyTable
+          caption="Glass variant, what moves and what does not"
+          rows={glassAnatomy}
+        />
+      </Section>
+    </StoryPage>
+  );
+};
+
+const ListFeedPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section
+        title="List feed"
+        description="List cards stack, so the seam to watch is the left rail: avatar size, title baseline, tag row and the thumbnail on the right should hold one vertical rhythm from post to ad and back."
+        note="The post list card puts a 40px source avatar on its own header line above the title. The ad card inlines a 32px favicon inside the title block, so the ad title starts on a different baseline."
+      >
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={listSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section
+        title="Signal feed"
+        description="The signal feed uses its own compact list row. SignalAdList is the ad that sits between SignalList posts."
+      >
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={signalSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="Anatomy">
+        <AnatomyTable
+          caption="The remove-ads control, placement by placement"
+          rows={removeAdAnatomy}
+          headers={['What the placement passes', 'How it renders']}
+        />
+      </Section>
+    </StoryPage>
+  );
+};
+
+const OtherPlacementsPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section
+        title="Post page placements"
+        description="These are not feed cards, so they do not line up with a post row. They are here because they render the same ad payload and should still use the same source image, title and CTA language."
+        note="Boosted post ads are not on this page: the feed renders them through the regular post card, so they are consistent by construction. Squad ads (SquadAdGrid / SquadAdList) are also left out because they resolve their squad and members through live queries."
+      >
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={postPageSlots}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="Anatomy">
+        <AnatomyTable
+          caption="Post page placements against the feed ad card"
+          rows={placementAnatomy}
+          headers={['Feed card and sidebar widget', 'Ad as a comment']}
+        />
+      </Section>
+    </StoryPage>
+  );
+};
+
+const arms: { variant: AdLabelVariant; label: string; summary: string }[] = [
+  {
+    variant: AdLabelVariant.Control,
+    label: 'control',
+    summary: '"Promoted by {advertiser}", both links inline',
+  },
+  {
+    variant: AdLabelVariant.Ad,
+    label: 'ad',
+    summary: '"Ad", both links still inline',
+  },
+  {
+    variant: AdLabelVariant.AdOnly,
+    label: 'ad_only',
+    summary: '"Ad"; on the glass card both links move into the options menu',
+  },
+];
+
+const ArmColumn = ({
+  variant,
+  label,
+  summary,
+  glass,
+  state,
+}: {
+  variant: AdLabelVariant;
+  label: string;
+  summary: string;
+  glass: boolean;
+  state: { showHeights: boolean; showGuides: boolean; v3Tags: boolean };
+}): ReactElement => (
+  <div className="flex w-80 shrink-0 flex-col gap-3">
+    <div className="flex flex-col gap-1">
+      <code className="font-bold text-text-primary typo-footnote">
+        ad_label = {label}
+      </code>
+      <span className="text-text-tertiary typo-caption1">{summary}</span>
+    </div>
+    {withFlags(
+      {
+        [featureAdLabel.id]: variant,
+        [featureFeedCardGlassActions.id]: glass,
+        [adImprovementsV3Feature.id]: state.v3Tags,
+      },
+      <SlotGrid
+        slots={[
+          {
+            key: `arm-${label}-${glass ? 'glass' : 'classic'}`,
+            label: glass ? 'Glass card' : 'Classic card',
+            isAd: true,
+            node: <AdGrid ad={shortCopyAd} {...adProps} />,
+          },
+        ]}
+        columns={1}
+        showHeights={state.showHeights}
+        showGuides={state.showGuides}
+      />,
+    )}
+  </div>
+);
+
+const ArmsPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section
+        title="Glass card: the ad_only arm moves both links into the options menu"
+        description="Hover the ad_only card and the three-dots button appears top right, next to the advertiser favicon, exactly where a post card puts it. The menu holds Advertise with us and Remove ads, so nothing is taken away, it just stops competing with the creative."
+        note="Only the ad_only arm and only the glass card change. Control and ad keep both links in a row above the image."
+      >
+        <div className="flex flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
+          {arms.map((arm) => (
+            <ArmColumn key={arm.variant} {...arm} glass state={state} />
+          ))}
+        </div>
+      </Section>
+      <Section
+        title="Classic card: untouched in every arm"
+        description="The old layout keeps Advertise here and Remove ads visible in the card body. ad_only still drops the advertise link there, as it has since the experiment shipped, and the remove link stays inline."
+      >
+        <div className="flex flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
+          {arms.map((arm) => (
+            <ArmColumn key={arm.variant} {...arm} glass={false} state={state} />
+          ))}
+        </div>
+      </Section>
+      <Section title="Anatomy">
+        <AnatomyTable
+          caption="Where the ad card's own links live"
+          rows={optionsMenuAnatomy}
+          headers={['Classic card', 'Glass card']}
+        />
+      </Section>
+    </StoryPage>
+  );
+};
+
+const MOBILE_CANVAS_ID =
+  'components-cards-ad-placement-consistency--mobile-canvas';
+
+const MobileCanvasPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section title="List cards at the frame width">
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={listSlots(state.v3Tags)}
+            fit="viewport"
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="Signal feed">
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={signalSlots(state.v3Tags)}
+            fit="viewport"
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+    </StoryPage>
+  );
+};
+
+const MobilePage = (): ReactElement => (
+  <StoryPage>
+    <Section
+      title="Mobile and tablet"
+      description="Every feed below laptop (1020px) renders the list layout, so this is the ad card most users actually see. Each frame is a real viewport, so the mobile list card shows its own layout: the cover stacks under the text and the action row moves below it."
+      note="The glass floating bar is a grid-card feature (ArticleGrid, ShareGrid, CollectionGrid, FreeformGrid, PollGrid, AdGrid and the wide hero cards). List cards never render it, so there is no mobile glass variant to review."
+    >
+      <div className="flex w-full flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
+        <DeviceFrame
+          label="Phone"
+          storyId={MOBILE_CANVAS_ID}
+          width={390}
+          height={1700}
+        />
+        <DeviceFrame
+          label="Large phone"
+          storyId={MOBILE_CANVAS_ID}
+          width={430}
+          height={1700}
+        />
+        <DeviceFrame
+          label="Tablet"
+          storyId={MOBILE_CANVAS_ID}
+          width={820}
+          height={1700}
+        />
+      </div>
+    </Section>
+    <Section title="Anatomy">
+      <AnatomyTable
+        caption="List card on mobile, element by element"
+        rows={mobileAnatomy}
+      />
+      <AnatomyTable
+        caption="The remove-ads control, placement by placement"
+        rows={removeAdAnatomy}
+        headers={['What the placement passes', 'How it renders']}
+      />
+    </Section>
+  </StoryPage>
+);
+
+const AllPlacementsPage = (): ReactElement => {
+  const { state, toolbar } = useToolbar();
+
+  return (
+    <StoryPage>
+      {toolbar}
+      <Section
+        title="1. Grid feed: classic action row"
+        description="Ad cards between every post type, in one grid, so a row resolves to a single height."
+      >
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotGrid
+            slots={gridSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section
+        title="2. Grid feed: glass variant, image at the bottom"
+        description="feed_card_glass_actions moves the cover image to the bottom of the card. The post cards float their action pill over it; the ad card leaves it bare and keeps its advertise and remove links above it."
+      >
+        {withFlags(
+          {
+            [featureFeedCardGlassActions.id]: true,
+            [adImprovementsV3Feature.id]: state.v3Tags,
+          },
+          <SlotGrid
+            slots={gridSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="3. List feed">
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={listSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="4. Signal feed">
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={signalSlots(state.v3Tags)}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section
+        title="5. ad_label arms on the glass card"
+        description="The ad_only arm moves Advertise with us and Remove ads into a three-dots menu in the card header. Control and ad keep them inline."
+      >
+        <div className="flex flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
+          {arms.map((arm) => (
+            <ArmColumn key={arm.variant} {...arm} glass state={state} />
+          ))}
+        </div>
+      </Section>
+      <Section
+        title="6. Mobile and tablet"
+        description="Below laptop every feed renders the list layout, so this is the ad card most users see. Each frame is a real viewport."
+      >
+        <div className="flex w-full flex-row flex-nowrap items-start gap-8 overflow-x-auto pb-2">
+          <DeviceFrame
+            label="Phone"
+            storyId={MOBILE_CANVAS_ID}
+            width={390}
+            height={1200}
+          />
+          <DeviceFrame
+            label="Tablet"
+            storyId={MOBILE_CANVAS_ID}
+            width={820}
+            height={1200}
+          />
+        </div>
+      </Section>
+      <Section
+        title="7. Post page placements"
+        description="Same ad payload, off the feed grid."
+      >
+        {withFlags(
+          { [adImprovementsV3Feature.id]: state.v3Tags },
+          <SlotStack
+            slots={postPageSlots}
+            showHeights={state.showHeights}
+            showGuides={state.showGuides}
+          />,
+        )}
+      </Section>
+      <Section title="8. Anatomy">
+        <AnatomyTable
+          caption="Grid card, element by element"
+          rows={gridAnatomy}
+        />
+        <AnatomyTable
+          caption="Glass variant, what moves and what does not"
+          rows={glassAnatomy}
+        />
+        <AnatomyTable
+          caption="Where the ad card's own links live"
+          rows={optionsMenuAnatomy}
+          headers={['Classic card', 'Glass card']}
+        />
+        <AnatomyTable
+          caption="List card on mobile, element by element"
+          rows={mobileAnatomy}
+        />
+        <AnatomyTable
+          caption="The remove-ads control, placement by placement"
+          rows={removeAdAnatomy}
+          headers={['What the placement passes', 'How it renders']}
+        />
+        <AnatomyTable
+          caption="Post page placements against the feed ad card"
+          rows={placementAnatomy}
+          headers={['Feed card and sidebar widget', 'Ad as a comment']}
+        />
+      </Section>
+    </StoryPage>
+  );
+};
+
+const meta: Meta = {
+  title: 'Components/Cards/Ad Placement Consistency',
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `Every ad placement lined up against every post type, so the ad card can be read as one of the family: source image, title, tag row, metadata line, cover image, bottom action row and card height. Includes the glass variant that moves the cover image to the bottom of the card. Served with the ${baseAd.company} fixture.`,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const AllPlacements: Story = {
+  render: () => <AllPlacementsPage />,
+  name: 'All placements',
+};
+
+export const GridFeed: Story = {
+  render: () => <GridFeedPage />,
+  name: 'Grid feed',
+};
+
+export const GlassGridFeed: Story = {
+  render: () => <GlassFeedPage />,
+  name: 'Grid feed (glass, image at bottom)',
+};
+
+export const ListFeed: Story = {
+  render: () => <ListFeedPage />,
+  name: 'List and signal feeds',
+};
+
+export const Arms: Story = {
+  render: () => <ArmsPage />,
+  name: 'ad_label arms and the options menu',
+};
+
+export const Mobile: Story = {
+  render: () => <MobilePage />,
+  name: 'Mobile and tablet (list layout)',
+};
+
+// The canvas the mobile frames embed. Kept as its own story so it can also be
+// opened directly and driven with Storybook's own viewport controls.
+export const MobileCanvas: Story = {
+  render: () => <MobileCanvasPage />,
+  name: 'Mobile canvas (embedded in the frames)',
+};
+
+export const PostPagePlacements: Story = {
+  render: () => <OtherPlacementsPage />,
+  name: 'Post page placements',
+};

--- a/packages/storybook/stories/components/cards/adPlacements.mocks.tsx
+++ b/packages/storybook/stories/components/cards/adPlacements.mocks.tsx
@@ -1,0 +1,475 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+import { fn } from 'storybook/test';
+import type { Ad, Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType, UserVote } from '@dailydotdev/shared/src/graphql/posts';
+import {
+  adImprovementsV3Feature,
+  featureAdLabel,
+  featureAutorotateAds,
+  featureFeedCardGlassActions,
+  AdLabelVariant,
+} from '@dailydotdev/shared/src/lib/featureManagement';
+import { FeatureOverrides } from '../../../mock/GrowthBookProvider';
+import { baseAd } from '../../experiments/adLabel.mocks';
+
+const mockSource = {
+  id: 'tds',
+  handle: 'tds',
+  name: 'Towards Data Science',
+  permalink: 'https://app.daily.dev/sources/tds',
+  image: 'https://media.daily.dev/image/upload/t_logo,f_auto/v1/logos/tds',
+  type: 'machine' as const,
+  active: true,
+};
+
+const mockSquadSource = {
+  id: 'squad-1',
+  handle: 'devs',
+  name: 'Developer Squad',
+  permalink: 'https://app.daily.dev/squads/devs',
+  image: 'https://media.daily.dev/image/upload/t_logo,f_auto/v1/logos/squad',
+  type: 'squad' as const,
+  active: true,
+  public: true,
+  membersCount: 150,
+};
+
+const mockAuthor = {
+  id: 'author-1',
+  name: 'John Developer',
+  image: 'https://media.daily.dev/image/upload/f_auto/v1/avatars/default',
+  permalink: 'https://app.daily.dev/johndeveloper',
+  username: 'johndeveloper',
+  bio: 'Full-stack developer',
+};
+
+const coverImage =
+  'https://media.daily.dev/image/upload/f_auto,q_auto/v1/posts/article-placeholder';
+
+const basePost = {
+  numUpvotes: 42,
+  numComments: 12,
+  bookmarked: false,
+  read: false,
+  upvoted: false,
+  commented: false,
+  tags: ['javascript', 'react', 'typescript'],
+  source: mockSource,
+  author: mockAuthor,
+  readTime: 8,
+  createdAt: '2024-01-15T10:30:00.000Z',
+  permalink: 'https://api.daily.dev/r/article-1',
+  commentsPermalink: 'https://daily.dev/posts/article-1',
+  image: coverImage,
+  type: PostType.Article,
+  userState: {
+    vote: UserVote.None,
+    flags: { feedbackDismiss: false },
+  },
+};
+
+const make = (overrides: Record<string, unknown>): Post =>
+  ({ ...basePost, ...overrides } as unknown as Post);
+
+export const articlePost = make({
+  id: 'ads-article',
+  title:
+    'Understanding React Server Components: A Deep Dive into the Future of Web Development',
+  summary:
+    'Learn how React Server Components change the way we build web applications.',
+});
+
+export const videoPost = make({
+  id: 'ads-video',
+  title: 'Watch: building a realtime collaborative editor from scratch',
+  type: PostType.VideoYouTube,
+  numUpvotes: 318,
+  numComments: 24,
+});
+
+export const sharePost = make({
+  id: 'ads-share',
+  title: 'Great breakdown of edge rendering, worth a read',
+  source: mockSquadSource,
+  type: PostType.Share,
+  sharedPost: {
+    id: 'ads-shared-article',
+    title: 'TypeScript Best Practices for 2024',
+    image: coverImage,
+    readTime: 11,
+    permalink: 'https://api.daily.dev/r/ads-shared-article',
+    commentsPermalink: 'https://app.daily.dev/posts/ads-shared-article',
+    summary: 'Learn the best TypeScript practices for modern development.',
+    createdAt: '2024-01-07T19:26:43.146Z',
+    private: false,
+    type: PostType.Article,
+    tags: ['typescript'],
+    source: mockSource,
+  },
+});
+
+export const collectionPost = make({
+  id: 'ads-collection',
+  title: 'Essential React Hooks Every Developer Should Know',
+  summary: 'A curated collection of the most useful React hooks.',
+  readTime: 15,
+  type: PostType.Collection,
+  collectionSources: [mockSource, mockSquadSource],
+  numCollectionSources: 5,
+});
+
+export const freeformPost = make({
+  id: 'ads-freeform',
+  title: 'Just shipped a new feature that suggests code improvements',
+  source: mockSquadSource,
+  type: PostType.Freeform,
+  contentHtml: '<p>Just shipped a new feature.</p>',
+});
+
+export const pollPost = make({
+  id: 'ads-poll',
+  title: 'What is your favorite programming language for 2024?',
+  source: mockSquadSource,
+  type: PostType.Poll,
+  image: undefined,
+  pollOptions: [
+    { id: 'opt-1', text: 'JavaScript', order: 1, numVotes: 45 },
+    { id: 'opt-2', text: 'Python', order: 2, numVotes: 32 },
+    { id: 'opt-3', text: 'TypeScript', order: 3, numVotes: 28 },
+  ],
+  endsAt: '2026-01-22T10:30:00.000Z',
+  numPollVotes: 105,
+});
+
+// Served creatives don't carry a `callToAction`, so no fixture here does
+// either: the ad card's bottom row is the advertise link and the remove-ads
+// button, and that is what has to line up with the post card's action row.
+const feedAd: Ad = { ...baseAd, callToAction: undefined };
+
+export const shortCopyAd: Ad = {
+  ...feedAd,
+  description: 'Deploy your Next.js app in seconds.',
+};
+
+export const longCopyAd: Ad = {
+  ...feedAd,
+  company: 'Datadog',
+  source: 'Datadog',
+  description:
+    'Observability for teams that ship daily: distributed tracing, log search, RUM and synthetic checks in one place, with alerts that route to the on-call engineer who owns the service.',
+};
+
+/** Carbon and EthicalAds creatives render contained over a blurred backdrop. */
+export const networkAd: Ad = {
+  ...feedAd,
+  company: 'Carbon',
+  source: 'Carbon',
+  companyLogo: undefined,
+  description: 'A network creative that keeps its own aspect ratio.',
+};
+
+export const taggedAd: Ad = {
+  ...feedAd,
+  matchingTags: ['nextjs', 'react', 'devops', 'webdev'],
+};
+
+export const actionHandlers = {
+  onPostClick: fn(),
+  onPostAuxClick: fn(),
+  onUpvoteClick: fn(),
+  onDownvoteClick: fn(),
+  onCommentClick: fn(),
+  onBookmarkClick: fn(),
+  onCopyLinkClick: fn(),
+  onShare: fn(),
+  onReadArticleClick: fn(),
+};
+
+export const adProps = { index: 0, feedIndex: 0, onLinkClick: fn() };
+
+// `control` is the blanket value the Storybook mock returns for every flag,
+// which would leave autorotation on a NaN timer and force the v3 tag row on.
+// Every section pins the flags that change an ad card, so only the one under
+// review differs.
+export const baseFlags: Record<string, unknown> = {
+  [featureAutorotateAds.id]: 0,
+  [adImprovementsV3Feature.id]: false,
+  [featureFeedCardGlassActions.id]: false,
+  [featureAdLabel.id]: AdLabelVariant.Control,
+};
+
+export const withFlags = (
+  overrides: Record<string, unknown>,
+  children: ReactNode,
+): ReactElement => (
+  <FeatureOverrides values={{ ...baseFlags, ...overrides }}>
+    {children}
+  </FeatureOverrides>
+);
+
+interface ToolbarState {
+  showHeights: boolean;
+  showGuides: boolean;
+  v3Tags: boolean;
+}
+
+export const defaultToolbar: ToolbarState = {
+  showHeights: true,
+  showGuides: false,
+  v3Tags: false,
+};
+
+interface ToolbarProps {
+  state: ToolbarState;
+  onChange: (next: ToolbarState) => void;
+}
+
+const toggles: { key: keyof ToolbarState; label: string; hint: string }[] = [
+  {
+    key: 'showHeights',
+    label: 'Card heights',
+    hint: 'rendered px height of every card',
+  },
+  {
+    key: 'showGuides',
+    label: 'Content guides',
+    hint: 'the 16px inset the card content should sit on',
+  },
+  {
+    key: 'v3Tags',
+    label: 'ad_improvements_v3',
+    hint: 'adds the matching-tags row to ad cards',
+  },
+];
+
+/** Frames embed the canvas story, and three stacked toolbars is just noise. */
+export const isEmbedded = (): boolean =>
+  typeof window !== 'undefined' &&
+  new URLSearchParams(window.location.search).has('embedded');
+
+export const Toolbar = ({ state, onChange }: ToolbarProps): ReactElement => (
+  <div className="sticky top-0 z-3 -mx-6 mb-2 flex flex-wrap items-center gap-4 border-b border-border-subtlest-tertiary bg-background-default px-6 py-3">
+    {toggles.map(({ key, label, hint }) => (
+      <label
+        key={key}
+        className="flex cursor-pointer items-center gap-2 typo-footnote"
+        title={hint}
+      >
+        <input
+          type="checkbox"
+          checked={state[key]}
+          onChange={(event) =>
+            onChange({ ...state, [key]: event.target.checked })
+          }
+        />
+        <span>{label}</span>
+      </label>
+    ))}
+    <span className="text-text-quaternary typo-footnote">
+      Ad slots are outlined in cabbage.
+    </span>
+  </div>
+);
+
+export interface Slot {
+  key: string;
+  label: string;
+  isAd?: boolean;
+  node: ReactNode;
+  /** Caps the slot for placements that are narrower than a feed card. */
+  width?: string;
+}
+
+const useMeasuredHeight = (
+  enabled: boolean,
+): [React.RefObject<HTMLDivElement>, number | undefined] => {
+  const ref = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<number>();
+
+  useEffect(() => {
+    const card = ref.current?.firstElementChild;
+
+    if (!enabled || !card) {
+      setHeight(undefined);
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(() =>
+      setHeight(Math.round(card.getBoundingClientRect().height)),
+    );
+    observer.observe(card);
+
+    return () => observer.disconnect();
+  }, [enabled]);
+
+  return [ref, height];
+};
+
+interface CardSlotProps extends Omit<Slot, 'key'> {
+  showHeights: boolean;
+  showGuides: boolean;
+}
+
+export const CardSlot = ({
+  label,
+  isAd,
+  node,
+  width,
+  showHeights,
+  showGuides,
+}: CardSlotProps): ReactElement => {
+  const [ref, height] = useMeasuredHeight(showHeights);
+
+  return (
+    <div className="flex h-full flex-col gap-2" style={{ maxWidth: width }}>
+      <div className="flex h-5 items-center gap-2">
+        <span
+          className={classNames(
+            'truncate font-bold typo-footnote',
+            isAd ? 'text-accent-cabbage-default' : 'text-text-tertiary',
+          )}
+        >
+          {label}
+        </span>
+        {showHeights && height ? (
+          <span className="ml-auto shrink-0 rounded-6 bg-surface-float px-1.5 tabular-nums text-text-tertiary typo-caption2">
+            {height}px
+          </span>
+        ) : null}
+      </div>
+      <div
+        ref={ref}
+        className={classNames(
+          'relative flex-1',
+          isAd && 'rounded-16 ring-2 ring-accent-cabbage-default',
+        )}
+      >
+        {node}
+        {showGuides && (
+          <span className="pointer-events-none absolute inset-y-0 left-4 right-4 z-3 border-x border-dashed border-accent-ketchup-default opacity-64" />
+        )}
+      </div>
+    </div>
+  );
+};
+
+interface SlotGridProps {
+  slots: Slot[];
+  columns?: number;
+  showHeights: boolean;
+  showGuides: boolean;
+}
+
+// Columns are pinned to the 20rem the feed gives a grid card, not to the
+// Storybook panel width: a squeezed card clamps its title and overlaps its
+// action row, which would read as an inconsistency that production never has.
+export const SlotGrid = ({
+  slots,
+  columns = 3,
+  showHeights,
+  showGuides,
+}: SlotGridProps): ReactElement => (
+  <div className="w-full overflow-x-auto pb-2">
+    <div
+      className="grid w-fit items-stretch"
+      style={{
+        gridTemplateColumns: `repeat(${columns}, 20rem)`,
+        gap: '2rem',
+      }}
+    >
+      {slots.map(({ key, ...slot }) => (
+        <CardSlot
+          key={key}
+          {...slot}
+          showHeights={showHeights}
+          showGuides={showGuides}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+interface SlotStackProps extends Omit<SlotGridProps, 'columns'> {
+  /**
+   * `desktop` matches list mode on laptop (FeedPageLayoutList caps the feed at
+   * 42.5rem); `viewport` fills the frame, which is what the mobile layout does.
+   */
+  fit?: 'desktop' | 'viewport';
+}
+
+export const SlotStack = ({
+  slots,
+  showHeights,
+  showGuides,
+  fit = 'desktop',
+}: SlotStackProps): ReactElement => (
+  <div
+    className={classNames(
+      'flex w-full flex-col gap-6',
+      fit === 'desktop' && 'min-w-[42.5rem] max-w-[42.5rem]',
+    )}
+  >
+    {slots.map(({ key, ...slot }) => (
+      <CardSlot
+        key={key}
+        {...slot}
+        showHeights={showHeights}
+        showGuides={showGuides}
+      />
+    ))}
+  </div>
+);
+
+/**
+ * Tailwind breakpoints answer to the viewport, not to a container, so a card
+ * squeezed into a narrow div still renders its laptop layout. Embedding the
+ * canvas story in a real iframe gives it a real viewport, which is the only
+ * way the mobile list card (stacked cover, action row moved below the text)
+ * shows up truthfully.
+ */
+export const DeviceFrame = ({
+  label,
+  storyId,
+  width,
+  height = 1600,
+}: {
+  label: string;
+  storyId: string;
+  width: number;
+  height?: number;
+}): ReactElement => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const read = () =>
+      setTheme(
+        document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+      );
+    read();
+
+    const observer = new MutationObserver(read);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div className="flex shrink-0 flex-col gap-2">
+      <span className="font-bold text-text-tertiary typo-footnote">
+        {label} ({width}px)
+      </span>
+      <iframe
+        title={label}
+        src={`/iframe.html?id=${storyId}&viewMode=story&globals=theme:${theme}&embedded=1`}
+        width={width}
+        height={height}
+        className="rounded-16 border border-border-subtlest-tertiary bg-background-default"
+      />
+    </div>
+  );
+};

--- a/packages/storybook/stories/components/cards/adPlacements.mocks.tsx
+++ b/packages/storybook/stories/components/cards/adPlacements.mocks.tsx
@@ -193,7 +193,7 @@ export const adProps = { index: 0, feedIndex: 0, onLinkClick: fn() };
 // which would leave autorotation on a NaN timer and force the v3 tag row on.
 // Every section pins the flags that change an ad card, so only the one under
 // review differs.
-export const baseFlags: Record<string, unknown> = {
+const baseFlags: Record<string, unknown> = {
   [featureAutorotateAds.id]: 0,
   [adImprovementsV3Feature.id]: false,
   [featureFeedCardGlassActions.id]: false,
@@ -312,7 +312,7 @@ interface CardSlotProps extends Omit<Slot, 'key'> {
   showGuides: boolean;
 }
 
-export const CardSlot = ({
+const CardSlot = ({
   label,
   isAd,
   node,

--- a/packages/storybook/stories/experiments/adLabel.mocks.tsx
+++ b/packages/storybook/stories/experiments/adLabel.mocks.tsx
@@ -111,19 +111,26 @@ export const AdProviders = ({
 
     // Seeded for both the signed-in and anonymous key, so the widgets read
     // their ad from the cache instead of hitting the (unmocked) ad server.
+    // `useAdQuery` appends a consent fingerprint to the key it was given, and
+    // whether GDPR applies depends on the geo the story mounts with, so both
+    // fingerprints are seeded.
+    const consentFingerprints = [
+      [false, ''],
+      [true, ''],
+    ];
     [user, undefined].forEach((keyUser) => {
-      client.setQueryData(
+      [
         generateQueryKey(
           RequestKey.Ads,
           keyUser,
           SIDEBAR_POST_ID,
           'post-sidebar',
         ),
-        widgetAd,
-      );
-      client.setQueryData(
         generateQueryKey(RequestKey.Ads, keyUser, COMMENT_POST_ID),
-        widgetAd,
+      ].forEach((key) =>
+        consentFingerprints.forEach((fingerprint) =>
+          client.setQueryData([...key, ...fingerprint], widgetAd),
+        ),
       );
     });
 


### PR DESCRIPTION
The Storybook pages the ad card work was reviewed on, plus the two UI issues that review turned up.

Stacked on #6462 — the base retargets to `main` when that merges. That PR holds the flag-gated three-dots menu and nothing else; everything else from this effort is here.

## Storybook

### Components → Cards → Ad Placement Consistency

Every ad placement lined up against every post type, so the ad card can be read as one of the family rather than one card at a time.

| Story | Covers |
| --- | --- |
| All placements | everything below, in order |
| Grid feed | `AdGrid` (short copy, long copy, network creative) between Article, Share, Collection, Freeform, Video, Poll |
| Grid feed (glass) | the same grid with `feed_card_glass_actions` on, where the cover image moves to the bottom |
| List and signal feeds | `AdList` between the five list post types, `SignalAdList` between `SignalList` posts |
| ad_label arms | all three arms on the glass card and on the classic card, side by side |
| Mobile and tablet | 390 / 430 / 820px **real viewport** iframes, since Tailwind breakpoints answer to the viewport and a card squeezed into a narrow div would render its laptop layout |
| Post page placements | sidebar widget (card and inline) and ad-as-a-comment |

Toolbar toggles for per-card rendered-height badges, a content-inset guide overlay, and the `ad_improvements_v3` tag row. Ad slots are outlined so the eye finds them. Six anatomy tables record, element by element, where the ad card matches the post card and where it does not.

What it surfaced beyond the two fixes below: the ad card uses a single `AdFavicon` circle where post cards use the author/source stack; it has no `min-h-card` floor, so it is the short card in a row; and `AdAsComment` uses the creative as its avatar, so one ad shows two different source images across surfaces. All three are left alone here and recorded on the page.

### Components → Cards → Ad Card Fixes

Before and after for each fix. "Before" is the same card with the old value forced back through one CSS property, not a mock-up. The remove control is the exception, shown as a separate pair of real `RemoveAd` instances, since a class swap cannot be reverted with CSS.

## Fix 1: the disclosure line touches the ad copy

`AdAttribution` sits at the bottom of a flex spacer. When the card is only as tall as its own content that spacer collapses, and "Promoted by {advertiser}" lands **4px** under the title, reading as part of it.

A 12px minimum (`mt-3`) fixes the collapsed case and is absorbed where the spacer already had room:

| | Before | After |
| --- | --- | --- |
| Grid card, own height | 0px | 12px |
| Grid card, stretched by a taller row | 30px | 30px (unchanged) |
| List card | 8px | 12px |

Applied to `AdGrid` and `AdList` through a shared `adAttributionSpacing` token so the two cannot drift apart again. The signal card and sidebar widget pass their own spacing and are untouched.

## Fix 2: the list card's remove control was not flat

`AdList` never passed a variant to `RemoveAd`, so it kept the component's own `ButtonVariant.Float` default and rendered "Remove ads" on an 8% filled surface (`btn-tertiaryFloat-bacon`) while the grid card passed `Tertiary` and rendered it flat (`btn-tertiary-bacon`). Same control, two treatments, in the same feed. It now passes `Tertiary`.

## Also

`AdProviders` seeded its ad cache without the consent fingerprint `useAdQuery` appends to the key, so the sidebar and comment placements rendered blank in every story that used them, including the existing Experiments → Ad label page. Fixed here.

`AdAttribution` gained a `data-testid="adAttribution"` hook, used by the new tests and by the story's before-state rule.

## Test plan

- Three new cases in `AdCard.spec.tsx`: the disclosure keeps its margin on the grid and the list card, and the list remove control renders `btn-tertiary-bacon` and not `btn-tertiaryFloat-bacon`.
- 240 shared card tests, 485 webapp, 43 extension, all passing.
- Measured in the browser: the long-copy glass card went 4px → 12px while the two roomy cards stayed at 44px and 54px.
- eslint and the changed-file strict typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-ad-card-spacing-and-remov.preview.app.daily.dev