### PR TITLE
feat(analytics): log server-side page requests from the proxy

### DIFF
--- a/packages/shared/src/hooks/log/useLogContextData.ts
+++ b/packages/shared/src/hooks/log/useLogContextData.ts
@@ -2,6 +2,7 @@ import type { MutableRefObject } from 'react';
 import { useMemo } from 'react';
 import type { LogEvent, PushToQueueFunc } from './useLogQueue';
 import { getCurrentLifecycleState } from '../../lib/lifecycle';
+import { generateLogEventId } from '../../lib/logEventId';
 import type { Origin } from '../../lib/log';
 
 export type LogContextData = {
@@ -9,12 +10,6 @@ export type LogContextData = {
   logEventStart: (id: string, event: LogEvent) => void;
   logEventEnd: (id: string, now?: Date) => void;
   sendBeacon: () => void;
-};
-
-const generateEventId = (now = new Date()): string => {
-  const randomStr = (Math.random() + 1).toString(36).substring(8);
-  const timePart = (now.getTime() / 1000).toFixed(0);
-  return `${timePart}${randomStr}`;
 };
 
 export type PostOrigin =
@@ -42,7 +37,7 @@ const generateEvent = (
   ...sharedPropsRef.current,
   ...getGlobalSharedProps(),
   event_timestamp: now,
-  event_id: generateEventId(now),
+  event_id: generateLogEventId(now),
   event_page: page,
   ...event,
 });

--- a/packages/shared/src/lib/logEventId.ts
+++ b/packages/shared/src/lib/logEventId.ts
@@ -1,0 +1,5 @@
+export const generateLogEventId = (now = new Date()): string => {
+  const randomStr = (Math.random() + 1).toString(36).substring(8);
+  const timePart = (now.getTime() / 1000).toFixed(0);
+  return `${timePart}${randomStr}`;
+};

--- a/packages/webapp/lib/serverPageRequestLog.ts
+++ b/packages/webapp/lib/serverPageRequestLog.ts
@@ -19,6 +19,7 @@ export const logServerPageRequest = async (
   }
 
   const { ua } = userAgent(req);
+  const clientIp = req.headers.get('cf-connecting-ip');
 
   try {
     const now = new Date();
@@ -48,6 +49,7 @@ export const logServerPageRequest = async (
       headers: {
         'content-type': 'application/json',
         'user-agent': ua,
+        ...(clientIp && { 'x-forwarded-for': clientIp }),
       },
     });
   } catch {

--- a/packages/webapp/lib/serverPageRequestLog.ts
+++ b/packages/webapp/lib/serverPageRequestLog.ts
@@ -1,0 +1,56 @@
+import type { NextRequest } from 'next/server';
+import { userAgent } from 'next/server';
+import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import { isDevelopment } from '@dailydotdev/shared/src/lib/constants';
+import { generateLogEventId } from '@dailydotdev/shared/src/lib/logEventId';
+
+const SERVER_PAGE_REQUEST_EVENT = 'server page request';
+const UNKNOWN_DEVICE_ID = 'unknown';
+
+export type ServerPageRequestVariant = 'html' | 'markdown';
+
+export const logServerPageRequest = async (
+  req: NextRequest,
+  variant: ServerPageRequestVariant,
+): Promise<void> => {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl || process.env.DISABLE_SERVER_REQUEST_LOGGING === 'true') {
+    return;
+  }
+
+  const { ua } = userAgent(req);
+
+  try {
+    const now = new Date();
+    const deviceId = req.cookies.get('da2')?.value ?? UNKNOWN_DEVICE_ID;
+    const eventPayload = {
+      app_platform: BootApp.Webapp,
+      device_id: deviceId,
+      event_id: generateLogEventId(now),
+      event_name: SERVER_PAGE_REQUEST_EVENT,
+      event_page: req.nextUrl.pathname,
+      event_timestamp: now,
+      extra: JSON.stringify({ content_variant: variant }),
+      session_id: crypto.randomUUID(),
+      user_agent: ua,
+      user_id: deviceId,
+      visit_id: crypto.randomUUID(),
+    };
+
+    if (isDevelopment) {
+      // eslint-disable-next-line no-console
+      console.log(eventPayload);
+    }
+
+    await fetch(`${apiUrl}/e`, {
+      method: 'POST',
+      body: JSON.stringify({ events: [eventPayload] }),
+      headers: {
+        'content-type': 'application/json',
+        'user-agent': ua,
+      },
+    });
+  } catch {
+    // Request logging must never affect the response.
+  }
+};

--- a/packages/webapp/proxy.ts
+++ b/packages/webapp/proxy.ts
@@ -1,15 +1,23 @@
 import type { NextRequest } from 'next/server';
 import { after, NextResponse } from 'next/server';
 import { acceptsMarkdown } from './lib/contentNegotiation';
