### PR TITLE
fix(world): one open signup per world visit, attributed to the world

### DIFF
--- a/packages/shared/src/components/auth/SignupWidget.spec.tsx
+++ b/packages/shared/src/components/auth/SignupWidget.spec.tsx
@@ -1,0 +1,110 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { SignupWidget } from './SignupWidget';
+import { AuthDisplay } from './common';
+import { AuthTriggers } from '../../lib/auth';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+jest.mock('../../contexts/AuthContext', () => ({
+  ...jest.requireActual('../../contexts/AuthContext'),
+  useAuthContext: jest.fn(),
+}));
+
+/* The real form is the whole auth stack. What this file is about is the handoff
+   it makes to the modal, so the mock stands in for the two ways out of it. */
+jest.mock('./AuthOptions', () => ({
+  __esModule: true,
+  default: ({
+    trigger,
+    onAuthStateUpdate,
+  }: {
+    trigger: string;
+    onAuthStateUpdate?: (props: Record<string, unknown>) => void;
+  }) => {
+    const { AuthDisplay: Display } = jest.requireActual('./common');
+
+    return (
+      <div>
+        <span data-testid="trigger">{trigger}</span>
+        <button
+          type="button"
+          onClick={() =>
+            onAuthStateUpdate?.({
+              isAuthenticating: true,
+              defaultDisplay: Display.Registration,
+            })
+          }
+        >
+          Continue with email
+        </button>
+        <button
+          type="button"
+          onClick={() =>
+            onAuthStateUpdate?.({
+              isAuthenticating: true,
+              isLoginFlow: true,
+              email: 'ido@daily.dev',
+            })
+          }
+        >
+          Existing email
+        </button>
+      </div>
+    );
+  },
+}));
+
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<
+  typeof useAuthContext
+>;
+const showLogin = jest.fn();
+
+beforeEach(() => {
+  showLogin.mockReset();
+  mockUseAuthContext.mockReturnValue({ showLogin } as never);
+});
+
+const renderWidget = () =>
+  render(
+    <SignupWidget
+      title="Build your world"
+      description="Every article you read grows the world."
+      trigger={AuthTriggers.World}
+    />,
+  );
+
+it('hands the inline form the surface that asked for it', () => {
+  renderWidget();
+
+  expect(screen.getByTestId('trigger')).toHaveTextContent(AuthTriggers.World);
+});
+
+it('keeps the surface trigger and the signup screen on the way to the modal', () => {
+  renderWidget();
+
+  fireEvent.click(screen.getByText('Continue with email'));
+
+  expect(showLogin).toHaveBeenCalledWith({
+    trigger: AuthTriggers.World,
+    options: {
+      isLogin: false,
+      defaultDisplay: AuthDisplay.Registration,
+      formValues: undefined,
+    },
+  });
+});
+
+it('carries an existing reader over to the login screen with their email', () => {
+  renderWidget();
+
+  fireEvent.click(screen.getByText('Existing email'));
+
+  expect(showLogin).toHaveBeenCalledWith({
+    trigger: AuthTriggers.World,
+    options: {
+      isLogin: true,
+      defaultDisplay: undefined,
+      formValues: { email: 'ido@daily.dev' },
+    },
+  });
+});

--- a/packages/shared/src/components/auth/SignupWidget.tsx
+++ b/packages/shared/src/components/auth/SignupWidget.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { useAuthContext } from '../../contexts/AuthContext';
 import type { AuthTriggersType } from '../../lib/auth';
-import { AuthTriggers } from '../../lib/auth';
 import { ButtonSize, ButtonVariant } from '../buttons/Button';
 import AuthOptions from './AuthOptions';
 import { AuthDisplay } from './common';
