### PR TITLE
feat(world): open a district's upvote feed when you click it

### DIFF
--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -290,6 +290,7 @@ export enum RequestKey {
   UserWorld = 'user_world',
   UserWorldTimeline = 'user_world_timeline',
   UserWorldEntitlements = 'user_world_entitlements',
+  UserWorldDistrictFeed = 'user_world_district_feed',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
+++ b/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import nock from 'nock';
+import { QueryClient } from '@tanstack/react-query';
+import type { MockedGraphQLResponse } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { mockGraphQL } from '@dailydotdev/shared/__tests__/helpers/graphql';
+import { waitForNock } from '@dailydotdev/shared/__tests__/helpers/utilities';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import defaultUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
+import defaultFeedPage from '@dailydotdev/shared/__tests__/fixture/feed';
+import type { Connection } from '@dailydotdev/shared/src/graphql/common';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
+import type { UserWorldDistrictFeedData } from '../graphql/world';
+import { USER_WORLD_DISTRICT_FEED_QUERY } from '../graphql/world';
+import { WorldDistrictFeed } from '../components/world/WorldDistrictFeed';
+import type { WorldSelectedDistrict } from '../components/world/worldState';
+
+const district: WorldSelectedDistrict = {
+  slug: 'rust',
+  name: 'Rust',
+  color: '#CE3F4B',
+};
+
+const feedMock = (
+  page: Connection<Post> = defaultFeedPage,
+  variables: Record<string, unknown> = {},
+): MockedGraphQLResponse<UserWorldDistrictFeedData> => ({
+  request: {
+    query: USER_WORLD_DISTRICT_FEED_QUERY,
+    variables: {
+      id: 'u1',
+      niches: ['rust'],
+      first: 20,
+      after: '',
+      ...variables,
+    },
+  },
+  result: { data: { page } },
+});
+
+const onClose = jest.fn();
+
+const renderFeed = (
+  mocks: MockedGraphQLResponse[] = [feedMock()],
+  isOwn = false,
+) => {
+  mocks.forEach(mockGraphQL);
+
+  return render(
+    <TestBootProvider client={new QueryClient()} auth={{ user: defaultUser }}>
+      <WorldDistrictFeed
+        userId="u1"
+        userName="Ida"
+        isOwn={isOwn}
+        district={district}
+        onClose={onClose}
+      />
+    </TestBootProvider>,
+  );
+};
+
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+});
+
+/* One heading carrying both facts, because the panel has room for one: whose
+   upvotes these are, and which district they belong to. */
+it('should title the panel with whose upvotes and which district', async () => {
+  renderFeed();
+
+  expect(
+    await screen.findByRole('heading', { name: "Ida's upvotes in Rust" }),
+  ).toBeInTheDocument();
+});
+
+it('should address the owner directly on their own world', async () => {
+  renderFeed([feedMock()], true);
+
+  expect(
+    await screen.findByRole('heading', { name: 'Your upvotes in Rust' }),
+  ).toBeInTheDocument();
+});
+
+/* The whole point of the panel: the same upvote feed the profile shows, scoped
+   to the one niche the district stands for. A request without `niches` is the
+   reader's entire upvote history under a district's name. */
+it('should ask for the upvotes of that niche only', async () => {
+  renderFeed();
+  await waitForNock();
+
+  expect(
+    await screen.findByText(defaultFeedPage.edges[0].node.title ?? ''),
+  ).toBeInTheDocument();
+});
+
+/* A district is built by READING, so a town can stand tall with nothing voted
+   in it. That is not an error and must not read as one. */
+it('should explain an empty district rather than showing nothing', async () => {
+  renderFeed([
+    feedMock({ pageInfo: { hasNextPage: false, endCursor: '' }, edges: [] }),
+  ]);
+  await waitForNock();
+
+  expect(
+    await screen.findByText(/Nothing upvoted in Rust yet/),
+  ).toBeInTheDocument();
+});
+
+it('should hand closing back to the caller, which clears the selection', async () => {
+  renderFeed();
+
+  fireEvent.click(await screen.findByLabelText('Close district'));
+
+  expect(onClose).toHaveBeenCalledTimes(1);
+});

