### PR TITLE
feat(world): open the world index on /world

### DIFF
--- a/packages/shared/src/components/quest/questDestinations.ts
+++ b/packages/shared/src/components/quest/questDestinations.ts
@@ -62,10 +62,8 @@ export const getQuestDestination = (
       return { label: 'Later', path: '/bookmarks/later' };
     case 'visit_watercooler_feed':
       return { label: 'Watercooler', path: '/watercooler' };
-    // Worlds have no index of their own: each one is reached from its owner's
-    // profile, so the leaderboards are where a tour starts.
     case 'visit_user_world':
-      return { label: 'Profiles', path: '/users' };
+      return { label: 'Worlds', path: '/world' };
     case 'feedback_submit':
       return { label: 'Feedback', path: '/settings/feedback' };
     case 'squad_join':

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -291,6 +291,11 @@ export enum RequestKey {
   UserWorldTimeline = 'user_world_timeline',
   UserWorldEntitlements = 'user_world_entitlements',
   UserWorldDistrictFeed = 'user_world_district_feed',
+  WorldTopicReaders = 'world_topic_readers',
+  WorldTopicRanking = 'world_topic_ranking',
+  WorldTopicRankPosition = 'world_topic_rank_position',
+  WorldRecentLevelUps = 'world_recent_level_ups',
+  FollowedWorlds = 'followed_worlds',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/webapp/components/world/WorldIndexCard.tsx
+++ b/packages/webapp/components/world/WorldIndexCard.tsx
@@ -52,19 +52,22 @@ export function WorldIndexCard({
             size={ProfileImageSize.Medium}
             nativeLazyLoading
           />
+          {/* Wraps rather than clips. `min-w-0` is what lets it: without it a
+              flex item refuses to shrink below its content and a long handle
+              pushes out of the card instead of breaking. */}
           <div className="flex min-w-0 flex-col">
             <Typography
               tag={TypographyTag.H3}
               type={TypographyType.Footnote}
               bold
-              truncate
+              className="break-words"
             >
               {world.user.name}
             </Typography>
             <Typography
               type={TypographyType.Caption1}
               color={TypographyColor.Tertiary}
-              truncate
+              className="break-words"
             >
               @{world.user.username}
             </Typography>
@@ -76,8 +79,7 @@ export function WorldIndexCard({
         <Typography
           type={TypographyType.Caption1}
           color={TypographyColor.Tertiary}
-          className="mt-auto tabular-nums"
-          truncate
+          className="mt-auto break-words tabular-nums"
         >
           {world.name ? `${world.name} · ` : ''}
           {world.topics} topics · {world.articles.toLocaleString()} articles

--- a/packages/webapp/components/world/WorldIndexCard.tsx
+++ b/packages/webapp/components/world/WorldIndexCard.tsx
@@ -1,0 +1,88 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  ProfileImageSize,
+  ProfilePicture,
+} from '@dailydotdev/shared/src/components/ProfilePicture';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import type { IndexedWorld } from '../../graphql/worldIndex';
+import { WorldTopicBars } from './WorldTopicBars';
+
+interface WorldIndexCardProps {
+  world: IndexedWorld;
+  /** Why this world is in the section it is in, when there is a reason. */
+  event?: string;
+  className?: string;
+}
+
+export function WorldIndexCard({
+  world,
+  event,
+  className,
+}: WorldIndexCardProps): ReactElement {
+  return (
+    <Link href={`/world/${world.user.username}`} passHref prefetch={false}>
+      <a
+        className={classNames(
+          'flex flex-col gap-3 rounded-16 border border-border-subtlest-tertiary bg-surface-float p-4 transition-colors hover:border-border-subtlest-secondary',
+          className,
+        )}
+      >
+        {!!event && (
+          <Typography
+            type={TypographyType.Caption2}
+            color={TypographyColor.Secondary}
+            bold
+            className="w-fit rounded-8 border border-border-subtlest-tertiary px-2 py-1"
+          >
+            {event}
+          </Typography>
+        )}
+
+        <div className="flex min-w-0 items-center gap-2">
+          <ProfilePicture
+            user={world.user}
+            size={ProfileImageSize.Medium}
+            nativeLazyLoading
+          />
+          <div className="flex min-w-0 flex-col">
+            <Typography
+              tag={TypographyTag.H3}
+              type={TypographyType.Footnote}
+              bold
+              truncate
+            >
+              {world.user.name}
+            </Typography>
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+              truncate
+            >
+              @{world.user.username}
+            </Typography>
+          </div>
+        </div>
+
+        <WorldTopicBars topics={world.topTopics} />
+
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          className="mt-auto tabular-nums"
+          truncate
+        >
+          {world.name ? `${world.name} · ` : ''}
+          {world.topics} topics · {world.articles.toLocaleString()} articles
+        </Typography>
+      </a>
+    </Link>
+  );
+}

--- a/packages/webapp/components/world/WorldTopicBars.tsx
+++ b/packages/webapp/components/world/WorldTopicBars.tsx
@@ -39,16 +39,20 @@ export function WorldTopicBars({
 
         return (
           <div key={topic.niche.id} className="flex items-center gap-2">
+            {/* The title takes the slack and the bar is fixed, rather than the
+                other way round: niche titles run to "JavaScript / TypeScript
+                ecosystem", and a bar is still comparable at any width so long
+                as every row shares it. It wraps rather than clipping, so the
+                row grows a line instead of hiding half a subject. */}
             <Typography
               type={TypographyType.Caption1}
               color={TypographyColor.Secondary}
-              truncate
-              className="w-20 shrink-0"
+              className="min-w-0 flex-1 break-words"
             >
               {topic.niche.title}
             </Typography>
 
-            <span className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-8 bg-accent-pepper-subtler">
+            <span className="h-1.5 w-16 shrink-0 overflow-hidden rounded-8 bg-accent-pepper-subtler">
               <span
                 className="block h-full rounded-8"
                 style={{

--- a/packages/webapp/components/world/WorldTopicBars.tsx
+++ b/packages/webapp/components/world/WorldTopicBars.tsx
@@ -1,0 +1,73 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import type { WorldTopic } from '../../graphql/worldIndex';
+import { categoryOfSlug, worldCategories } from './worldIndexTaxonomy';
+
+interface WorldTopicBarsProps {
+  topics: WorldTopic[];
+  className?: string;
+}
+
+/**
+ * What a world is made of, said in words rather than drawn as a picture.
+ *
+ * An abstract mark of the world reads as decoration at this size: it says a
+ * world is big or small and nothing else. The claim worth making on a card is
+ * which subjects this person actually reads, and labelled bars make it in a
+ * form nobody has to be taught to read.
+ */
+export function WorldTopicBars({
+  topics,
+  className,
+}: WorldTopicBarsProps): ReactElement | null {
+  if (!topics.length) {
+    return null;
+  }
+
+  const max = Math.max(...topics.map((topic) => topic.articles));
+
+  return (
+    <div className={classNames('flex flex-col gap-1.5', className)}>
+      {topics.map((topic) => {
+        const category = categoryOfSlug(topic.niche.slug) ?? worldCategories[0];
+
+        return (
+          <div key={topic.niche.id} className="flex items-center gap-2">
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Secondary}
+              truncate
+              className="w-20 shrink-0"
+            >
+              {topic.niche.title}
+            </Typography>
+
+            <span className="h-1.5 min-w-0 flex-1 overflow-hidden rounded-8 bg-accent-pepper-subtler">
+              <span
+                className="block h-full rounded-8"
+                style={{
+                  width: `${Math.round((topic.articles / max) * 100)}%`,
+                  backgroundColor: category.accent,
+                }}
+              />
+            </span>
+
+            <Typography
+              type={TypographyType.Caption2}
+              color={TypographyColor.Tertiary}
+              className="w-10 shrink-0 text-right tabular-nums"
+            >
+              {topic.articles.toLocaleString()}
+            </Typography>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/webapp/components/world/useWorldIndex.ts
+++ b/packages/webapp/components/world/useWorldIndex.ts
@@ -1,0 +1,189 @@
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import {
+  generateQueryKey,
+  RequestKey,
+  StaleTime,
+} from '@dailydotdev/shared/src/lib/query';
+import type {
+  IndexedWorld,
+  WorldLevelUp,
+  WorldNicheSummary,
+  WorldRankEntry,
+  WorldRankPosition,
+  WorldRankPeriod,
+} from '../../graphql/worldIndex';
+import {
+  FOLLOWED_WORLDS_QUERY,
+  WORLD_RECENT_LEVEL_UPS_QUERY,
+  WORLD_TOPIC_RANKING_QUERY,
+  WORLD_TOPIC_RANK_POSITION_QUERY,
+  WORLD_TOPIC_READERS_QUERY,
+} from '../../graphql/worldIndex';
+import type { WorldCategory } from './worldIndexTaxonomy';
+import { worldCategories } from './worldIndexTaxonomy';
+
+/** Rankings and counts are the same answer for everyone, and rebuilt nightly. */
+const indexStaleTime = StaleTime.OneHour;
+
+export interface WorldCatalogue {
+  /** Every topic the index knows, keyed by slug. */
+  bySlug: Map<string, WorldNicheSummary>;
+  /** Categories that actually have topics behind them. */
+  categories: WorldCategory[];
+  isPending: boolean;
+}
+
+/**
+ * The topic catalogue, which every other query on the page is keyed by.
+ *
+ * The grouping is local taxonomy and the ids are the API's, so the two are
+ * joined on the slug here rather than in each consumer. A category whose
+ * niches the API does not return is dropped: an empty tab is worse than one
+ * fewer.
+ */
+export const useWorldCatalogue = (): WorldCatalogue => {
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.WorldTopicReaders),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        worldTopicReaders: { niche: WorldNicheSummary; readers: number }[];
+      }>(WORLD_TOPIC_READERS_QUERY);
+
+      return res.worldTopicReaders.map(({ niche, readers }) => ({
+        ...niche,
+        readers,
+      }));
+    },
+    staleTime: indexStaleTime,
+  });
+
+  return useMemo(() => {
+    const bySlug = new Map((data ?? []).map((niche) => [niche.slug, niche]));
+
+    return {
+      bySlug,
+      categories: worldCategories.filter((category) =>
+        category.topics.some((slug) => bySlug.has(slug)),
+      ),
+      isPending,
+    };
+  }, [data, isPending]);
+};
+
+interface UseWorldTopicRanking {
+  entries: WorldRankEntry[];
+  isPending: boolean;
+}
+
+export const useWorldTopicRanking = ({
+  nicheId,
+  period,
+  limit,
+}: {
+  nicheId?: string;
+  period: WorldRankPeriod;
+  limit?: number;
+}): UseWorldTopicRanking => {
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.WorldTopicRanking, undefined, {
+      nicheId,
+      period,
+      limit,
+    }),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        worldTopicRanking: WorldRankEntry[];
+      }>(WORLD_TOPIC_RANKING_QUERY, { nicheId, period, limit });
+
+      return res.worldTopicRanking;
+    },
+    enabled: !!nicheId,
+    staleTime: indexStaleTime,
+  });
+
+  return { entries: data ?? [], isPending: isPending && !!nicheId };
+};
+
+/**
+ * Where the viewer stands, which the ranking's own page usually will not hold.
+ *
+ * Signed in only, and never merged into the ranking: a row that is already
+ * there must not be drawn twice.
+ */
+export const useWorldTopicRankPosition = ({
+  nicheId,
+  period,
+}: {
+  nicheId?: string;
+  period: WorldRankPeriod;
+}): WorldRankPosition | undefined => {
+  const { isLoggedIn } = useAuthContext();
+
+  const { data } = useQuery({
+    queryKey: generateQueryKey(RequestKey.WorldTopicRankPosition, undefined, {
+      nicheId,
+      period,
+    }),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        worldTopicRankPosition: WorldRankPosition;
+      }>(WORLD_TOPIC_RANK_POSITION_QUERY, { nicheId, period });
+
+      return res.worldTopicRankPosition;
+    },
+    enabled: isLoggedIn && !!nicheId,
+    staleTime: indexStaleTime,
+  });
+
+  return data;
+};
+
+interface UseWorldSection<T> {
+  items: T[];
+  isPending: boolean;
+}
+
+export const useWorldRecentLevelUps = (
+  limit?: number,
+): UseWorldSection<WorldLevelUp> => {
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.WorldRecentLevelUps, undefined, {
+      limit,
+    }),
+    queryFn: async () => {
+      const res = await gqlClient.request<{
+        worldRecentLevelUps: WorldLevelUp[];
+      }>(WORLD_RECENT_LEVEL_UPS_QUERY, { limit });
+
+      return res.worldRecentLevelUps;
+    },
+    staleTime: indexStaleTime,
+  });
+
+  return { items: data ?? [], isPending };
+};
+
+export const useFollowedWorlds = (
+  limit?: number,
+): UseWorldSection<IndexedWorld> => {
+  const { user, isLoggedIn } = useAuthContext();
+
+  const { data, isPending } = useQuery({
+    queryKey: generateQueryKey(RequestKey.FollowedWorlds, user, { limit }),
+    queryFn: async () => {
+      const res = await gqlClient.request<{ followedWorlds: IndexedWorld[] }>(
+        FOLLOWED_WORLDS_QUERY,
+        { limit },
+      );
+
+      return res.followedWorlds;
+    },
+    enabled: isLoggedIn,
+    staleTime: indexStaleTime,
+  });
+
+  return { items: data ?? [], isPending: isPending && isLoggedIn };
+};

