### PR TITLE
feat(world): explain the place to somebody seeing it for the first time

### DIFF
--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -380,6 +380,15 @@ export enum LogEvent {
   WorldReady = 'world ready',
   WorldBootFailed = 'world boot failed',
   WorldCustomize = 'world customize',
+  /* What a reader did once the world was standing, against `world ready` as the
+     denominator. Walking into a realm is the first step of every path through
+     the place, so a visit that never fires one is a visit that only ever looked
+     at the map. */
+  WorldRealmOpen = 'world realm open',
+  WorldDistrictOpen = 'world district open',
+  WorldRide = 'world ride',
+  WorldReplay = 'world replay',
+  WorldGuideOpen = 'world guide open',
   // End World
   // Navigation
   NavigatePrevious = 'navigate previous',

--- a/packages/webapp/__tests__/WorldGuide.spec.tsx
+++ b/packages/webapp/__tests__/WorldGuide.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import type { WorldDistrict } from '../graphql/world';
+import { WorldGuide } from '../components/world/WorldGuide';
+import { LEVELS } from '../components/world/ladder';
+
+const district = (slug: string, reads: number): WorldDistrict =>
+  ({ niche: { id: slug, slug }, reads } as WorldDistrict);
+
+const renderGuide = (props: Partial<Parameters<typeof WorldGuide>[0]> = {}) =>
+  render(<WorldGuide isOwn onClose={jest.fn()} {...props} />);
+
+describe('WorldGuide', () => {
+  it('writes the ladder down, every rung of it', () => {
+    renderGuide();
+
+    const rungs = within(
+      screen.getByRole('list', { name: 'Levels' }),
+    ).getAllByRole('listitem');
+
+    expect(rungs).toHaveLength(LEVELS.length);
+    LEVELS.forEach(({ reads }, index) => {
+      const rung = rungs[index];
+      expect(within(rung).getByText(`L${index + 1}`)).toBeInTheDocument();
+      expect(
+        within(rung).getByText(reads.toLocaleString()),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('marks the rung the world is actually standing on', () => {
+    // 40 is L7 and 12 is L5, so the busiest district carries the mark.
+    renderGuide({ districts: [district('rust', 12), district('css', 40)] });
+
+    expect(screen.getByText(/busiest district is L7/)).toBeInTheDocument();
+  });
+
+  /* A world with nothing read into it has no rung to point at, and "L0" is not
+     one: the ladder starts at the first article. */
+  it('says nothing about a rung on a world with no districts', () => {
+    renderGuide({ districts: [] });
+
+    expect(screen.queryByText(/busiest district/)).not.toBeInTheDocument();
+  });
+
+  it('promises the replay only where there is one to play', () => {
+    const { rerender } = renderGuide({ hasReplay: true });
+    expect(screen.getByText(/Play the bar below/)).toBeInTheDocument();
+
+    rerender(<WorldGuide isOwn onClose={jest.fn()} />);
+    expect(screen.queryByText(/Play the bar below/)).not.toBeInTheDocument();
+  });
+
+  /* Nobody else's world is yours to dress, so the bench is not offered on one. */
+  it('points at the bench only on your own world', () => {
+    const { rerender } = renderGuide({ canCustomize: true });
+    expect(screen.getByText(/Make it yours/)).toBeInTheDocument();
+
+    rerender(
+      <WorldGuide isOwn={false} canCustomize={false} onClose={jest.fn()} />,
+    );
+    expect(screen.queryByText(/Make it yours/)).not.toBeInTheDocument();
+  });
+
+  it('speaks about the reader on their own world and about the owner on anyone else’s', () => {
+    const { rerender } = renderGuide();
+    expect(screen.getByText(/Every article you read/)).toBeInTheDocument();
+
+    rerender(<WorldGuide isOwn={false} onClose={jest.fn()} />);
+    expect(screen.getByText(/Every article they read/)).toBeInTheDocument();
+  });
+});

--- a/packages/webapp/__tests__/WorldPanelRank.spec.tsx
+++ b/packages/webapp/__tests__/WorldPanelRank.spec.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+import { WorldPanel } from '../components/world/WorldPanel';
+import type {
+  WorldOpenRealm,
+  WorldState,
+} from '../components/world/worldState';
+
+/* The real card mounts the whole auth form, and none of this is about it. */
+jest.mock('../components/world/WorldSignupCta', () => ({
+  WorldSignupCta: () => <div data-testid="signup" />,
+}));
+
+const owner = {
+  id: 'owner',
+  name: 'Ido',
+  username: 'ido',
+  permalink: 'http://localhost:5002/ido',
+} as PublicProfile;
+
+const row = (key: string, name: string, level: number, reads: number) => ({
+  key,
+  name,
+  level,
+  reads,
+  color: '#fff',
+  share: 100,
+  selected: false,
+});
+
+const renderRail = (open?: WorldOpenRealm) =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <AuthContext.Provider
+        value={
+          {
+            user: null,
+            isAuthReady: true,
+            isLoggedIn: false,
+            showLogin: jest.fn(),
+            closeLogin: jest.fn(),
+          } as never
+        }
+      >
+        <WorldPanel
+          user={owner}
+          state={
+            {
+              status: 'ready',
+              open,
+              rank: [row('frame', 'Frameworks', 4, 64)],
+            } as WorldState
+          }
+          isImmersive={false}
+          isOwn={false}
+          canShare
+          onToggleImmersive={jest.fn()}
+          onFocus={jest.fn()}
+          onLeaveRealm={jest.fn()}
+        />
+      </AuthContext.Provider>
+    </QueryClientProvider>,
+  );
+
+const realm: WorldOpenRealm = {
+  id: 'frame',
+  name: 'Frameworks',
+  theme: 'the frameworks you build with',
+  districts: 4,
+  articles: 64,
+};
+
+describe('the world rail ranking', () => {
+  /* The whole reason this file exists. The level badge is a tooltip trigger, and
+     a trigger is a Radix `asChild` slot handed a ref: put anything there that
+     builds a new component type per render (Typography does) and every render
+     deletes and remounts the fiber, whose ref detach renders it again. It does
+     not degrade, it exceeds the update depth and takes the page down. */
+  it('renders rank rows without looping', () => {
+    renderRail();
+
+    expect(screen.getByText('Frameworks')).toBeInTheDocument();
+    expect(screen.getByText('L4')).toBeInTheDocument();
+  });
+
+  /* At world scale a row is a REALM, scored on the ladder with its thresholds
+     stretched by REALM_DIV. 64 articles is L4 of that stretched ladder. */
+  it('reads a realm row off the stretched ladder', () => {
+    renderRail();
+
+    expect(
+      screen.getByLabelText('Level 4 · 16 articles to L5'),
+    ).toBeInTheDocument();
+  });
+
+  /* The same 64 articles inside a realm is a DISTRICT on the plain ladder, which
+     is a different rung entirely. Getting the divisor from `open` is the whole
+     of the difference, and it is invisible without both cases side by side. */
+  it('reads a district row off the plain ladder', () => {
+    renderRail(realm);
+
+    expect(
+      screen.getByLabelText('Level 7 · 16 articles to L8'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/webapp/__tests__/ladder.spec.ts
+++ b/packages/webapp/__tests__/ladder.spec.ts
@@ -23,7 +23,7 @@ describe('levelOf', () => {
   });
 
   it('holds the rung until the next threshold is reached', () => {
-    // 3 is CAMP and 5 is HOLD, so 4 is still a camp.
+    // L3 is 3 and L4 is 5, so 4 is still L3.
     expect(levelOf(4)).toEqual(3);
     expect(levelOf(1279)).toEqual(MAX_LEVEL - 1);
   });
@@ -35,12 +35,12 @@ describe('levelOf', () => {
 
 describe('levelProgress', () => {
   it('counts the articles left to the next rung', () => {
-    // SANCTUM is 20.
+    // L6 is 20.
     expect(levelProgress(18)).toMatchObject({ level: 5, toNext: 2 });
   });
 
   it('places the district across the rung it is on', () => {
-    // Half way from ATELIER (10) to SANCTUM (20).
+    // Half way from L5 (10) to L6 (20).
     expect(levelProgress(15).fraction).toEqual(0.5);
   });
 
@@ -109,7 +109,7 @@ describe('nearestLevelUp', () => {
   });
 
   it('picks the closest district, not the biggest', () => {
-    // The 318 district is 2 off ARCANUM; the 400 one is 240 off CITADEL.
+    // The 318 district is 2 off L10; the 400 one is 240 off L11.
     const nearest = nearestLevelUp([row('LLMs', 400), row('CSS & UI', 318)]);
 
     expect(nearest).toMatchObject({ name: 'CSS & UI', toNext: 2 });
@@ -126,16 +126,13 @@ describe('nearestLevelUp', () => {
   });
 
   it('breaks a tie towards the district further along', () => {
-    // Both one article out, from CAIRN and from SKY COURT respectively.
+    // Both one article out, from L2 and from L12 respectively.
     const nearest = nearestLevelUp([row('PHP', 1), row('LLMs', 1279)]);
 
     expect(nearest).toMatchObject({ name: 'LLMs', toNext: 1 });
   });
 
   it('carries the rung it is walking towards', () => {
-    expect(nearestLevelUp([row('Go', 39)])?.next).toMatchObject({
-      n: 'CONCLAVE',
-      reads: 40,
-    });
+    expect(nearestLevelUp([row('Go', 39)])?.next).toMatchObject({ reads: 40 });
   });
 });

--- a/packages/webapp/components/world/WorldGuide.tsx
+++ b/packages/webapp/components/world/WorldGuide.tsx
@@ -1,0 +1,229 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
+import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import type { WorldDistrict } from '../../graphql/world';
+import { LEVELS, levelOf } from './ladder';
+
+/* The four numbers the rail puts on one line, defined in the order they stand
+   in. The level badge used to be defined here with them, as a fifth row reading
+   "L1-L12: how built up a district is"; it has a section of its own above now,
+   because a range and an adjective is not what somebody looking at "L7" needs
+   to know. */
+const STAT_INFO: [string, string][] = [
+  ['Articles', 'every article read on daily.dev'],
+  ['Districts', 'one per topic read at least once'],
+  ['Realms', 'districts that share a subject'],
+  ['Active', 'first article read to last'],
+];
+
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}): ReactElement => (
+  <section className="flex flex-col gap-2">
+    <Typography
+      tag={TypographyTag.H2}
+      type={TypographyType.Footnote}
+      color={TypographyColor.Tertiary}
+      bold
+    >
+      {title}
+    </Typography>
+    {children}
+  </section>
+);
+
+const Line = ({ children }: { children: ReactNode }): ReactElement => (
+  <Typography
+    tag={TypographyTag.P}
+    type={TypographyType.Caption1}
+    color={TypographyColor.Tertiary}
+  >
+    {children}
+  </Typography>
+);
+
+/* A term and what it means, which is the shape of nearly everything in here:
+   the stat definitions, and the list of what a click does. */
+const Term = ({
+  term,
+  children,
+}: {
+  term: string;
+  children: ReactNode;
+}): ReactElement => (
+  <li className="typo-caption1">
+    <b className="text-text-primary">{term}</b>
+    <span className="text-text-tertiary"> {children}</span>
+  </li>
+);
+
+interface WorldGuideProps {
+  isOwn: boolean;
+  districts?: WorldDistrict[];
+  /** No replay on bare ground and none on a handheld, so it is not promised. */
+  hasReplay?: boolean;
+  /** Only the owner has a bench to be pointed at. */
+  canCustomize?: boolean;
+  onClose: () => void;
+}
+
+/**
+ * What this place is, how it grows, and what the things on it do.
+ *
+ * It replaces the rail rather than opening over the world, the same way the
+ * bench does: the one thing a reader is here to look at is the world, and an
+ * explanation of a map that covers the map is answering the question by taking
+ * away the reason to ask it.
+ *
+ * The ladder is the whole of the mechanic and the one part of it that was never
+ * written down anywhere a reader could reach: the rungs were dev-facing, and all
+ * anyone ever saw was "L7" with nothing to measure it against. Twelve
+ * thresholds and a mark on the one this world is standing on is the shortest
+ * honest answer.
+ */
+export function WorldGuide({
+  isOwn,
+  districts,
+  hasReplay,
+  canCustomize,
+  onClose,
+}: WorldGuideProps): ReactElement {
+  /* Off the districts rather than the rank rows, which hold REALMS at world
+     scale and are scored on the stretched ladder. The level anyone is ever shown
+     is a district's, so the one marked here has to be too. */
+  const topLevel =
+    districts?.reduce((top, { reads }) => Math.max(top, levelOf(reads)), 0) ??
+    0;
+
+  return (
+    <aside
+      data-world-overlay
+      className="pointer-events-auto absolute inset-y-0 left-0 z-1 flex w-80 flex-col gap-4 overflow-y-auto border-r border-border-subtlest-tertiary bg-background-default p-4"
+    >
+      <header className="flex items-center justify-between gap-2">
+        <Typography type={TypographyType.Body} bold>
+          How this world works
+        </Typography>
+        <CloseButton
+          type="button"
+          size={ButtonSize.Small}
+          aria-label="Close the guide"
+          onClick={onClose}
+        />
+      </header>
+
+      <Section title="What this is">
+        <Line>
+          Every article {isOwn ? 'you read' : 'they read'} on daily.dev grows a
+          district here. Reading is the only thing that builds it.
+        </Line>
+      </Section>
+
+      <Section title="How it grows">
+        <Line>
+          Every topic read becomes a district, and the more articles in it, the
+          more it builds up. Each of the twelve levels needs twice as many
+          articles as the one below, so the first few come fast and the last
+          ones stay out of reach.
+        </Line>
+        {/* Twelve thresholds, wrapped three to a row. The one this world is
+            standing on is filled in, so the ladder is read against something
+            rather than in the abstract. */}
+        <ul aria-label="Levels" className="grid grid-cols-3 gap-1">
+          {LEVELS.map(({ reads }, index) => {
+            const level = index + 1;
+            const isTop = level === topLevel;
+
+            return (
+              <li
+                key={reads}
+                className={classNames(
+                  'flex items-baseline justify-between gap-1 rounded-8 border border-border-subtlest-tertiary px-2 py-1',
+                  isTop && 'bg-surface-float',
+                )}
+              >
+                <Typography
+                  tag={TypographyTag.Span}
+                  type={TypographyType.Caption2}
+                  color={isTop ? undefined : TypographyColor.Quaternary}
+                  bold={isTop}
+                >
+                  L{level}
+                </Typography>
+                <Typography
+                  tag={TypographyTag.Span}
+                  type={TypographyType.Caption2}
+                  color={
+                    isTop
+                      ? TypographyColor.Secondary
+                      : TypographyColor.Quaternary
+                  }
+                  className="tabular-nums"
+                >
+                  {reads.toLocaleString()}
+                </Typography>
+              </li>
+            );
+          })}
+        </ul>
+        {topLevel > 0 && (
+          <Typography
+            type={TypographyType.Caption2}
+            color={TypographyColor.Quaternary}
+          >
+            {isOwn ? 'Your' : 'Their'} busiest district is L{topLevel}.
+          </Typography>
+        )}
+      </Section>
+
+      <Section title="What you can do here">
+        <ul className="flex flex-col gap-1">
+          <Term term="Click a realm">to go inside and see its districts.</Term>
+          <Term term="Click a district">
+            to read the posts {isOwn ? 'you' : 'they'} upvoted there.
+          </Term>
+          {/* The one interaction on the world with no permanent sign that it
+              exists: birds only announce themselves once the pointer is already
+              on one, and nothing leads a pointer there. */}
+          <Term term="Click a bird">
+            to ride it. They circle the bigger districts.
+          </Term>
+          <Term term="Drag and scroll">to move around the map and zoom.</Term>
+          {!!hasReplay && (
+            <Term term="Play the bar below">
+              to watch the world grow from the first article to today.
+            </Term>
+          )}
+          {!!canCustomize && (
+            <Term term="Make it yours">
+              to name the place and change its crest, sky and colours. None of
+              that builds land.
+            </Term>
+          )}
+        </ul>
+      </Section>
+
+      <Section title="The numbers">
+        <ul className="flex flex-col gap-1">
+          {STAT_INFO.map(([term, meaning]) => (
+            <Term key={term} term={`${term}:`}>
+              {meaning}
+            </Term>
+          ))}
+        </ul>
+      </Section>
+    </aside>
+  );
+}

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement } from 'react';
-import React, { memo } from 'react';
+import React, { memo, useState } from 'react';
 import classNames from 'classnames';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import { ProfileImageSize } from '@dailydotdev/shared/src/components/ProfilePicture';
 import { ProfileImageLink } from '@dailydotdev/shared/src/components/profile/ProfileImageLink';
@@ -36,53 +38,57 @@ import {
 import type { Author } from '@dailydotdev/shared/src/graphql/comments';
 import type { WorldDistrict } from '../../graphql/world';
 import { WorldCustomizeRail } from './WorldCustomize';
+import { WorldGuide } from './WorldGuide';
 import { WorldImmersiveToggle } from './WorldMark';
 import { WorldShare } from './WorldShare';
 import { WorldNudge } from './WorldNudge';
 import { WorldSignupCta } from './WorldSignupCta';
 import { WorldViewerAction } from './WorldViewerAction';
+import { levelProgress, REALM_DIV } from './ladder';
 import type { WorldDraft } from './useWorldDraft';
-import type { WorldState } from './worldState';
+import type { WorldRankRow, WorldState } from './worldState';
 
-const STAT_INFO: [string, string][] = [
-  ['Articles', 'every article read on daily.dev'],
-  ['Districts', 'one per topic read at least once'],
-  ['Realms', 'districts that share a subject'],
-  ['Active', 'first article read to last'],
-  ['L1-L12', 'how built up a district is'],
-];
-
-/* One icon for all of them. A rail this narrow cannot carry an info button per
-   number, and read together the definitions explain the world, which one at a
-   time they do not. The level badge is in here rather than beside the rows for
-   the same reason: it is a number in a list of numbers, and the one place a
-   reader looks for what a number means is the one info icon on the panel. */
-const StatsLegend = () => (
-  <Tooltip
-    // The list does not fit the default 18rem, and the content row is a
-    // centred flex: without these it is squeezed and mid-aligned.
-    className="!max-w-[21rem] items-start whitespace-normal"
-    content={
-      <ul className="flex min-w-0 flex-col gap-1">
-        {STAT_INFO.map(([term, meaning]) => (
-          <li key={term} className="typo-caption1">
-            <b className="text-text-primary">{term}:</b>
-            <span className="text-text-tertiary"> {meaning}</span>
-          </li>
-        ))}
-      </ul>
-    }
-    enableMobileClick
-  >
+/* One icon for all of them, in the stat row, because that is where a reader
+   looks when a number on a panel means nothing to them. It used to hover a list
+   of five definitions; it now opens the guide, which holds those definitions
+   plus the two things a tooltip had no room for and the world states nowhere
+   else: what the levels are, and what clicking anything does. */
+const StatsLegend = ({ onOpen }: { onOpen: () => void }) => (
+  <Tooltip content="How this world works">
     <button
       type="button"
-      aria-label="What these numbers mean"
+      aria-label="How this world works"
       className="flex flex-none items-center text-text-quaternary hover:text-text-primary"
+      onClick={onOpen}
     >
       <InfoIcon size={IconSize.Size16} />
     </button>
   </Tooltip>
 );
+
+/* What the bare "L7" on a row is measured against. A realm and a district are
+   scored on the same ladder with the realm's thresholds stretched by REALM_DIV,
+   so which one a row is decides the divisor, and `open` is what says which:
+   because the rail lists realms at world scale and districts inside one.
+   The level comes back out of `levelProgress` rather than off the row so the
+   badge and the sentence explaining it can never disagree. */
+const levelHint = (row: WorldRankRow, isDistrict: boolean): string => {
+  const { level, toNext } = levelProgress(
+    row.reads,
+    isDistrict ? 1 : REALM_DIV,
+  );
+
+  if (toNext <= 0) {
+    return `Level ${level} · the top of the ladder`;
+  }
+
+  /* Said the way the plates on the world say it, because they are the other
+     place this number shows up and two phrasings of one fact read as two. */
+  return `Level ${level} · ${formatDataTileValue(toNext)} ${pluralize(
+    'article',
+    toNext,
+  )} to L${level + 1}`;
+};
 
 const Stat = ({ label, value }: { label: string; value: string }) => (
   <div className="flex min-w-0 flex-1 flex-col">
@@ -234,6 +240,17 @@ const WorldPanelHeader = memo(function WorldPanelHeader({
           {worldName}
         </Typography>
       )}
+      {/* The one sentence that says what the page is, for the reader who never
+          clicks anything. Most arrivals here are strangers following a link, so
+          the mechanic cannot live behind an info icon alone. */}
+      <Typography
+        type={TypographyType.Caption1}
+        color={TypographyColor.Tertiary}
+      >
+        {isOwn
+          ? 'Every article you read grows a district here.'
+          : 'Built from what they read on daily.dev.'}
+      </Typography>
       <WorldViewerAction user={user} />
     </header>
   );
@@ -293,6 +310,8 @@ function WorldPanelRail({
   onLeaveRealm,
 }: WorldPanelProps): ReactElement {
   const { open, rank = [] } = state;
+  const { logEvent } = useLogContext();
+  const [isGuideOpen, setIsGuideOpen] = useState(false);
 
   /* Bench replaces the rail's contents rather than opening beside it — the single column changes, nothing else moves. */
   if (draft?.isOpen && draft.settings) {
@@ -302,6 +321,22 @@ function WorldPanelRail({
         draft={draft}
         districts={districts}
         settings={draft.settings}
+      />
+    );
+  }
+
+  /* Same column, same trade as the bench: an explanation of a map that stands
+     over the map is answering the question by hiding the reason for it. Second,
+     so the bench wins if both are somehow open. Dressing the world is a job
+     with unsaved state in it, and reading about it is not. */
+  if (isGuideOpen) {
+    return (
+      <WorldGuide
+        isOwn={isOwn}
+        districts={districts}
+        hasReplay={!unbuilt && !!state.replayable}
+        canCustomize={!!draft}
+        onClose={() => setIsGuideOpen(false)}
       />
     );
   }
@@ -339,7 +374,16 @@ function WorldPanelRail({
           value={formatDataTileValue(state.realms ?? 0)}
         />
         <Stat label="Active" value={state.span ?? '-'} />
-        <StatsLegend />
+        <StatsLegend
+          onOpen={() => {
+            setIsGuideOpen(true);
+            logEvent({
+              event_name: LogEvent.WorldGuideOpen,
+              target_id: user.id,
+              extra: JSON.stringify({ is_own: isOwn, in_realm: !!open }),
+            });
+          }}
+        />
       </div>
 
       {/* Natural height, not flex-1: the rail scrolls as a whole, and a ranking
@@ -399,13 +443,23 @@ function WorldPanelRail({
                     a name with nothing after it. */}
                 {!unbuilt && (
                   <>
-                    <Typography
-                      tag={TypographyTag.Span}
-                      type={TypographyType.Caption1}
-                      color={TypographyColor.Quaternary}
-                    >
-                      L{row.level}
-                    </Typography>
+                    {/* The badge is the one number on this panel with nothing
+                        beside it to measure it against, and the distance to the
+                        next rung is the only reading of it that means anything
+                        to somebody who has never seen the ladder.
+
+                        A PLAIN span, not a Typography. The tooltip trigger is a
+                        Radix `asChild` slot, so whatever sits here is handed a
+                        ref, and Typography builds its element type inside its
+                        own render body, so it is a new component type every
+                        pass. Handed a ref, that is a fiber deleted and remounted
+                        on every render, and the ref detach re-renders the
+                        trigger: an infinite loop, not a slow component. */}
+                    <Tooltip content={levelHint(row, !!open)}>
+                      <span className="text-text-quaternary typo-caption1">
+                        L{row.level}
+                      </span>
+                    </Tooltip>
                     <Typography
                       tag={TypographyTag.Span}
                       type={TypographyType.Caption1}

--- a/packages/webapp/components/world/WorldTimeline.tsx
+++ b/packages/webapp/components/world/WorldTimeline.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import classNames from 'classnames';
 import { format, parseISO } from 'date-fns';
 import {
@@ -25,6 +25,18 @@ const SPEEDS = [1, 4, 16];
    it west of Greenwich. */
 const asDate = (day?: string): string =>
   day ? format(parseISO(day), 'd MMM yyyy') : '-';
+
+const caption = (state: WorldState, hasPlayed: boolean): string => {
+  if (!hasPlayed && !state.open) {
+    return 'Play to watch how this world grew';
+  }
+
+  if (state.open) {
+    return `${state.open.name} · ${worldCounts(state)}`;
+  }
+
+  return worldCounts(state);
+};
 
 /* The transport glyphs are text rather than icons, so the button has to be
    squared off by hand: the icon-only sizing never kicks in for a label. */
@@ -95,6 +107,20 @@ export function WorldTimeline({
   onEnd,
   onSpeed,
 }: WorldTimelineProps): ReactElement {
+  /* Three transport glyphs, a scrubber and a sparkline read as a media player,
+     and a media player over a map does not say what it would play. So the line
+     under the date says it, once, until the reader has pressed play and found
+     out, after which it goes back to the counts, which is the thing worth
+     having there while a replay is actually running.
+     Only at world scale: inside a realm the same line is the only place the open
+     realm is named next to its own totals. */
+  const [hasPlayed, setHasPlayed] = useState(false);
+  useEffect(() => {
+    if (state.playing) {
+      setHasPlayed(true);
+    }
+  }, [state.playing]);
+
   const max = Math.max(1, (state.totalDays ?? 1) - 1);
   /* Pinned to today while the log is on the wire, which is where the world it
      is sitting over is standing: a marker parked at the left edge would read
@@ -144,9 +170,7 @@ export function WorldTimeline({
             className="hidden laptop:block"
             truncate
           >
-            {state.open
-              ? `${state.open.name} · ${worldCounts(state)}`
-              : worldCounts(state)}
+            {caption(state, hasPlayed)}
           </Typography>
         </div>
         <ButtonGroup className="ml-auto flex-none">

--- a/packages/webapp/components/world/engine/styles.js
+++ b/packages/webapp/components/world/engine/styles.js
@@ -29,8 +29,19 @@ export const WORLD_CSS = `
 .world-root canvas{display:block}
 .world-stage{position:absolute;inset:0}
 .world-stage.grab{cursor:grab}
-.world-stage.grabbing{cursor:grabbing}
-.world-stage.ride,.world-stage.ride.grab{cursor:pointer}
+/* NO BACKTICKS ANYWHERE IN THIS FILE: it is all one template literal, and one
+   of them ends the stylesheet in the middle of a comment.
+   The plates already say they are clickable (.lb below carries its own pointer),
+   but the GROUND is the bigger target and said nothing: a realm you walk into by
+   clicking its island looked exactly like a map you can only drag. The cursor is
+   the whole of the affordance on purpose: the labels deliberately do not react
+   to a pointer (see the note in world.js), because anything that swells or
+   lights up rewrites the map under the reader mid-read. */
+.world-stage.pick,.world-stage.pick.grab{cursor:pointer}
+/* Both of these beat pick: a drag in progress is not an offer to click, and a
+   bird under the pointer is the more specific offer of the two. */
+.world-stage.grabbing,.world-stage.grabbing.pick{cursor:grabbing}
+.world-stage.ride,.world-stage.ride.grab,.world-stage.ride.pick{cursor:pointer}
 
 /* =================================================================== labels */
 /* ONE component at both levels. A realm label and a district label are the same

--- a/packages/webapp/components/world/engine/world.js
+++ b/packages/webapp/components/world/engine/world.js
@@ -8101,7 +8101,7 @@ function enterRealm(q){
   if(W.unbuilt)return;
   handAbort(); unpossess(); birdsDirty();
   worldDay=DAY;
-  OPEN=q; selected=null; hovered=null;
+  OPEN=q; selected=null; hovered=null; stageEl.classList.remove('pick');
   for(const d of W.districts) hideDistrict(d);
   for(const d of q.list){
     if(d.shown>0) raise(d,levelOf(d.shown),false);
@@ -8119,6 +8119,9 @@ function leaveRealm(){
   handAbort(); unpossess(); birdsDirty();
   for(const d of OPEN.list) hideDistrict(d);
   landRoot.clear(); OPEN=null; selected=null; hovered=null;
+  /* The ground under a stationary pointer is a different thing on either side of
+     this, so the offer is withdrawn and the next move makes it again. */
+  stageEl.classList.remove('pick');
   worldRoot.visible=true;
   landRoot.visible=townRoot.visible=false;
   /* Bring the islands up to the day the scrubber is actually on. Land is
@@ -8489,12 +8492,12 @@ function pick(cx,cy,click){
       if(Math.hypot(p.x-q.x,p.z-q.z)<=spec(Math.max(1,q.level)).radius+3){ hit=q; break; }
     }
   }
-  /* No hover card at either scale. Nothing follows the cursor now: `hovered` is
-     still tracked, but the only thing it does is light the plot border under the
-     pointer. The affordance the card used to carry — "click to walk in" — is
-     already stated in the hint bar, permanently, where it does not have to
-     appear over the world to be read. */
   if(hit!==hovered){ hovered=hit; paintBorders(); }
+  /* Only ground a click does something with. An unread realm does not open, and
+     inside one, only a district with something standing on it has a feed. Never
+     while riding: the pointer is a flight stick then, not a cursor. */
+  stageEl.classList.toggle('pick',
+    !POV.bird&&!!hit&&(OPEN?!!hit.built:hit.shown>0));
   if(click){
     /* Only the bird the reticle is already on. Re-testing the cursor here
        instead would let a bird that happened to fly under the pointer between

--- a/packages/webapp/components/world/ladder.ts
+++ b/packages/webapp/components/world/ladder.ts
@@ -14,8 +14,6 @@
  */
 
 export interface WorldLevel {
-  /** Build name, for whoever edits the geometry. See the note below. */
-  n: string;
   /** Lifetime article count at which this rung is reached. */
   reads: number;
   /** What this rung is supposed to BUILD. */
@@ -37,72 +35,59 @@ export interface WorldLevel {
    reader. And nothing can split the districts holding exactly one article, so
    L1 is a floor we accept rather than a rung anybody earns.
 
-   SKY COURT stays out of reach on purpose. A ladder whose ceiling is reachable
-   stops being a ceiling.
+   L12 stays out of reach on purpose. A ladder whose ceiling is reachable stops
+   being a ceiling.
 
-   `reads` is the only field that has ever reached a reader, as "L7". The names
-   and the descriptions are for whoever edits the geometry: they say what each
-   rung is supposed to BUILD, next to the threshold that triggers it. Twelve
-   invented names is a second vocabulary to learn before a level means anything,
-   so the UI counts instead of naming. */
+   The rungs are numbered and nothing else. `reads` is the only field that ever
+   reaches a reader, as "L7"; the descriptions are for whoever edits the
+   geometry, and say what each rung is supposed to BUILD next to the threshold
+   that triggers it. */
 export const LEVELS: WorldLevel[] = [
   {
-    n: 'WAYSTONE',
     reads: 1,
     d: 'A single lodestone on bare rock. One article is a real thing that happened — it gets land, however little.',
   },
   {
-    n: 'CAIRN',
     reads: 2,
     d: 'Somebody stacked stones and planted the first crystal sprout. Still wild, no longer untouched.',
   },
   {
-    n: 'CAMP',
     reads: 3,
     d: "A tended camp: lantern, path, the district's signature motif appears — identity arrives early, before size does.",
   },
   {
-    n: 'HOLD',
     reads: 5,
     d: 'Ground is cut into two terraces and the first roof goes up. The plot starts reading as built, not found.',
   },
   {
-    n: 'ATELIER',
     reads: 10,
     d: 'A working hamlet with a pool at its heart. Gardens, hedges, the first real greenery.',
   },
   {
-    n: 'SANCTUM',
     reads: 20,
     d: 'Three terraces, a dome, and the first spire. Birds arrive — the place is worth circling.',
   },
   {
-    n: 'CONCLAVE',
     reads: 40,
     d: 'Water spills off the rim as a falls. Lamps line the paths. Density picks up faster than the land does.',
   },
   {
-    n: 'SPIRE',
     reads: 80,
     d: 'Ground runs out before the reading does: cantilever decks brace out past the cliff on struts. The silhouette stops being a lump.',
   },
   {
-    n: 'ACADEMY',
     reads: 160,
     d: 'Four terraces, a spire cluster, and sky bridges strung between the towers. Legible from across the map.',
   },
   {
-    n: 'ARCANUM',
     reads: 320,
     d: 'Lanterns and hanging gardens spill over the terrace lips, a second hall opens, and the district starts growing downward as well as out.',
   },
   {
-    n: 'CITADEL',
     reads: 640,
     d: 'The Great Spire goes up — one landmark that owns the skyline — over a full upper tier of decks and bridges.',
   },
   {
-    n: 'SKY COURT',
     reads: 1280,
     d: 'The endgame plot. Everything lit, everything tended, everything moving. A capital of one subject.',
   },

--- a/packages/webapp/components/world/useWorldLog.ts
+++ b/packages/webapp/components/world/useWorldLog.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { LogEvent } from '@dailydotdev/shared/src/lib/log';
 import type { WorldDistrict } from '../../graphql/world';
@@ -51,7 +51,8 @@ interface UseWorldLogProps {
 
 /**
  * The world's own funnel: one `world view` per visit, resolving to exactly one
- * `world ready` or one `world boot failed`.
+ * `world ready` or one `world boot failed`, and then whatever the reader did
+ * with the world once it was standing.
  *
  * Kept as three events rather than one with an outcome field because the view is
  * knowable long before the outcome is, and a single event would have to wait for
@@ -183,4 +184,97 @@ export const useWorldLog = ({
       }),
     });
   }, [failure, isReady, isUnbuilt, userId]);
+
+  /* One event per distinct thing per visit. Opening a realm you have already
+     been in is the reader going back rather than a second realm opened, and the
+     ride and the replay are each a binary "did they ever find it" rather than a
+     count of play/pause. So the rate against `world ready` is readable straight
+     off, and the number of DISTINCT realms or districts in a visit still falls
+     out of counting the events.
+     Keyed by reader, like every guard above: a soft navigation to another world
+     keeps this hook and its refs, and that is another visit. */
+  const fired = useRef<{ userId: string | null; keys: Set<string> }>({
+    userId: null,
+    keys: new Set(),
+  });
+  const logOnce = useCallback(
+    (key: string, eventName: LogEvent, extra: Record<string, unknown>) => {
+      if (fired.current.userId !== userId) {
+        fired.current = { userId, keys: new Set() };
+      }
+      if (fired.current.keys.has(key)) {
+        return;
+      }
+      fired.current.keys.add(key);
+
+      const { current } = latest;
+      current.logEvent({
+        event_name: eventName,
+        target_id: userId,
+        extra: JSON.stringify({
+          is_own: current.isOwn,
+          is_lite: current.isLite,
+          ...extra,
+        }),
+      });
+    },
+    [userId],
+  );
+
+  /* Each of these watches ONE primitive pulled off the state object rather than
+     the object itself. The engine replaces that object every frame the replay
+     runs, so an effect depending on `state` (or on `state.open`, which is a new
+     object every time) would re-run sixty times a second to do nothing. */
+  const realmId = state.open?.id ?? null;
+  const districtId = state.district?.nicheId ?? null;
+  const isRiding = !!state.riding;
+  const { playing } = state;
+
+  useEffect(() => {
+    if (!isReady || !realmId) {
+      return;
+    }
+    const realm = latest.current.state.open;
+    logOnce(`realm:${realmId}`, LogEvent.WorldRealmOpen, {
+      realm: realmId,
+      districts: realm?.districts ?? 0,
+      articles: realm?.articles ?? 0,
+    });
+  }, [isReady, logOnce, realmId]);
+
+  useEffect(() => {
+    if (!isReady || !districtId) {
+      return;
+    }
+    const { current } = latest;
+    /* Off the districts query rather than off the selection, which carries only
+       what the plate needs to draw itself: the reads are the point of the event,
+       because a district opened at L1 and one opened at L9 are different reads
+       of the same click. */
+    const reads =
+      current.districts?.find(({ niche }) => niche.id === districtId)?.reads ??
+      0;
+    logOnce(`district:${districtId}`, LogEvent.WorldDistrictOpen, {
+      district: current.state.district?.name ?? null,
+      realm: current.state.open?.id ?? null,
+      reads,
+      level: levelOf(reads),
+    });
+  }, [districtId, isReady, logOnce]);
+
+  useEffect(() => {
+    if (!isReady || !isRiding) {
+      return;
+    }
+    logOnce('ride', LogEvent.WorldRide, { realm: realmId });
+  }, [isReady, isRiding, logOnce, realmId]);
+
+  useEffect(() => {
+    if (!isReady || !playing) {
+      return;
+    }
+    logOnce('replay', LogEvent.WorldReplay, {
+      total_days: latest.current.state.totalDays ?? 0,
+    });
+  }, [isReady, logOnce, playing]);
 };


### PR DESCRIPTION
## Why

`/world` has a real mechanic (articles read raise a district up a twelve-rung ladder) and never states it anywhere. The complete set of explanation before this PR:

- A hover tooltip of five definitions behind an info icon in the rail.
- Two sentences on the empty state.
- Keyboard hints that appear only once you are already riding a bird.

So nothing told a first-time visitor that clicking a realm walks into it, that clicking a town opens its posts, that birds are rideable at all, or what `L7` is measured against. Most arrivals are strangers following a shared link, which is the audience least equipped to guess.

While reading the engine I also found a comment claiming the "click to walk in" affordance was "already stated in the hint bar, permanently". There is no hint bar anywhere in the codebase. That removed surface is a good part of why the feature reads as unexplained.

## What changed

**A guide.** `WorldGuide` replaces the rail contents the way the customise bench already does, opened from the info icon that was already sitting beside the stats. Four sections: what this is, how it grows (the twelve thresholds, with the rung this world is standing on marked), what you can do here, and the stat definitions the old tooltip carried.

**A permanent line** under the world name, so a reader who clicks nothing still learns what the page is.

**The level badge** on every rank row now carries the distance to its next rung. It reads realm rows off the stretched ladder (`REALM_DIV`) and district rows off the plain one, and takes the level back out of `levelProgress` so the badge and its explanation cannot disagree.

**The replay bar** says what it would replay until the first time it is played, then goes back to the counts.

**A pointer cursor** on ground a click does something with. The plates already carried one; the islands, which are the much bigger target, looked like a map you could only drag. The labels still deliberately do not react to a pointer, per the note in the label solver: anything that swells or lights up rewrites the map under the reader mid-read.

**The rung names are gone.** All twelve were dev-only by design, and a second vocabulary to learn before a level means anything is worse than a number. `WorldLevel` is now `{ reads, d }`; the `d` descriptions stay, since those are geometry build notes rather than a naming scheme.

## Instrumentation

There was no event for opening a realm or a district, so there is currently no way to tell whether anyone gets past looking at the map. The funnel stopped at `world ready`. This adds `world realm open`, `world district open`, `world ride`, `world replay` and `world guide open`, each fired once per distinct thing per visit so the rate against `world ready` reads straight off while distinct counts still fall out of counting events.

They watch primitives pulled off the engine state rather than the state object, which the engine replaces every frame during a replay.

## Testing

`WorldPanel`'s rank rows had no coverage at all: the one spec that mounts the panel uses `rank: []`. `WorldPanelRank.spec.tsx` now renders real rows and pins the divisor split, where the same 64 articles reads as L4 on a realm row and L7 on a district row. `WorldGuide.spec.tsx` covers the ladder rendering and the owner/visitor variants.

111 world tests pass, lint and the changed-file strict typecheck are clean.

## Note for review

The level tooltip trigger is a plain `<span>`, not a `Typography`, and there is a comment saying why. `Typography` builds its element type inside its render body, so as a direct Radix `asChild` target it is remounted every render and the ref detach loops the page into "Maximum update depth exceeded". That is a repo-wide trap rather than anything specific to this file, and it is being fixed separately; this PR just stays off it.

## Not in scope

Mobile still has none of this. Everything here lives in the rail, which is laptop-only, so a phone visitor following a shared link still gets no explanation. That is the next and probably most valuable step, given where shared links actually land.

### Preview domain
https://feat-world-explainability.preview.app.daily.dev