### PR TITLE
feat(world): give the index somewhere to be found from

### DIFF
--- a/packages/shared/src/components/sidebar/sections/DiscoverSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/DiscoverSection.tsx
@@ -10,6 +10,7 @@ import {
   HashtagIcon,
   HotIcon,
   TourIcon,
+  WorldIcon,
 } from '../../icons';
 import { MedalIcon } from '../../icons/Medal';
 import { Section } from '../Section';
@@ -82,6 +83,14 @@ export const DiscoverSection = ({
         ),
         title: 'Leaderboard',
         path: `${webappUrl}users`,
+        isForcedLink: true,
+      },
+      {
+        icon: (active: boolean) => (
+          <ListIcon Icon={() => <WorldIcon secondary={active} />} />
+        ),
+        title: 'Worlds',
+        path: `${webappUrl}world`,
         isForcedLink: true,
       },
       {

--- a/packages/webapp/components/world/WorldDistrictFeed.tsx
+++ b/packages/webapp/components/world/WorldDistrictFeed.tsx
@@ -7,8 +7,12 @@ import { PostEngagementCounts } from '@dailydotdev/shared/src/components/cards/S
 import { ListItemPlaceholder } from '@dailydotdev/shared/src/components/widgets/ListItemPlaceholder';
 import InfiniteScrolling from '@dailydotdev/shared/src/components/containers/InfiniteScrolling';
 import { ButtonSize } from '@dailydotdev/shared/src/components/buttons/Button';
-import { UpvoteIcon } from '@dailydotdev/shared/src/components/icons';
+import {
+  ArrowIcon,
+  UpvoteIcon,
+} from '@dailydotdev/shared/src/components/icons';
 import { IconSize } from '@dailydotdev/shared/src/components/Icon';
+import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
 import {
   Typography,
   TypographyTag,
@@ -83,6 +87,21 @@ export function WorldDistrictFeed({
           aria-label="Close district"
         />
       </header>
+
+      {/* The most pointed link the world has to the index: a reader looking at
+          one district is already asking who else built here, and the topic
+          board answers exactly that. Carries the niche id because that is what
+          a selected district knows itself by; the index accepts either. */}
+      <Link
+        href={`${webappUrl}world?topic=${district.nicheId}`}
+        passHref
+        prefetch={false}
+      >
+        <a className="mx-4 mb-1 flex items-center gap-1 rounded-8 py-1 text-text-tertiary typo-caption1 hover:text-text-primary">
+          See who else reads {district.name}
+          <ArrowIcon className="rotate-90" size={IconSize.XSmall} />
+        </a>
+      </Link>
 
       {/* The rows carry their own horizontal padding so the hover fill runs the
           full width of the panel rather than stopping inside a gutter. */}

--- a/packages/webapp/pages/world/index.tsx
+++ b/packages/webapp/pages/world/index.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import React, { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/router';
 import type { NextSeoProps } from 'next-seo';
 import classNames from 'classnames';
 import {
@@ -235,6 +236,7 @@ const CardsPlaceholder = ({ cards }: { cards: number }): ReactElement => (
 
 function WorldIndexPage(): ReactElement {
   const { isV2 } = useLayoutVariant();
+  const router = useRouter();
   const { user, isLoggedIn } = useAuthContext();
   const { domains, isPending: isCataloguePending } = useWorldCatalogue();
 
@@ -255,13 +257,46 @@ function WorldIndexPage(): ReactElement {
   );
   const isWholeDomain = !topic;
 
-  /* The catalogue arrives after the first render, so the opening domain is
-     settled once it lands rather than guessed from an id that may not exist. */
+  /**
+   * Where the page opens.
+   *
+   * The catalogue arrives after the first render, so this settles once it
+   * lands rather than guessing at an id that may not exist. A `topic` in the
+   * query wins: it is how the world's own district panel hands a reader
+   * straight to that topic's board.
+   *
+   * Matched on either the slug or the niche id, because the two callers have
+   * different halves. A hand-written link says `?topic=rust`; the district
+   * panel only carries the id the feed is filtered by.
+   */
   useEffect(() => {
-    if (!domainId && domains.length) {
-      setDomainId(domains[0].id);
+    if (domainId || !domains.length) {
+      return;
     }
-  }, [domains, domainId]);
+
+    const wanted = Array.isArray(router.query.topic)
+      ? router.query.topic[0]
+      : router.query.topic;
+    const found = wanted
+      ? domains.find((item) =>
+          item.topics.some(
+            (candidate) => candidate.slug === wanted || candidate.id === wanted,
+          ),
+        )
+      : undefined;
+
+    if (found) {
+      setDomainId(found.id);
+      setTopicSlug(
+        found.topics.find(
+          (candidate) => candidate.slug === wanted || candidate.id === wanted,
+        )?.slug ?? null,
+      );
+      return;
+    }
+
+    setDomainId(domains[0].id);
+  }, [domains, domainId, router.query.topic]);
 
   const topicRanking = useWorldTopicRanking({
     nicheId: topic?.id,


### PR DESCRIPTION
The index shipped with no way in except a quest reward. This adds the two links that matter. Frontend only, no API change.

## A sidebar row

`Worlds` in the discovery list, immediately after `Leaderboard`. That is the right neighbourhood: Tags, Sources and Leaderboard are all browse-and-rank surfaces and so is this.

**One edit covers both sidebar variants.** v2's `ExploreSection` renders `DiscoverSection` rather than repeating its items, so the row appears in both. Worth knowing so nobody goes hunting for a second place to add it.

## A link out of a district panel

"See who else reads Rust", under the panel header on a world, going to that topic's board.

This is the most pointed link the feature has. A reader who has opened one district in one world is already asking who else built there, and the topic board is the answer. Low traffic, very high intent.

## `?topic=` accepts a slug or a niche id

The two callers carry different halves. A selected district only knows its `nicheId`, because that is what filters its feed; a link somebody writes or shares wants `?topic=rust`. Accepting either means the district panel does not need renderer changes to carry a slug it currently does not have, and readable URLs still work.

A topic in the query takes precedence over the default domain, and falls back to the first domain if it matches nothing.

## Not included

A generic "browse all worlds" link on a world's chrome. The district link covers that surface with much better intent, and the chrome already carries a back button, share, an immersive toggle and the mark. Easy to add if wanted, but it looked like a fifth control for a weaker version of a link that is already there.

## Verification

Strict typecheck and lint pass on both packages. 37 sidebar tests and 11 world tests pass.


### Preview domain
https://world-index-entrypoints.preview.app.daily.dev