--- a/packages/webapp/components/world/worldIndexTaxonomy.ts
+++ b/packages/webapp/components/world/worldIndexTaxonomy.ts
@@ -1,0 +1,132 @@
+import type { WorldNicheSummary } from '../../graphql/worldIndex';
+
+/**
+ * The six realms and the niches inside them, in taxonomy order.
+ *
+ * A standalone copy of what `engine/taxonomy.js` carries, for the same reason
+ * `ladder.ts` is standalone: taxonomy imports three on its first line, and the
+ * index has no renderer to drag half a megabyte in for.
+ *
+ * The index also drops the world's vocabulary, so realms are categories and
+ * districts are topics. The flavour name survives one size down, where it
+ * connects the two without having to be learned first.
+ */
+
+export interface WorldCategory {
+  id: string;
+  /** What the taxonomy calls it, kept small so it never has to be decoded. */
+  worldName: string;
+  name: string;
+  /** Theme variable, for the bars that have to be coloured inline. */
+  accent: string;
+  accentBg: string;
+  /** Niche slugs, in taxonomy order. */
+  topics: string[];
+}
+
+export const worldCategories: WorldCategory[] = [
+  {
+    id: 'swarm',
+    worldName: 'Arcane Swarm',
+    name: 'AI & data',
+    accent: 'var(--theme-accent-cabbage-default)',
+    accentBg: 'bg-accent-cabbage-default',
+    topics: [
+      'ai_llm',
+      'ai_agents',
+      'ai_infra',
+      'ml_ds',
+      'data_eng',
+      'ai_safety',
+      'python',
+    ],
+  },
+  {
+    id: 'frame',
+    worldName: 'Frameworks',
+    name: 'Web & mobile',
+    accent: 'var(--theme-accent-avocado-default)',
+    accentBg: 'bg-accent-avocado-default',
+    topics: [
+      'js_ts',
+      'css_design',
+      'android',
+      'ios_apple',
+      'jvm',
+      'dotnet',
+      'php',
+      'ruby',
+    ],
+  },
+  {
+    id: 'forge',
+    worldName: 'Metal Forges',
+    name: 'Systems & low level',
+    accent: 'var(--theme-accent-bun-default)',
+    accentBg: 'bg-accent-bun-default',
+    topics: ['c_cpp', 'rust', 'linux_os', 'embedded', 'gamedev', 'niche_langs'],
+  },
+  {
+    id: 'ship',
+    worldName: 'Shipyards',
+    name: 'Cloud & infra',
+    accent: 'var(--theme-accent-blueCheese-default)',
+    accentBg: 'bg-accent-blueCheese-default',
+    topics: [
+      'k8s',
+      'cloud',
+      'go',
+      'ci_devex',
+      'observability',
+      'databases',
+      'distributed_arch',
+      'selfhost',
+    ],
+  },
+  {
+    id: 'bastion',
+    worldName: 'Bastion',
+    name: 'Security',
+    accent: 'var(--theme-accent-water-default)',
+    accentBg: 'bg-accent-water-default',
+    topics: ['sec_appsec', 'sec_crypto', 'sec_threats'],
+  },
+  {
+    id: 'quarter',
+    worldName: 'Artisan’s Quarter',
+    name: 'Craft & career',
+    accent: 'var(--theme-accent-bacon-default)',
+    accentBg: 'bg-accent-bacon-default',
+    topics: [
+      'devtools',
+      'git_vcs',
+      'software_craft',
+      'cs_fundamentals',
+      'career',
+      'eng_mgmt',
+      'industry_news',
+      'other',
+    ],
+  },
+];
+
+const categoryBySlug = new Map(
+  worldCategories.flatMap((category) =>
+    category.topics.map((slug) => [slug, category] as const),
+  ),
+);
+
+export const categoryOfSlug = (slug: string): WorldCategory | undefined =>
+  categoryBySlug.get(slug);
+
+export const categoryById = (id: string): WorldCategory =>
+  worldCategories.find((category) => category.id === id) ?? worldCategories[0];
+
+/** Topics of one category, ordered by the taxonomy and named by the API. */
+export const topicsOfCategory = (
+  category: WorldCategory,
+  niches: Map<string, WorldNicheSummary>,
+): WorldNicheSummary[] =>
+  category.topics
+    .map((slug) => niches.get(slug))
+    .filter((niche): niche is WorldNicheSummary => !!niche);