--- a/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
+++ b/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
@@ -103,9 +103,6 @@ it('should explain an empty district rather than showing nothing', async () => {
   await waitForNock();
 
   expect(await screen.findByText('Nothing upvoted yet')).toBeInTheDocument();
-  expect(
-    await screen.findByText(/Districts grow by reading, not by voting/),
-  ).toBeInTheDocument();
 });
 
 it('should hand closing back to the caller, which clears the selection', async () => {

--- a/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
+++ b/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
@@ -102,8 +102,9 @@ it('should explain an empty district rather than showing nothing', async () => {
   ]);
   await waitForNock();
 
+  expect(await screen.findByText('Nothing upvoted yet')).toBeInTheDocument();
   expect(
-    await screen.findByText(/Nothing upvoted in Rust yet/),
+    await screen.findByText(/Districts grow by reading, not by voting/),
   ).toBeInTheDocument();
 });
 

--- a/packages/webapp/components/world/WorldDistrictFeed.tsx
+++ b/packages/webapp/components/world/WorldDistrictFeed.tsx
@@ -7,6 +7,8 @@ import { PostEngagementCounts } from '@dailydotdev/shared/src/components/cards/S
 import { ListItemPlaceholder } from '@dailydotdev/shared/src/components/widgets/ListItemPlaceholder';
 import InfiniteScrolling from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
 import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
+import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import {
   Typography,
   TypographyColor,
@@ -139,16 +141,31 @@ export function WorldDistrictFeed({
           </InfiniteScrolling>
         )}
 
+        {/* Centred in what is left of the panel rather than tucked under the
+            header: on laptop this is a full-height column, and two lines of
+            grey text at the top of it read as a list that failed to arrive. */}
         {!isPending && !posts.length && (
-          <Typography
-            type={TypographyType.Callout}
-            color={TypographyColor.Tertiary}
-            className="px-4 py-6"
-          >
-            {isError
-              ? 'These upvotes could not be loaded.'
-              : `Nothing upvoted in ${district.name} yet. The district was built by reading, not by voting.`}
-          </Typography>
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
+            <UpvoteIcon
+              size={IconSize.XXLarge}
+              className="text-text-disabled"
+            />
+            <Typography type={TypographyType.Callout} bold>
+              {isError
+                ? 'These upvotes could not be loaded'
+                : 'Nothing upvoted yet'}
+            </Typography>
+            {!isError && (
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Tertiary}
+              >
+                {isOwn
+                  ? 'Districts grow by reading. Upvote what you rate and it lands here.'
+                  : 'Districts grow by reading, not by voting.'}
+              </Typography>
+            )}
+          </div>
         )}
       </div>
     </aside>

