### PR TITLE
feat(interests): post reference markers in agent chat

### DIFF
--- a/packages/shared/src/features/interests/AgentContext.tsx
+++ b/packages/shared/src/features/interests/AgentContext.tsx
@@ -27,7 +27,7 @@ import { interestHistoryQueryOptions } from './queries';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 import type { Post } from '../../graphql/posts';
 import type { AgentAttachment, AgentBlock, AgentMessage } from './chat';
-import { promptWithContext } from './chat';
+import { promptWithContext, restoreCommandText } from './chat';
 import type { AgentFeedItem } from './hooks/useAgentFeed';
 
 export type AgentSummaryPost = Pick<
@@ -210,6 +210,7 @@ const turnsToMessages = ({
         role: 'user',
         at: turn.createdAt,
         text: turn.text ?? '',
+        relationships: turn.relationships,
       });
       return acc;
     }
@@ -264,7 +265,7 @@ const echoResolved = (echo: CommandEcho, turns: InterestTurn[]): boolean =>
   turns.some(
     (turn) =>
       turn.role === 'user' &&
-      turn.text === echo.prompt &&
+      restoreCommandText(turn) === echo.prompt &&
       new Date(turn.createdAt).getTime() >= echo.sentAt - echoMatchWindowMs,
   );
 

--- a/packages/shared/src/features/interests/attachments.spec.ts
+++ b/packages/shared/src/features/interests/attachments.spec.ts
@@ -9,7 +9,7 @@ import {
   targetAttachment,
 } from './attachments';
 import type { AgentMessage } from './chat';
