### PR TITLE
feat(world): filter a district's upvote feed by niche id

### DIFF
--- a/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
+++ b/packages/webapp/__tests__/WorldDistrictFeed.spec.tsx
@@ -15,8 +15,10 @@ import { USER_WORLD_DISTRICT_FEED_QUERY } from '../graphql/world';
 import { WorldDistrictFeed } from '../components/world/WorldDistrictFeed';
 import type { WorldSelectedDistrict } from '../components/world/worldState';
 
+/* A real niche id, because that is what the feed is filtered by now: the slug
+   never leaves the engine. */
 const district: WorldSelectedDistrict = {
-  slug: 'rust',
+  nicheId: '7f14a4b1-6c1c-4f0e-9b3a-2d5c8e0f1a2b',
   name: 'Rust',
   color: '#CE3F4B',
 };
@@ -29,7 +31,7 @@ const feedMock = (
     query: USER_WORLD_DISTRICT_FEED_QUERY,
     variables: {
       id: 'u1',
-      niches: ['rust'],
+      nicheIds: [district.nicheId],
       first: 20,
       after: '',
       ...variables,
@@ -83,7 +85,7 @@ it('should address the owner directly on their own world', async () => {
 });
 
 /* The whole point of the panel: the same upvote feed the profile shows, scoped
-   to the one niche the district stands for. A request without `niches` is the
+   to the one niche the district stands for. A request without `nicheIds` is the
    reader's entire upvote history under a district's name. */
 it('should ask for the upvotes of that niche only', async () => {
   renderFeed();

--- a/packages/webapp/__tests__/buildWorld.spec.ts
+++ b/packages/webapp/__tests__/buildWorld.spec.ts
@@ -21,7 +21,7 @@ const growth = (date: string, slug: string, reads: number) => ({
 });
 
 interface BuiltWorld {
-  districts: { slug: string; i: number; first: string }[];
+  districts: { slug: string; nicheId?: string; i: number; first: string }[];
   days: string[];
   cum: Int32Array;
   lvl: Uint8Array;
@@ -173,6 +173,28 @@ describe('buildWorld', () => {
       expect(readsOn(full, full.nT - 1, i)).toBe(readsOn(bare, 0, i));
       expect(full.lvl[(full.nT - 1) * full.nD + i]).toBe(bare.lvl[i]);
     }
+  });
+
+  /* The taxonomy is keyed by slug and the API filters posts by niche id, and the
+     taxonomy entry that replaces `niche` on every district carries the SLUG as
+     its own `id`. So the two have to survive side by side: a district that lost
+     its niche id opens a feed panel that can never fill. */
+  it('keeps the niche id beside the slug it is not', () => {
+    const world = build(
+      'u1',
+      [
+        { ...district('js_ts', 5), niche: { slug: 'js_ts', id: 'niche-js' } },
+        { ...district('rust', 2), niche: { slug: 'rust', id: 'niche-rs' } },
+      ],
+      [],
+    );
+
+    expect(
+      world.districts.map(({ slug, nicheId }) => ({ slug, nicheId })),
+    ).toEqual([
+      { slug: 'js_ts', nicheId: 'niche-js' },
+      { slug: 'rust', nicheId: 'niche-rs' },
+    ]);
   });
 
   it('refuses a world with nothing placeable in it', () => {

--- a/packages/webapp/components/world/WorldDistrictFeed.tsx
+++ b/packages/webapp/components/world/WorldDistrictFeed.tsx
@@ -59,7 +59,7 @@ export function WorldDistrictFeed({
     canFetchMore,
     isFetchingNextPage,
     fetchNextPage,
-  } = useWorldDistrictFeed(userId, district.slug);
+  } = useWorldDistrictFeed(userId, district.nicheId);
 
   return (
     <aside data-world-overlay className={PANEL}>

--- a/packages/webapp/components/world/engine/buildWorld.js
+++ b/packages/webapp/components/world/engine/buildWorld.js
@@ -26,7 +26,13 @@ const day=v=>{
 
 export function buildWorld(userId,districts,timeline){
   const ds=(districts||[])
-    .map(d=>({ slug:d.niche&&d.niche.slug, articles:d.reads,
+    /* Both keys, and they are not interchangeable. The SLUG keys the taxonomy,
+       which is what decides where a district stands and what it looks like; the
+       nicheId is what the API filters posts by. Copied off here because `niche`
+       is replaced with the taxonomy entry below, and that entry's own `id` is
+       the slug. */
+    .map(d=>({ slug:d.niche&&d.niche.slug, nicheId:d.niche&&d.niche.id,
+               articles:d.reads,
                first:day(d.firstReadAt), last:day(d.lastReadAt),
                activeDays:d.activeDays }))
     /* Placeable, and standing. `articles>0` is not a rule of its own — it is

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -8528,15 +8528,15 @@ function select(i){
   selected=i;
   paintBorders(); renderRank(true); emitDistrict();
 }
-/* Which district is selected, by SLUG, so the overlay can ask the API what this
-   reader upvoted in that niche. The slug is the one fact about a district only
-   the engine holds: everything else the overlay has is a rank row, and a rank
-   row is capped at fourteen while a realm can hold more than fourteen towns.
-   Emitted from `select` and from both realm doors, which are the only three
-   places `selected` moves. */
+/* Which district is selected, by NICHE ID, so the overlay can ask the API what
+   this reader upvoted in that niche. That id is the one fact about a district
+   only the engine holds: everything else the overlay has is a rank row, and a
+   rank row is capped at fourteen while a realm can hold more than fourteen
+   towns. Emitted from `select` and from both realm doors, which are the only
+   three places `selected` moves. */
 function emitDistrict(){
   const d=OPEN&&selected!==null?W.districts[selected]:null;
-  emit({district:d?{slug:d.niche.id, name:nameOf(d),
+  emit({district:d?{nicheId:d.nicheId, name:nameOf(d),
                     color:hexs(d.niche.accent)}:null});
 }
 function paintBorders(){

--- a/packages/webapp/components/world/useWorldDistrictFeed.ts
+++ b/packages/webapp/components/world/useWorldDistrictFeed.ts
@@ -27,31 +27,31 @@ export interface WorldDistrictFeedResult {
  * The upvotes behind one district: what this reader marked as worth keeping in
  * that niche, newest vote first.
  *
- * Keyed by slug rather than held per district, so walking back into a town you
+ * Keyed by niche rather than held per district, so walking back into a town you
  * already opened reads the cache instead of the wire, and the panel opens
  * populated. Nothing is prefetched: a realm holds up to fourteen towns and only
  * the one that was clicked is worth a request.
  */
 export const useWorldDistrictFeed = (
   userId: string,
-  slug?: string,
+  nicheId?: string,
 ): WorldDistrictFeedResult => {
   const query = useInfiniteQuery({
     queryKey: generateQueryKey(RequestKey.UserWorldDistrictFeed, undefined, {
       id: userId,
-      slug,
+      nicheId,
     }),
     queryFn: ({ pageParam }) =>
       gqlClient.request<UserWorldDistrictFeedData>(
         USER_WORLD_DISTRICT_FEED_QUERY,
         {
           id: userId,
-          niches: [slug],
+          nicheIds: [nicheId],
           first: PAGE_SIZE,
           after: pageParam,
         },
       ),
-    enabled: !!userId && !!slug,
+    enabled: !!userId && !!nicheId,
     staleTime: StaleTime.Default,
     initialPageParam: '',
     getNextPageParam: ({ page }) =>

--- a/packages/webapp/components/world/worldState.ts
+++ b/packages/webapp/components/world/worldState.ts
@@ -32,8 +32,8 @@ export interface WorldOpenRealm {
 
 /** The district a click has opened, and the niche its feed is filtered by. */
 export interface WorldSelectedDistrict {
-  /** The niche slug the API knows the district by. */
-  slug: string;
+  /** The niche the API knows the district by, which is what filters the feed. */
+  nicheId: string;
   /** What the taxonomy calls the topic: "Rust", "CSS & UI". */
   name: string;
   /** Hex, from the district's own accent. */

--- a/packages/webapp/graphql/world.ts
+++ b/packages/webapp/graphql/world.ts
@@ -5,6 +5,13 @@ import type { Post } from '@dailydotdev/shared/src/graphql/posts';
 
 export interface WorldNiche {
   slug: string;
+  /**
+   * What the API filters posts by. Optional because an unbuilt world fabricates
+   * its six seed districts out of the taxonomy (`buildUnbuiltWorld`), and those
+   * have no niche behind them to carry an id: nothing can be selected on bare
+   * ground, so nothing ever asks them for one.
+   */
+  id?: string;
 }
 
 export interface WorldDistrict {
@@ -178,6 +185,7 @@ export const USER_WORLD_QUERY = gql`
   query UserWorld($id: ID!) {
     userWorld(id: $id) {
       niche {
+        id
         slug
       }
       reads
@@ -280,6 +288,10 @@ export interface UserWorldDistrictFeedData {
 /**
  * What the world's owner upvoted in one district's niche, newest vote first.
  *
+ * Filtered by niche ID rather than slug. Resolving slugs inside the subquery
+ * hid the niche from the query planner's per-value stats, which flipped a heavy
+ * upvoter onto a plan that scanned the whole niche instead of that user's votes.
+ *
  * Deliberately NOT the shared feed fragment. That one carries everything a feed
  * card can draw (content, awards, flags, translations, campaign fields), and
  * a row here is three lines in a 20rem column. The world page is already
@@ -289,14 +301,14 @@ export interface UserWorldDistrictFeedData {
 export const USER_WORLD_DISTRICT_FEED_QUERY = gql`
   query UserWorldDistrictFeed(
     $id: ID!
-    $niches: [String!]
+    $nicheIds: [ID!]
     $after: String
     $first: Int
     ${SUPPORTED_TYPES}
   ) {
     page: userUpvotedFeed(
       userId: $id
-      niches: $niches
+      nicheIds: $nicheIds
       after: $after
       first: $first
       supportedTypes: $supportedTypes


### PR DESCRIPTION
Follows #6466. The district panel now filters by niche **id** instead of slug.

> [!IMPORTANT]
> **Merge after the API change.** `userUpvotedFeed` drops `niches: [String!]` for `nicheIds: [ID!]`, so this branch does not work against today's API. Until the API ships, opening a district reads "These upvotes could not be loaded"; the world, the panel, its title and the rest of the page are unaffected.

### Why

Resolving slugs inside the `EXISTS` subquery hid the niche from the query planner's per-value stats, which flipped a heavy upvoter onto a plan that scanned the whole niche instead of that user's votes. Filtering on `pn."nicheId"` drops the join to `niche` entirely.

### The two keys are not interchangeable

`USER_WORLD_QUERY` now asks for `niche { id slug }` and `buildWorld` carries both onto every district:

- the **slug** keys the taxonomy, which decides where a district stands, what it is called and what it looks like. Note the taxonomy entry that replaces `niche` on each district carries the slug as its own `id`, which is exactly the confusion worth guarding against.
- the **niche id** is what the API filters posts by, and is now what the engine emits for the panel to query with.

`WorldNiche.id` is optional on purpose: `buildUnbuiltWorld` fabricates six seed districts out of the taxonomy and those have no niche behind them to carry an id. Nothing can be selected on bare ground, so nothing ever asks them for one.

The growth-log query is untouched. It selects `niche { slug }` only, and it is one row per district per day over years of reading, so an id repeated across every row would cost the page the largest response it takes.

### Verification

- `userWorld` returning `niche { id slug }` works against the production API today, so the world still stands and the panel opens with the right district: only the feed request waits on the API.
- Confirmed the pre-merge failure is graceful in the browser, screenshot below.
- New `buildWorld` test asserts the id survives beside the slug it is not. 492 webapp tests, lint and the changed-file strict typecheck pass.

https://claude.ai/code/session_01RqHMGskSfMgfAhmJD9AGfq


### Preview domain
https://feat-world-district-feed-niche-i.preview.app.daily.dev