### PR TITLE
feat(world): render the district level-up notification

### DIFF
--- a/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
+++ b/packages/shared/src/components/notifications/NotificationItemAvatar.tsx
@@ -6,7 +6,12 @@ import SourceButton from '../cards/common/SourceButton';
 import { ProfileTooltip } from '../profile/ProfileTooltip';
 import { ProfileImageLink } from '../profile/ProfileImageLink';
 import { ProfileImageSize } from '../ProfilePicture';
-import { BriefGradientIcon, BriefIcon, MedalBadgeIcon } from '../icons';
+import {
+  BriefGradientIcon,
+  BriefIcon,
+  MedalBadgeIcon,
+  WorldIcon,
+} from '../icons';
 import { IconSize } from '../Icon';
 import { BadgeIconGoldGradient } from '../badges/BadgeIcon';
 import { Image, ImageType } from '../image/Image';
@@ -95,6 +100,14 @@ function NotificationItemAvatar({
     return (
       <span className="rounded-8 bg-surface-float p-1">
         <BriefIcon secondary size={IconSize.Small} />
+      </span>
+    );
+  }
+
+  if (type === NotificationAvatarType.World) {
+    return (
+      <span className="rounded-8 bg-surface-float p-1">
+        <WorldIcon secondary size={IconSize.Small} />
       </span>
     );
   }

--- a/packages/shared/src/components/notifications/utils.ts
+++ b/packages/shared/src/components/notifications/utils.ts
@@ -22,6 +22,7 @@ import {
   AddUserIcon,
   SquadIcon,
   MegaphoneIcon,
+  WorldIcon,
 } from '../icons';
 import type { NotificationPromptSource } from '../../lib/log';
 import { BookmarkReminderIcon } from '../icons/Bookmark/Reminder';
@@ -98,6 +99,7 @@ export enum NotificationType {
   WarmIntro = 'warm_intro',
   ExperienceCompanyEnriched = 'experience_company_enriched',
   LiveRoomStarted = 'live_room_started',
+  WorldDistrictLevelUp = 'world_district_level_up',
 }
 
 export enum NotificationIconType {
@@ -118,6 +120,7 @@ export enum NotificationIconType {
   Core = 'Core',
   Analytics = 'Analytics',
   Opportunity = 'Opportunity',
+  World = 'World',
 }
 
 export const notificationIcon: Record<
@@ -141,6 +144,7 @@ export const notificationIcon: Record<
   [NotificationIconType.Core]: CoreIcon,
   [NotificationIconType.Analytics]: AnalyticsIcon,
   [NotificationIconType.Opportunity]: JobIcon,
+  [NotificationIconType.World]: WorldIcon,
 };
 
 export const notificationIconAsPrimary: NotificationIconType[] = [
@@ -166,6 +170,7 @@ export const notificationIconTypeTheme: Record<NotificationIconType, string> = {
   [NotificationIconType.Core]: '',
   [NotificationIconType.Analytics]: 'text-brand-default',
   [NotificationIconType.Opportunity]: 'text-black',
+  [NotificationIconType.World]: 'text-brand-default',
 };
 
 export const notificationIconStyle: Record<
@@ -189,6 +194,7 @@ export const notificationIconStyle: Record<
   [NotificationIconType.Core]: null,
   [NotificationIconType.Analytics]: null,
   [NotificationIconType.Opportunity]: { background: briefButtonBg },
+  [NotificationIconType.World]: null,
 };
 
 export const notificationTypeTheme: Partial<Record<NotificationType, string>> =
@@ -294,6 +300,7 @@ export const ACHIEVEMENT_KEYS = [
   NotificationType.UserTopReaderBadge,
   NotificationType.DevCardUnlocked,
   NotificationType.ArticleAnalytics,
+  NotificationType.WorldDistrictLevelUp,
 ];
 export const MENTION_KEYS = [
   NotificationType.PostMention,
@@ -430,6 +437,7 @@ export const notificationCategoryToTypes: Record<
     NotificationType.WarmIntro,
     NotificationType.ExperienceCompanyEnriched,
     NotificationType.LiveRoomStarted,
+    NotificationType.WorldDistrictLevelUp,
   ],
 };
 

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -14,6 +14,7 @@ export enum NotificationAvatarType {
   Brief = 'brief',
   Digest = 'digest',
   Achievement = 'achievement',
+  World = 'world',
 }
 
 export interface NotificationAvatar extends WithClassNameProps {


### PR DESCRIPTION
Client side of dailydotdev/daily-api#4066, which adds a `world_district_level_up` notification: **"Rust reached L7 in your world"**, in-app and push.

- `NotificationAvatarType.World`, drawn from the shared `WorldIcon` in a `bg-surface-float` chip, the same shape the brief, digest and top-reader-badge avatars use. A glyph rather than an image because it is the same mark whoever is looking, so the server sends `emptyImage`.
- `NotificationIconType.World` and its three map entries.
- The type joins `ACHIEVEMENT_KEYS`, so it gets a toggle in the existing "achievements" settings group rather than new settings UI, and the Updates filter chip.

Nothing existing changes shape: both additions are new branches in maps that already fall through.

## Merge order

Behind dailydotdev/streams#105 and dailydotdev/daily-api#4066. Landing this first is harmless (nothing emits the type yet); landing it last means the notification renders without its glyph for a while.

### Preview domain
https://feat-world-district-level-up-not.preview.app.daily.dev