--- a/packages/webapp/graphql/worldIndex.ts
+++ b/packages/webapp/graphql/worldIndex.ts
@@ -1,0 +1,168 @@
+import { gql } from 'graphql-request';
+import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
+
+/** The two windows a topic's ranking is scored over. */
+export enum WorldRankPeriod {
+  Week = 'week',
+  All = 'all',
+}
+
+export interface WorldNiche {
+  id: string;
+  slug: string;
+  title: string;
+}
+
+/** A niche as the index holds it: the topic, plus how many worlds read it. */
+export interface WorldNicheSummary extends WorldNiche {
+  readers: number;
+}
+
+export type WorldIndexOwner = Pick<
+  PublicProfile,
+  'id' | 'name' | 'username' | 'image'
+>;
+
+export interface WorldTopic {
+  niche: WorldNiche;
+  articles: number;
+  level: number;
+}
+
+export interface IndexedWorld {
+  user: WorldIndexOwner;
+  /** Null when nobody has named the place. */
+  name: string | null;
+  topics: number;
+  articles: number;
+  topTopics: WorldTopic[];
+}
+
+export interface WorldRankEntry {
+  rank: number;
+  user: WorldIndexOwner;
+  worldName: string | null;
+  articles: number;
+  level: number;
+}
+
+export interface WorldRankPosition {
+  /** Null beyond `cappedAt`, or when the viewer's world is not listed. */
+  rank: number | null;
+  articles: number;
+  level: number;
+  cappedAt: number;
+}
+
+export interface WorldLevelUp {
+  world: IndexedWorld;
+  niche: WorldNiche;
+  level: number;
+  createdAt: string;
+}
+
+const WORLD_OWNER_FRAGMENT = gql`
+  fragment WorldIndexOwner on User {
+    id
+    name
+    username
+    image
+  }
+`;
+
+const INDEXED_WORLD_FRAGMENT = gql`
+  fragment IndexedWorld on IndexedWorld {
+    user {
+      ...WorldIndexOwner
+    }
+    name
+    topics
+    articles
+    topTopics {
+      niche {
+        id
+        slug
+        title
+      }
+      articles
+      level
+    }
+  }
+  ${WORLD_OWNER_FRAGMENT}
+`;
+
+/**
+ * Every topic and how many worlds read it.
+ *
+ * Doubles as the index's catalogue: the taxonomy the page groups by is local,
+ * but niche ids are the API's, and every other query here is keyed by one.
+ */
+export const WORLD_TOPIC_READERS_QUERY = gql`
+  query WorldTopicReaders {
+    worldTopicReaders {
+      niche {
+        id
+        slug
+        title
+      }
+      readers
+    }
+  }
+`;
+
+export const WORLD_TOPIC_RANKING_QUERY = gql`
+  query WorldTopicRanking(
+    $nicheId: ID!
+    $period: WorldRankPeriod!
+    $limit: Int
+  ) {
+    worldTopicRanking(nicheId: $nicheId, period: $period, limit: $limit) {
+      rank
+      user {
+        ...WorldIndexOwner
+      }
+      worldName
+      articles
+      level
+    }
+  }
+  ${WORLD_OWNER_FRAGMENT}
+`;
+
+export const WORLD_TOPIC_RANK_POSITION_QUERY = gql`
+  query WorldTopicRankPosition($nicheId: ID!, $period: WorldRankPeriod!) {
+    worldTopicRankPosition(nicheId: $nicheId, period: $period) {
+      rank
+      articles
+      level
+      cappedAt
+    }
+  }
+`;
+
+export const WORLD_RECENT_LEVEL_UPS_QUERY = gql`
+  query WorldRecentLevelUps($limit: Int) {
+    worldRecentLevelUps(limit: $limit) {
+      world {
+        ...IndexedWorld
+      }
+      niche {
+        id
+        slug
+        title
+      }
+      level
+      createdAt
+    }
+  }
+  ${INDEXED_WORLD_FRAGMENT}
+`;
+
+export const FOLLOWED_WORLDS_QUERY = gql`
+  query FollowedWorlds($limit: Int) {
+    followedWorlds(limit: $limit) {
+      ...IndexedWorld
+    }
+  }
+  ${INDEXED_WORLD_FRAGMENT}
+`;