-import { promptWithContext } from './chat';
+import { promptWithContext, restoreCommandText } from './chat';
 
 const makePost = (id: string, title = `Post ${id}`): Post =>
   ({
@@ -184,14 +184,44 @@ describe('promptWithContext', () => {
     expect(promptWithContext('raise the bar', [])).toBe('raise the bar');
   });
 
-  it('names every attachment so the backend knows what was meant', () => {
+  it('serializes posts as markers and names other attachments', () => {
     const prompt = promptWithContext('why this one', [
       postAttachment(makePost('a', 'Zig 0.15')),
       quoteAttachment('self-hosted backend'),
     ]);
 
     expect(prompt).toContain('why this one');
-    expect(prompt).toContain('Zig 0.15');
+    expect(prompt).toContain('@dailydev:post:a');
+    expect(prompt).not.toContain('Zig 0.15');
     expect(prompt).toContain('self-hosted backend');
+  });
+});
+
+describe('restoreCommandText', () => {
+  it('strips relIds from resolved markers and restores marker-replaced urls', () => {
+    expect(
+      restoreCommandText({
+        text: 'love @dailydev:post:a:r1 and @dailydev:post:b:r2',
+        relationships: [
+          {
+            id: 'r2',
+            entity: 'post',
+            entityId: 'b',
+            url: 'https://dly.to/xyz',
+            title: 'B',
+            summary: null,
+          },
+        ],
+      }),
+    ).toBe('love @dailydev:post:a and https://dly.to/xyz');
+  });
+
+  it('leaves unswept and failed markers alone', () => {
+    expect(
+      restoreCommandText({
+        text: '@dailydev:post:a plus @dailydev:post:b:null',
+        relationships: [],
+      }),
+    ).toBe('@dailydev:post:a plus @dailydev:post:b');
   });
 });

--- a/packages/shared/src/features/interests/chat.ts
+++ b/packages/shared/src/features/interests/chat.ts
@@ -1,4 +1,8 @@
 import type { Post } from '../../graphql/posts';
+import type {
+  InterestTurn,
+  InterestTurnRelationship,
+} from '../../graphql/interests';
 
 export type AgentBlock =
   | { type: 'text'; html: string }
@@ -18,6 +22,7 @@ export type AgentMessage = {
   role: 'user' | 'agent';
   at: string;
   text?: string;
+  relationships?: InterestTurnRelationship[] | null;
   attachments?: AgentAttachment[];
   blocks?: AgentBlock[];
   summaryPost?: Pick<Post, 'id' | 'title' | 'createdAt' | 'contentHtml'>;
@@ -35,6 +40,24 @@ export const promptWithContext = (
 ): string =>
   attachments.length
     ? `${text}\n\nIn the context of: ${attachments
-        .map(({ label }) => `“${label}”`)
+        .map(({ id, kind, label }) =>
+          kind === 'post' ? `@dailydev:${id}` : `“${label}”`,
+        )
         .join(', ')}`
     : text;
+
+export const FEEDBACK_MARKER_REGEX =
+  /@dailydev:post:([a-zA-Z0-9]+)(?::([a-zA-Z0-9]+))?/g;
+
+export const restoreCommandText = (
+  turn: Pick<InterestTurn, 'text' | 'relationships'>,
+): string => {
+  const text = turn.text ?? '';
+  return text.replace(FEEDBACK_MARKER_REGEX, (full, postId, relId) => {
+    if (!relId) {
+      return full;
+    }
+    const entry = turn.relationships?.find((rel) => rel.id === relId);
+    return entry?.url ?? `@dailydev:post:${postId}`;
+  });
+};

--- a/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
@@ -52,6 +52,39 @@ beforeEach(() => {
 
 afterEach(() => jest.restoreAllMocks());
 
+describe('a user message with post markers', () => {
+  it('renders resolved markers as titled links and failed ones as text', () => {
+    const userMessage: AgentMessage = {
+      id: 'u1',
+      role: 'user',
+      at: new Date(0).toISOString(),
+      text: 'love @dailydev:post:p9:r1 not @dailydev:post:gone:null',
+      relationships: [
+        {
+          id: 'r1',
+          entity: 'post',
+          entityId: 'p9',
+          url: null,
+          title: 'Zig rocks',
+          summary: null,
+        },
+      ],
+    };
+
+    render(
+      <TestBootProvider client={new QueryClient()}>
+        <AgentProvider id="a1" isDemo initialMessages={[userMessage]}>
+          <AgentChatSection />
+        </AgentProvider>
+      </TestBootProvider>,
+    );
+
+    const link = screen.getByRole('link', { name: '@Zig rocks' });
+    expect(link).toHaveAttribute('href', expect.stringContaining('posts/p9'));
+    expect(document.body).toHaveTextContent('@dailydev:post:gone:null');
+  });
+});
+
 describe('copying a reply', () => {
   const copied = () => {
     const copyText = jest.fn();

--- a/packages/shared/src/features/interests/components/AgentChatSection.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
 import Markdown from '../../../components/Markdown';
 import { Tooltip } from '../../../components/tooltip/Tooltip';
@@ -32,6 +32,8 @@ import { DateFormat } from '../../../components/utilities/DateFormat';
 import { TimeFormatType } from '../../../lib/dateFormat';
 import type { Post } from '../../../graphql/posts';
 import type { AgentBlock, AgentMessage } from '../chat';
+import { FEEDBACK_MARKER_REGEX } from '../chat';
+import { webappUrl } from '../../../lib/constants';
 import { useAgent } from '../AgentContext';
 import { transcriptProse } from '../prose';
 import { messageAsMarkdown, messageAsText } from '../replyText';
@@ -297,6 +299,43 @@ const ErrorTurn = ({ message }: { message: AgentMessage }): ReactElement => {
   );
 };
 
+const UserMessageText = ({
+  message,
+}: {
+  message: AgentMessage;
+}): ReactElement => {
+  const text = message.text ?? '';
+  const nodes: ReactNode[] = [];
+  let cursor = 0;
+
+  Array.from(text.matchAll(FEEDBACK_MARKER_REGEX)).forEach((match) => {
+    const [marker, postId, relId] = match;
+    nodes.push(text.slice(cursor, match.index));
+    cursor = match.index + marker.length;
+
+    if (relId === 'null') {
+      nodes.push(marker);
+      return;
+    }
+
+    const entry = message.relationships?.find((rel) => rel.id === relId);
+    nodes.push(
+      <a
+        key={`${match.index}-${postId}`}
+        href={`${webappUrl}posts/${postId}`}
+        target="_blank"
+        rel="noopener"
+        className="font-bold text-text-link hover:underline"
+      >
+        @{entry?.title ?? 'post'}
+      </a>,
+    );
+  });
+  nodes.push(text.slice(cursor));
+
+  return <>{nodes}</>;
+};
+
 const MessageRow = ({
   message,
   onPostClick,
@@ -325,7 +364,7 @@ const MessageRow = ({
         )}
         <div className="max-w-[85%] rounded-12 rounded-br-4 bg-surface-float px-3 py-2 tablet:max-w-[30rem]">
           <Typography type={TypographyType.Callout} className="!leading-normal">
-            {message.text}
+            <UserMessageText message={message} />
           </Typography>
         </div>
       </FlexCol>

--- a/packages/shared/src/graphql/interests.ts
+++ b/packages/shared/src/graphql/interests.ts
@@ -88,11 +88,21 @@ export type InterestRunBlock =
   | { type: 'picks'; caption?: string; postIds: string[] }
   | { type: 'feedLink'; label: string; count: number; postIds?: string[] };
 
+export type InterestTurnRelationship = {
+  id: string;
+  entity: 'post';
+  entityId: string;
+  url: string | null;
+  title: string | null;
+  summary: string | null;
+};
+
 export type InterestTurn = {
   id: string;
   role: 'user' | 'agent';
   createdAt: string;
   text?: string | null;
+  relationships?: InterestTurnRelationship[] | null;
   status?: InterestRunStatus | null;
   trigger?: InterestRunTrigger | null;
   feedbackId?: string | null;
@@ -186,6 +196,7 @@ export const INTEREST_HISTORY_QUERY = `
       role
       createdAt
       text
+      relationships
       status
       trigger
       feedbackId


### PR DESCRIPTION
Serialize post attachments as @dailydev markers, expose feedback relationships from interestHistory, render resolved markers as titled post links in user messages, and reconcile optimistic echoes against the server-rewritten text.

API PR: https://github.com/dailydotdev/daily-api/pull/4117

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://interest-feedback-post-reference.preview.app.daily.dev