### PR TITLE
feat(world): fetch more followed worlds instead of stopping at fifty

### DIFF
--- a/packages/webapp/components/world/useWorldIndex.ts
+++ b/packages/webapp/components/world/useWorldIndex.ts
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import {
@@ -8,6 +8,7 @@ import {
   StaleTime,
 } from '@dailydotdev/shared/src/lib/query';
 import type {
+  FollowedWorldsConnection,
   IndexedWorld,
   WorldDomainRankEntry,
   WorldDomainReaders,
@@ -239,24 +240,41 @@ export const useWorldRecentLevelUps = (
   return { items: data ?? [], isPending };
 };
 
-export const useFollowedWorlds = (
-  limit?: number,
-): UseWorldSection<IndexedWorld> => {
+export interface UseFollowedWorlds extends UseWorldSection<IndexedWorld> {
+  fetchNextPage: () => void;
+  /* Separate from `fetchNextPage` on purpose: deriving "can I fetch more" from
+     a callback's existence is always true and hides the end of the list. */
+  canFetchMore: boolean;
+  isFetchingNextPage: boolean;
+}
+
+export const useFollowedWorlds = (first?: number): UseFollowedWorlds => {
   const { user, isLoggedIn } = useAuthContext();
 
-  const { data, isPending } = useQuery({
-    queryKey: generateQueryKey(RequestKey.FollowedWorlds, user, { limit }),
-    queryFn: async () => {
-      const res = await gqlClient.request<{ followedWorlds: IndexedWorld[] }>(
-        FOLLOWED_WORLDS_QUERY,
-        { limit },
-      );
+  const query = useInfiniteQuery({
+    queryKey: generateQueryKey(RequestKey.FollowedWorlds, user, { first }),
+    queryFn: async ({ pageParam }) => {
+      const res = await gqlClient.request<{
+        followedWorlds: FollowedWorldsConnection;
+      }>(FOLLOWED_WORLDS_QUERY, { first, after: pageParam || null });
 
       return res.followedWorlds;
     },
     enabled: isLoggedIn,
     staleTime: indexStaleTime,
+    initialPageParam: '',
+    getNextPageParam: ({ pageInfo }) =>
+      pageInfo.hasNextPage ? pageInfo.endCursor : null,
   });
 
-  return { items: data ?? [], isPending: isPending && isLoggedIn };
+  return {
+    items:
+      query.data?.pages.flatMap((page) =>
+        page.edges.map((edge) => edge.node),
+      ) ?? [],
+    isPending: query.isPending && isLoggedIn,
+    fetchNextPage: query.fetchNextPage,
+    canFetchMore: !!query.hasNextPage && !query.isFetchingNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+  };
 };

--- a/packages/webapp/graphql/worldIndex.ts
+++ b/packages/webapp/graphql/worldIndex.ts
@@ -69,6 +69,11 @@ export interface WorldRankPosition {
   cappedAt: number;
 }
 
+export interface FollowedWorldsConnection {
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  edges: { node: IndexedWorld }[];
+}
+
 export interface WorldLevelUp {
   world: IndexedWorld;
   niche: WorldNiche;
@@ -177,9 +182,17 @@ export const WORLD_RECENT_LEVEL_UPS_QUERY = gql`
 `;
 
 export const FOLLOWED_WORLDS_QUERY = gql`
-  query FollowedWorlds($limit: Int) {
-    followedWorlds(limit: $limit) {
-      ...IndexedWorld
+  query FollowedWorlds($first: Int, $after: String) {
+    followedWorlds(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      edges {
+        node {
+          ...IndexedWorld
+        }
+      }
     }
   }
   ${INDEXED_WORLD_FRAGMENT}

--- a/packages/webapp/pages/world/index.tsx
+++ b/packages/webapp/pages/world/index.tsx
@@ -58,9 +58,6 @@ const seo: NextSeoProps = {
 
 const RANKING_LIMIT = 10;
 const SECTION_LIMIT = 8;
-/* The most one call may ask a section for, matching the API's own ceiling.
-   Past this the section needs real pagination rather than a bigger number. */
-const SECTION_EXPANDED_LIMIT = 50;
 
 interface SectionHeaderProps {
   title: string;
@@ -296,13 +293,13 @@ function WorldIndexPage(): ReactElement {
   });
   const { items: levelUps, isPending: isLevelUpsPending } =
     useWorldRecentLevelUps(SECTION_LIMIT);
-  const [followLimit, setFollowLimit] = useState(SECTION_LIMIT);
-  const { items: followed, isPending: isFollowedPending } =
-    useFollowedWorlds(followLimit);
-  /* A full page is the only signal there may be more: the query answers with a
-     list, not a total. Worth one wasted press at exactly eight follows. */
-  const canExpandFollowed =
-    followLimit === SECTION_LIMIT && followed.length === SECTION_LIMIT;
+  const {
+    items: followed,
+    isPending: isFollowedPending,
+    fetchNextPage: fetchMoreFollowed,
+    canFetchMore: canFetchMoreFollowed,
+    isFetchingNextPage: isFetchingMoreFollowed,
+  } = useFollowedWorlds(SECTION_LIMIT);
 
   const maxArticles = rows.length ? rows[0].articles : 0;
   const isOwnRanked = rows.some((entry) => entry.user.id === user?.id);
@@ -583,12 +580,13 @@ function WorldIndexPage(): ReactElement {
                 </div>
               )}
 
-              {canExpandFollowed && (
+              {(canFetchMoreFollowed || isFetchingMoreFollowed) && (
                 <Button
                   type="button"
                   variant={ButtonVariant.Float}
                   size={ButtonSize.Small}
-                  onClick={() => setFollowLimit(SECTION_EXPANDED_LIMIT)}
+                  loading={isFetchingMoreFollowed}
+                  onClick={() => fetchMoreFollowed()}
                   className="self-center"
                 >
                   Show more


### PR DESCRIPTION
Reads the paginated `followedWorlds` from dailydotdev/daily-api#4079. **Merge the API first**, since this query no longer type-checks against the current schema.

## What changes

The section asked for eight worlds and could expand once to fifty, then stopped. It reads the connection now, so "Show more" fetches the next page and keeps going until there is none.

`useFollowedWorlds` moves to `useInfiniteQuery` and returns `fetchNextPage`, `canFetchMore` and `isFetchingNextPage` as separate values. `canFetchMore` comes off `hasNextPage`, not off whether a callback exists, which would be true forever and hide the end of the list.

The button stays visible while a page is in flight so it can show its loading state, rather than vanishing and reappearing.

## Verification

Strict typecheck and lint pass.


### Preview domain
https://world-follow-pagination.preview.app.daily.dev