### PR TITLE
fix(cookies): one-click consent on the iubenda banner

### DIFF
--- a/packages/shared/src/styles/components/iubenda.css
+++ b/packages/shared/src/styles/components/iubenda.css
@@ -39,10 +39,6 @@
   }
 }
 
-/* The card grows to show the full notice; iubenda refuses one-click
-   consent while .iubenda-banner-content is clipped ("Press again to
-   continue"), so that element must never be the scroll container —
-   on short viewports the rationale scrolls with the buttons sticky. */
 #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-rationale {
   display: block !important;
   max-height: calc(100vh - 10rem) !important;

--- a/packages/shared/src/styles/components/iubenda.css
+++ b/packages/shared/src/styles/components/iubenda.css
@@ -39,14 +39,22 @@
   }
 }
 
+/* The card grows to show the full notice; iubenda refuses one-click
+   consent while .iubenda-banner-content is clipped ("Press again to
+   continue"), so that element must never be the scroll container —
+   on short viewports the rationale scrolls with the buttons sticky. */
 #iubenda-cs-banner#iubenda-cs-banner .iubenda-cs-rationale {
-  max-height: 16.25rem !important;
+  display: block !important;
+  max-height: calc(100vh - 10rem) !important;
   overflow-y: auto !important;
   margin: 0 !important;
   padding: 0 !important;
 }
 
 #iubenda-cs-banner#iubenda-cs-banner .iubenda-banner-content {
+  height: auto !important;
+  max-height: none !important;
+  overflow: visible !important;
   margin: 0 !important;
   padding: 0 !important;
   font-size: inherit !important;
@@ -70,7 +78,12 @@
   display: flex !important;
   flex-direction: column !important;
   gap: 0.5rem !important;
-  margin: 1rem 0 0 !important;
+  position: sticky !important;
+  bottom: 0 !important;
+  width: 100% !important;
+  margin: 0.5rem 0 0 !important;
+  padding: 0.5rem 0 0 !important;
+  background: var(--theme-accent-pepper-subtlest) !important;
   float: none !important;
 }
 

--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -122,6 +122,15 @@ export const Iubenda = (): ReactElement | null => {
       callback: {
         onPreferenceExpressed: (pref: IubendaPreference) =>
           onPreferenceRef.current?.(pref),
+        // one-click consent guard: iubenda blocks Accept/Reject until its
+        // scrolled-to-bottom flag is refreshed, and its setup can race the
+        // first click; our card never clips .iubenda-banner-content, so
+        // poking its scroll listener always resolves the flag to true
+        onBannerShown: () => {
+          document
+            .querySelector('#iubenda-cs-banner .iubenda-banner-content')
+            ?.dispatchEvent(new Event('scroll'));
+        },
       },
     };
 

--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -122,10 +122,6 @@ export const Iubenda = (): ReactElement | null => {
       callback: {
         onPreferenceExpressed: (pref: IubendaPreference) =>
           onPreferenceRef.current?.(pref),
-        // one-click consent guard: iubenda blocks Accept/Reject until its
-        // scrolled-to-bottom flag is refreshed, and its setup can race the
-        // first click; our card never clips .iubenda-banner-content, so
-        // poking its scroll listener always resolves the flag to true
         onBannerShown: () => {
           document
             .querySelector('#iubenda-cs-banner .iubenda-banner-content')


### PR DESCRIPTION
## Problem

Same issue just fixed on the marketing homepage (dailydotdev/recruiter-landing#448): clicking **Accept** or **Reject** on the TCF banner took multiple presses with iubenda showing *"Press again to continue 1/4"*.

Cause: iubenda's core refuses consent until `.iubenda-banner-content` is scrolled to the bottom, paginating on each press. On the webapp two things clipped that element: iubenda's own `iubenda-cs-scrollable` theme styles, and the rationale being a flex container that `flex-shrink`s it (confirmed 492px clipped on production).

## Fix (mirrors recruiter-landing#448)

- The rationale cap grows from 260px to `calc(100vh - 10rem)`, so the full notice fits on normal screens and the gate never engages.
- `.iubenda-banner-content` is kept unclipped — `display: block` on the rationale stops the flex shrink, and `height/max-height` resets beat the `iubenda-cs-scrollable` theme rules. On short viewports the **rationale** scrolls (which the gate doesn't measure) with the button row `position: sticky`.
- An `onBannerShown` callback in `Iubenda.tsx` pokes iubenda's scroll listener so the gate flag is refreshed even if iubenda's setup races the first click.

## Testing

Verified against the live production webapp banner (EU/TCF geo) with the new CSS injected and the callback simulated:
- Gate element clipping went 492px → 0; iubenda's `hasTheUserScrolledToBottom` flag resolves to `true`.
- **Reject consented and dismissed the banner in a single click** (full trusted pointer event sequence).
- Strict typecheck, ESLint, Prettier pass.

### Preview domain
https://fix-iubenda-one-click-consent.preview.app.daily.dev