### PR TITLE
feat: add Google AdSense seller record to ads.txt

### DIFF
--- a/packages/webapp/public/ads.txt
+++ b/packages/webapp/public/ads.txt
@@ -1,2 +1,3 @@
 CONTACT=hi@daily.dev
 OWNERDOMAIN=daily.dev
+google.com, pub-6445455356070086, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
- Add the AdSense-authorized seller line (`google.com, pub-6445455356070086, DIRECT, f08c47fec0942fa0`) to `ads.txt` so Google can verify daily.dev inventory.
- File is already served from the site root at `https://daily.dev/ads.txt`.

## Test plan
- [ ] After deploy, open `https://daily.dev/ads.txt` and confirm the Google seller line is present
- [ ] In AdSense → Sites, run **Check for updates** and confirm status moves to Authorized (can take a few days)


Made with [Cursor](https://cursor.com)

### Preview domain
https://feat-adsense-ads-txt.preview.app.daily.dev