### PR TITLE
fix(typography): stop remounting on every render

### DIFF
--- a/packages/shared/src/components/typography/Typography.spec.tsx
+++ b/packages/shared/src/components/typography/Typography.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { Typography, TypographyTag, TypographyType } from './Typography';
+import { Tooltip } from '../tooltip/Tooltip';
+
+describe('Typography', () => {
+  it('renders the requested tag with its computed classes', () => {
+    render(
+      <Typography
+        tag={TypographyTag.H2}
+        type={TypographyType.Title3}
+        bold
+        className="custom"
+      >
+        heading
+      </Typography>,
+    );
+
+    const element = screen.getByRole('heading', { level: 2 });
+    expect(element).toHaveClass('custom', 'typo-title3', 'font-bold');
+  });
+
+  it('forwards the ref to the rendered element', () => {
+    const ref = React.createRef<HTMLSpanElement>();
+    render(
+      <Typography tag={TypographyTag.Span} ref={ref}>
+        label
+      </Typography>,
+    );
+
+    expect(ref.current).toBe(screen.getByText('label'));
+  });
+
+  // The element type has to be stable across renders. Building it during render
+  // makes React remount on every pass, which loops a Radix `asChild` slot.
+  it('keeps the same DOM node across re-renders', () => {
+    const { rerender } = render(
+      <Typography tag={TypographyTag.Span}>label</Typography>,
+    );
+    const first = screen.getByText('label');
+
+    rerender(<Typography tag={TypographyTag.Span}>label</Typography>);
+
+    expect(screen.getByText('label')).toBe(first);
+  });
+
+  it('does not loop when used as a Tooltip trigger', () => {
+    expect(() =>
+      render(
+        <QueryClientProvider client={new QueryClient()}>
+          <Tooltip content="tooltip content">
+            <Typography tag={TypographyTag.Span}>trigger</Typography>
+          </Tooltip>
+        </QueryClientProvider>,
+      ),
+    ).not.toThrow();
+
+    expect(screen.getByText('trigger')).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/typography/Typography.tsx
+++ b/packages/shared/src/components/typography/Typography.tsx
@@ -1,7 +1,6 @@
 import type { ReactElement, RefAttributes } from 'react';
 import React, { forwardRef } from 'react';
 import classNames from 'classnames';
-import classed from '../../lib/classed';
 import { truncateTextClassNames } from '../utilities/common';
 
 export enum TypographyTag {
@@ -97,12 +96,14 @@ function BaseTypography<TagName extends AllowedTags>(
     color ?? (tagToColor as Record<string, TypographyColor | undefined>)[tag],
     truncate && truncateTextClassNames,
   );
-  const Tag = classed(tag, classes);
 
-  return (
-    <Tag {...props} ref={ref}>
-      {children}
-    </Tag>
+  // Never build the element type with classed() here: a type created during
+  // render remounts on every pass, which makes a Radix `asChild` slot (the
+  // Tooltip trigger) detach its ref in a loop until the update depth blows.
+  return React.createElement(
+    tag,
+    { ...props, className: classes, ref },
+    children,
   );
 }
 


### PR DESCRIPTION
## Changes

`Typography` built its element type with `classed(tag, classes)` **inside its render body**, so every render produced a brand new component type. React cannot reconcile across a changed type, so it deleted the old fiber and mounted a fresh one on every pass.

That is merely wasteful in normal use, but it is fatal when a `Typography` is the direct child of a Radix `asChild` slot, which is what `Tooltip` renders for its trigger: the slot hands the child a ref, the per-render remount fires `safelyDetachRef` on every commit, that updates Radix's state, which renders the trigger again, and the page dies with `Maximum update depth exceeded` (stack: `safelyDetachRef` -> `commitDeletionEffectsOnFiber`).

This was hit for real on the world panel level badge and worked around locally there with a plain `<span>` trigger, but the trap is repo wide: any `<Tooltip><Typography /></Tooltip>` anywhere hard crashes the page, and it looks completely reasonable in review.

- `Typography` now renders the intrinsic tag directly via `React.createElement` instead of going through a `classed()` call made during render, so the element type is a stable string.
- Adds `Typography.spec.tsx` as a regression guard.

No cache or memoization was needed. The wrapper was pure indirection here: `className` is destructured out of `props` before the `classed()` call, so the generated component only ever applied the already computed `classes` string and never combined anything.

- **Styling contract:** unchanged. `classed`'s `classNames(props.className, className, ...classes)` reduced to `classes` in this call site, which is exactly what is now passed through.
- **Ref forwarding:** unchanged. `forwardRef(BaseTypography)` still supplies `ref`; it now lands on the host element in one hop rather than through the wrapper's own `forwardRef`.
- `classed` itself is untouched, so every other consumer is unaffected.

### Why a test rather than an eslint rule

Both were on the table. A lint rule banning `Typography` under `Tooltip` would have to enumerate "components that call `classed` at render", which is exactly the list that goes stale, and it would only cover the one symptom. The spec asserts the property that actually matters:

- `keeps the same DOM node across re-renders` catches the unstable element type directly, so it still fires if a future `Tooltip` refactor stops surfacing the loop.
- `does not loop when used as a Tooltip trigger` renders the exact crashing combination.

Both of these fail against the old render path (verified by stashing the fix back in, reproducing the reported `commitDeletionEffectsOnFiber` stack), while the styling and ref tests keep passing. That confirms the guard is real rather than vacuous.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

`Typography` is used nearly everywhere and this touches its render path, so verification leaned on the full suites plus a type check:

- `pnpm --filter shared test`: 325 suites, 2163 tests, all pass
- `pnpm --filter webapp test`: 67 suites, 507 tests, all pass, including the existing `WorldPanelRank.spec.tsx` "renders rank rows without looping"
- `node ./scripts/typecheck-strict-changed.js`: clean
- Full `pnpm --filter webapp exec tsc --noEmit`: 17 errors, byte identical to the pre-change baseline. All pre-existing backlog in unrelated test files, none `Typography` related.
- eslint on both changed files: clean

### Note for the reviewer

The `<span>` workaround on the world panel level badge is now unnecessary, but it is harmless and reverting it is not needed for this fix, so it is deliberately left alone and out of scope here.

### Preview domain
https://fix-typography-stable-element-ty.preview.app.daily.dev