### PR TITLE
fix(webapp): exclude static assets from proxy logging

### DIFF
--- a/packages/webapp/proxy.ts
+++ b/packages/webapp/proxy.ts
@@ -37,10 +37,11 @@ export const config = {
     // every other request, minus:
     // - `api`: JSON endpoints, never documents
     // - `_next/static`, `_next/image`: build output and the image optimizer
-    // - trailing extensions: `public/` assets (icons, fonts, sw.js, robots, sitemap)
+    // - `.well-known`: static platform association files without extensions
+    // - trailing extensions: `public/` assets (icons, fonts, audio, sw.js, robots, sitemap)
     // All three have to stay in one pattern: matcher entries are OR'd, so a
     // separate entry per group would re-admit what the others skip.
-    '/((?!api|_next/static|_next/image|.*\\.(?:avif|css|eot|gif|ico|jpe?g|js|json|map|mp4|otf|png|svg|ttf|txt|wasm|webm|webp|woff2?|xml)$).*)',
+    '/((?!api|_next/static|_next/image|\\.well-known(?:/|$)|.*\\.(?:avif|css|eot|gif|ico|jpe?g|js|json|map|mp3|mp4|otf|png|svg|ttf|txt|wasm|webm|webp|woff2?|xml)$).*)',
   ],
 };
 


### PR DESCRIPTION
## Summary

- exclude `.mp3` assets from the proxy matcher
- exclude extensionless `/.well-known/*` platform association files
- keep server page request analytics focused on document traffic

## Context

A ClickHouse check after #6484 found four static audio requests logged as `server page request`:

- `/app/assets/log/1.mp3`
- `/app/assets/log/2.mp3`
- `/app/assets/log/3.mp3`
- `/world/ride-lofi.mp3`

The webapp also serves extensionless platform association files under `public/.well-known/`, which would otherwise pass through the matcher.

## Testing

- manually verified matcher cases for document routes, MP3 assets, `.well-known`, `_next/static`, and API routes
- `git diff --check`


### Preview domain
https://fix-proxy-static-asset-matcher.preview.app.daily.dev