### PR TITLE
fix(agent): open a run's feed link with its own findings

### DIFF
--- a/packages/shared/src/features/interests/AgentContext.spec.tsx
+++ b/packages/shared/src/features/interests/AgentContext.spec.tsx
@@ -359,6 +359,40 @@ describe('the live path', () => {
       'p1',
     ]);
     expect(blocks[2]).toMatchObject({ type: 'feedLink' });
+    expect((blocks[2] as { posts: Post[] }).posts.map(({ id }) => id)).toEqual([
+      'p1',
+    ]);
+  });
+
+  it('scopes a feed link to its own postIds instead of every finding', async () => {
+    const agent = mountLive({
+      turns: [
+        {
+          id: 'run-1',
+          role: 'agent',
+          createdAt: '2026-01-01T00:01:00Z',
+          status: 'completed',
+          trigger: 'scheduled',
+          blocks: [
+            {
+              type: 'feedLink',
+              label: 'Open all 2 findings',
+              count: 2,
+              postIds: ['p2', 'gone'],
+            },
+          ],
+        } as InterestTurn,
+      ],
+      findings: [feedItem('p1'), feedItem('p2')],
+    });
+
+    await waitForHistory(agent, (current) => current.messages.length === 1);
+
+    const blocks = agent.current.messages.at(-1)?.blocks ?? [];
+    expect(blocks[0]).toMatchObject({ type: 'feedLink' });
+    expect((blocks[0] as { posts: Post[] }).posts.map(({ id }) => id)).toEqual([
+      'p2',
+    ]);
   });
 
   it('shows a queued or running run as the working state', async () => {

--- a/packages/shared/src/features/interests/AgentContext.tsx
+++ b/packages/shared/src/features/interests/AgentContext.tsx
@@ -143,6 +143,18 @@ const isRunPending = (turn: InterestTurn): boolean =>
   (turn.status === InterestRunStatus.Queued ||
     turn.status === InterestRunStatus.Running);
 
+const resolvePosts = (
+  postIds: string[],
+  postsById: Map<string, Post>,
+): Post[] =>
+  postIds.reduce<Post[]>((found, postId) => {
+    const post = postsById.get(postId);
+    if (post) {
+      found.push(post);
+    }
+    return found;
+  }, []);
+
 const mapServerBlocks = (
   turn: InterestTurn,
   postsById: Map<string, Post>,
@@ -155,13 +167,7 @@ const mapServerBlocks = (
     }
 
     if (block.type === 'picks') {
-      const posts = block.postIds.reduce<Post[]>((found, postId) => {
-        const post = postsById.get(postId);
-        if (post) {
-          found.push(post);
-        }
-        return found;
-      }, []);
+      const posts = resolvePosts(block.postIds, postsById);
 
       if (posts.length) {
         acc.push({ type: 'picks', caption: block.caption, posts });
@@ -169,8 +175,11 @@ const mapServerBlocks = (
       return acc;
     }
 
-    if (allPosts.length) {
-      acc.push({ type: 'feedLink', label: block.label, posts: allPosts });
+    const posts = block.postIds?.length
+      ? resolvePosts(block.postIds, postsById)
+      : allPosts;
+    if (posts.length) {
+      acc.push({ type: 'feedLink', label: block.label, posts });
     }
     return acc;
   }, []);

--- a/packages/shared/src/graphql/interests.ts
+++ b/packages/shared/src/graphql/interests.ts
@@ -80,7 +80,7 @@ export type InterestFinding = {
 export type InterestRunBlock =
   | { type: 'text'; html: string }
   | { type: 'picks'; caption?: string; postIds: string[] }
-  | { type: 'feedLink'; label: string; count: number };
+  | { type: 'feedLink'; label: string; count: number; postIds?: string[] };
 
 export type InterestTurn = {
   id: string;


### PR DESCRIPTION
Resolve the feedLink block's persisted postIds against the findings map, mirroring picks; blocks written before postIds existed keep the full findings feed as fallback.

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://interest-feedlink-postids.preview.app.daily.dev