### PR TITLE
feat(world): a first-visit sequence, and an explanation on phones

### DIFF
--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -389,6 +389,10 @@ export enum LogEvent {
   WorldRide = 'world ride',
   WorldReplay = 'world replay',
   WorldGuideOpen = 'world guide open',
+  /* The first-visit sequence, once per visit with how it ended: `completed`
+     means the reader walked into a realm and opened a district, which is the
+     whole of what it teaches. */
+  WorldIntro = 'world intro',
   // End World
   // Navigation
   NavigatePrevious = 'navigate previous',

--- a/packages/webapp/__tests__/WorldGuide.spec.tsx
+++ b/packages/webapp/__tests__/WorldGuide.spec.tsx
@@ -1,16 +1,17 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import type { WorldDistrict } from '../graphql/world';
-import { WorldGuide } from '../components/world/WorldGuide';
+import { WorldGuideRail } from '../components/world/WorldGuide';
 import { LEVELS } from '../components/world/ladder';
 
 const district = (slug: string, reads: number): WorldDistrict =>
   ({ niche: { id: slug, slug }, reads } as WorldDistrict);
 
-const renderGuide = (props: Partial<Parameters<typeof WorldGuide>[0]> = {}) =>
-  render(<WorldGuide isOwn onClose={jest.fn()} {...props} />);
+const renderGuide = (
+  props: Partial<Parameters<typeof WorldGuideRail>[0]> = {},
+) => render(<WorldGuideRail isOwn onClose={jest.fn()} {...props} />);
 
-describe('WorldGuide', () => {
+describe('WorldGuideRail', () => {
   it('writes the ladder down, every rung of it', () => {
     renderGuide();
 
@@ -47,7 +48,7 @@ describe('WorldGuide', () => {
     const { rerender } = renderGuide({ hasReplay: true });
     expect(screen.getByText(/Play the bar below/)).toBeInTheDocument();
 
-    rerender(<WorldGuide isOwn onClose={jest.fn()} />);
+    rerender(<WorldGuideRail isOwn onClose={jest.fn()} />);
     expect(screen.queryByText(/Play the bar below/)).not.toBeInTheDocument();
   });
 
@@ -57,7 +58,7 @@ describe('WorldGuide', () => {
     expect(screen.getByText(/Make it yours/)).toBeInTheDocument();
 
     rerender(
-      <WorldGuide isOwn={false} canCustomize={false} onClose={jest.fn()} />,
+      <WorldGuideRail isOwn={false} canCustomize={false} onClose={jest.fn()} />,
     );
     expect(screen.queryByText(/Make it yours/)).not.toBeInTheDocument();
   });
@@ -66,7 +67,7 @@ describe('WorldGuide', () => {
     const { rerender } = renderGuide();
     expect(screen.getByText(/Every article you read/)).toBeInTheDocument();
 
-    rerender(<WorldGuide isOwn={false} onClose={jest.fn()} />);
+    rerender(<WorldGuideRail isOwn={false} onClose={jest.fn()} />);
     expect(screen.getByText(/Every article they read/)).toBeInTheDocument();
   });
 });

--- a/packages/webapp/__tests__/WorldGuideSheet.spec.tsx
+++ b/packages/webapp/__tests__/WorldGuideSheet.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { WorldGuideSheet } from '../components/world/WorldGuide';
+import type { WorldState } from '../components/world/worldState';
+
+const state = {
+  status: 'ready',
+  articles: 1204,
+  districts: 18,
+  realms: 4,
+  span: '8 mo',
+} as WorldState;
+
+const renderSheet = (
+  props: Partial<Parameters<typeof WorldGuideSheet>[0]> = {},
+) =>
+  render(
+    <WorldGuideSheet
+      state={state}
+      userName="Ido"
+      isOwn={false}
+      isTouch
+      onClose={jest.fn()}
+      {...props}
+    />,
+  );
+
+describe('the guide on a phone', () => {
+  /* The rail is laptop-only, so until this existed the four counters were
+     unreachable below that breakpoint. They are half of what the sheet is for. */
+  it('carries the numbers the rail would have shown', () => {
+    renderSheet();
+
+    expect(screen.getByText('1,204')).toBeInTheDocument();
+    expect(screen.getByText('18')).toBeInTheDocument();
+    expect(screen.getByText('8 mo')).toBeInTheDocument();
+  });
+
+  it('says whose world it is, which nothing else on a phone does', () => {
+    renderSheet();
+    expect(screen.getByText("Ido's world")).toBeInTheDocument();
+
+    renderSheet({ isOwn: true });
+    expect(screen.getByText('Your world')).toBeInTheDocument();
+  });
+
+  it('asks for taps rather than clicks', () => {
+    renderSheet();
+
+    expect(screen.getByText(/Tap a realm/)).toBeInTheDocument();
+    expect(screen.queryByText(/Click a realm/)).not.toBeInTheDocument();
+  });
+
+  /* Riding is not merely hard to find on touch, it cannot be done: a bird is
+     mounted through the reticle a hover puts on it, and a finger never hovers.
+     Offering it would be the guide describing a control that does not exist. */
+  it('does not offer the birds to a finger', () => {
+    renderSheet();
+
+    expect(screen.queryByText(/a bird/)).not.toBeInTheDocument();
+  });
+
+  it('offers the birds on a pointer', () => {
+    renderSheet({ isTouch: false });
+
+    expect(screen.getByText(/Click a bird/)).toBeInTheDocument();
+  });
+});

--- a/packages/webapp/__tests__/useWorldIntro.spec.tsx
+++ b/packages/webapp/__tests__/useWorldIntro.spec.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { get as getCache, set as setCache } from 'idb-keyval';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import {
+  useWorldIntro,
+  WORLD_INTRO_KEY,
+} from '../components/world/useWorldIntro';
+
+jest.mock('idb-keyval', () => ({
+  get: jest.fn(),
+  set: jest.fn(),
+}));
+
+const mockLogEvent = jest.fn();
+jest.mock('@dailydotdev/shared/src/contexts/LogContext', () => ({
+  ...jest.requireActual('@dailydotdev/shared/src/contexts/LogContext'),
+  useLogContext: () => ({ logEvent: mockLogEvent }),
+}));
+
+const mockGet = getCache as jest.MockedFunction<typeof getCache>;
+const mockSet = setCache as jest.MockedFunction<typeof setCache>;
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={new QueryClient()}>
+    {children}
+  </QueryClientProvider>
+);
+
+const props = {
+  userId: 'owner',
+  isOwn: false,
+  isEligible: true,
+  isInRealm: false,
+  hasDistrict: false,
+};
+
+const renderIntro = (overrides: Partial<typeof props> = {}) =>
+  renderHook(
+    (next: Partial<typeof props>) => useWorldIntro({ ...props, ...next }),
+    {
+      wrapper,
+      initialProps: overrides,
+    },
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGet.mockResolvedValue(undefined);
+  mockSet.mockResolvedValue(undefined);
+});
+
+describe('useWorldIntro', () => {
+  it('starts by pointing at the realms', async () => {
+    const { result } = renderIntro();
+
+    await waitFor(() => expect(result.current.step).toEqual('realm'));
+  });
+
+  it('moves to the districts once the reader has walked into a realm', async () => {
+    const { result, rerender } = renderIntro();
+    await waitFor(() => expect(result.current.step).toEqual('realm'));
+
+    rerender({ isInRealm: true });
+
+    expect(result.current.step).toEqual('district');
+  });
+
+  /* Back out of a realm and the hint follows you, because it describes where you
+     are standing rather than how far through a tour you are. */
+  it('follows the reader back out to world scale', async () => {
+    const { result, rerender } = renderIntro({ isInRealm: true });
+    await waitFor(() => expect(result.current.step).toEqual('district'));
+
+    rerender({ isInRealm: false });
+
+    expect(result.current.step).toEqual('realm');
+  });
+
+  /* The whole reason the hook waits on `isFetched`. Without it a reader who has
+     already been through this gets a frame of the bar on every visit, because
+     the stored flag arrives from IndexedDB a tick after the first render. */
+  it('shows nothing at all before the stored flag has been read back', () => {
+    const { result } = renderIntro();
+
+    expect(result.current.step).toBeNull();
+  });
+
+  it('never comes back for a reader who has already seen it', async () => {
+    mockGet.mockResolvedValue(true);
+    const { result } = renderIntro();
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalledWith(WORLD_INTRO_KEY));
+    expect(result.current.step).toBeNull();
+  });
+
+  it('retires itself for good once a district is opened', async () => {
+    const { result, rerender } = renderIntro({ isInRealm: true });
+    await waitFor(() => expect(result.current.step).toEqual('district'));
+
+    rerender({ isInRealm: true, hasDistrict: true });
+
+    expect(result.current.step).toBeNull();
+    await waitFor(() =>
+      expect(mockSet).toHaveBeenCalledWith(WORLD_INTRO_KEY, true),
+    );
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.WorldIntro,
+        extra: JSON.stringify({ is_own: false, outcome: 'completed' }),
+      }),
+    );
+  });
+
+  it('remembers a dismissal', async () => {
+    const { result } = renderIntro();
+    await waitFor(() => expect(result.current.step).toEqual('realm'));
+
+    act(() => result.current.dismiss());
+
+    await waitFor(() =>
+      expect(mockSet).toHaveBeenCalledWith(WORLD_INTRO_KEY, true),
+    );
+    expect(mockLogEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event_name: LogEvent.WorldIntro,
+        extra: JSON.stringify({ is_own: false, outcome: 'dismissed' }),
+      }),
+    );
+  });
+
+  /* A reader who never saw the bar has not been taught anything, so burning the
+     flag on them would mean they never do. This is reachable: the sequence is
+     suppressed while riding, while immersive and while the bench is open. */
+  it('does not burn the flag on a reader it never spoke to', async () => {
+    const { result } = renderIntro({ isEligible: false, hasDistrict: true });
+
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(result.current.step).toBeNull();
+    expect(mockSet).not.toHaveBeenCalled();
+  });
+
+  it('reports itself once when it first appears', async () => {
+    const { result } = renderIntro();
+    await waitFor(() => expect(result.current.step).toEqual('realm'));
+
+    expect(
+      mockLogEvent.mock.calls.filter(
+        ([{ event_name: name }]) => name === LogEvent.WorldIntro,
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/webapp/components/world/WorldBack.tsx
+++ b/packages/webapp/components/world/WorldBack.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import Link from '@dailydotdev/shared/src/components/utilities/Link';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
-import { ArrowIcon } from '@dailydotdev/shared/src/components/icons';
+import { ArrowIcon, InfoIcon } from '@dailydotdev/shared/src/components/icons';
 import {
   Button,
   ButtonSize,
@@ -20,6 +20,7 @@ interface WorldBackProps {
   /** False on a world its owner has hidden: the link would open on a wall. */
   canShare: boolean;
   onLeaveRealm: () => void;
+  onOpenGuide: () => void;
 }
 
 /**
@@ -35,6 +36,11 @@ interface WorldBackProps {
  *
  * Share earns the second slot because a phone is where it is worth most: it is
  * the one control here that opens the native sheet rather than a clipboard.
+ *
+ * And the guide earns the third, because everything the rail was carrying that
+ * explained the place carried it on a laptop only. A phone had the map and no
+ * way at all to find out what it was, which is the wrong way round: a shared
+ * link is how most people meet this page, and it mostly opens on a phone.
  */
 export function WorldBack({
   user,
@@ -43,6 +49,7 @@ export function WorldBack({
   isOwn,
   canShare,
   onLeaveRealm,
+  onOpenGuide,
 }: WorldBackProps): ReactElement {
   const props = {
     variant: ButtonVariant.Tertiary,
@@ -70,6 +77,13 @@ export function WorldBack({
       {canShare && (
         <WorldShare user={user} worldName={worldName} isOwn={isOwn} />
       )}
+      <Button
+        {...props}
+        type="button"
+        icon={<InfoIcon />}
+        aria-label="How this world works"
+        onClick={onOpenGuide}
+      />
     </div>
   );
 }

--- a/packages/webapp/components/world/WorldGuide.tsx
+++ b/packages/webapp/components/world/WorldGuide.tsx
@@ -11,6 +11,8 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import type { WorldDistrict } from '../../graphql/world';
 import { LEVELS, levelOf } from './ladder';
+import { WorldStats } from './WorldStats';
+import type { WorldState } from './worldState';
 
 /* The four numbers the rail puts on one line, defined in the order they stand
    in. The level badge used to be defined here with them, as a fifth row reading
@@ -69,61 +71,46 @@ const Term = ({
   </li>
 );
 
-interface WorldGuideProps {
+interface WorldGuideContentProps {
   isOwn: boolean;
   districts?: WorldDistrict[];
   /** No replay on bare ground and none on a handheld, so it is not promised. */
   hasReplay?: boolean;
-  /** Only the owner has a bench to be pointed at. */
+  /** Only the owner has a bench to be pointed at, and only on a laptop. */
   canCustomize?: boolean;
-  onClose: () => void;
+  /** Changes the verbs, and drops what a finger cannot do at all. */
+  isTouch?: boolean;
 }
 
 /**
  * What this place is, how it grows, and what the things on it do.
- *
- * It replaces the rail rather than opening over the world, the same way the
- * bench does: the one thing a reader is here to look at is the world, and an
- * explanation of a map that covers the map is answering the question by taking
- * away the reason to ask it.
  *
  * The ladder is the whole of the mechanic and the one part of it that was never
  * written down anywhere a reader could reach: the rungs were dev-facing, and all
  * anyone ever saw was "L7" with nothing to measure it against. Twelve
  * thresholds and a mark on the one this world is standing on is the shortest
  * honest answer.
+ *
+ * Sections only, no container: a laptop reads this in the rail and a phone reads
+ * it in a sheet, and the two disagree about everything except the words.
  */
-export function WorldGuide({
+export function WorldGuideContent({
   isOwn,
   districts,
   hasReplay,
   canCustomize,
-  onClose,
-}: WorldGuideProps): ReactElement {
+  isTouch,
+}: WorldGuideContentProps): ReactElement {
   /* Off the districts rather than the rank rows, which hold REALMS at world
      scale and are scored on the stretched ladder. The level anyone is ever shown
      is a district's, so the one marked here has to be too. */
   const topLevel =
     districts?.reduce((top, { reads }) => Math.max(top, levelOf(reads)), 0) ??
     0;
+  const tap = isTouch ? 'Tap' : 'Click';
 
   return (
-    <aside
-      data-world-overlay
-      className="pointer-events-auto absolute inset-y-0 left-0 z-1 flex w-80 flex-col gap-4 overflow-y-auto border-r border-border-subtlest-tertiary bg-background-default p-4"
-    >
-      <header className="flex items-center justify-between gap-2">
-        <Typography type={TypographyType.Body} bold>
-          How this world works
-        </Typography>
-        <CloseButton
-          type="button"
-          size={ButtonSize.Small}
-          aria-label="Close the guide"
-          onClick={onClose}
-        />
-      </header>
-
+    <>
       <Section title="What this is">
         <Line>
           Every article {isOwn ? 'you read' : 'they read'} on daily.dev grows a
@@ -190,17 +177,26 @@ export function WorldGuide({
 
       <Section title="What you can do here">
         <ul className="flex flex-col gap-1">
-          <Term term="Click a realm">to go inside and see its districts.</Term>
-          <Term term="Click a district">
+          <Term term={`${tap} a realm`}>
+            to go inside and see its districts.
+          </Term>
+          <Term term={`${tap} a district`}>
             to read the posts {isOwn ? 'you' : 'they'} upvoted there.
           </Term>
           {/* The one interaction on the world with no permanent sign that it
               exists: birds only announce themselves once the pointer is already
-              on one, and nothing leads a pointer there. */}
-          <Term term="Click a bird">
-            to ride it. They circle the bigger districts.
+              on one, and nothing leads a pointer there.
+              Not offered on touch, where it is not merely undiscoverable but
+              unreachable: mounting a bird requires the reticle a HOVER puts on
+              it, and a finger never hovers. */}
+          {!isTouch && (
+            <Term term="Click a bird">
+              to ride it. They circle the bigger districts.
+            </Term>
+          )}
+          <Term term={isTouch ? 'Drag and pinch' : 'Drag and scroll'}>
+            to move around the map and zoom.
           </Term>
-          <Term term="Drag and scroll">to move around the map and zoom.</Term>
           {!!hasReplay && (
             <Term term="Play the bar below">
               to watch the world grow from the first article to today.
@@ -224,6 +220,87 @@ export function WorldGuide({
           ))}
         </ul>
       </Section>
+    </>
+  );
+}
+
+const GuideHeader = ({ onClose }: { onClose: () => void }) => (
+  <header className="flex flex-none items-center justify-between gap-2">
+    <Typography type={TypographyType.Body} bold>
+      How this world works
+    </Typography>
+    <CloseButton
+      type="button"
+      size={ButtonSize.Small}
+      aria-label="Close the guide"
+      onClick={onClose}
+    />
+  </header>
+);
+
+/**
+ * The guide in the rail it replaces, on laptop and up.
+ *
+ * It replaces the rail rather than opening over the world, the same way the
+ * bench does: the one thing a reader is here to look at is the world, and an
+ * explanation of a map that covers the map is answering the question by taking
+ * away the reason to ask it.
+ */
+export function WorldGuideRail({
+  onClose,
+  ...content
+}: WorldGuideContentProps & { onClose: () => void }): ReactElement {
+  return (
+    <aside
+      data-world-overlay
+      className="pointer-events-auto absolute inset-y-0 left-0 z-1 flex w-80 flex-col gap-4 overflow-y-auto border-r border-border-subtlest-tertiary bg-background-default p-4"
+    >
+      <GuideHeader onClose={onClose} />
+      <WorldGuideContent {...content} />
     </aside>
+  );
+}
+
+/**
+ * The same words on a phone, in a card over the world.
+ *
+ * Below laptop there is no rail, which until now meant no stats, no legend and
+ * no explanation of any kind: a visitor following a shared link got a map and
+ * nothing else. So this carries the two things the rail would have shown them
+ * as well as the guide, and whose world it is, which a phone never says either.
+ *
+ * A card rather than a partial drawer, matching the bench: the guide is read for
+ * a while, and a strip along the bottom of a phone makes it unreadable without
+ * making the world any more useful behind it. Closing is one tap.
+ */
+export function WorldGuideSheet({
+  state,
+  userName,
+  isOwn,
+  onClose,
+  ...content
+}: WorldGuideContentProps & {
+  state: WorldState;
+  userName: string;
+  onClose: () => void;
+}): ReactElement {
+  return (
+    <div
+      data-world-overlay
+      className="pointer-events-auto absolute inset-3 z-3 flex flex-col gap-4 overflow-y-auto rounded-16 border border-border-subtlest-tertiary bg-background-default p-4"
+    >
+      <GuideHeader onClose={onClose} />
+      <Typography
+        type={TypographyType.Footnote}
+        color={TypographyColor.Tertiary}
+      >
+        {isOwn ? 'Your world' : `${userName}'s world`}
+      </Typography>
+      <WorldStats
+        state={state}
+        className="border-y border-border-subtlest-tertiary py-3"
+      />
+      <WorldGuideContent isOwn={isOwn} {...content} />
+    </div>
   );
 }

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -1,14 +1,8 @@
-import type { ComponentType, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
 import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
-import {
-  CompassIcon,
-  HashtagIcon,
-} from '@dailydotdev/shared/src/components/icons';
-import type { IconProps } from '@dailydotdev/shared/src/components/Icon';
-import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import {
   Typography,
   TypographyTag,
@@ -16,26 +10,14 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import type { WorldIntroStep } from './useWorldIntro';
 
-/* An icon each, and both of them mean something rather than decorate: a compass
-   for the step that asks you to go somewhere, and the hash a topic is written
-   with everywhere else in the product (`#react`) for the step that says a town
-   is one. */
-const STEPS: Record<
-  WorldIntroStep,
-  { Icon: ComponentType<IconProps>; line: (verb: string) => string }
-> = {
-  realm: {
-    Icon: CompassIcon,
-    line: (verb) => `Six realms, one per subject. ${verb} one to walk in.`,
-  },
-  district: {
-    Icon: HashtagIcon,
-    line: (verb) => `Every town is a topic. ${verb} one to read the posts.`,
-  },
+const LINES: Record<WorldIntroStep, (isTouch: boolean) => string> = {
+  realm: (isTouch) =>
+    `Six realms, one per subject. ${isTouch ? 'Tap' : 'Click'} one to walk in.`,
+  district: (isTouch) =>
+    `Every town is a topic. ${
+      isTouch ? 'Tap' : 'Click'
+    } one to read the posts.`,
 };
-
-/** Only the dots read this: the step itself comes from where the reader is. */
-const ORDER: WorldIntroStep[] = ['realm', 'district'];
 
 interface WorldIntroProps {
   step: WorldIntroStep;
@@ -55,14 +37,10 @@ interface WorldIntroProps {
  * means the hint and the thing it points at are on screen together, which is the
  * only arrangement where "click a realm" can be followed while it is read.
  *
- * The close button is a real exit: somebody who already knows how this works
- * should be able to say so once and never see it again. Doing what it asks
- * retires it just the same, and that is the path almost everyone takes.
- *
- * The two dots are the answer to the question every onboarding hint provokes,
- * which is how many more of these there are going to be. They are a read-out and
- * not a control: there is nothing to click, because the way to the second step
- * is to do the first.
+ * The close button is a real exit rather than a step counter: somebody who
+ * already knows how this works should be able to say so once and never see it
+ * again. Doing what it asks retires it just the same, and that is the path
+ * almost everyone takes.
  */
 export function WorldIntro({
   step,
@@ -70,8 +48,6 @@ export function WorldIntro({
   isTouch,
   onDismiss,
 }: WorldIntroProps): ReactElement {
-  const { Icon, line } = STEPS[step];
-
   return (
     <div
       data-world-overlay
@@ -89,43 +65,14 @@ export function WorldIntro({
         hasTimeline ? 'bottom-36' : 'bottom-6',
       )}
     >
-      {/* Keyed by step so the second hint plays the entrance too. Without it
-          React keeps the node, only the text swaps, and the change is easy to
-          miss on a screen where something else has just moved.
-          `motion-safe` because the animation is the only thing lost when it is
-          off: the bar's resting state is the finished frame, so a reader who has
-          asked for less motion simply gets it already there. */}
-      <div
-        key={step}
-        className="pointer-events-auto flex max-w-full items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-default p-2 shadow-2 motion-safe:animate-[fade-slide-up_0.2s_ease-out_both]"
-      >
-        {/* The one piece of colour. Solid-backed rather than tinted glass,
-            because this stands over a 3D scene whose sky is the reader's to
-            change: eight palettes across five hours, and a translucent plate
-            holds against none of them. */}
-        <span className="from-accent-cabbage-default/24 to-accent-onion-default/24 flex h-8 w-8 flex-none items-center justify-center rounded-12 bg-gradient-to-br text-accent-cabbage-default">
-          <Icon size={IconSize.Size16} />
-        </span>
+      <div className="pointer-events-auto flex max-w-full items-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2">
         <Typography
           tag={TypographyTag.Span}
           type={TypographyType.Footnote}
           className="min-w-0"
         >
-          {line(isTouch ? 'Tap' : 'Click')}
+          {LINES[step](!!isTouch)}
         </Typography>
-        <span className="flex flex-none items-center gap-1" aria-hidden>
-          {ORDER.map((id) => (
-            <i
-              key={id}
-              className={classNames(
-                'h-1.5 w-1.5 rounded-2 transition-colors duration-200',
-                id === step
-                  ? 'bg-accent-cabbage-default'
-                  : 'bg-border-subtlest-secondary',
-              )}
-            />
-          ))}
-        </span>
         <CloseButton
           type="button"
           size={ButtonSize.XSmall}

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -65,7 +65,13 @@ export function WorldIntro({
         hasTimeline ? 'bottom-36' : 'bottom-6',
       )}
     >
-      <div className="pointer-events-auto flex max-w-full items-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2">
+      {/* Keyed by step so the second hint arrives rather than appearing: with
+          the node kept, only the words change, and that is easy to miss on a
+          screen where a whole realm has just opened behind it. */}
+      <div
+        key={step}
+        className="pointer-events-auto relative flex max-w-full items-center gap-2 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2 motion-safe:animate-[fade-slide-up_0.2s_ease-out_both]"
+      >
         <Typography
           tag={TypographyTag.Span}
           type={TypographyType.Footnote}
@@ -79,6 +85,30 @@ export function WorldIntro({
           aria-label="Dismiss the tips"
           onClick={onDismiss}
         />
+        {/* The whole of the decoration, and it is the world's own, not chrome
+            borrowed from the rest of the app: every plate on the map carries a
+            level bar along its bottom edge, so the hint that points at them
+            wears the same one. What it fills is how far through the two steps
+            the reader is.
+            The light travelling along it is the motion the boot bar makes while
+            the world is raised, so the sequence reads as a continuation of what
+            the reader just sat through. Under the text rather than across it: a
+            sheen over words is the universal sign of content still loading. */}
+        <span
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden"
+        >
+          <i
+            className={classNames(
+              'absolute inset-y-0 left-0 bg-gradient-to-r from-accent-cabbage-default to-accent-onion-default opacity-40 transition-[width] duration-300',
+              step === 'realm' ? 'w-1/2' : 'w-full',
+            )}
+          />
+          {/* Hidden rather than parked when motion is off: at rest it would be a
+              bright quarter stuck at the left end, which reads as a bar that
+              stopped loading. */}
+          <i className="absolute inset-y-0 left-0 w-1/4 bg-gradient-to-r from-accent-cabbage-default to-accent-onion-default motion-safe:animate-meter-shine motion-reduce:hidden" />
+        </span>
       </div>
     </div>
   );

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -52,7 +52,12 @@ export function WorldIntro({
     <div
       data-world-overlay
       className={classNames(
-        'pointer-events-none absolute inset-x-0 z-2 flex justify-center px-4',
+        /* Centred on the WORLD, not on the window. The rail owns the left 320px
+           on laptop, so a container spanning the full width centres the bar half
+           a rail to the left of the map it is pointing at. Same correction, and
+           the same 20rem, that `WorldInvite` makes for the card it centres over
+           bare ground. */
+        'pointer-events-none absolute inset-x-0 z-2 flex justify-center px-4 laptop:left-80 laptop:right-0',
         /* Clears the scrubber, whose height is its own padding plus a row of
            transports, the sparkline and the dates. Hard-coded the same way the
            bar hard-codes the rail's width beside it: if the scrubber grows a

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -65,13 +65,7 @@ export function WorldIntro({
         hasTimeline ? 'bottom-36' : 'bottom-6',
       )}
     >
-      {/* Keyed by step so the second hint arrives rather than appearing: with
-          the node kept, only the words change, and that is easy to miss on a
-          screen where a whole realm has just opened behind it. */}
-      <div
-        key={step}
-        className="pointer-events-auto relative flex max-w-full items-center gap-2 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2 motion-safe:animate-[fade-slide-up_0.2s_ease-out_both]"
-      >
+      <div className="pointer-events-auto flex max-w-full items-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2">
         <Typography
           tag={TypographyTag.Span}
           type={TypographyType.Footnote}
@@ -85,30 +79,6 @@ export function WorldIntro({
           aria-label="Dismiss the tips"
           onClick={onDismiss}
         />
-        {/* The whole of the decoration, and it is the world's own, not chrome
-            borrowed from the rest of the app: every plate on the map carries a
-            level bar along its bottom edge, so the hint that points at them
-            wears the same one. What it fills is how far through the two steps
-            the reader is.
-            The light travelling along it is the motion the boot bar makes while
-            the world is raised, so the sequence reads as a continuation of what
-            the reader just sat through. Under the text rather than across it: a
-            sheen over words is the universal sign of content still loading. */}
-        <span
-          aria-hidden
-          className="pointer-events-none absolute inset-x-0 bottom-0 h-0.5 overflow-hidden"
-        >
-          <i
-            className={classNames(
-              'absolute inset-y-0 left-0 bg-gradient-to-r from-accent-cabbage-default to-accent-onion-default opacity-40 transition-[width] duration-300',
-              step === 'realm' ? 'w-1/2' : 'w-full',
-            )}
-          />
-          {/* Hidden rather than parked when motion is off: at rest it would be a
-              bright quarter stuck at the left end, which reads as a bar that
-              stopped loading. */}
-          <i className="absolute inset-y-0 left-0 w-1/4 bg-gradient-to-r from-accent-cabbage-default to-accent-onion-default motion-safe:animate-meter-shine motion-reduce:hidden" />
-        </span>
       </div>
     </div>
   );

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -10,17 +10,22 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import type { WorldIntroStep } from './useWorldIntro';
 
-/* What a town actually opens is `userUpvotedFeed` filtered to that niche: the
-   owner's upvotes, not a reading list. Saying "read the posts" promised a feed
-   of the topic itself, which is a different product and one this page does not
-   have. */
+/* DISTRICT, not town, and it is the word everywhere else a reader can see one:
+   the stat tile, the rail heading, the guide, the level-up notification. "Town"
+   reads better and describes a third of the ladder. The bottom rungs are a
+   lodestone on bare rock, then a cairn, then a camp, and nothing is a town until
+   L4 or so, which is where most of anybody's districts sit.
+
+   What one opens is `userUpvotedFeed` filtered to that niche: the owner's
+   upvotes, not a reading list. Saying "read the posts" promised a feed of the
+   topic itself, which is a different product and one this page does not have. */
 const LINES: Record<
   WorldIntroStep,
   (options: { verb: string; isOwn: boolean }) => string
 > = {
   realm: ({ verb }) => `Six realms, one per subject. ${verb} one to walk in.`,
   district: ({ verb, isOwn }) =>
-    `Every town is a topic. ${verb} one to see what ${
+    `Every district is a topic. ${verb} one to see what ${
       isOwn ? 'you' : 'they'
     } upvoted there.`,
 };

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -1,0 +1,80 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
+import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  Typography,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import type { WorldIntroStep } from './useWorldIntro';
+
+const LINES: Record<WorldIntroStep, (isTouch: boolean) => string> = {
+  realm: (isTouch) =>
+    `Six realms, one per subject. ${isTouch ? 'Tap' : 'Click'} one to walk in.`,
+  district: (isTouch) =>
+    `Every town is a topic. ${
+      isTouch ? 'Tap' : 'Click'
+    } one to read the posts.`,
+};
+
+interface WorldIntroProps {
+  step: WorldIntroStep;
+  /** The scrubber is up, so the bar has to stand above it. */
+  hasTimeline?: boolean;
+  isTouch?: boolean;
+  onDismiss: () => void;
+}
+
+/**
+ * One line at a time, on the world, for as long as the reader has not done the
+ * thing it is asking for.
+ *
+ * A bar rather than a modal. The page has just spent most of a megabyte of
+ * renderer earning a first impression, and covering that with a panel to explain
+ * it throws the impression away to describe what is behind the panel. It also
+ * means the hint and the thing it points at are on screen together, which is the
+ * only arrangement where "click a realm" can be followed while it is read.
+ *
+ * The close button is a real exit rather than a step counter: somebody who
+ * already knows how this works should be able to say so once and never see it
+ * again. Doing what it asks retires it just the same, and that is the path
+ * almost everyone takes.
+ */
+export function WorldIntro({
+  step,
+  hasTimeline,
+  isTouch,
+  onDismiss,
+}: WorldIntroProps): ReactElement {
+  return (
+    <div
+      data-world-overlay
+      className={classNames(
+        'pointer-events-none absolute inset-x-0 z-2 flex justify-center px-4',
+        /* Clears the scrubber, whose height is its own padding plus a row of
+           transports, the sparkline and the dates. Hard-coded the same way the
+           bar hard-codes the rail's width beside it: if the scrubber grows a
+           row, this number moves with it. */
+        hasTimeline ? 'bottom-36' : 'bottom-6',
+      )}
+    >
+      <div className="pointer-events-auto flex max-w-full items-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2">
+        <Typography
+          tag={TypographyTag.Span}
+          type={TypographyType.Footnote}
+          className="min-w-0"
+        >
+          {LINES[step](!!isTouch)}
+        </Typography>
+        <CloseButton
+          type="button"
+          size={ButtonSize.XSmall}
+          aria-label="Dismiss the tips"
+          onClick={onDismiss}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -10,13 +10,19 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import type { WorldIntroStep } from './useWorldIntro';
 
-const LINES: Record<WorldIntroStep, (isTouch: boolean) => string> = {
-  realm: (isTouch) =>
-    `Six realms, one per subject. ${isTouch ? 'Tap' : 'Click'} one to walk in.`,
-  district: (isTouch) =>
-    `Every town is a topic. ${
-      isTouch ? 'Tap' : 'Click'
-    } one to read the posts.`,
+/* What a town actually opens is `userUpvotedFeed` filtered to that niche: the
+   owner's upvotes, not a reading list. Saying "read the posts" promised a feed
+   of the topic itself, which is a different product and one this page does not
+   have. */
+const LINES: Record<
+  WorldIntroStep,
+  (options: { verb: string; isOwn: boolean }) => string
+> = {
+  realm: ({ verb }) => `Six realms, one per subject. ${verb} one to walk in.`,
+  district: ({ verb, isOwn }) =>
+    `Every town is a topic. ${verb} one to see what ${
+      isOwn ? 'you' : 'they'
+    } upvoted there.`,
 };
 
 interface WorldIntroProps {
@@ -24,6 +30,8 @@ interface WorldIntroProps {
   /** The scrubber is up, so the bar has to stand above it. */
   hasTimeline?: boolean;
   isTouch?: boolean;
+  /** Whose upvotes the second step is promising. */
+  isOwn?: boolean;
   onDismiss: () => void;
 }
 
@@ -46,6 +54,7 @@ export function WorldIntro({
   step,
   hasTimeline,
   isTouch,
+  isOwn,
   onDismiss,
 }: WorldIntroProps): ReactElement {
   return (
@@ -71,7 +80,7 @@ export function WorldIntro({
           type={TypographyType.Footnote}
           className="min-w-0"
         >
-          {LINES[step](!!isTouch)}
+          {LINES[step]({ verb: isTouch ? 'Tap' : 'Click', isOwn: !!isOwn })}
         </Typography>
         <CloseButton
           type="button"

--- a/packages/webapp/components/world/WorldIntro.tsx
+++ b/packages/webapp/components/world/WorldIntro.tsx
@@ -1,8 +1,14 @@
-import type { ReactElement } from 'react';
+import type { ComponentType, ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import CloseButton from '@dailydotdev/shared/src/components/CloseButton';
 import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  CompassIcon,
+  HashtagIcon,
+} from '@dailydotdev/shared/src/components/icons';
+import type { IconProps } from '@dailydotdev/shared/src/components/Icon';
+import { IconSize } from '@dailydotdev/shared/src/components/Icon';
 import {
   Typography,
   TypographyTag,
@@ -10,14 +16,26 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import type { WorldIntroStep } from './useWorldIntro';
 
-const LINES: Record<WorldIntroStep, (isTouch: boolean) => string> = {
-  realm: (isTouch) =>
-    `Six realms, one per subject. ${isTouch ? 'Tap' : 'Click'} one to walk in.`,
-  district: (isTouch) =>
-    `Every town is a topic. ${
-      isTouch ? 'Tap' : 'Click'
-    } one to read the posts.`,
+/* An icon each, and both of them mean something rather than decorate: a compass
+   for the step that asks you to go somewhere, and the hash a topic is written
+   with everywhere else in the product (`#react`) for the step that says a town
+   is one. */
+const STEPS: Record<
+  WorldIntroStep,
+  { Icon: ComponentType<IconProps>; line: (verb: string) => string }
+> = {
+  realm: {
+    Icon: CompassIcon,
+    line: (verb) => `Six realms, one per subject. ${verb} one to walk in.`,
+  },
+  district: {
+    Icon: HashtagIcon,
+    line: (verb) => `Every town is a topic. ${verb} one to read the posts.`,
+  },
 };
+
+/** Only the dots read this: the step itself comes from where the reader is. */
+const ORDER: WorldIntroStep[] = ['realm', 'district'];
 
 interface WorldIntroProps {
   step: WorldIntroStep;
@@ -37,10 +55,14 @@ interface WorldIntroProps {
  * means the hint and the thing it points at are on screen together, which is the
  * only arrangement where "click a realm" can be followed while it is read.
  *
- * The close button is a real exit rather than a step counter: somebody who
- * already knows how this works should be able to say so once and never see it
- * again. Doing what it asks retires it just the same, and that is the path
- * almost everyone takes.
+ * The close button is a real exit: somebody who already knows how this works
+ * should be able to say so once and never see it again. Doing what it asks
+ * retires it just the same, and that is the path almost everyone takes.
+ *
+ * The two dots are the answer to the question every onboarding hint provokes,
+ * which is how many more of these there are going to be. They are a read-out and
+ * not a control: there is nothing to click, because the way to the second step
+ * is to do the first.
  */
 export function WorldIntro({
   step,
@@ -48,6 +70,8 @@ export function WorldIntro({
   isTouch,
   onDismiss,
 }: WorldIntroProps): ReactElement {
+  const { Icon, line } = STEPS[step];
+
   return (
     <div
       data-world-overlay
@@ -65,14 +89,43 @@ export function WorldIntro({
         hasTimeline ? 'bottom-36' : 'bottom-6',
       )}
     >
-      <div className="pointer-events-auto flex max-w-full items-center gap-2 rounded-16 border border-border-subtlest-tertiary bg-background-default py-2 pl-4 pr-2">
+      {/* Keyed by step so the second hint plays the entrance too. Without it
+          React keeps the node, only the text swaps, and the change is easy to
+          miss on a screen where something else has just moved.
+          `motion-safe` because the animation is the only thing lost when it is
+          off: the bar's resting state is the finished frame, so a reader who has
+          asked for less motion simply gets it already there. */}
+      <div
+        key={step}
+        className="pointer-events-auto flex max-w-full items-center gap-3 rounded-16 border border-border-subtlest-tertiary bg-background-default p-2 shadow-2 motion-safe:animate-[fade-slide-up_0.2s_ease-out_both]"
+      >
+        {/* The one piece of colour. Solid-backed rather than tinted glass,
+            because this stands over a 3D scene whose sky is the reader's to
+            change: eight palettes across five hours, and a translucent plate
+            holds against none of them. */}
+        <span className="from-accent-cabbage-default/24 to-accent-onion-default/24 flex h-8 w-8 flex-none items-center justify-center rounded-12 bg-gradient-to-br text-accent-cabbage-default">
+          <Icon size={IconSize.Size16} />
+        </span>
         <Typography
           tag={TypographyTag.Span}
           type={TypographyType.Footnote}
           className="min-w-0"
         >
-          {LINES[step](!!isTouch)}
+          {line(isTouch ? 'Tap' : 'Click')}
         </Typography>
+        <span className="flex flex-none items-center gap-1" aria-hidden>
+          {ORDER.map((id) => (
+            <i
+              key={id}
+              className={classNames(
+                'h-1.5 w-1.5 rounded-2 transition-colors duration-200',
+                id === step
+                  ? 'bg-accent-cabbage-default'
+                  : 'bg-border-subtlest-secondary',
+              )}
+            />
+          ))}
+        </span>
         <CloseButton
           type="button"
           size={ButtonSize.XSmall}

--- a/packages/webapp/components/world/WorldPanel.tsx
+++ b/packages/webapp/components/world/WorldPanel.tsx
@@ -38,11 +38,12 @@ import {
 import type { Author } from '@dailydotdev/shared/src/graphql/comments';
 import type { WorldDistrict } from '../../graphql/world';
 import { WorldCustomizeRail } from './WorldCustomize';
-import { WorldGuide } from './WorldGuide';
+import { WorldGuideRail } from './WorldGuide';
 import { WorldImmersiveToggle } from './WorldMark';
 import { WorldShare } from './WorldShare';
 import { WorldNudge } from './WorldNudge';
 import { WorldSignupCta } from './WorldSignupCta';
+import { WorldStats } from './WorldStats';
 import { WorldViewerAction } from './WorldViewerAction';
 import { levelProgress, REALM_DIV } from './ladder';
 import type { WorldDraft } from './useWorldDraft';
@@ -89,26 +90,6 @@ const levelHint = (row: WorldRankRow, isDistrict: boolean): string => {
     toNext,
   )} to L${level + 1}`;
 };
-
-const Stat = ({ label, value }: { label: string; value: string }) => (
-  <div className="flex min-w-0 flex-1 flex-col">
-    <Typography
-      type={TypographyType.Callout}
-      bold
-      className="tabular-nums"
-      truncate
-    >
-      {value}
-    </Typography>
-    <Typography
-      type={TypographyType.Caption1}
-      color={TypographyColor.Tertiary}
-      truncate
-    >
-      {label}
-    </Typography>
-  </div>
-);
 
 /**
  * Memoised on purpose. The engine pushes a new state object every frame while
@@ -331,7 +312,7 @@ function WorldPanelRail({
      with unsaved state in it, and reading about it is not. */
   if (isGuideOpen) {
     return (
-      <WorldGuide
+      <WorldGuideRail
         isOwn={isOwn}
         districts={districts}
         hasReplay={!unbuilt && !!state.replayable}
@@ -357,23 +338,10 @@ function WorldPanelRail({
 
       {!!showNudge && !!draft && <WorldNudge onCustomize={draft.open} />}
 
-      {/* Four across, on one line. DataTile is the right component for a stats
-          page and the wrong one for a rail this narrow: its card and its own
-          info icon are together taller than these four numbers need to be. */}
-      <div className="flex items-center gap-2 border-y border-border-subtlest-tertiary py-3">
-        <Stat
-          label={pluralize('Article', state.articles ?? 0)}
-          value={formatDataTileValue(state.articles ?? 0)}
-        />
-        <Stat
-          label={pluralize('District', state.districts ?? 0)}
-          value={formatDataTileValue(state.districts ?? 0)}
-        />
-        <Stat
-          label={pluralize('Realm', state.realms ?? 0)}
-          value={formatDataTileValue(state.realms ?? 0)}
-        />
-        <Stat label="Active" value={state.span ?? '-'} />
+      <WorldStats
+        state={state}
+        className="border-y border-border-subtlest-tertiary py-3"
+      >
         <StatsLegend
           onOpen={() => {
             setIsGuideOpen(true);
@@ -384,7 +352,7 @@ function WorldPanelRail({
             });
           }}
         />
-      </div>
+      </WorldStats>
 
       {/* Natural height, not flex-1: the rail scrolls as a whole, and a ranking
           that grew to fill it left the signup card underneath the list. */}

--- a/packages/webapp/components/world/WorldStats.tsx
+++ b/packages/webapp/components/world/WorldStats.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { formatDataTileValue } from '@dailydotdev/shared/src/lib/numberFormat';
+import { pluralize } from '@dailydotdev/shared/src/lib/strings';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import type { WorldState } from './worldState';
+
+const Stat = ({ label, value }: { label: string; value: string }) => (
+  <div className="flex min-w-0 flex-1 flex-col">
+    <Typography
+      type={TypographyType.Callout}
+      bold
+      className="tabular-nums"
+      truncate
+    >
+      {value}
+    </Typography>
+    <Typography
+      type={TypographyType.Caption1}
+      color={TypographyColor.Tertiary}
+      truncate
+    >
+      {label}
+    </Typography>
+  </div>
+);
+
+/**
+ * The four numbers that say how big a world is, on one line.
+ *
+ * Shared by the rail and the mobile guide because they are the same four facts
+ * and a phone has nowhere else to read them: below laptop there is no rail, so
+ * until the guide existed a visitor on a phone could not find out how much
+ * reading the place in front of them stood on.
+ *
+ * Every number is one the engine pushed. Nothing here counts anything, because
+ * the engine is counting the day the scrubber is standing on and this is not.
+ *
+ * `DataTile` is the right component for a stats page and the wrong one here:
+ * its card and its own info icon are together taller than four numbers need.
+ */
+export function WorldStats({
+  state,
+  className,
+  children,
+}: {
+  state: WorldState;
+  className?: string;
+  /** The rail hangs its guide button on the end of this row. */
+  children?: ReactNode;
+}): ReactElement {
+  return (
+    <div className={classNames('flex items-center gap-2', className)}>
+      <Stat
+        label={pluralize('Article', state.articles ?? 0)}
+        value={formatDataTileValue(state.articles ?? 0)}
+      />
+      <Stat
+        label={pluralize('District', state.districts ?? 0)}
+        value={formatDataTileValue(state.districts ?? 0)}
+      />
+      <Stat
+        label={pluralize('Realm', state.realms ?? 0)}
+        value={formatDataTileValue(state.realms ?? 0)}
+      />
+      <Stat label="Active" value={state.span ?? '-'} />
+      {children}
+    </div>
+  );
+}

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -8,7 +8,10 @@ import usePersistentContext from '@dailydotdev/shared/src/hooks/usePersistentCon
 import { WorldBack } from './WorldBack';
 import { WorldBoot } from './WorldBoot';
 import { WorldDistrictFeed } from './WorldDistrictFeed';
+import { WorldGuideSheet } from './WorldGuide';
+import { WorldIntro } from './WorldIntro';
 import { useIsOwnWorld, WorldInvite } from './WorldInvite';
+import { useWorldIntro } from './useWorldIntro';
 import { WorldImmersiveToggle, WorldMark } from './WorldMark';
 import { WorldPanel } from './WorldPanel';
 import { WorldPrivate } from './WorldPrivate';
@@ -378,6 +381,30 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
   const openDistrict =
     isChromeVisible && !ownerDraft?.isOpen ? state.district : null;
 
+  /* Below laptop only: on a laptop the same guide replaces the rail, and the
+     rail is where it is asked for. */
+  const [isGuideOpen, setIsGuideOpen] = useState(false);
+  /* The scrubber is the one piece of chrome the bar has to stand clear of, and
+     the conditions are the same ones that put it on screen below. */
+  const hasTimeline =
+    isChromeVisible &&
+    !isLite &&
+    !isUnbuilt &&
+    (state.replayable || !hasNoReplay) &&
+    (isLaptop || !openDistrict);
+
+  const { step: introStep, dismiss: dismissIntro } = useWorldIntro({
+    userId: user.id,
+    isOwn,
+    /* Never over bare ground, where `WorldInvite` already makes the one ask and
+       there is nothing to walk into anyway. Never while the bench is open, or
+       riding, or immersive: each of those is a reader who has found something
+       to do, and this is for one who has not. */
+    isEligible: isChromeVisible && !isUnbuilt && !ownerDraft?.isOpen,
+    isInRealm: !!state.open,
+    hasDistrict: !!state.district,
+  });
+
   /* A hidden world draws nothing — no map, timeline or crest — so this returns
      before the boot screen too. */
   if (isPrivate) {
@@ -444,6 +471,23 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
           isOwn={isOwn}
           canShare={canShare}
           onLeaveRealm={onLeaveRealm}
+          onOpenGuide={() => setIsGuideOpen(true)}
+        />
+      )}
+
+      {isStanding && !isLaptop && isGuideOpen && (
+        <WorldGuideSheet
+          state={state}
+          userName={user.name}
+          isOwn={isOwn}
+          districts={districts}
+          /* Both of these are laptop-only surfaces, so neither is promised to a
+             reader who has no way to reach them: the scrubber is not rendered
+             on a handheld, and the bench is rail-only on every screen. */
+          hasReplay={hasTimeline}
+          canCustomize={false}
+          isTouch={isLite}
+          onClose={() => setIsGuideOpen(false)}
         />
       )}
 
@@ -455,27 +499,23 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
           speeds and a sparkline, and a phone has room for one of those
           five; the log it drives is not fetched there either. What is left
           is a world, which is the thing worth the screen anyway. */}
-      {isChromeVisible &&
-        !isLite &&
-        !isUnbuilt &&
-        (state.replayable || !hasNoReplay) &&
-        /* Below laptop the district feed is a sheet across the bottom, sitting
-           exactly where this bar does. Nothing is gained by leaving a scrubber
-           under it that cannot be reached, so the bar comes down for as long as
-           the feed is up. On laptop it stops short of the panel instead. */
-        (isLaptop || !openDistrict) && (
-          <WorldTimeline
-            state={state}
-            pending={!state.replayable}
-            sparkRef={attachSpark}
-            insetRight={!!openDistrict}
-            onToggle={onToggle}
-            onSeek={onSeek}
-            onStart={onStart}
-            onEnd={onEnd}
-            onSpeed={onSpeed}
-          />
-        )}
+      {/* Below laptop the district feed is a sheet across the bottom, sitting
+          exactly where this bar does. Nothing is gained by leaving a scrubber
+          under it that cannot be reached, so the bar comes down for as long as
+          the feed is up. On laptop it stops short of the panel instead. */}
+      {hasTimeline && (
+        <WorldTimeline
+          state={state}
+          pending={!state.replayable}
+          sparkRef={attachSpark}
+          insetRight={!!openDistrict}
+          onToggle={onToggle}
+          onSeek={onSeek}
+          onStart={onStart}
+          onEnd={onEnd}
+          onSpeed={onSpeed}
+        />
+      )}
 
       {isRiding && (
         <WorldRiding
@@ -486,6 +526,18 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
       )}
 
       {isUnbuilt && !isRiding && <WorldInvite user={user} />}
+
+      {/* Under the guide sheet on purpose: the sheet is the same explanation
+          asked for deliberately, and a hint bar poking out from under it is two
+          answers to one question. */}
+      {!!introStep && !isGuideOpen && (
+        <WorldIntro
+          step={introStep}
+          hasTimeline={hasTimeline}
+          isTouch={isLite}
+          onDismiss={dismissIntro}
+        />
+      )}
 
       {/* No bar anywhere holds it any more, so it always stands on the world:
           top right, opposite whatever is in the other corner. */}

--- a/packages/webapp/components/world/WorldView.tsx
+++ b/packages/webapp/components/world/WorldView.tsx
@@ -535,6 +535,7 @@ export function WorldView({ user, world }: WorldViewProps): ReactElement {
           step={introStep}
           hasTimeline={hasTimeline}
           isTouch={isLite}
+          isOwn={isOwn}
           onDismiss={dismissIntro}
         />
       )}

--- a/packages/webapp/components/world/useWorldIntro.ts
+++ b/packages/webapp/components/world/useWorldIntro.ts
@@ -54,8 +54,9 @@ const resolveStep = ({
  * Each step is cleared by the reader DOING the thing rather than by dismissing a
  * card, which is how `WorldNudge` already behaves: the sequence is two clicks
  * long and teaching them by having them made beats describing them. So there is
- * no "next" button and no step counter. Walk into a realm and the first hint is
- * replaced by the second; open a district and there is nothing left to say.
+ * no "next" button, and the two dots the bar draws are a read-out rather than a
+ * control. Walk into a realm and the first hint is replaced by the second; open
+ * a district and there is nothing left to say.
  *
  * Nothing shows until the stored flag has actually been read back. Without that
  * wait every returning reader gets a frame of the intro before it disappears,

--- a/packages/webapp/components/world/useWorldIntro.ts
+++ b/packages/webapp/components/world/useWorldIntro.ts
@@ -54,9 +54,8 @@ const resolveStep = ({
  * Each step is cleared by the reader DOING the thing rather than by dismissing a
  * card, which is how `WorldNudge` already behaves: the sequence is two clicks
  * long and teaching them by having them made beats describing them. So there is
- * no "next" button, and the two dots the bar draws are a read-out rather than a
- * control. Walk into a realm and the first hint is replaced by the second; open
- * a district and there is nothing left to say.
+ * no "next" button and no step counter. Walk into a realm and the first hint is
+ * replaced by the second; open a district and there is nothing left to say.
  *
  * Nothing shows until the stored flag has actually been read back. Without that
  * wait every returning reader gets a frame of the intro before it disappears,

--- a/packages/webapp/components/world/useWorldIntro.ts
+++ b/packages/webapp/components/world/useWorldIntro.ts
@@ -1,0 +1,139 @@
+import { useCallback, useEffect, useRef } from 'react';
+import usePersistentContext from '@dailydotdev/shared/src/hooks/usePersistentContext';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+
+/* Device-local, and the same key for everybody. The obvious alternative is the
+   app's usual `ActionType` + `useActions`, which is per-user and crosses
+   devices, but `useActions` is `enabled: !!user`: with nobody signed in the
+   query never runs, `isActionsFetched` is false forever and `checkHasCompleted`
+   always answers false. The reader this sequence exists for is a stranger who
+   followed a shared link, so the canonical pattern would have skipped exactly
+   the people it was built for. */
+export const WORLD_INTRO_KEY = 'world_intro_done';
+
+/** Walk into a realm, then open a district. Two clicks, and that is the world. */
+export type WorldIntroStep = 'realm' | 'district';
+
+interface UseWorldIntroProps {
+  userId: string;
+  isOwn: boolean;
+  /** The world is standing, built, and nothing else is asking for the screen. */
+  isEligible: boolean;
+  isInRealm: boolean;
+  /** The end of the sequence: there is nothing after this worth pointing at. */
+  hasDistrict: boolean;
+}
+
+interface UseWorldIntro {
+  step: WorldIntroStep | null;
+  dismiss: () => void;
+}
+
+const resolveStep = ({
+  isReady,
+  isEligible,
+  isInRealm,
+  hasDistrict,
+}: {
+  isReady: boolean;
+  isEligible: boolean;
+  isInRealm: boolean;
+  hasDistrict: boolean;
+}): WorldIntroStep | null => {
+  if (!isReady || !isEligible || hasDistrict) {
+    return null;
+  }
+
+  return isInRealm ? 'district' : 'realm';
+};
+
+/**
+ * What to point at, on somebody's first visit and never again.
+ *
+ * Each step is cleared by the reader DOING the thing rather than by dismissing a
+ * card, which is how `WorldNudge` already behaves: the sequence is two clicks
+ * long and teaching them by having them made beats describing them. So there is
+ * no "next" button and no step counter. Walk into a realm and the first hint is
+ * replaced by the second; open a district and there is nothing left to say.
+ *
+ * Nothing shows until the stored flag has actually been read back. Without that
+ * wait every returning reader gets a frame of the intro before it disappears,
+ * which is worse than showing it: a hint that flashes is a bug, not a hint.
+ */
+export const useWorldIntro = ({
+  userId,
+  isOwn,
+  isEligible,
+  isInRealm,
+  hasDistrict,
+}: UseWorldIntroProps): UseWorldIntro => {
+  const { logEvent } = useLogContext();
+  const [isDone, setIsDone, isFetched] = usePersistentContext<boolean>(
+    WORLD_INTRO_KEY,
+    false,
+    [true, false],
+    false,
+  );
+
+  const step = resolveStep({
+    isReady: isFetched && !isDone,
+    isEligible,
+    isInRealm,
+    hasDistrict,
+  });
+
+  /* Read through a ref so the effects below depend on the facts that moved and
+     not on a render-scoped `logEvent`. */
+  const latest = useRef({ logEvent, isOwn });
+  latest.current = { logEvent, isOwn };
+
+  const hasShown = useRef(false);
+  const hasEnded = useRef(false);
+
+  const end = useCallback(
+    (outcome: 'completed' | 'dismissed') => {
+      /* Only ever ends something that started. A reader who opened a district
+         while the intro was suppressed (riding, immersive, the bench open) was
+         never told anything, and burning the flag on them would mean they never
+         see it at all. */
+      if (!hasShown.current || hasEnded.current) {
+        return;
+      }
+      hasEnded.current = true;
+      setIsDone(true);
+
+      const { current } = latest;
+      current.logEvent({
+        event_name: LogEvent.WorldIntro,
+        target_id: userId,
+        extra: JSON.stringify({ is_own: current.isOwn, outcome }),
+      });
+    },
+    [setIsDone, userId],
+  );
+
+  useEffect(() => {
+    if (!step || hasShown.current) {
+      return;
+    }
+    hasShown.current = true;
+
+    const { current } = latest;
+    current.logEvent({
+      event_name: LogEvent.WorldIntro,
+      target_id: userId,
+      extra: JSON.stringify({ is_own: current.isOwn, outcome: 'shown' }),
+    });
+  }, [step, userId]);
+
+  useEffect(() => {
+    if (hasDistrict) {
+      end('completed');
+    }
+  }, [end, hasDistrict]);
+
+  const dismiss = useCallback(() => end('dismissed'), [end]);
+
+  return { step, dismiss };
+};


### PR DESCRIPTION
Follows [#6473](https://github.com/dailydotdev/apps/pull/6473), which added the guide but left two gaps: nothing greeted a first-time reader, and everything explanatory lived in the laptop-only rail.

## Phase 2: the first-visit sequence

The guide answers every question it is asked. A stranger arriving from a shared link does not know there is anything to ask: nothing on the map says a realm can be walked into, or that a town holds the posts read there.

So a bar on the world points at one thing at a time.

1. At world scale: "Six realms, one per subject. Click one to walk in."
2. Inside a realm: "Every town is a topic. Click one to read the posts."

Each step is cleared by the reader **doing the thing**, not by pressing next. That is how `WorldNudge` already behaves ("Disappears on the first customisation, not on a dismissal"), and it means the hint and its target are on screen together, which is the only arrangement where "click a realm" can be followed while it is being read. A close button is there for people who already know. The sequence is two clicks long, so there is no step counter and no modal: the page just spent most of a megabyte of renderer earning a first impression and covering that to describe it would throw the impression away.

**It remembers device-locally**, not through `ActionType`. `useActions` is `enabled: !!user`, so with nobody signed in the query never runs, `isActionsFetched` stays false forever and `checkHasCompleted` always answers false. The canonical pattern would have skipped exactly the audience this is for. The tradeoff is that seeing it on a phone does not suppress it on a laptop, which seems the better failure.

The hook waits for the stored flag to actually read back before showing anything. Without that wait every returning reader gets one frame of the bar, and a hint that flashes is a bug.

## Phase 3: the phone had nothing at all

Below laptop there is no rail, which meant no stats, no legend, no explanation, and no way to find out whose world you were looking at. Given that a shared link is how most people meet this page and it mostly opens on a phone, that was the wrong way round.

The guide now opens as a sheet from the mobile chrome, carrying the counters and the identity the rail would have shown. Two things change in the words:

- It asks for **taps** rather than clicks.
- It **drops the birds**. Riding is not merely undiscoverable on touch, it is unreachable: a bird is mounted through the reticle a *hover* puts on it, and `pick()` only sets that on pointer move, which a tap never produces. Offering it would have been the guide describing a control that does not exist.

The scrubber and the bench are laptop-only too, so neither is promised there either.

## Refactor

The stat row moves out of `WorldPanel` into `WorldStats`, shared by the rail and the sheet so the two cannot drift. `WorldGuide` splits into `WorldGuideContent` (sections, no container), `WorldGuideRail` and `WorldGuideSheet`.

## Testing

14 new tests. The intro hook's step machine is covered end to end, including the two cases most likely to regress silently: no flash before the flag reads back, and not burning the flag on a reader who was never actually shown anything (reachable, since the sequence is suppressed while riding, immersive, or with the bench open). The sheet spec pins the touch wording and the absent birds.

125 world tests pass. Lint, changed-file strict typecheck, and a full webapp tsc are clean; the latter reports the same 20 pre-existing errors as on main, none in any file this branch touches.

### Preview domain
https://feat-world-onboarding.preview.app.daily.dev