### PR TITLE
fix: resolve Mazatlan timezone correctly

### DIFF
--- a/packages/shared/src/components/widgets/TimezoneDropdown.spec.tsx
+++ b/packages/shared/src/components/widgets/TimezoneDropdown.spec.tsx
@@ -29,7 +29,10 @@ const defaultLoggedUser: LoggedUser = {
 
 const updateUser = jest.fn();
 
-const renderComponent = (): RenderResult => {
+const renderComponent = (
+  userTimeZone = 'Europe/Amsterdam',
+  setUserTimeZone = jest.fn(),
+): RenderResult => {
   const client = new QueryClient();
 
   return render(
@@ -41,8 +44,8 @@ const renderComponent = (): RenderResult => {
         tokenRefreshed
       >
         <TimezoneDropdown
-          userTimeZone="Europe/Amsterdam"
-          setUserTimeZone={jest.fn()}
+          userTimeZone={userTimeZone}
+          setUserTimeZone={setUserTimeZone}
         />
       </AuthContextProvider>
     </QueryClientProvider>,
@@ -69,5 +72,36 @@ it('should change user timezone', async () => {
   });
   fireEvent.click(timezone);
   await act(() => new Promise((resolve) => setTimeout(resolve, 100)));
+  expect(mutationCalled).toBeTruthy();
+});
+
+it('should select and persist Mazatlan timezone by IANA value', async () => {
+  const setUserTimeZone = jest.fn();
+  renderComponent('America/Mazatlan', setUserTimeZone);
+
+  const { firstChild } = await screen.findByTestId('timezone_dropdown');
+  expect(firstChild).toHaveTextContent('Mazatlan');
+  fireEvent.click(firstChild!);
+
+  const timezone = await screen.findByRole('menuitem', {
+    name: '(UTC -7) Mazatlan, La Paz (Baja California Sur)',
+  });
+  let mutationCalled = false;
+
+  mockGraphQL({
+    request: {
+      query: UPDATE_USER_PROFILE_MUTATION,
+      variables: { data: { timezone: 'America/Mazatlan' } },
+    },
+    result: () => {
+      mutationCalled = true;
+      return { data: { id: '' } };
+    },
+  });
+
+  fireEvent.click(timezone);
+  await act(() => new Promise((resolve) => setTimeout(resolve, 100)));
+
+  expect(setUserTimeZone).toHaveBeenCalledWith('America/Mazatlan');
   expect(mutationCalled).toBeTruthy();
 });

--- a/packages/shared/src/components/widgets/TimezoneDropdown.tsx
+++ b/packages/shared/src/components/widgets/TimezoneDropdown.tsx
@@ -28,6 +28,11 @@ const TimezoneDropdown = ({
     const findTimeZoneRow = timeZoneOptions.find((_timeZone) => {
       return _timeZone.label === timezone;
     });
+
+    if (!findTimeZoneRow) {
+      throw new Error(`Timezone option not found: ${timezone}`);
+    }
+
     setUserTimeZone(findTimeZoneRow.value);
     await updateUserProfile({ timezone: findTimeZoneRow.value });
   };

--- a/packages/shared/src/lib/timezones.spec.ts
+++ b/packages/shared/src/lib/timezones.spec.ts
@@ -1,6 +1,66 @@
-import { getTimeZoneOptions, getTimezoneOffsetLabel } from './timezones';
+import { getTimezoneOffset } from 'date-fns-tz';
+import {
+  getTimeZoneOptions,
+  getTimezoneOffsetLabel,
+  getUserDefaultTimezone,
+  TIME_ZONES,
+} from './timezones';
+
+const timezoneAuditDates = [
+  new Date('2026-01-15T12:00:00Z'),
+  new Date('2026-07-15T12:00:00Z'),
+];
+
+const auditedCityTimeZones: Record<string, string> = {
+  Chihuahua: 'America/Chihuahua',
+  Mazatlan: 'America/Mazatlan',
+  'La Paz (Baja California Sur)': 'America/Mazatlan',
+  'Ciudad Juarez': 'America/Ciudad_Juarez',
+  Georgetown: 'America/Guyana',
+  'La Paz (Bolivia)': 'America/La_Paz',
+  Manaus: 'America/Manaus',
+  Astrakhan: 'Europe/Astrakhan',
+  Ulyanovsk: 'Europe/Ulyanovsk',
+  Volgograd: 'Europe/Volgograd',
+  Beijing: 'Asia/Shanghai',
+  Chongqing: 'Asia/Chongqing',
+  'Hong Kong SAR': 'Asia/Hong_Kong',
+  Urumqi: 'Asia/Urumqi',
+};
+
+const getLabelCities = (label: string): string[] => {
+  return label.split(',').map((city) => city.trim());
+};
+
+const mockDeviceTimezone = (timeZone: string): jest.SpyInstance => {
+  const OriginalDateTimeFormat = Intl.DateTimeFormat;
+
+  return jest.spyOn(Intl, 'DateTimeFormat').mockImplementation(((
+    locales?: Intl.LocalesArgument,
+    options?: Intl.DateTimeFormatOptions,
+  ): Intl.DateTimeFormat => {
+    const formatter = new OriginalDateTimeFormat(locales, options);
+
+    if (typeof locales !== 'undefined' || typeof options !== 'undefined') {
+      return formatter;
+    }
+
+    const resolvedOptions = formatter.resolvedOptions();
+
+    return Object.assign(formatter, {
+      resolvedOptions: () => ({
+        ...resolvedOptions,
+        timeZone,
+      }),
+    });
+  }) as typeof Intl.DateTimeFormat);
+};
 
 describe('timezones', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   it('formats quarter-hour offsets using minutes', () => {
     expect(getTimeZoneOptions()).toEqual(
       expect.arrayContaining([
@@ -27,5 +87,38 @@ describe('timezones', () => {
     expect(getTimezoneOffsetLabel('Asia/Katmandu')).toBe(
       '(UTC +5:45) Asia/Katmandu',
     );
+  });
+
+  it('returns the device IANA timezone when it is in the allowlist', () => {
+    mockDeviceTimezone('America/Mazatlan');
+
+    expect(getUserDefaultTimezone()).toBe('America/Mazatlan');
+  });
+
+  it('falls back to matching the device offset when its IANA timezone is absent', () => {
+    mockDeviceTimezone('Europe/Trondheim');
+
+    expect(getUserDefaultTimezone()).not.toBe('Europe/Trondheim');
+    expect(
+      TIME_ZONES.some(({ value }) => value === getUserDefaultTimezone()),
+    ).toBeTruthy();
+  });
+
+  it('keeps audited city label offsets aligned with their IANA timezones', () => {
+    TIME_ZONES.forEach(({ value, label }) => {
+      getLabelCities(label).forEach((city) => {
+        const cityTimeZone = auditedCityTimeZones[city];
+
+        if (!cityTimeZone) {
+          return;
+        }
+
+        timezoneAuditDates.forEach((date) => {
+          expect(getTimezoneOffset(value, date)).toBe(
+            getTimezoneOffset(cityTimeZone, date),
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/shared/src/lib/timezones.ts
+++ b/packages/shared/src/lib/timezones.ts
@@ -42,7 +42,7 @@ const formatTimezoneOffset = (offsetInMinutes: number): string => {
   return `${sign}${hours}:${minutes.toString().padStart(2, '0')}`;
 };
 
-const TIME_ZONES: TimeZoneItem[] = [
+export const TIME_ZONES: TimeZoneItem[] = [
   {
     value: 'Pacific/Midway',
     label: 'Midway Island, American Samoa',
@@ -77,11 +77,19 @@ const TIME_ZONES: TimeZoneItem[] = [
   },
   {
     value: 'America/Chihuahua',
-    label: 'Chihuahua, La Paz, Mazatlan',
+    label: 'Chihuahua',
+  },
+  {
+    value: 'America/Mazatlan',
+    label: 'Mazatlan, La Paz (Baja California Sur)',
   },
   {
     value: 'America/Denver',
     label: 'Mountain Time (US and Canada), Navajo Nation',
+  },
+  {
+    value: 'America/Ciudad_Juarez',
+    label: 'Ciudad Juarez',
   },
   {
     value: 'America/Belize',
@@ -145,7 +153,7 @@ const TIME_ZONES: TimeZoneItem[] = [
   },
   {
     value: 'America/Manaus',
-    label: 'Georgetown, La Paz, Manaus, San Juan',
+    label: 'Georgetown, La Paz (Bolivia), Manaus',
   },
   {
     value: 'America/Santiago',
@@ -304,6 +312,10 @@ const TIME_ZONES: TimeZoneItem[] = [
     label: 'Moscow, St. Petersburg',
   },
   {
+    value: 'Europe/Volgograd',
+    label: 'Volgograd',
+  },
+  {
     value: 'Africa/Nairobi',
     label: 'Nairobi',
   },
@@ -317,7 +329,7 @@ const TIME_ZONES: TimeZoneItem[] = [
   },
   {
     value: 'Europe/Astrakhan',
-    label: 'Astrakhan, Ulyanovsk, Volgograd',
+    label: 'Astrakhan, Ulyanovsk',
   },
   {
     value: 'Asia/Baku',
@@ -405,7 +417,11 @@ const TIME_ZONES: TimeZoneItem[] = [
   },
   {
     value: 'Asia/Chongqing',
-    label: 'Beijing, Chongqing, Hong Kong SAR, Urumqi',
+    label: 'Beijing, Chongqing, Hong Kong SAR',
+  },
+  {
+    value: 'Asia/Urumqi',
+    label: 'Urumqi',
   },
   {
     value: 'Asia/Irkutsk',
@@ -558,6 +574,12 @@ export const getTimeZoneOptions = (): TimeZoneItem[] => {
 };
 
 export const getUserDefaultTimezone = (): string => {
+  const deviceTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+  if (TIME_ZONES.some((timezone) => timezone.value === deviceTimezone)) {
+    return deviceTimezone;
+  }
+
   const timeZoneOptions = getTimeZoneOptions();
   const timeZoneOffset = formatTimezoneOffset(-new Date().getTimezoneOffset());
   const timezoneGuess = timeZoneOptions.find((timezone) =>


### PR DESCRIPTION
## Summary
- Add Mazatlan and related split timezone entries to the shared timezone list used by apps.
- Update stale city labels so Mazatlan, Baja California Sur La Paz, Volgograd, and Urumqi map to zones with matching offsets.
- Prefer the browser/device IANA timezone when it exists in our allowlist, with the existing offset heuristic as fallback.
- Make timezone dropdown selection fail explicitly if a stale label cannot be resolved.

## Key decisions
- Kept the existing allowlist model and matched against our own `TIME_ZONES` values instead of `Intl.supportedValuesOf`, so existing alias values remain selectable.
- Added focused regression tests instead of new E2E infrastructure because the shared component and timezone utility cover the reported behavior directly.

Closes ENG-1963

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1963-feedback-bug-report-inc.preview.app.daily.dev