--- a/packages/webapp/pages/world/index.tsx
+++ b/packages/webapp/pages/world/index.tsx
@@ -184,11 +184,14 @@ const LadderRow = ({
             </Typography>
           </div>
 
+          {/* Fixed width, or a two-digit level makes this badge wider than a
+              one-digit one and every column to its left starts somewhere
+              different from the row above. */}
           <Typography
             type={TypographyType.Caption1}
             bold
             color={TypographyColor.Tertiary}
-            className="shrink-0 rounded-8 border border-border-subtlest-tertiary px-2 py-0.5"
+            className="w-14 shrink-0 rounded-8 border border-border-subtlest-tertiary px-2 py-0.5 text-center tabular-nums"
           >
             Lv {level}
           </Typography>
@@ -207,7 +210,7 @@ const RowsPlaceholder = ({ rows }: { rows: number }): ReactElement => (
 );
 
 const CardsPlaceholder = ({ cards }: { cards: number }): ReactElement => (
-  <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-4">
+  <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-3">
     {Array.from({ length: cards }, (_, index) => (
       <ElementPlaceholder key={index} className="h-44 w-full rounded-16" />
     ))}
@@ -416,13 +419,16 @@ function WorldIndexPage(): ReactElement {
                 >
                   in {category?.name ?? ''}
                 </Typography>
+                {/* An all-time count whichever period is showing, because it
+                    is the only one the API keeps. Said plainly, so it does not
+                    read as a weekly number that never moves. */}
                 {!!topic && (
                   <Typography
                     type={TypographyType.Caption1}
                     color={TypographyColor.Tertiary}
                     className="ml-auto tabular-nums"
                   >
-                    {topic.readers.toLocaleString()} people read this topic
+                    {topic.readers.toLocaleString()} readers all time
                   </Typography>
                 )}
               </div>
@@ -492,7 +498,7 @@ function WorldIndexPage(): ReactElement {
                       key={`${entry.world.user.id}-${entry.niche.id}`}
                       world={entry.world}
                       event={`${entry.niche.title} hit level ${entry.level}`}
-                      className="w-72 shrink-0"
+                      className="w-64 shrink-0 tablet:w-80"
                     />
                   ))}
                 </div>

--- a/packages/webapp/pages/world/index.tsx
+++ b/packages/webapp/pages/world/index.tsx
@@ -1,0 +1,534 @@
+import type { ReactElement } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import type { NextSeoProps } from 'next-seo';
+import classNames from 'classnames';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import { ProgressBar } from '@dailydotdev/shared/src/components/fields/ProgressBar';
+import { LayoutHeader } from '@dailydotdev/shared/src/components/layout/common';
+import { PageHeader } from '@dailydotdev/shared/src/components/layout/PageHeader';
+import {
+  ProfileImageSize,
+  ProfilePicture,
+} from '@dailydotdev/shared/src/components/ProfilePicture';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import {
+  pageBorders,
+  ResponsivePageContainer,
+} from '@dailydotdev/shared/src/components/utilities';
+import Link from '@dailydotdev/shared/src/components/utilities/Link';
+import { ElementPlaceholder } from '@dailydotdev/shared/src/components/ElementPlaceholder';
+import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { getLayout as getFooterNavBarLayout } from '../../components/layouts/FooterNavBarLayout';
+import { getLayout } from '../../components/layouts/MainLayout';
+import { getPageSeoTitles } from '../../components/layouts/utils';
+import { defaultOpenGraph } from '../../next-seo';
+import { WorldIndexCard } from '../../components/world/WorldIndexCard';
+import type {
+  WorldNicheSummary,
+  WorldRankEntry,
+} from '../../graphql/worldIndex';
+import { WorldRankPeriod } from '../../graphql/worldIndex';
+import type { WorldCategory } from '../../components/world/worldIndexTaxonomy';
+import { topicsOfCategory } from '../../components/world/worldIndexTaxonomy';
+import {
+  useFollowedWorlds,
+  useWorldCatalogue,
+  useWorldRecentLevelUps,
+  useWorldTopicRankPosition,
+  useWorldTopicRanking,
+} from '../../components/world/useWorldIndex';
+
+const seoTitles = getPageSeoTitles('Worlds');
+const seo: NextSeoProps = {
+  title: seoTitles.title,
+  openGraph: { ...seoTitles.openGraph, ...defaultOpenGraph },
+  description:
+    'Reading builds your world. See who reads the same topics you do.',
+};
+
+const RANKING_LIMIT = 10;
+const SECTION_LIMIT = 8;
+
+interface SectionHeaderProps {
+  title: string;
+  description: string;
+  action?: ReactElement;
+}
+
+const SectionHeader = ({
+  title,
+  description,
+  action,
+}: SectionHeaderProps): ReactElement => (
+  <div className="flex flex-col gap-2 laptop:flex-row laptop:items-end laptop:justify-between">
+    <div className="flex flex-col gap-1">
+      <Typography tag={TypographyTag.H2} type={TypographyType.Body} bold>
+        {title}
+      </Typography>
+      <Typography
+        type={TypographyType.Callout}
+        color={TypographyColor.Tertiary}
+        className="max-w-2xl"
+      >
+        {description}
+      </Typography>
+    </div>
+    {action}
+  </div>
+);
+
+interface LadderRowProps {
+  rank: number;
+  user: WorldRankEntry['user'];
+  worldName: string | null;
+  articles: number;
+  level: number;
+  accent: string;
+  accentBg: string;
+  max: number;
+  isOwn?: boolean;
+  /** True where the ranking skips, so the jump is drawn instead of implied. */
+  afterGap?: boolean;
+}
+
+const LadderRow = ({
+  rank,
+  user,
+  worldName,
+  articles,
+  level,
+  accent,
+  accentBg,
+  max,
+  isOwn,
+  afterGap,
+}: LadderRowProps): ReactElement => (
+  <>
+    {afterGap && (
+      <li
+        aria-hidden
+        role="presentation"
+        className="px-2 text-text-quaternary typo-caption1"
+      >
+        ···
+      </li>
+    )}
+    {/* The viewer's row is marked with the topic's own colour and full-contrast
+        text rather than a grey fill: a tint dark enough to see behind a row is
+        a tint that drags the text on it below contrast in one of the themes. */}
+    <li
+      className={classNames('rounded-10', isOwn && 'border-l-2')}
+      style={isOwn ? { borderLeftColor: accent } : undefined}
+    >
+      <Link href={`/world/${user.username}`} passHref prefetch={false}>
+        <a
+          className={classNames(
+            'flex items-center gap-3 rounded-10 py-2 pr-2',
+            isOwn ? 'pl-1.5' : 'pl-2 hover:bg-surface-hover',
+          )}
+        >
+          <Typography
+            type={TypographyType.Callout}
+            bold
+            color={isOwn ? TypographyColor.Primary : TypographyColor.Quaternary}
+            className="inline-flex w-8 shrink-0 justify-center tabular-nums"
+          >
+            {rank}
+          </Typography>
+
+          <ProfilePicture
+            user={user}
+            size={ProfileImageSize.Medium}
+            nativeLazyLoading
+          />
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <Typography type={TypographyType.Footnote} bold truncate>
+              {user.name}
+            </Typography>
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Tertiary}
+              truncate
+            >
+              {worldName ?? `@${user.username}`}
+            </Typography>
+          </div>
+
+          <div className="hidden w-36 shrink-0 items-center gap-2 laptop:flex">
+            <ProgressBar
+              percentage={max ? Math.round((articles / max) * 100) : 0}
+              shouldShowBg
+              className={{
+                wrapper: 'h-1.5 flex-1 rounded-8',
+                bar: 'h-1.5 rounded-8',
+                barColor: accentBg,
+              }}
+            />
+            <Typography
+              type={TypographyType.Caption2}
+              color={TypographyColor.Tertiary}
+              className="w-10 shrink-0 text-right tabular-nums"
+            >
+              {articles.toLocaleString()}
+            </Typography>
+          </div>
+
+          <Typography
+            type={TypographyType.Caption1}
+            bold
+            color={TypographyColor.Tertiary}
+            className="shrink-0 rounded-8 border border-border-subtlest-tertiary px-2 py-0.5"
+          >
+            Lv {level}
+          </Typography>
+        </a>
+      </Link>
+    </li>
+  </>
+);
+
+const RowsPlaceholder = ({ rows }: { rows: number }): ReactElement => (
+  <div className="flex flex-col gap-2 p-2">
+    {Array.from({ length: rows }, (_, index) => (
+      <ElementPlaceholder key={index} className="h-11 w-full rounded-10" />
+    ))}
+  </div>
+);
+
+const CardsPlaceholder = ({ cards }: { cards: number }): ReactElement => (
+  <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-4">
+    {Array.from({ length: cards }, (_, index) => (
+      <ElementPlaceholder key={index} className="h-44 w-full rounded-16" />
+    ))}
+  </div>
+);
+
+function WorldIndexPage(): ReactElement {
+  const { isV2 } = useLayoutVariant();
+  const { user, isLoggedIn } = useAuthContext();
+  const {
+    bySlug,
+    categories,
+    isPending: isCataloguePending,
+  } = useWorldCatalogue();
+
+  const [categoryId, setCategoryId] = useState<string | null>(null);
+  const [topicSlug, setTopicSlug] = useState<string | null>(null);
+  const [period, setPeriod] = useState<WorldRankPeriod>(WorldRankPeriod.Week);
+
+  const category = useMemo(
+    () => categories.find((item) => item.id === categoryId) ?? categories[0],
+    [categories, categoryId],
+  );
+  const topics = useMemo(
+    () => (category ? topicsOfCategory(category, bySlug) : []),
+    [category, bySlug],
+  );
+  const topic = useMemo(
+    () => topics.find((item) => item.slug === topicSlug) ?? topics[0],
+    [topics, topicSlug],
+  );
+
+  /* The catalogue arrives after the first render, so the opening topic is
+     settled once it lands rather than guessed from a slug that may not exist. */
+  useEffect(() => {
+    if (!categoryId && categories.length) {
+      setCategoryId(categories[0].id);
+    }
+  }, [categories, categoryId]);
+
+  const { entries, isPending: isRankingPending } = useWorldTopicRanking({
+    nicheId: topic?.id,
+    period,
+    limit: RANKING_LIMIT,
+  });
+  const position = useWorldTopicRankPosition({ nicheId: topic?.id, period });
+  const { items: levelUps, isPending: isLevelUpsPending } =
+    useWorldRecentLevelUps(SECTION_LIMIT);
+  const { items: followed, isPending: isFollowedPending } =
+    useFollowedWorlds(SECTION_LIMIT);
+
+  const maxArticles = entries.length ? entries[0].articles : 0;
+  const isOwnRanked = entries.some((entry) => entry.user.id === user?.id);
+  /* Only when the ranking's page does not already hold the viewer, and only
+     when the ranking states a placing for them at all. */
+  const ownRow =
+    isLoggedIn && user && position?.rank != null && !isOwnRanked
+      ? {
+          rank: position.rank,
+          articles: position.articles,
+          level: position.level,
+          user,
+        }
+      : null;
+
+  const onCategoryChange = (next: WorldCategory): void => {
+    setCategoryId(next.id);
+    setTopicSlug(null);
+  };
+
+  const rankingDescription =
+    period === WorldRankPeriod.Week
+      ? `Ranked by ${
+          topic?.title ?? 'topic'
+        } articles read in the last seven days. The count starts over every week, so a good week is enough to place.`
+      : `Ranked by every ${
+          topic?.title ?? 'topic'
+        } article read. Someone who only reads one topic can beat someone who reads a bit of everything.`;
+
+  return (
+    <>
+      {isV2 && <PageHeader title="Worlds" />}
+      <div className="mx-auto w-full max-w-[72rem]">
+        {!isV2 && (
+          <LayoutHeader
+            className={classNames('!mb-0 gap-2 border-b px-4', pageBorders)}
+          >
+            <Typography type={TypographyType.Title3} bold className="flex-1">
+              Worlds
+            </Typography>
+          </LayoutHeader>
+        )}
+
+        <ResponsivePageContainer className="!mx-0 !w-full !max-w-full gap-8 pb-10">
+          {/* ---------- pick a topic ---------- */}
+          <section className="flex flex-col gap-4">
+            <SectionHeader
+              title="Browse by category"
+              description="Six categories, forty topics. Pick one to see who reads it most."
+            />
+
+            {isCataloguePending ? (
+              <div className="grid grid-cols-2 gap-2 tablet:grid-cols-3 laptop:grid-cols-6">
+                {Array.from({ length: 6 }, (_, index) => (
+                  <ElementPlaceholder
+                    key={index}
+                    className="h-24 w-full rounded-12"
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-2 tablet:grid-cols-3 laptop:grid-cols-6">
+                {categories.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    aria-pressed={item.id === category?.id}
+                    onClick={() => onCategoryChange(item)}
+                    className={classNames(
+                      'flex flex-col gap-2 rounded-12 border p-3 text-left transition-colors',
+                      item.id === category?.id
+                        ? 'border-border-subtlest-secondary bg-surface-float'
+                        : 'border-border-subtlest-tertiary hover:border-border-subtlest-secondary',
+                    )}
+                  >
+                    <span
+                      className="h-1 w-full rounded-6"
+                      style={{ backgroundColor: item.accent }}
+                    />
+                    <Typography type={TypographyType.Footnote} bold>
+                      {item.name}
+                    </Typography>
+                    <Typography
+                      type={TypographyType.Caption2}
+                      color={TypographyColor.Quaternary}
+                    >
+                      {item.worldName}
+                    </Typography>
+                    <Typography
+                      type={TypographyType.Caption2}
+                      color={TypographyColor.Tertiary}
+                      className="mt-auto tabular-nums"
+                    >
+                      {item.topics.filter((slug) => bySlug.has(slug)).length}{' '}
+                      topics
+                    </Typography>
+                  </button>
+                ))}
+              </div>
+            )}
+          </section>
+
+          {/* ---------- the ranking ---------- */}
+          <section className="flex flex-col gap-4">
+            <SectionHeader
+              title={topic ? `Top in ${topic.title}` : 'Top readers'}
+              description={rankingDescription}
+              action={
+                <div className="flex gap-1">
+                  <Button
+                    type="button"
+                    variant={ButtonVariant.Float}
+                    size={ButtonSize.Small}
+                    pressed={period === WorldRankPeriod.Week}
+                    onClick={() => setPeriod(WorldRankPeriod.Week)}
+                  >
+                    This week
+                  </Button>
+                  <Button
+                    type="button"
+                    variant={ButtonVariant.Float}
+                    size={ButtonSize.Small}
+                    pressed={period === WorldRankPeriod.All}
+                    onClick={() => setPeriod(WorldRankPeriod.All)}
+                  >
+                    All time
+                  </Button>
+                </div>
+              }
+            />
+
+            <div className="flex gap-2 overflow-x-auto pb-1">
+              {topics.map((item: WorldNicheSummary) => (
+                <Button
+                  key={item.id}
+                  type="button"
+                  variant={ButtonVariant.Float}
+                  size={ButtonSize.Small}
+                  pressed={item.id === topic?.id}
+                  onClick={() => setTopicSlug(item.slug)}
+                  className="shrink-0"
+                >
+                  {item.title}
+                </Button>
+              ))}
+            </div>
+
+            <div className="rounded-16 border border-border-subtlest-tertiary bg-surface-float">
+              <div className="flex flex-wrap items-center gap-2 border-b border-border-subtlest-tertiary px-4 py-3">
+                <Typography type={TypographyType.Footnote} bold>
+                  {topic?.title ?? ''}
+                </Typography>
+                <Typography
+                  type={TypographyType.Caption1}
+                  color={TypographyColor.Tertiary}
+                >
+                  in {category?.name ?? ''}
+                </Typography>
+                {!!topic && (
+                  <Typography
+                    type={TypographyType.Caption1}
+                    color={TypographyColor.Tertiary}
+                    className="ml-auto tabular-nums"
+                  >
+                    {topic.readers.toLocaleString()} people read this topic
+                  </Typography>
+                )}
+              </div>
+
+              {isRankingPending || isCataloguePending ? (
+                <RowsPlaceholder rows={6} />
+              ) : (
+                <ol className="flex flex-col gap-0.5 p-2">
+                  {entries.map((entry) => (
+                    <LadderRow
+                      key={entry.user.id}
+                      rank={entry.rank}
+                      user={entry.user}
+                      worldName={entry.worldName}
+                      articles={entry.articles}
+                      level={entry.level}
+                      accent={category?.accent ?? ''}
+                      accentBg={category?.accentBg ?? ''}
+                      max={maxArticles}
+                      isOwn={entry.user.id === user?.id}
+                    />
+                  ))}
+
+                  {!!ownRow && (
+                    <LadderRow
+                      rank={ownRow.rank}
+                      user={ownRow.user}
+                      worldName={null}
+                      articles={ownRow.articles}
+                      level={ownRow.level}
+                      accent={category?.accent ?? ''}
+                      accentBg={category?.accentBg ?? ''}
+                      max={maxArticles}
+                      isOwn
+                      afterGap
+                    />
+                  )}
+
+                  {!entries.length && (
+                    <Typography
+                      type={TypographyType.Callout}
+                      color={TypographyColor.Tertiary}
+                      className="px-2 py-6 text-center"
+                    >
+                      Nobody has read enough of this topic yet. Be the first.
+                    </Typography>
+                  )}
+                </ol>
+              )}
+            </div>
+          </section>
+
+          {/* ---------- fresh, and mostly small worlds ---------- */}
+          {(isLevelUpsPending || !!levelUps.length) && (
+            <section className="flex flex-col gap-4">
+              <SectionHeader
+                title="Just leveled up"
+                description="Topics that reached a new level today. Small worlds level up far more often than big ones, so this list changes daily."
+              />
+
+              {isLevelUpsPending ? (
+                <CardsPlaceholder cards={4} />
+              ) : (
+                <div className="flex gap-3 overflow-x-auto pb-2">
+                  {levelUps.map((entry) => (
+                    <WorldIndexCard
+                      key={`${entry.world.user.id}-${entry.niche.id}`}
+                      world={entry.world}
+                      event={`${entry.niche.title} hit level ${entry.level}`}
+                      className="w-72 shrink-0"
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+
+          {/* ---------- people already known to the viewer ---------- */}
+          {isLoggedIn && (isFollowedPending || !!followed.length) && (
+            <section className="flex flex-col gap-4">
+              <SectionHeader
+                title="People you follow"
+                description="Worlds built by the people you follow and everyone in your squads."
+              />
+
+              {isFollowedPending ? (
+                <CardsPlaceholder cards={4} />
+              ) : (
+                <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-4">
+                  {followed.map((world) => (
+                    <WorldIndexCard key={world.user.id} world={world} />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
+        </ResponsivePageContainer>
+      </div>
+    </>
+  );
+}
+
+const getWorldIndexLayout: typeof getLayout = (...props) =>
+  getFooterNavBarLayout(getLayout(...props));
+
+WorldIndexPage.getLayout = getWorldIndexLayout;
+WorldIndexPage.layoutProps = { screenCentered: false, seo };
+
+export default WorldIndexPage;


### PR DESCRIPTION
The front end for the world index at `/world`. Depends on dailydotdev/daily-api#4070, which adds the queries; **do not merge this first** or the quest below will point at a page whose queries do not exist yet.

## What it is

Every reader builds a world, and until now each one was only reachable from its owner's profile. The index ranks readers **by topic** rather than by world size, so somebody deep in one subject places against the people who read that subject instead of against everyone.

Two periods, defaulting to the week. All time is largely a record of who started earliest; a week resets, so a good week is enough to place. On `js_ts` today that is 264 articles at the top of the week against 8,749 all time, with no overlap in the names.

## Sections

- **Browse by category** — six categories over forty topics
- **Top in {topic}** — the ranking, with the viewer's own placing appended when the page does not already hold it
- **Just leveled up** — topics that crossed a rung, which skews to small worlds by construction
- **People you follow** — signed in only

## Notes for review

**The taxonomy is local.** `engine/taxonomy.js` imports three on its first line, so the index would have pulled the whole renderer in to group six categories. `worldIndexTaxonomy.ts` carries the grouping only, the same reasoning that split `ladder.ts` out. Niche ids come from `worldTopicReaders`, which doubles as the catalogue, and the two join on slug.

**The readers count is all-time on both tabs**, because that is the only count the API keeps. It says "readers all time" rather than sitting unlabelled under a weekly tab and reading as a number that never moves. A real weekly figure needs a period argument on `worldTopicReaders`.

**Categories have no stats of their own.** The API only knows niches; the six categories exist only here. Aggregating them client side would double-count readers and, worse, would bias the ranking toward specialists, because `user_niche_rank` only keeps the top 1,000 per niche and a generalist can sit past that cap in every one. That needs a server-side view and is deliberately not in this PR.

**The quest destination moved.** `visit_user_world` pointed at `/users` because worlds had no index. It points here now.

## Verification

Lint and the changed-file strict typecheck pass. The shared quest suites (30) and the dependent webapp world suites (14) pass. Queries were checked against production before wiring.


### Preview domain
https://feat-world-index.preview.app.daily.dev