### PR TITLE
feat: canonicalize own profile URL

### DIFF
--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -29,6 +29,7 @@ import { ProfileCompletion } from '@dailydotdev/shared/src/features/profile/comp
 import { Share } from '@dailydotdev/shared/src/features/profile/components/ProfileWidgets/Share';
 import { useRouter } from 'next/router';
 import { useProfileCompletionIndicator } from '@dailydotdev/shared/src/hooks/profile/useProfileCompletionIndicator';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import {
   getLayout as getProfileLayout,
   getProfileSeoDefaults,
@@ -48,6 +49,7 @@ const ProfilePage = ({
 }: ProfileLayoutProps): ReactElement => {
   useJoinReferral();
   const router = useRouter();
+  const { isAuthReady } = useAuthContext();
   const { status, onUpload, shouldShow } = useUploadCv();
   const { checkHasCompleted } = useActions();
   const hasClosedBanner = useMemo(
@@ -60,7 +62,12 @@ const ProfilePage = ({
   const { user, isUserSame: isUserSameBase } = useProfile(initialUser);
 
   useEffect(() => {
-    if (!router.isReady || !isUserSameBase || router.query.userId !== user.id) {
+    if (
+      !isAuthReady ||
+      !router.isReady ||
+      !isUserSameBase ||
+      router.query.userId !== user.id
+    ) {
       return;
     }
 
@@ -72,7 +79,7 @@ const ProfilePage = ({
       undefined,
       { shallow: true },
     );
-  }, [isUserSameBase, router, user.id, user.username]);
+  }, [isAuthReady, isUserSameBase, router, user.id, user.username]);
 
   // Check if preview mode is enabled via query param
   const isPreviewMode = router.query.preview === 'true';

--- a/packages/webapp/pages/[userId]/index.tsx
+++ b/packages/webapp/pages/[userId]/index.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { AboutMe } from '@dailydotdev/shared/src/features/profile/components/AboutMe';
 import { Activity } from '@dailydotdev/shared/src/features/profile/components/Activity';
 import { useProfile } from '@dailydotdev/shared/src/hooks/profile/useProfile';
@@ -58,6 +58,21 @@ const ProfilePage = ({
     useProfileCompletionIndicator();
 
   const { user, isUserSame: isUserSameBase } = useProfile(initialUser);
+
+  useEffect(() => {
+    if (!router.isReady || !isUserSameBase || router.query.userId !== user.id) {
+      return;
+    }
+
+    router.replace(
+      {
+        pathname: router.pathname,
+        query: { ...router.query, userId: user.username },
+      },
+      undefined,
+      { shallow: true },
+    );
+  }, [isUserSameBase, router, user.id, user.username]);
 
   // Check if preview mode is enabled via query param
   const isPreviewMode = router.query.preview === 'true';


### PR DESCRIPTION
## Summary

- replace an authenticated users ID profile URL with their username after boot resolves
- preserve existing query parameters and use shallow routing

## Validation

- package lint passed
- no app test changes requested

### Preview domain
https://feat-me-profile-redirect.preview.app.daily.dev