-import { POST_MARKDOWN_PATH, RESERVED_POST_SLUGS } from './lib/markdownRoutes';
+import {
+  MARKDOWN_ROUTES,
+  POST_MARKDOWN_PATH,
+  RESERVED_POST_SLUGS,
+} from './lib/markdownRoutes';
 import {
   getAgentSignupRequiredBody,
   hasValidAgentMarkdownToken,
   evaluateAgentSignupWall,
   trackAgentSignupWallAllocation,
 } from './lib/agentMarkdownAccess';
+import { logServerPageRequest } from './lib/serverPageRequestLog';
 
 const POSTS_PREFIX = '/posts/';
+const MARKDOWN_PAGE_PATHS = Object.keys(MARKDOWN_ROUTES).map(
+  (path) => `${path}.md`,
+);
 const TRACKING_ID_ALPHABET =
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz';
 const TRACKING_ID_LENGTH = 21;
@@ -24,11 +32,15 @@ const generateTrackingId = (): string => {
 
 export const config = {
   matcher: [
-    '/posts/:id',
-    '/sources.md',
-    '/tags.md',
-    '/squads/discover.md',
+    // markdown routes live under `/api`, which the pattern below skips
     '/api/md/:path*',
+    // every other request, minus:
+    // - `api`: JSON endpoints, never documents
+    // - `_next/static`, `_next/image`: build output and the image optimizer
+    // - trailing extensions: `public/` assets (icons, fonts, sw.js, robots, sitemap)
+    // All three have to stay in one pattern: matcher entries are OR'd, so a
+    // separate entry per group would re-admit what the others skip.
+    '/((?!api|_next/static|_next/image|.*\\.(?:avif|css|eot|gif|ico|jpe?g|js|json|map|mp4|otf|png|svg|ttf|txt|wasm|webm|webp|woff2?|xml)$).*)',
   ],
 };
 
@@ -42,7 +54,7 @@ const getMarkdownResponse = (req: NextRequest): NextResponse => {
   const id = pathname.slice(POSTS_PREFIX.length);
 
   // `.md` URLs are handled by the beforeFiles rewrite, which runs after
-  // middleware. Rewriting here too would pass the id along with its suffix.
+  // proxy. Rewriting here too would pass the id along with its suffix.
   if (
     !id ||
     id.endsWith('.md') ||
@@ -89,15 +101,37 @@ const handleMarkdownRequest = async (
   });
 };
 
-export async function middleware(req: NextRequest): Promise<NextResponse> {
+const isMarkdownRequest = (req: NextRequest): boolean => {
   const { pathname } = req.nextUrl;
-  const isMarkdownRequest =
-    pathname.startsWith('/api/md/') ||
-    pathname.endsWith('.md') ||
-    (pathname.startsWith(POSTS_PREFIX) &&
-      acceptsMarkdown(req.headers.get('accept')));
 
-  if (isMarkdownRequest) {
+  if (
+    pathname.startsWith('/api/md/') ||
+    MARKDOWN_PAGE_PATHS.includes(pathname)
+  ) {
+    return true;
+  }
+
+  if (!pathname.startsWith(POSTS_PREFIX)) {
+    return false;
+  }
+
+  const id = pathname.slice(POSTS_PREFIX.length);
+
+  return (
+    !!id &&
+    !id.includes('/') &&
+    (id.endsWith('.md') || acceptsMarkdown(req.headers.get('accept')))
+  );
+};
+
+export async function proxy(req: NextRequest): Promise<NextResponse> {
+  const isMarkdown = isMarkdownRequest(req);
+
+  after(async () => {
+    await logServerPageRequest(req, isMarkdown ? 'markdown' : 'html');
+  });
+
+  if (isMarkdown) {
     return handleMarkdownRequest(req);
   }
 


### PR DESCRIPTION
Adds a `server page request` event dispatched through `after()` for every document request the proxy sees, so agent and crawler traffic is measurable beyond Vercel's one-day log retention. Kept separate from client `page view` so existing reporting is unaffected.

The proxy matcher now covers all document requests instead of only the markdown routes, excluding `api`, `_next/static`, `_next/image` and static asset extensions. Markdown negotiation and the agent signup wall stay pinned to the routes they covered before via `isMarkdownRequest`.

`DISABLE_SERVER_REQUEST_LOGGING=true` turns the logging off without a GrowthBook lookup per request.

Also renames middleware.ts to proxy.ts for Next 16 naming, and moves the log event id generator into shared so the client and the proxy use one copy (also makes proxy run on Node.js APIs instead of outdated edge APIs that Next.js used to push).

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://feat-server-page-request-logging.preview.app.daily.dev