### PR TITLE
feat(agent): render the summary post as the reply and open post links…

### DIFF
--- a/packages/shared/src/features/interests/AgentContext.spec.tsx
+++ b/packages/shared/src/features/interests/AgentContext.spec.tsx
@@ -525,7 +525,7 @@ describe('the live path', () => {
     expect(agent.current.status).toBe('active');
   });
 
-  it('attaches the summary post to the run that wrote it and keeps quiet writers visible', async () => {
+  it('keeps a blockless run visible when it wrote a summary post', async () => {
     const agent = mountLive({
       turns: [
         {
@@ -549,10 +549,7 @@ describe('the live path', () => {
 
     await waitForHistory(agent, (current) => current.messages.length === 1);
 
-    expect(agent.current.messages[0].summaryPost).toMatchObject({
-      id: 'sp-1',
-      title: 'Zig this week',
-    });
+    expect(agent.current.messages[0].role).toBe('agent');
     expect(agent.current.summaryPosts).toHaveLength(1);
   });
 

--- a/packages/shared/src/features/interests/AgentContext.tsx
+++ b/packages/shared/src/features/interests/AgentContext.tsx
@@ -188,13 +188,11 @@ const turnsToMessages = ({
   turns,
   postsById,
   allPosts,
-  summaryPostsById,
   interest,
 }: {
   turns: InterestTurn[];
   postsById: Map<string, Post>;
   allPosts: Post[];
-  summaryPostsById: Map<string, AgentSummaryPost>;
   interest?: UserInterest;
 }): AgentMessage[] => {
   const feedbackTextById = new Map(
@@ -242,10 +240,6 @@ const turnsToMessages = ({
       isError,
       retryText,
       blocks: isPending || isError ? undefined : blocks,
-      summaryPost:
-        !isPending && !isError && turn.summaryPostId
-          ? summaryPostsById.get(turn.summaryPostId)
-          : undefined,
     });
     return acc;
   }, []);
@@ -352,11 +346,6 @@ export const AgentProvider = ({
     return { postsById: byId, allPosts: findings.map(({ post }) => post) };
   }, [findings]);
 
-  const summaryPostsById = useMemo(
-    () => new Map(posts.map((post) => [post.id, post])),
-    [posts],
-  );
-
   const unresolvedEchoes = useMemo(
     () => echoes.filter((echo) => !echoResolved(echo, turns)),
     [echoes, turns],
@@ -398,7 +387,6 @@ export const AgentProvider = ({
         turns,
         postsById,
         allPosts,
-        summaryPostsById,
         interest,
       }),
       ...echoed,
@@ -409,7 +397,6 @@ export const AgentProvider = ({
     interest,
     isDemo,
     postsById,
-    summaryPostsById,
     turns,
     unresolvedEchoes,
   ]);

--- a/packages/shared/src/features/interests/chat.ts
+++ b/packages/shared/src/features/interests/chat.ts
@@ -20,7 +20,6 @@ export type AgentMessage = {
   text?: string;
   attachments?: AgentAttachment[];
   blocks?: AgentBlock[];
-  summaryPost?: Pick<Post, 'id' | 'title' | 'createdAt' | 'contentHtml'>;
   isPending?: boolean;
   isScheduled?: boolean;
   isError?: boolean;

--- a/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
@@ -10,7 +10,7 @@ import * as lazyModal from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../../components/modals/common/types';
 import { Origin } from '../../../lib/log';
 import type { AgentMessage } from '../chat';
-import { AgentProvider } from '../AgentContext';
+import { AgentProvider, useAgent } from '../AgentContext';
 import { AgentChatSection } from './AgentChatSection';
 
 const post = (id: string, title: string): Post =>
@@ -231,5 +231,69 @@ describe('sharing a reply', () => {
         name: /Copy link/,
       }),
     ).toBeEnabled();
+  });
+});
+
+describe('a post link in the reply text', () => {
+  const ActivePostProbe = () => {
+    const { activeContent } = useAgent();
+    return (
+      <div data-testid="active-post">
+        {activeContent?.type === 'post' ? activeContent.post.id : 'none'}
+      </div>
+    );
+  };
+
+  const linked: AgentMessage = {
+    id: 'm2',
+    role: 'agent',
+    at: new Date(0).toISOString(),
+    blocks: [
+      {
+        type: 'text',
+        html: '<p>Read <a href="https://app.daily.dev/posts/p1/">Zig 0.15</a> or <a href="https://example.com/posts/xyz">elsewhere</a>.</p>',
+      },
+    ],
+  };
+
+  const renderLinked = () =>
+    render(
+      <TestBootProvider client={new QueryClient()}>
+        <AgentProvider
+          id="a1"
+          isDemo
+          initialMessages={[linked]}
+          findings={[
+            {
+              id: 'f1',
+              post: post('p1', 'Zig 0.15'),
+              score: 0.9,
+              rationale: '',
+              createdAt: new Date(0).toISOString(),
+            },
+          ]}
+        >
+          <AgentChatSection />
+          <ActivePostProbe />
+        </AgentProvider>
+      </TestBootProvider>,
+    );
+
+  it('opens a known post in the side pane instead of navigating', () => {
+    renderLinked();
+
+    fireEvent.click(screen.getByRole('link', { name: 'Zig 0.15' }));
+
+    expect(screen.getByTestId('active-post')).toHaveTextContent('p1');
+  });
+
+  it('leaves links it cannot resolve alone', () => {
+    renderLinked();
+
+    const link = screen.getByRole('link', { name: 'elsewhere' });
+    link.addEventListener('click', (event) => event.preventDefault());
+    fireEvent.click(link);
+
+    expect(screen.getByTestId('active-post')).toHaveTextContent('none');
   });
 });

--- a/packages/shared/src/features/interests/components/AgentChatSection.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Markdown from '../../../components/Markdown';
 import { Tooltip } from '../../../components/tooltip/Tooltip';
 import {
@@ -18,7 +18,6 @@ import {
   BulletListIcon,
   CopyIcon,
   DownvoteIcon,
-  FeatherIcon,
   ShareIcon,
   MiniCloseIcon,
   TimerIcon,
@@ -44,19 +43,46 @@ import { AgentThinkingStrip } from './AgentThinkingStrip';
 import { AgentPostCard } from './AgentPostCard';
 import { AgentEmbedCard } from './blocks/AgentEmbedCard';
 
+const postLinkKey = (href: string): string => {
+  try {
+    const url = new URL(href);
+    return `${url.origin}${url.pathname.replace(/\/+$/, '')}`;
+  } catch {
+    return href;
+  }
+};
+
 const BlockRenderer = ({
   block,
   onPostClick,
   onFeedClick,
+  resolvePostLink,
   activePostId,
 }: {
   block: AgentBlock;
   onPostClick: (post: Post) => void;
   onFeedClick: (label: string, posts: Post[]) => void;
+  resolvePostLink: (href: string) => Post | undefined;
   activePostId?: string;
 }): ReactElement => {
   if (block.type === 'text') {
-    return <Markdown className={transcriptProse} content={block.html} />;
+    return (
+      // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+      <div
+        onClick={(event) => {
+          const anchor = (event.target as Element).closest('a');
+          const post = anchor && resolvePostLink(anchor.href);
+          if (!post) {
+            return;
+          }
+          event.preventDefault();
+          event.stopPropagation();
+          onPostClick(post);
+        }}
+      >
+        <Markdown className={transcriptProse} content={block.html} />
+      </div>
+    );
   }
 
   if (block.type === 'feedLink') {
@@ -301,13 +327,13 @@ const MessageRow = ({
   message,
   onPostClick,
   onFeedClick,
-  onSummaryClick,
+  resolvePostLink,
   activePostId,
 }: {
   message: AgentMessage;
   onPostClick: (post: Post) => void;
   onFeedClick: (label: string, posts: Post[]) => void;
-  onSummaryClick: (postId?: string) => void;
+  resolvePostLink: (href: string) => Post | undefined;
   activePostId?: string;
 }): ReactElement => {
   if (message.role === 'user') {
@@ -357,18 +383,10 @@ const MessageRow = ({
               block={block}
               onPostClick={onPostClick}
               onFeedClick={onFeedClick}
+              resolvePostLink={resolvePostLink}
               activePostId={activePostId}
             />
           ))}
-          {!!message.summaryPost && (
-            <AgentEmbedCard
-              icon={<FeatherIcon size={IconSize.Size16} />}
-              title={message.summaryPost.title ?? 'Summary post'}
-              subtitle="Post written this run"
-              actionLabel="Open"
-              onAction={() => onSummaryClick(message.summaryPost?.id)}
-            />
-          )}
           {!!message.blocks?.length && <MessageActions message={message} />}
         </>
       )}
@@ -383,9 +401,19 @@ export const AgentChatSection = (): ReactElement => {
     activeContent,
     queuedCommands,
     removeQueuedCommand,
+    findingsPosts,
   } = useAgent();
   const activePostId =
     activeContent?.type === 'post' ? activeContent.post.id : undefined;
+  const postsByLink = useMemo(
+    () =>
+      new Map(
+        findingsPosts
+          .filter((post) => post.commentsPermalink)
+          .map((post) => [postLinkKey(post.commentsPermalink), post]),
+      ),
+    [findingsPosts],
+  );
 
   return (
     <FlexCol className="gap-6">
@@ -397,9 +425,7 @@ export const AgentChatSection = (): ReactElement => {
           onFeedClick={(label, posts) =>
             openContentTarget({ type: 'feed', label, posts })
           }
-          onSummaryClick={(postId) =>
-            openContentTarget({ type: 'posts', postId })
-          }
+          resolvePostLink={(href) => postsByLink.get(postLinkKey(href))}
           activePostId={activePostId}
         />
       ))}

--- a/packages/shared/src/features/interests/components/AgentPickList.tsx
+++ b/packages/shared/src/features/interests/components/AgentPickList.tsx
@@ -72,7 +72,7 @@ const PickRow = ({
           onClick={() => onOpen(post)}
           className="w-full text-left after:absolute after:inset-0"
         >
-          {post.title}
+          {post.title ?? post.sharedPost?.title}
         </button>
       </Typography>
       <AgentRowActions post={post} reveal />

--- a/packages/shared/src/features/interests/components/AgentPostCard.tsx
+++ b/packages/shared/src/features/interests/components/AgentPostCard.tsx
@@ -91,7 +91,7 @@ export const AgentPostCard = ({
           onClick={() => onOpen(post)}
           className="line-clamp-2 w-full text-left after:absolute after:inset-0 after:rounded-12"
         >
-          {post.title}
+          {post.title ?? post.sharedPost?.title}
         </button>
       </Typography>
       <FlexRow className="items-center gap-3">


### PR DESCRIPTION
… in the side pane

The run's text block now carries the summary post's full content (API-side change), so the 'Open' embed card and the summaryPost message field are gone; the Posts tab and activity log keep their summary-post entries. Post links inside reply text resolve against the findings' commentsPermalink and open as a focused post pane instead of navigating; unknown links keep their default behavior.

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://agent-summary-reply-links.preview.app.daily.dev