### PR TITLE
fix(world): let the follow section grow, and stop it clipping

### DIFF
--- a/packages/webapp/pages/world/index.tsx
+++ b/packages/webapp/pages/world/index.tsx
@@ -58,6 +58,9 @@ const seo: NextSeoProps = {
 
 const RANKING_LIMIT = 10;
 const SECTION_LIMIT = 8;
+/* The most one call may ask a section for, matching the API's own ceiling.
+   Past this the section needs real pagination rather than a bigger number. */
+const SECTION_EXPANDED_LIMIT = 50;
 
 interface SectionHeaderProps {
   title: string;
@@ -293,8 +296,13 @@ function WorldIndexPage(): ReactElement {
   });
   const { items: levelUps, isPending: isLevelUpsPending } =
     useWorldRecentLevelUps(SECTION_LIMIT);
+  const [followLimit, setFollowLimit] = useState(SECTION_LIMIT);
   const { items: followed, isPending: isFollowedPending } =
-    useFollowedWorlds(SECTION_LIMIT);
+    useFollowedWorlds(followLimit);
+  /* A full page is the only signal there may be more: the query answers with a
+     list, not a total. Worth one wasted press at exactly eight follows. */
+  const canExpandFollowed =
+    followLimit === SECTION_LIMIT && followed.length === SECTION_LIMIT;
 
   const maxArticles = rows.length ? rows[0].articles : 0;
   const isOwnRanked = rows.some((entry) => entry.user.id === user?.id);
@@ -562,17 +570,29 @@ function WorldIndexPage(): ReactElement {
             <section className="flex flex-col gap-4">
               <SectionHeader
                 title="People you follow"
-                description="Worlds built by the people you follow and everyone in your squads."
+                description="Worlds built by the people you follow."
               />
 
               {isFollowedPending ? (
                 <CardsPlaceholder cards={4} />
               ) : (
-                <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-4">
+                <div className="grid gap-3 tablet:grid-cols-2 laptop:grid-cols-3">
                   {followed.map((world) => (
                     <WorldIndexCard key={world.user.id} world={world} />
                   ))}
                 </div>
+              )}
+
+              {canExpandFollowed && (
+                <Button
+                  type="button"
+                  variant={ButtonVariant.Float}
+                  size={ButtonSize.Small}
+                  onClick={() => setFollowLimit(SECTION_EXPANDED_LIMIT)}
+                  className="self-center"
+                >
+                  Show more
+                </Button>
               )}
             </section>
           )}


### PR DESCRIPTION
Three fixes in the world index's follow section. Pairs with dailydotdev/daily-api#4077, which stops the query returning squadmates; **merge the API first** or the copy here will under-promise what the section shows.

## The copy

No longer says "and everyone in your squads", because it no longer does.

## A show-more control

The section never had one; it showed eight worlds and stopped. It now expands to the API's own per-section ceiling.

The button only appears when the last call came back full. The query answers with a list and no total, so a full page is the only available signal that there may be more. That costs one wasted press for somebody following exactly eight people with listable worlds, which seemed better than a count the API would have to be extended to provide.

**This is not unbounded.** It tops out at `WORLD_RANK_MAX_LIMIT` (50) server-side, so somebody following more than fifty people with listable worlds cannot reach the rest. A true "see all" needs cursor pagination on `followedWorlds`, deliberately left out of the original PR because every consumer took a small limit. Worth doing, but as its own change.

## The grid, which was my mistake

It was still four across. When card truncation was raised earlier I narrowed the loading placeholder to three columns but the replacement on the real grid silently did nothing, so the skeleton was three across, the cards were four, and the layout jumped the moment data landed. The cards also never got the extra width that change was supposed to give them. Both are three now.

## Verification

Strict typecheck and lint pass.


### Preview domain
https://world-following-only.preview.app.daily.dev