@@ -104,8 +103,12 @@ export function SignupWidget({
           forceDefaultDisplay
           onAuthStateUpdate={(props) => {
             showLogin({
-              trigger: AuthTriggers.Onboarding,
-              options: { isLogin: true, formValues: props },
+              trigger,
+              options: {
+                isLogin: !!props.isLoginFlow,
+                defaultDisplay: props.defaultDisplay,
+                formValues: props.email ? { email: props.email } : undefined,
+              },
             });
           }}
           onboardingSignupButton={{

--- a/packages/webapp/__tests__/WorldSignupMount.spec.tsx
+++ b/packages/webapp/__tests__/WorldSignupMount.spec.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { useViewSize } from '@dailydotdev/shared/src/hooks';
+import { WorldView } from '../components/world/WorldView';
+import type { UserWorldResult } from '../components/world/useUserWorld';
+import type { WorldState } from '../components/world/worldState';
+import { createWorldEngine } from '../components/world/engine/world';
+
+/* The card logs `open signup` from a mount effect, so how many times it mounts
+   IS the event count. Counted here rather than asserted on the log context,
+   which the real card only reaches through the whole auth form. */
+const mockSignupMounted = jest.fn();
+jest.mock('../components/world/WorldSignupCta', () => ({
+  WorldSignupCta: () => {
+    const { useEffect } = jest.requireActual('react');
+    useEffect(() => mockSignupMounted(), []);
+
+    return <div data-testid="signup" />;
+  },
+}));
+
+jest.mock('../components/world/engine/world', () => ({
+  createWorldEngine: jest.fn(),
+}));
+
+jest.mock('../components/world/engine/buildWorld', () => ({
+  buildWorld: () => ({ districts: [], quarters: [], replayable: false }),
+}));
+
+jest.mock('@dailydotdev/shared/src/hooks', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/hooks'),
+  useViewSize: jest.fn(),
+}));
+
+jest.mock('@dailydotdev/shared/src/contexts/SettingsContext', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/contexts/SettingsContext'),
+  useSettingsContext: () => ({ autoDismissNotifications: true }),
+}));
+
+jest.mock('../components/world/useWorldDraft', () => ({
+  useWorldDraft: () => ({ isOpen: false, applied: undefined }),
+}));
+
+jest.mock('../components/world/useWorldPlate', () => ({
+  useWorldPlate: jest.fn(),
+}));
+
+jest.mock('../components/world/useWorldMusic', () => ({
+  RIDE_MUTED_KEY: 'ride:muted',
+  useWorldMusic: jest.fn(),
+}));
+
+jest.mock('../components/world/useWorldLog', () => ({
+  useWorldLog: jest.fn(),
+}));
+
+const mockCreateEngine = createWorldEngine as jest.MockedFunction<
+  typeof createWorldEngine
+>;
+const mockUseViewSize = useViewSize as jest.MockedFunction<typeof useViewSize>;
+
+const owner = {
+  id: 'owner',
+  name: 'Ido',
+  username: 'ido',
+  permalink: 'http://localhost:5002/ido',
+} as PublicProfile;
+
+const world: UserWorldResult = {
+  districts: [
+    {
+      niche: { slug: 'web', name: 'Web', realm: 'frameworks' },
+      reads: 12,
+    },
+  ],
+  isPending: false,
+  isHistoryPending: false,
+  isEmpty: false,
+  isPrivate: false,
+} as unknown as UserWorldResult;
+
+const ready: Partial<WorldState> = {
+  status: 'ready',
+  progress: 1,
+  rank: [],
+  articles: 12,
+  districts: 1,
+  realms: 1,
+};
+
+beforeEach(() => {
+  mockSignupMounted.mockReset();
+  mockUseViewSize.mockReturnValue(true);
+  mockCreateEngine.mockImplementation(({ onState }) => {
+    // The world stands as soon as it is asked to load, which is all this test
+    // needs the engine for: the rail only exists once something is standing.
+    return {
+      load: async () =>
+        onState((previous: WorldState) => ({ ...previous, ...ready })),
+      dispose: jest.fn(),
+      setLook: jest.fn(),
+      setCrest: jest.fn(),
+      setSky: jest.fn(),
+      setLevelProgress: jest.fn(),
+      setPadding: jest.fn(),
+      attachHistory: () => false,
+      attachSpark: jest.fn(),
+      focus: jest.fn(),
+      leaveRealm: jest.fn(),
+      seek: jest.fn(),
+      toggle: jest.fn(),
+      toStart: jest.fn(),
+      toEnd: jest.fn(),
+      setSpeed: jest.fn(),
+    } as never;
+  });
+});
+
+const renderWorld = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <AuthContext.Provider
+        value={
+          {
+            user: null,
+            isAuthReady: true,
+            isLoggedIn: false,
+            showLogin: jest.fn(),
+            closeLogin: jest.fn(),
+          } as never
+        }
+      >
+        <WorldView user={owner} world={world} />
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  );
+
+it('mounts the signup card once per visit, not once per panel toggle', async () => {
+  renderWorld();
+
+  await screen.findByTestId('signup');
+  expect(mockSignupMounted).toHaveBeenCalledTimes(1);
+
+  /* By role, so a hidden rail counts as gone: display:none takes its own copy
+     of this toggle out of the accessibility tree, which is the difference
+     between out of the way and unmounted. */
+  for (let i = 0; i < 3; i += 1) {
+    fireEvent.click(screen.getByRole('button', { name: 'Hide the panels' }));
+    // eslint-disable-next-line no-await-in-loop
+    await screen.findByRole('button', { name: 'Show the panels' });
+    fireEvent.click(screen.getByRole('button', { name: 'Show the panels' }));
+    // eslint-disable-next-line no-await-in-loop
+    await screen.findByRole('button', { name: 'Hide the panels' });
+  }
+
+  await waitFor(() => expect(screen.getByTestId('signup')).toBeInTheDocument());
+  expect(mockSignupMounted).toHaveBeenCalledTimes(1);
+});

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -247,6 +247,12 @@ interface WorldPanelProps {
   state: WorldState;
   /** Six realms of bare ground: every number is a zero and nothing is standing. */
   unbuilt?: boolean;
+  /**
+   * Mounted, off screen. The rail stays in the tree while the panels are hidden
+   * so the signup card does not re-log its mount, and nothing in here has to
+   * keep up with the engine while nobody can see it.
+   */
+  isHidden?: boolean;
   isImmersive: boolean;
   worldName?: string;
   isOwn: boolean;
@@ -271,7 +277,7 @@ const RAIL =
  * own, because the engine is counting the day the scrubber is standing on and
  * the panel is not.
  */
-export function WorldPanel({
+function WorldPanelRail({
   user,
   state,
   unbuilt,
@@ -431,3 +437,14 @@ export function WorldPanel({
     </aside>
   );
 }
+
+/**
+ * Nothing in a rail nobody can see is worth a render, and the engine pushes a
+ * new state through here every frame of a replay whether the panels are up or
+ * not. Hidden to hidden is the only pass worth skipping: coming back has to
+ * land on the day the scrubber is standing on now, not the one it left.
+ */
+export const WorldPanel = memo(
+  WorldPanelRail,
+  (previous, next) => !!previous.isHidden && !!next.isHidden,
+);

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -382,56 +382,65 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     <div className="fixed inset-0 overflow-hidden bg-background-default">
       <div ref={mountRef} className="absolute inset-0" />
 
-      {isChromeVisible && (
-        <>
-          {isLaptop ? (
-            <WorldPanel
-              user={user}
-              state={state}
-              unbuilt={isUnbuilt}
-              isImmersive={isImmersive}
-              worldName={worldName}
-              isOwn={isOwn}
-              canShare={canShare}
-              draft={ownerDraft}
-              districts={districts}
-              showNudge={showNudge}
-              onToggleImmersive={onToggleImmersive}
-              onFocus={onFocus}
-              onLeaveRealm={onLeaveRealm}
-            />
-          ) : (
-            <WorldBack
-              user={user}
-              isInRealm={!!state.open}
-              worldName={worldName}
-              isOwn={isOwn}
-              canShare={canShare}
-              onLeaveRealm={onLeaveRealm}
-            />
-          )}
-          {/* On screen while the growth log is still on the wire, inert, in the
-              place it will be live in. It is the last thing to arrive and the
-              only one that changes the layout, so it reserves its own room.
-
-              Never on a handheld. The bar is a transport, a scrubber, three
-              speeds and a sparkline, and a phone has room for one of those
-              five; the log it drives is not fetched there either. What is left
-              is a world, which is the thing worth the screen anyway. */}
-          {!isLite && !isUnbuilt && (state.replayable || !hasNoReplay) && (
-            <WorldTimeline
-              state={state}
-              pending={!state.replayable}
-              sparkRef={attachSpark}
-              onToggle={onToggle}
-              onSeek={onSeek}
-              onStart={onStart}
-              onEnd={onEnd}
-              onSpeed={onSpeed}
-            />
-          )}
-        </>
+      {/* Hidden rather than dropped: the rail carries the signup card, which
+          logs `open signup` from its mount, so dropping it reports another
+          signup open every time the panels come back. Standing is what it is
+          mounted on, because that is the visit worth counting. */}
+      {isStanding && isLaptop && (
+        <div hidden={!isChromeVisible}>
+          <WorldPanel
+            user={user}
+            state={state}
+            unbuilt={isUnbuilt}
+            isHidden={!isChromeVisible}
+            isImmersive={isImmersive}
+            worldName={worldName}
+            isOwn={isOwn}
+            canShare={canShare}
+            draft={ownerDraft}
+            districts={districts}
+            showNudge={showNudge}
+            onToggleImmersive={onToggleImmersive}
+            onFocus={onFocus}
+            onLeaveRealm={onLeaveRealm}
+          />
+        </div>
       )}
+
+      {isChromeVisible && !isLaptop && (
+        <WorldBack
+          user={user}
+          isInRealm={!!state.open}
+          worldName={worldName}
+          isOwn={isOwn}
+          canShare={canShare}
+          onLeaveRealm={onLeaveRealm}
+        />
+      )}
+
+      {/* On screen while the growth log is still on the wire, inert, in the
+          place it will be live in. It is the last thing to arrive and the
+          only one that changes the layout, so it reserves its own room.
+
+          Never on a handheld. The bar is a transport, a scrubber, three
+          speeds and a sparkline, and a phone has room for one of those
+          five; the log it drives is not fetched there either. What is left
+          is a world, which is the thing worth the screen anyway. */}
+      {isChromeVisible &&
+        !isLite &&
+        !isUnbuilt &&
+        (state.replayable || !hasNoReplay) && (
+          <WorldTimeline
+            state={state}
+            pending={!state.replayable}
+            sparkRef={attachSpark}
+            onToggle={onToggle}
+            onSeek={onSeek}
+            onStart={onStart}
+            onEnd={onEnd}
+            onSpeed={onSpeed}
+          />
+        )}
 
       {isRiding && (
         <WorldRiding


### PR DESCRIPTION
`/world` was reporting more `open signup` events than there were readers opening a signup, and attributing the ones that converted to the wrong surface.

## Measured on production

Anonymous visitor on `app.daily.dev/world/idoshamun`, capturing the `/e` batches:

| action | events |
| --- | --- |
| one world view | `world view`, `page view`, `open signup {"trigger":"world"}`, `world ready` |
| 3× hide/show the panels | 3 more `open signup {"trigger":"world"}`, one per cycle |

Signed in, the same run logs zero: the card is gated on there being no user, and that guard holds. This is an anonymous-only over-count.

## What was wrong

**The rail was dropped, not hidden.** The signup card logs `open signup` from a mount effect, and `isChromeVisible` unmounted the whole rail whenever the panels went away. Hiding the panels, riding a bird and crossing the laptop breakpoint all mounted the card again, each one reporting another signup open (and re-arming Google One Tap with it). The rail is now mounted from the moment the world stands and hidden while it is out of the way, so the card mounts once per visit. It is memoised on `isHidden` so a rail nobody can see does not follow the engine through a replay.

**The widget dropped its own trigger on the handoff.** `SignupWidget` takes a `trigger` for the analytics on the signup it starts, passed it to the inline form, then hardcoded `onboarding` on the `showLogin` call that continues the flow. It also hardcoded `isLogin: true`, so "Continue with email" on a signup card landed the reader on the **log in** screen and the funnel recorded `open login` under a trigger they never came from. `formValues` was being handed the auth state object, which has no email on it. Now forwarded the way `AuthenticationBanner` already does it, so the world rail and the post sidebar keep their own trigger and land on registration.

## Not in this PR

`open signup` firing on mount at all is an impression rather than an intent, and that is true of every inline `AuthOptions` surface (`PostSignupWidget`, `AuthenticationBanner`), not just this one. Changing it moves numbers on surfaces beyond the world, so it wants a data call first.

## Tests

- `WorldSignupMount.spec.tsx` drives `WorldView` through three panel toggles and asserts the card mounted once. It reports 4 against the old code.
- `SignupWidget.spec.tsx` covers both ways out of the widget: the email path keeps the caller's trigger and opens on registration, the existing-reader path opens on login with the email.

`pnpm --filter webapp test World`, the shared auth and post suites, eslint and a full webapp `tsc` are clean.

## Verification gap

Behaviour is covered by the tests above and the production measurement of the old code. The new rendering has **not** been eyeballed in a browser: local dev can only reach the API from the staging host alias, and that port was in use. Worth a look at the rail on a laptop, and at the immersive toggle, before merging.

### Preview domain
https://claude-world-signup-event-leak-a.preview.app.daily.dev