--- a/packages/webapp/components/world/WorldDistrictFeed.tsx
+++ b/packages/webapp/components/world/WorldDistrictFeed.tsx
@@ -1,0 +1,156 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
+import { LazyImage } from '@dailydotdev/shared/src/components/LazyImage';
+import { PostEngagementCounts } from '@dailydotdev/shared/src/components/cards/SimilarPosts/PostEngagementCounts';
+import { ListItemPlaceholder } from '@dailydotdev/shared/src/components/widgets/ListItemPlaceholder';
+import InfiniteScrolling from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
+import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import type { WorldSelectedDistrict } from './worldState';
+import { useWorldDistrictFeed } from './useWorldDistrictFeed';
+
+interface WorldDistrictFeedProps {
+  userId: string;
+  /** Whose upvotes these are, for the title on somebody else's world. */
+  userName: string;
+  isOwn: boolean;
+  district: WorldSelectedDistrict;
+  onClose: () => void;
+}
+
+/* The right rail on laptop, a sheet along the bottom below it. Never full
+   screen on a phone: the district you clicked is the thing the list is about,
+   and a panel that covers the town covers the reason you opened it. */
+const PANEL =
+  'pointer-events-auto absolute inset-x-0 bottom-0 z-2 flex max-h-[60%] flex-col rounded-t-16 border-t border-border-subtlest-tertiary bg-background-default laptop:inset-y-0 laptop:left-auto laptop:right-0 laptop:w-80 laptop:max-h-none laptop:rounded-none laptop:border-l laptop:border-t-0';
+
+/**
+ * The reading behind a district: every post its owner upvoted in that niche.
+ *
+ * A district is a count, how much of a topic somebody read, and the count is
+ * the one thing the map cannot show you the substance of. This is that
+ * substance, and upvotes rather than reads on purpose: a read is a click, an
+ * upvote is a verdict, so the list is a recommendation instead of a log.
+ *
+ * Rows open in a NEW TAB. Following a link out of here tears down the WebGL
+ * context and rebuilds the whole world on the way back (camera reframed, the
+ * realm you had walked into closed), which is a steep price for reading one
+ * article out of a list of twenty.
+ */
+export function WorldDistrictFeed({
+  userId,
+  userName,
+  isOwn,
+  district,
+  onClose,
+}: WorldDistrictFeedProps): ReactElement {
+  const {
+    posts,
+    isPending,
+    isError,
+    canFetchMore,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useWorldDistrictFeed(userId, district.slug);
+
+  return (
+    <aside data-world-overlay className={PANEL}>
+      <header className="flex flex-none items-start gap-2 border-b border-border-subtlest-tertiary p-4">
+        <i
+          className="mt-1.5 h-2 w-2 flex-none rounded-2"
+          style={{ background: district.color }}
+        />
+        <Typography
+          tag={TypographyTag.H2}
+          type={TypographyType.Callout}
+          className="min-w-0 flex-1 break-words"
+          bold
+        >
+          {isOwn ? 'Your' : `${userName}'s`} upvotes in {district.name}
+        </Typography>
+        <CloseButton
+          type="button"
+          size={ButtonSize.Small}
+          onClick={onClose}
+          aria-label="Close district"
+        />
+      </header>
+
+      {/* The rows carry their own horizontal padding so the hover fill runs the
+          full width of the panel rather than stopping inside a gutter. */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto py-2">
+        {isPending && (
+          <>
+            <ListItemPlaceholder />
+            <ListItemPlaceholder />
+            <ListItemPlaceholder />
+          </>
+        )}
+
+        {!isPending && !!posts.length && (
+          <InfiniteScrolling
+            canFetchMore={canFetchMore}
+            isFetchingNextPage={isFetchingNextPage}
+            fetchNextPage={fetchNextPage}
+            placeholder={<ListItemPlaceholder />}
+          >
+            {posts.map((post) => {
+              /* A share carries its title on the post it shares, not on itself. */
+              const title = post.title || post.sharedPost?.title;
+
+              return (
+                <Link key={post.id} href={post.commentsPermalink} passHref>
+                  <a
+                    className="flex items-start gap-3 px-4 py-3 hover:bg-surface-hover"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={title}
+                  >
+                    <LazyImage
+                      imgSrc={post.source?.image ?? ''}
+                      imgAlt={post.source?.name ?? ''}
+                      className="mt-0.5 h-7 w-7 rounded-full"
+                    />
+                    <div className="flex min-w-0 flex-1 flex-col">
+                      <Typography
+                        tag={TypographyTag.Span}
+                        type={TypographyType.Callout}
+                        className="line-clamp-3 break-words"
+                      >
+                        {title}
+                      </Typography>
+                      <PostEngagementCounts
+                        upvotes={post.numUpvotes ?? 0}
+                        comments={post.numComments ?? 0}
+                        className="text-text-tertiary"
+                      />
+                    </div>
+                  </a>
+                </Link>
+              );
+            })}
+          </InfiniteScrolling>
+        )}
+
+        {!isPending && !posts.length && (
+          <Typography
+            type={TypographyType.Callout}
+            color={TypographyColor.Tertiary}
+            className="px-4 py-6"
+          >
+            {isError
+              ? 'These upvotes could not be loaded.'
+              : `Nothing upvoted in ${district.name} yet. The district was built by reading, not by voting.`}
+          </Typography>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/packages/webapp/components/world/WorldDistrictFeed.tsx
+++ b/packages/webapp/components/world/WorldDistrictFeed.tsx
@@ -11,7 +11,6 @@ import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import {
   Typography,
-  TypographyColor,
   TypographyTag,
   TypographyType,
 } from '@dailydotdev/shared/src/components/typography/Typography';
@@ -142,8 +141,8 @@ export function WorldDistrictFeed({
         )}
 
         {/* Centred in what is left of the panel rather than tucked under the
-            header: on laptop this is a full-height column, and two lines of
-            grey text at the top of it read as a list that failed to arrive. */}
+            header: on laptop this is a full-height column, and a line of grey
+            text at the top of it reads as a list that failed to arrive. */}
         {!isPending && !posts.length && (
           <div className="flex flex-1 flex-col items-center justify-center gap-2 px-6 py-10 text-center">
             <UpvoteIcon
@@ -155,16 +154,6 @@ export function WorldDistrictFeed({
                 ? 'These upvotes could not be loaded'
                 : 'Nothing upvoted yet'}
             </Typography>
-            {!isError && (
-              <Typography
-                type={TypographyType.Footnote}
-                color={TypographyColor.Tertiary}
-              >
-                {isOwn
-                  ? 'Districts grow by reading. Upvote what you rate and it lands here.'
-                  : 'Districts grow by reading, not by voting.'}
-              </Typography>
-            )}
           </div>
         )}
       </div>

--- a/packages/webapp/components/world/WorldMark.tsx
+++ b/packages/webapp/components/world/WorldMark.tsx
@@ -75,7 +75,18 @@ export function WorldImmersiveToggle({
  * viewBox scales 1:1, so the element carries ~8px of dead space on its right
  * that no amount of equal padding can balance out.
  */
-export function WorldMark({ floating }: { floating?: boolean }): ReactElement {
+export function WorldMark({
+  floating,
+  insetRight,
+}: {
+  floating?: boolean;
+  /**
+   * The district feed is standing on the right edge, so the mark steps aside
+   * rather than sitting on its header. Laptop only: below that the feed is a
+   * sheet along the bottom and this corner is clear.
+   */
+  insetRight?: boolean;
+}): ReactElement {
   return (
     <div
       {...(floating && { 'data-world-overlay': true })}
@@ -83,6 +94,7 @@ export function WorldMark({ floating }: { floating?: boolean }): ReactElement {
         'flex flex-none items-center',
         floating &&
           'pointer-events-auto absolute right-3 top-3 z-2 rounded-16 border border-border-subtlest-tertiary bg-background-default py-2.5 pl-3 pr-1',
+        floating && insetRight && 'laptop:right-[21rem]',
       )}
     >
       <Logo

--- a/packages/webapp/components/world/WorldTimeline.tsx
+++ b/packages/webapp/components/world/WorldTimeline.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import classNames from 'classnames';
 import { format, parseISO } from 'date-fns';
 import {
   Button,
@@ -63,6 +64,11 @@ interface WorldTimelineProps {
      is replayable, which is well after the engine was created, so the engine
      has to be told about it at the moment it mounts. */
   sparkRef: (canvas: HTMLCanvasElement | null) => void;
+  /* Something is standing on the world's right edge (the district feed), so the
+     bar stops short of it, the same way it already stops short of the rail on
+     the left. Laptop only: below that the feed is a sheet across the bottom and
+     the bar is taken down rather than squeezed. */
+  insetRight?: boolean;
   onToggle: () => void;
   onSeek: (day: number) => void;
   onStart: () => void;
@@ -82,6 +88,7 @@ export function WorldTimeline({
   state,
   pending,
   sparkRef,
+  insetRight,
   onToggle,
   onSeek,
   onStart,
@@ -97,7 +104,10 @@ export function WorldTimeline({
   return (
     <div
       data-world-overlay
-      className="pointer-events-auto absolute bottom-3 left-3 right-3 z-1 rounded-16 border border-border-subtlest-tertiary bg-background-default p-3 laptop:left-[21rem]"
+      className={classNames(
+        'pointer-events-auto absolute bottom-3 left-3 right-3 z-1 rounded-16 border border-border-subtlest-tertiary bg-background-default p-3 laptop:left-[21rem]',
+        insetRight && 'laptop:right-[21rem]',
+      )}
     >
       <div className="flex items-center gap-2 laptop:gap-3">
         <Transport

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -7,6 +7,7 @@ import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsCon
 import usePersistentContext from '@dailydotdev/shared/src/hooks/usePersistentContext';
 import { WorldBack } from './WorldBack';
 import { WorldBoot } from './WorldBoot';
+import { WorldDistrictFeed } from './WorldDistrictFeed';
 import { useIsOwnWorld, WorldInvite } from './WorldInvite';
 import { WorldImmersiveToggle, WorldMark } from './WorldMark';
 import { WorldPanel } from './WorldPanel';
@@ -295,6 +296,12 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
     [],
   );
   const onLeaveRealm = useCallback(() => engineRef.current?.leaveRealm(), []);
+  /* Closing the feed drops the engine's selection rather than hiding the panel
+     in React: the lit plot border and the highlighted rail row are the same
+     fact, and a panel dismissed on its own would leave the world claiming a
+     town is open. Dropping the selection is also what lets clicking the same
+     town again reopen it. */
+  const onCloseDistrict = useCallback(() => engineRef.current?.deselect(), []);
   const attachSpark = useCallback(
     (canvas: HTMLCanvasElement | null) =>
       engineRef.current?.attachSpark(canvas),
@@ -363,6 +370,13 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
   /* Never on an unbuilt world: WorldInvite already makes the one ask there,
      and it makes it nowhere else. */
   const showNudge = isOwn && !isUnbuilt && !isWorldCustomised(applied);
+  /* A district is only ever selected inside a realm, so this is also what says
+     the reader has walked in and clicked a town. Not while the bench is open:
+     dressing a world means clicking towns to see chips land on them, and a feed
+     opening over every one of those clicks is noise on top of the one job the
+     owner is there to do. */
+  const openDistrict =
+    isChromeVisible && !ownerDraft?.isOpen ? state.district : null;
 
   /* A hidden world draws nothing — no map, timeline or crest — so this returns
      before the boot screen too. */
@@ -407,6 +421,21 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
         </div>
       )}
 
+      {/* Whatever the last click selected, read out. Deliberately does NOT
+          repad the camera: `setPadding` refits the whole realm, which would
+          throw away the reader's zoom and pan every time they clicked a town,
+          a steep price for a panel that opens and closes on single clicks. So
+          it overlays the world's edge and the reader pans if they need to. */}
+      {!!openDistrict && (
+        <WorldDistrictFeed
+          userId={user.id}
+          userName={user.name}
+          isOwn={isOwn}
+          district={openDistrict}
+          onClose={onCloseDistrict}
+        />
+      )}
+
       {isChromeVisible && !isLaptop && (
         <WorldBack
           user={user}
@@ -429,11 +458,17 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
       {isChromeVisible &&
         !isLite &&
         !isUnbuilt &&
-        (state.replayable || !hasNoReplay) && (
+        (state.replayable || !hasNoReplay) &&
+        /* Below laptop the district feed is a sheet across the bottom, sitting
+           exactly where this bar does. Nothing is gained by leaving a scrubber
+           under it that cannot be reached, so the bar comes down for as long as
+           the feed is up. On laptop it stops short of the panel instead. */
+        (isLaptop || !openDistrict) && (
           <WorldTimeline
             state={state}
             pending={!state.replayable}
             sparkRef={attachSpark}
+            insetRight={!!openDistrict}
             onToggle={onToggle}
             onSeek={onSeek}
             onStart={onStart}
@@ -454,7 +489,7 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
 
       {/* No bar anywhere holds it any more, so it always stands on the world:
           top right, opposite whatever is in the other corner. */}
-      {isStanding && <WorldMark floating />}
+      {isStanding && <WorldMark floating insetRight={!!openDistrict} />}
 
       {/* The toggle lives in whatever chrome is on screen. Once none is, it
           stands on the world too, opposite the mark, because it is then the

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -8112,7 +8112,7 @@ function enterRealm(q){
   fade=0; fadeTo=1;
   frameBounds(q.bounds);
   rootEl.classList.add('inrealm');
-  updateHud(); renderRank(true); buildAir(); placeClouds();
+  updateHud(); renderRank(true); emitDistrict(); buildAir(); placeClouds();
 }
 function leaveRealm(){
   if(!OPEN)return;
@@ -8139,7 +8139,7 @@ function leaveRealm(){
   fade=0; fadeTo=1;
   frameBounds(W.worldBounds);
   rootEl.classList.remove('inrealm');
-  updateHud(); renderRank(true); buildAir(); placeClouds();
+  updateHud(); renderRank(true); emitDistrict(); buildAir(); placeClouds();
 }
 
 /* The sky, its eight palettes and its five hours, all in `sky.js` — the bench
@@ -8526,7 +8526,18 @@ function pick(cx,cy,click){
 function select(i){
   if(selected===i)return;
   selected=i;
-  paintBorders(); renderRank(true);
+  paintBorders(); renderRank(true); emitDistrict();
+}
+/* Which district is selected, by SLUG, so the overlay can ask the API what this
+   reader upvoted in that niche. The slug is the one fact about a district only
+   the engine holds: everything else the overlay has is a rank row, and a rank
+   row is capped at fourteen while a realm can hold more than fourteen towns.
+   Emitted from `select` and from both realm doors, which are the only three
+   places `selected` moves. */
+function emitDistrict(){
+  const d=OPEN&&selected!==null?W.districts[selected]:null;
+  emit({district:d?{slug:d.niche.id, name:nameOf(d),
+                    color:hexs(d.niche.accent)}:null});
 }
 function paintBorders(){
   const on=VIEW.border&&!!OPEN;
@@ -9131,7 +9142,12 @@ function drawSpark(c){
 
 /* ==================================================================== boot */
 async function boot(model){
-  emit({status:'loading',progress:0.05,message:'Raising the land…'});
+  /* `district` is cleared here and nowhere else in boot: a soft navigation from
+     one world to another reuses this engine, and everything else the overlay
+     reads is rewritten by the first frame of the new world. A selection is not
+     (nothing selects a town on the way in), so without this the next world opens
+     with the last one's district still named over the new reader's upvotes. */
+  emit({status:'loading',progress:0.05,message:'Raising the land…',district:null});
   booting=true; booted=false;
   if(W){ for(const d of W.districts) hideDistrict(d);
          for(const q of W.quarters) hideRealm(q); }
@@ -10747,6 +10763,10 @@ return {
   toEnd: ()=>{ if(W) seekTo(W.nT-1); },
   setSpeed: s=>{ speed=s; emit({speed:s}); },
   focus,
+  /* Drops the selection without leaving the realm: closing the district's feed
+     has to take the plot's lit border with it, or the world still says a town
+     is open after the panel reading it has gone. */
+  deselect: ()=>{ if(W) select(null); },
   leaveRealm,
   frameWorld: ()=>{ if(W) frameWorld(); },
   attachSpark: c=>drawSpark(c),

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -8505,12 +8505,12 @@ function pick(cx,cy,click){
     if(bird&&bird[0].parent){ possess(bird[0],bird[1]); return; }
     if(!OPEN) { if(hit) enterRealm(hit); }
     else{
-      /* Inside a realm a click on a town is a SLAP, full stop. It used to have
-         to earn it by selecting first, which meant the one gesture people
-         actually try on a town did nothing the first time. Selection still
-         happens — it lights the plot border and syncs the sidebar — but it
-         moves nothing, so the two never fight over the same click. */
-      if(hit&&hit.built) slap(hit,clock.getElapsedTime());
+      /* Inside a realm the first click on a town OPENS it: the plot lights and
+         the panel beside it reads out what was upvoted there, which is the
+         thing somebody clicking a district is asking for. The slap is what a
+         second click on the town already open does, so the toy is still one
+         click away and never lands on top of the answer. */
+      if(hit&&hit.built&&hit.i===selected) slap(hit,clock.getElapsedTime());
       select(hit?hit.i:null);
     }
   }

--- a/packages/webapp/components/world/useWorldDistrictFeed.ts
+++ b/packages/webapp/components/world/useWorldDistrictFeed.ts
@@ -1,0 +1,74 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import {
+  generateQueryKey,
+  RequestKey,
+  StaleTime,
+} from '@dailydotdev/shared/src/lib/query';
+import type {
+  UserWorldDistrictFeedData,
+  WorldDistrictPost,
+} from '../../graphql/world';
+import { USER_WORLD_DISTRICT_FEED_QUERY } from '../../graphql/world';
+
+/** Enough to fill the panel twice over without a second round trip. */
+const PAGE_SIZE = 20;
+
+export interface WorldDistrictFeedResult {
+  posts: WorldDistrictPost[];
+  isPending: boolean;
+  isError: boolean;
+  canFetchMore: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => Promise<unknown>;
+}
+
+/**
+ * The upvotes behind one district: what this reader marked as worth keeping in
+ * that niche, newest vote first.
+ *
+ * Keyed by slug rather than held per district, so walking back into a town you
+ * already opened reads the cache instead of the wire, and the panel opens
+ * populated. Nothing is prefetched: a realm holds up to fourteen towns and only
+ * the one that was clicked is worth a request.
+ */
+export const useWorldDistrictFeed = (
+  userId: string,
+  slug?: string,
+): WorldDistrictFeedResult => {
+  const query = useInfiniteQuery({
+    queryKey: generateQueryKey(RequestKey.UserWorldDistrictFeed, undefined, {
+      id: userId,
+      slug,
+    }),
+    queryFn: ({ pageParam }) =>
+      gqlClient.request<UserWorldDistrictFeedData>(
+        USER_WORLD_DISTRICT_FEED_QUERY,
+        {
+          id: userId,
+          niches: [slug],
+          first: PAGE_SIZE,
+          after: pageParam,
+        },
+      ),
+    enabled: !!userId && !!slug,
+    staleTime: StaleTime.Default,
+    initialPageParam: '',
+    getNextPageParam: ({ page }) =>
+      page.pageInfo.hasNextPage ? page.pageInfo.endCursor : null,
+  });
+
+  return {
+    posts:
+      query.data?.pages.flatMap(({ page }) =>
+        page.edges.map(({ node }) => node),
+      ) ?? [],
+    /* A query that has not been enabled yet reports itself as pending, and this
+       one is only ever mounted with a slug in hand, so that never surfaces. */
+    isPending: query.isPending,
+    isError: query.isError,
+    canFetchMore: !!query.hasNextPage && !query.isFetchingNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+  };
+};

--- a/packages/webapp/components/world/worldState.ts
+++ b/packages/webapp/components/world/worldState.ts
@@ -30,6 +30,16 @@ export interface WorldOpenRealm {
   articles: number;
 }
 
+/** The district a click has opened, and the niche its feed is filtered by. */
+export interface WorldSelectedDistrict {
+  /** The niche slug the API knows the district by. */
+  slug: string;
+  /** What the taxonomy calls the topic: "Rust", "CSS & UI". */
+  name: string;
+  /** Hex, from the district's own accent. */
+  color: string;
+}
+
 export interface WorldState {
   status: 'loading' | 'ready';
   progress: number;
@@ -50,6 +60,8 @@ export interface WorldState {
   districts?: number;
   realms?: number;
   open?: WorldOpenRealm | null;
+  /** Only ever set inside a realm: at world scale a click enters one instead. */
+  district?: WorldSelectedDistrict | null;
   rank?: WorldRankRow[];
   /** Set while you are riding a bird. */
   riding?: { manual: boolean } | null;
@@ -97,6 +109,8 @@ export interface WorldEngine {
   toEnd: () => void;
   setSpeed: (speed: number) => void;
   focus: (key: string) => void;
+  /** Clears the selected district without leaving the realm it is in. */
+  deselect: () => void;
   leaveRealm: () => void;
   frameWorld: () => void;
   attachSpark: (canvas: HTMLCanvasElement | null) => void;

--- a/packages/webapp/graphql/world.ts
+++ b/packages/webapp/graphql/world.ts
@@ -1,4 +1,7 @@
 import { gql } from 'graphql-request';
+import { SUPPORTED_TYPES } from '@dailydotdev/shared/src/graphql/feed';
+import type { Connection } from '@dailydotdev/shared/src/graphql/common';
+import type { Post } from '@dailydotdev/shared/src/graphql/posts';
 
 export interface WorldNiche {
   slug: string;
@@ -250,6 +253,76 @@ export const USER_WORLD_TIMELINE_QUERY = gql`
         slug
       }
       reads
+    }
+  }
+`;
+
+/**
+ * A row in the district panel, and nothing more: its source's mark, a title and
+ * two counts. A share carries its title on the post it shares rather than on
+ * itself, which is the only reason `sharedPost` is here.
+ */
+export type WorldDistrictPost = Pick<
+  Post,
+  | 'id'
+  | 'title'
+  | 'commentsPermalink'
+  | 'numUpvotes'
+  | 'numComments'
+  | 'source'
+  | 'sharedPost'
+>;
+
+export interface UserWorldDistrictFeedData {
+  page: Connection<WorldDistrictPost>;
+}
+
+/**
+ * What the world's owner upvoted in one district's niche, newest vote first.
+ *
+ * Deliberately NOT the shared feed fragment. That one carries everything a feed
+ * card can draw (content, awards, flags, translations, campaign fields), and
+ * a row here is three lines in a 20rem column. The world page is already
+ * holding a WebGL context and most of a megabyte of renderer, so the fields it
+ * does not draw are the ones worth not asking for.
+ */
+export const USER_WORLD_DISTRICT_FEED_QUERY = gql`
+  query UserWorldDistrictFeed(
+    $id: ID!
+    $niches: [String!]
+    $after: String
+    $first: Int
+    ${SUPPORTED_TYPES}
+  ) {
+    page: userUpvotedFeed(
+      userId: $id
+      niches: $niches
+      after: $after
+      first: $first
+      supportedTypes: $supportedTypes
+    ) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          id
+          title
+          commentsPermalink
+          numUpvotes
+          numComments
+          source {
+            id
+            name
+            image
+          }
+          sharedPost {
+            id
+            title
+          }
+        }
+      }
     }
   }
 `;


### PR DESCRIPTION
Clicking a district in a world now opens what its owner upvoted in that niche.

A district is a count of how much of a topic somebody read, and the count is the one thing the map cannot show the substance of. This is that substance, and upvotes rather than reads on purpose: a read is a click, an upvote is a verdict, so the list reads as a recommendation instead of a log.

Client only. `userUpvotedFeed` already takes a `niches` argument, and the engine's taxonomy niche ids (`js_ts`, `rust`, `css_design`) are exactly the API's niche slugs.

### How it behaves

- The engine emits the selected district from the three places selection moves, so clicking a town, its floating label or a rail row all open the same panel. Closing the panel drops the engine's selection, so the lit plot border and the highlighted rail row go with it, and clicking the same town again reopens it.
- Right rail on laptop, sheet along the bottom (60% height) below it. Never full screen: the town you clicked is the thing the list is about.
- The scrubber and the daily.dev mark inset on laptop so nothing sits on the panel, and the scrubber comes down on mobile where the sheet covers it.
- The camera is deliberately not repadded. `setPadding` refits the realm, which would throw away the reader's zoom and pan on every town click.
- Rows open in a new tab: following a link out tears down the WebGL context and rebuilds the whole world on the way back.
- Suppressed while the customisation bench is open, where clicking towns is how the owner previews chips.
- An empty district is normal (districts are built by reading, not by voting), so it says so rather than reading as a failure.

The query is lean by design, three lines in a 20rem column rather than everything the shared feed fragment carries. `PostItemCard` was tried first and its 96px cover left ~150px for the title, so rows use the narrow-column shape the post sidebar uses.

### Verification

- The query against the production API, then live on desktop (1564px) and narrow (517px): entering realms, clicking towns, labels and rail rows, infinite scroll, close, and leaving the realm.
- 491 webapp tests pass, including 5 new ones in `WorldDistrictFeed.spec.tsx`. Lint and the changed-file strict typecheck are clean.

https://claude.ai/code/session_01RqHMGskSfMgfAhmJD9AGfq


### Preview domain
https://feat-world-district-upvotes.preview.app.daily.dev