### PR TITLE
feat(agent): pick agent settings on the spawn screen

### DIFF
--- a/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
@@ -4,7 +4,11 @@ import { QueryClient } from '@tanstack/react-query';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 import { mockDesktop } from '../../../../__tests__/helpers/media';
 import { AgentHomeScreen } from './AgentHomeScreen';
-import { interestDisplayName } from '../../../graphql/interests';
+import {
+  UserInterestCadence,
+  defaultCreateInterestSettings,
+  interestDisplayName,
+} from '../../../graphql/interests';
 import { recentMockAgents } from '../mock';
 
 const renderHome = (
@@ -19,6 +23,11 @@ const renderHome = (
       />
     </TestBootProvider>,
   );
+
+const field = () =>
+  screen.getByLabelText(
+    'What should the agent hunt for?',
+  ) as HTMLTextAreaElement;
 
 beforeEach(() => mockDesktop());
 
@@ -89,11 +98,6 @@ describe('AgentHomeScreen rows at both readings', () => {
 });
 
 describe('AgentHomeScreen given a shared prompt', () => {
-  const field = () =>
-    screen.getByLabelText(
-      'What should the agent hunt for?',
-    ) as HTMLTextAreaElement;
-
   it('puts it in the field, ready to send', () => {
     renderHome({ initialQuery: 'Rust in production' });
 
@@ -151,5 +155,63 @@ describe('AgentHomeScreen given a shared prompt', () => {
     );
 
     expect(field().value).toBe('My own topic');
+  });
+});
+
+describe('AgentHomeScreen spawn settings', () => {
+  it('spawns with the default settings untouched', () => {
+    const onCreate = jest.fn();
+    render(
+      <TestBootProvider client={new QueryClient()}>
+        <AgentHomeScreen agents={[]} onCreate={onCreate} />
+      </TestBootProvider>,
+    );
+
+    fireEvent.change(field(), { target: { value: 'Rust in production' } });
+    fireEvent.click(screen.getByLabelText('Spawn the agent'));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      query: 'Rust in production',
+      settings: defaultCreateInterestSettings,
+    });
+  });
+
+  it('spawns with what was picked in the settings', () => {
+    const onCreate = jest.fn();
+    render(
+      <TestBootProvider client={new QueryClient()}>
+        <AgentHomeScreen agents={[]} onCreate={onCreate} />
+      </TestBootProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }));
+    fireEvent.click(screen.getByLabelText('Every week'));
+    fireEvent.click(screen.getByLabelText('Send a digest email'));
+    fireEvent.change(field(), { target: { value: 'Zig internals' } });
+    fireEvent.click(screen.getByLabelText('Spawn the agent'));
+
+    expect(onCreate).toHaveBeenCalledWith({
+      query: 'Zig internals',
+      settings: {
+        cadence: UserInterestCadence.Weekly,
+        fomoThreshold: 0.5,
+        outputModes: {
+          feed: true,
+          post: true,
+          digest: true,
+          notification: true,
+        },
+      },
+    });
+  });
+
+  it('keeps the settings hidden until asked for', () => {
+    renderHome();
+
+    expect(screen.queryByLabelText('Every week')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }));
+
+    expect(screen.getByLabelText('Every week')).toBeInTheDocument();
   });
 });

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
@@ -205,13 +205,27 @@ describe('AgentHomeScreen spawn settings', () => {
     });
   });
 
-  it('keeps the settings hidden until asked for', () => {
+  it('peeks the current values until the controls are asked for', () => {
     renderHome();
 
+    expect(screen.getByText('Every hour')).toBeInTheDocument();
+    expect(screen.getByText('Balanced')).toBeInTheDocument();
+    expect(screen.getByText('feed, posts, notifications')).toBeInTheDocument();
     expect(screen.queryByLabelText('Every week')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }));
 
     expect(screen.getByLabelText('Every week')).toBeInTheDocument();
+  });
+
+  it('reflects what was picked back into the peek', () => {
+    renderHome();
+
+    const toggle = screen.getByRole('button', { name: 'Agent settings' });
+    fireEvent.click(toggle);
+    fireEvent.click(screen.getByLabelText('Every week'));
+    fireEvent.click(toggle);
+
+    expect(screen.getByText('Every week')).toBeInTheDocument();
   });
 });

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
@@ -15,7 +15,7 @@ import {
   ButtonVariant,
 } from '../../../components/buttons/Button';
 import { Tooltip } from '../../../components/tooltip/Tooltip';
-import { ArrowIcon } from '../../../components/icons';
+import { ArrowIcon, SettingsIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
 import { ElementPlaceholder } from '../../../components/ElementPlaceholder';
 import { DateFormat } from '../../../components/utilities/DateFormat';
@@ -30,8 +30,20 @@ import {
   stateMeaning,
   toMonitorItems,
 } from '../monitorItems';
+import type { CreateInterestSettings } from '../../../graphql/interests';
+import {
+  UserInterestCadence,
+  defaultCreateInterestSettings,
+} from '../../../graphql/interests';
 import { composerBar, composerColumn, composerFrame } from './AgentComposer';
 import { AgentSendButton } from './AgentSendButton';
+import {
+  CadenceSection,
+  FomoSection,
+  OutputModesSection,
+  cadenceOptions,
+  outputOptions,
+} from './AgentSettingsFields';
 
 const maxFieldHeight = 120;
 
@@ -138,7 +150,10 @@ export const AgentHomeScreen = ({
 }: {
   agents: AgentMonitorSource[];
   isPending?: boolean;
-  onCreate: (query: string) => void | Promise<unknown>;
+  onCreate: (input: {
+    query: string;
+    settings?: CreateInterestSettings;
+  }) => void | Promise<unknown>;
   isCreating?: boolean;
   isStandalone?: boolean;
   /** Never runs on its own: a shared link must not spend someone's allowance. */
@@ -148,6 +163,10 @@ export const AgentHomeScreen = ({
   const fieldRef = useRef<HTMLTextAreaElement>(null);
   const resizeFrame = useRef<number>();
   const [query, setQuery] = useState(initialQuery);
+  const [isSettingsOpen, setSettingsOpen] = useState(false);
+  const [settings, setSettings] = useState<CreateInterestSettings>(
+    defaultCreateInterestSettings,
+  );
   // On this statically optimised route the query is empty until after hydration,
   // so it arrives a render after `useState` read its argument. Only adopted into
   // an empty field, so it cannot overwrite what was typed.
@@ -202,8 +221,18 @@ export const AgentHomeScreen = ({
 
     // The mutation reports its own failure with a toast, so swallowing here only
     // stops the same failure escaping as an unhandled rejection.
-    Promise.resolve(onCreate(trimmed)).catch(() => undefined);
+    Promise.resolve(onCreate({ query: trimmed, settings })).catch(
+      () => undefined,
+    );
   };
+
+  const cadenceSummary =
+    cadenceOptions.find(({ value }) => value === settings.cadence)?.label ??
+    'Every hour';
+  const deliverySummary = outputOptions
+    .filter(({ key }) => settings.outputModes?.[key])
+    .map(({ short }) => short)
+    .join(', ');
 
   return (
     <FlexCol className={classNames('w-full overflow-hidden', shellHeight)}>
@@ -338,6 +367,57 @@ export const AgentHomeScreen = ({
               />
             </FlexRow>
           </FlexCol>
+
+          <FlexRow className="min-w-0 items-center gap-2">
+            <Button
+              size={ButtonSize.XSmall}
+              variant={ButtonVariant.Subtle}
+              icon={<SettingsIcon size={IconSize.Size16} />}
+              aria-expanded={isSettingsOpen}
+              className="shrink-0"
+              onClick={() => setSettingsOpen((open) => !open)}
+            >
+              Agent settings
+            </Button>
+            <Typography
+              type={TypographyType.Caption1}
+              color={TypographyColor.Quaternary}
+              className="min-w-0 flex-1 truncate"
+            >
+              {cadenceSummary} ·{' '}
+              {deliverySummary
+                ? `Delivers ${deliverySummary}`
+                : 'Delivers nothing'}
+            </Typography>
+          </FlexRow>
+
+          {isSettingsOpen && (
+            <FlexCol className="agent-scroll max-h-[50vh] overflow-y-auto rounded-16 border border-border-subtlest-tertiary bg-surface-float px-4">
+              <CadenceSection
+                value={settings.cadence ?? UserInterestCadence.Hourly}
+                disabled={isCreating}
+                onChange={(cadence) =>
+                  setSettings((current) => ({ ...current, cadence }))
+                }
+              />
+              <FomoSection
+                value={settings.fomoThreshold ?? 0.5}
+                onChange={(fomoThreshold) =>
+                  setSettings((current) => ({ ...current, fomoThreshold }))
+                }
+              />
+              <OutputModesSection
+                value={settings.outputModes}
+                disabled={isCreating}
+                onChange={(outputModes) =>
+                  setSettings((current) => ({
+                    ...current,
+                    outputModes: { ...current.outputModes, ...outputModes },
+                  }))
+                }
+              />
+            </FlexCol>
+          )}
 
           {/* `pr-6` matches the fade's width, so the last starter clears the mask
               when the row is scrolled to its end. */}

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
@@ -358,26 +358,38 @@ export const AgentHomeScreen = ({
               className="flex w-full flex-col gap-2 px-4 py-3 text-left transition-colors hover:bg-surface-hover"
               onClick={() => setSettingsOpen((open) => !open)}
             >
-              <FlexRow className="w-full items-center gap-2">
-                <SettingsIcon
-                  size={IconSize.Size16}
-                  className="text-text-tertiary"
-                />
-                <strong className="flex-1 text-text-secondary typo-footnote">
-                  Agent settings
-                </strong>
-                <span className="text-text-quaternary typo-caption1">
-                  {isSettingsOpen ? 'Done' : 'Adjust'}
-                </span>
-                <ArrowIcon
-                  size={IconSize.Size16}
-                  className={classNames(
-                    'text-text-quaternary transition-transform',
-                    !isSettingsOpen && 'rotate-180',
-                  )}
-                  aria-hidden
-                />
-              </FlexRow>
+              <div className="flex w-full flex-col gap-1 tablet:flex-row tablet:items-center tablet:gap-2">
+                <FlexRow className="w-full items-center gap-2 tablet:w-auto tablet:flex-1">
+                  <SettingsIcon
+                    size={IconSize.Size16}
+                    className="text-text-tertiary"
+                  />
+                  <strong className="flex-1 text-text-secondary typo-footnote">
+                    Agent settings
+                  </strong>
+                  <ArrowIcon
+                    size={IconSize.Size16}
+                    className={classNames(
+                      'text-text-quaternary transition-transform tablet:hidden',
+                      isSettingsOpen ? 'rotate-180' : 'rotate-90',
+                    )}
+                    aria-hidden
+                  />
+                </FlexRow>
+                <FlexRow className="items-center gap-2 pl-6 tablet:pl-0">
+                  <span className="font-bold text-text-quaternary typo-caption1">
+                    {isSettingsOpen ? 'Done' : 'Tailor it to your needs'}
+                  </span>
+                  <ArrowIcon
+                    size={IconSize.Size16}
+                    className={classNames(
+                      'hidden text-text-quaternary transition-transform tablet:block',
+                      isSettingsOpen ? 'rotate-180' : 'rotate-90',
+                    )}
+                    aria-hidden
+                  />
+                </FlexRow>
+              </div>
               {!isSettingsOpen && (
                 <FlexCol className="w-full gap-1">
                   {peekRows.map(([label, value]) => (

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
@@ -9,12 +9,6 @@ import {
 } from '../../../components/typography/Typography';
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import Link from '../../../components/utilities/Link';
-import {
-  Button,
-  ButtonSize,
-  ButtonVariant,
-} from '../../../components/buttons/Button';
-import { Tooltip } from '../../../components/tooltip/Tooltip';
 import { ArrowIcon, SettingsIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
 import { ElementPlaceholder } from '../../../components/ElementPlaceholder';
@@ -46,13 +40,6 @@ import {
 } from './AgentSettingsFields';
 
 const maxFieldHeight = 120;
-
-const starters = [
-  'Rust in production',
-  'Database internals',
-  'What is happening with WebGPU',
-  'CLI tools worth stealing from',
-];
 
 // One DOM for both readings: the wrappers become `display: contents` from tablet
 // up and the fields reorder, so nothing is rendered twice for a screen reader.
@@ -161,7 +148,6 @@ export const AgentHomeScreen = ({
 }): ReactElement => {
   const shellHeight = useAgentShellHeight(isStandalone);
   const fieldRef = useRef<HTMLTextAreaElement>(null);
-  const resizeFrame = useRef<number>();
   const [query, setQuery] = useState(initialQuery);
   const [isSettingsOpen, setSettingsOpen] = useState(false);
   const [settings, setSettings] = useState<CreateInterestSettings>(
@@ -178,15 +164,6 @@ export const AgentHomeScreen = ({
     setQuery((current) => current || initialQuery);
   }, [initialQuery]);
 
-  useEffect(
-    () => () => {
-      if (resizeFrame.current) {
-        cancelAnimationFrame(resizeFrame.current);
-      }
-    },
-    [],
-  );
-
   const items = toMonitorItems(agents);
   const waiting = items.filter(({ state }) => state === 'waiting').length;
   const working = items.filter(({ state }) =>
@@ -202,14 +179,6 @@ export const AgentHomeScreen = ({
 
     field.style.height = 'auto';
     field.style.height = `${Math.min(field.scrollHeight, maxFieldHeight)}px`;
-  };
-
-  const write = (value: string) => {
-    setQuery(value);
-    fieldRef.current?.focus();
-    // The field has not re-rendered with the new value yet, so it is measured on
-    // the next frame rather than against the old text.
-    resizeFrame.current = requestAnimationFrame(resize);
   };
 
   const onSubmit = () => {
@@ -233,6 +202,19 @@ export const AgentHomeScreen = ({
     .filter(({ key }) => settings.outputModes?.[key])
     .map(({ short }) => short)
     .join(', ');
+  const threshold = settings.fomoThreshold ?? 0.5;
+  let fomoSummary = 'Balanced';
+  if (threshold > 0.7) {
+    fomoSummary = 'Only the best';
+  }
+  if (threshold < 0.3) {
+    fomoSummary = 'Show me everything';
+  }
+  const peekRows = [
+    ['When it runs', cadenceSummary],
+    ['FOMO vs quality', fomoSummary],
+    ['What it delivers', deliverySummary || 'Nothing yet'],
+  ];
 
   return (
     <FlexCol className={classNames('w-full overflow-hidden', shellHeight)}>
@@ -368,76 +350,78 @@ export const AgentHomeScreen = ({
             </FlexRow>
           </FlexCol>
 
-          <FlexRow className="min-w-0 items-center gap-2">
-            <Button
-              size={ButtonSize.XSmall}
-              variant={ButtonVariant.Subtle}
-              icon={<SettingsIcon size={IconSize.Size16} />}
+          <FlexCol className="overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-surface-float">
+            <button
+              type="button"
+              aria-label="Agent settings"
               aria-expanded={isSettingsOpen}
-              className="shrink-0"
+              className="flex w-full flex-col gap-2 px-4 py-3 text-left transition-colors hover:bg-surface-hover"
               onClick={() => setSettingsOpen((open) => !open)}
             >
-              Agent settings
-            </Button>
-            <Typography
-              type={TypographyType.Caption1}
-              color={TypographyColor.Quaternary}
-              className="min-w-0 flex-1 truncate"
-            >
-              {cadenceSummary} ·{' '}
-              {deliverySummary
-                ? `Delivers ${deliverySummary}`
-                : 'Delivers nothing'}
-            </Typography>
-          </FlexRow>
+              <FlexRow className="w-full items-center gap-2">
+                <SettingsIcon
+                  size={IconSize.Size16}
+                  className="text-text-tertiary"
+                />
+                <strong className="flex-1 text-text-secondary typo-footnote">
+                  Agent settings
+                </strong>
+                <span className="text-text-quaternary typo-caption1">
+                  {isSettingsOpen ? 'Done' : 'Adjust'}
+                </span>
+                <ArrowIcon
+                  size={IconSize.Size16}
+                  className={classNames(
+                    'text-text-quaternary transition-transform',
+                    !isSettingsOpen && 'rotate-180',
+                  )}
+                  aria-hidden
+                />
+              </FlexRow>
+              {!isSettingsOpen && (
+                <FlexCol className="w-full gap-1">
+                  {peekRows.map(([label, value]) => (
+                    <FlexRow key={label} className="items-baseline gap-3">
+                      <span className="w-28 shrink-0 text-text-quaternary typo-caption1">
+                        {label}
+                      </span>
+                      <span className="min-w-0 flex-1 truncate text-text-tertiary typo-caption1">
+                        {value}
+                      </span>
+                    </FlexRow>
+                  ))}
+                </FlexCol>
+              )}
+            </button>
 
-          {isSettingsOpen && (
-            <FlexCol className="agent-scroll max-h-[50vh] overflow-y-auto rounded-16 border border-border-subtlest-tertiary bg-surface-float px-4">
-              <CadenceSection
-                value={settings.cadence ?? UserInterestCadence.Hourly}
-                disabled={isCreating}
-                onChange={(cadence) =>
-                  setSettings((current) => ({ ...current, cadence }))
-                }
-              />
-              <FomoSection
-                value={settings.fomoThreshold ?? 0.5}
-                onChange={(fomoThreshold) =>
-                  setSettings((current) => ({ ...current, fomoThreshold }))
-                }
-              />
-              <OutputModesSection
-                value={settings.outputModes}
-                disabled={isCreating}
-                onChange={(outputModes) =>
-                  setSettings((current) => ({
-                    ...current,
-                    outputModes: { ...current.outputModes, ...outputModes },
-                  }))
-                }
-              />
-            </FlexCol>
-          )}
-
-          {/* `pr-6` matches the fade's width, so the last starter clears the mask
-              when the row is scrolled to its end. */}
-          <FlexRow className="agent-fade-right no-scrollbar items-center gap-1.5 overflow-x-auto pl-0.5 pr-6">
-            {starters.map((starter) => (
-              <Tooltip
-                key={starter}
-                content="Drops it in the field. Edit it before you send."
-              >
-                <Button
-                  size={ButtonSize.XSmall}
-                  variant={ButtonVariant.Subtle}
-                  className="shrink-0"
-                  onClick={() => write(starter)}
-                >
-                  {starter}
-                </Button>
-              </Tooltip>
-            ))}
-          </FlexRow>
+            {isSettingsOpen && (
+              <FlexCol className="agent-scroll max-h-[50vh] overflow-y-auto border-t border-border-subtlest-tertiary px-4">
+                <CadenceSection
+                  value={settings.cadence ?? UserInterestCadence.Hourly}
+                  disabled={isCreating}
+                  onChange={(cadence) =>
+                    setSettings((current) => ({ ...current, cadence }))
+                  }
+                />
+                <FomoSection
+                  value={settings.fomoThreshold ?? 0.5}
+                  onChange={(fomoThreshold) =>
+                    setSettings((current) => ({ ...current, fomoThreshold }))
+                  }
+                />
+                <OutputModesSection
+                  value={settings.outputModes}
+                  disabled={isCreating}
+                  onChange={(outputModes) =>
+                    setSettings((current) => ({
+                      ...current,
+                      outputModes: { ...current.outputModes, ...outputModes },
+                    }))
+                  }
+                />
+              </FlexCol>
+            )}
+          </FlexCol>
         </FlexCol>
       </div>
     </FlexCol>

--- a/packages/shared/src/features/interests/components/AgentSettingsFields.tsx
+++ b/packages/shared/src/features/interests/components/AgentSettingsFields.tsx
@@ -1,0 +1,174 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useState } from 'react';
+import {
+  Typography,
+  TypographyColor,
+  TypographyType,
+} from '../../../components/typography/Typography';
+import { FlexCol, FlexRow } from '../../../components/utilities';
+import { Switch } from '../../../components/fields/Switch';
+import { Slider } from '../../../components/fields/Slider';
+import { Radio } from '../../../components/fields/Radio';
+import type { InterestOutputModes } from '../../../graphql/interests';
+import { UserInterestCadence } from '../../../graphql/interests';
+
+export const cadenceOptions = [
+  { value: UserInterestCadence.Hourly, label: 'Every hour' },
+  { value: UserInterestCadence.Daily, label: 'Every day' },
+  { value: UserInterestCadence.Weekly, label: 'Every week' },
+];
+
+export const outputOptions = [
+  {
+    key: 'feed',
+    label: 'Add findings to my feed',
+    short: 'feed',
+    hint: 'Curated cards you can browse here',
+  },
+  {
+    key: 'post',
+    label: 'Write summary posts',
+    short: 'posts',
+    hint: 'A markdown recap of what it found',
+  },
+  {
+    key: 'notification',
+    label: 'Notify me about new content',
+    short: 'notifications',
+    hint: 'In-app and push ping when something lands',
+  },
+  {
+    key: 'digest',
+    label: 'Send a digest email',
+    short: 'email digest',
+    hint: 'Up to 5 picks, delivered at your chosen time',
+  },
+] as const;
+
+export const SettingsSection = ({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint?: string;
+  children: ReactNode;
+}): ReactElement => (
+  <FlexCol className="gap-3 border-b border-border-subtlest-tertiary py-5 last:border-b-0">
+    <FlexCol className="gap-0.5">
+      <Typography type={TypographyType.Body} bold>
+        {title}
+      </Typography>
+      {hint && (
+        <Typography
+          type={TypographyType.Footnote}
+          color={TypographyColor.Tertiary}
+        >
+          {hint}
+        </Typography>
+      )}
+    </FlexCol>
+    {children}
+  </FlexCol>
+);
+
+export const CadenceSection = ({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: UserInterestCadence;
+  disabled?: boolean;
+  onChange: (cadence: UserInterestCadence) => void;
+}): ReactElement => (
+  <SettingsSection
+    title="When it runs"
+    hint="How often the agent goes hunting for new content."
+  >
+    <Radio
+      name="agent-cadence"
+      value={value}
+      options={cadenceOptions}
+      disabled={disabled}
+      onChange={onChange}
+    />
+  </SettingsSection>
+);
+
+export const FomoSection = ({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (fomoThreshold: number) => void;
+}): ReactElement => {
+  const [draft, setDraft] = useState<number | null>(null);
+  const threshold = draft ?? value;
+
+  return (
+    <SettingsSection
+      title="FOMO vs quality"
+      hint={
+        threshold > 0.7
+          ? 'Only the very best makes it through.'
+          : 'You will see more, including the borderline stuff.'
+      }
+    >
+      <Slider
+        min={0}
+        max={1}
+        step={0.05}
+        value={[threshold]}
+        onValueChange={([next]) => setDraft(next)}
+        onValueCommit={([next]) => onChange(next)}
+      />
+      <FlexRow className="justify-between">
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+        >
+          Show me everything
+        </Typography>
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+        >
+          Only the best
+        </Typography>
+      </FlexRow>
+    </SettingsSection>
+  );
+};
+
+export const OutputModesSection = ({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: Partial<InterestOutputModes> | undefined;
+  disabled?: boolean;
+  onChange: (outputModes: Partial<InterestOutputModes>) => void;
+}): ReactElement => (
+  <SettingsSection title="What it delivers">
+    {outputOptions.map(({ key, label, hint }) => (
+      <FlexCol key={key} className="gap-0.5">
+        <Switch
+          inputId={`agent-output-${key}`}
+          name={`agent-output-${key}`}
+          checked={!!value?.[key]}
+          disabled={disabled}
+          onToggle={() => onChange({ [key]: !value?.[key] })}
+        >
+          {label}
+        </Switch>
+        <Typography
+          type={TypographyType.Caption1}
+          color={TypographyColor.Tertiary}
+          className="pl-14"
+        >
+          {hint}
+        </Typography>
+      </FlexCol>
+    ))}
+  </SettingsSection>
+);

--- a/packages/shared/src/features/interests/components/AgentSettingsPane.tsx
+++ b/packages/shared/src/features/interests/components/AgentSettingsPane.tsx
@@ -7,8 +7,6 @@ import {
 } from '../../../components/typography/Typography';
 import { FlexCol, FlexRow } from '../../../components/utilities';
 import { Switch } from '../../../components/fields/Switch';
-import { Slider } from '../../../components/fields/Slider';
-import { Radio } from '../../../components/fields/Radio';
 import {
   Button,
   ButtonColor,
@@ -24,68 +22,18 @@ import {
   interestDisplayName,
 } from '../../../graphql/interests';
 import { useAgent } from '../AgentContext';
-
-const cadenceOptions = [
-  { value: UserInterestCadence.Hourly, label: 'Every hour' },
-  { value: UserInterestCadence.Daily, label: 'Every day' },
-  { value: UserInterestCadence.Weekly, label: 'Every week' },
-];
-
-const outputOptions = [
-  {
-    key: 'feed',
-    label: 'Add findings to my feed',
-    hint: 'Curated cards you can browse here',
-  },
-  {
-    key: 'post',
-    label: 'Write summary posts',
-    hint: 'A markdown recap of what it found',
-  },
-  {
-    key: 'notification',
-    label: 'Notify me about new content',
-    hint: 'In-app and push ping when something lands',
-  },
-  {
-    key: 'digest',
-    label: 'Send a digest email',
-    hint: 'Up to 5 picks, delivered at your chosen time',
-  },
-] as const;
+import {
+  CadenceSection,
+  FomoSection,
+  OutputModesSection,
+  SettingsSection,
+} from './AgentSettingsFields';
 
 const sourceOptions = [
   { key: 'dailyDev', label: 'daily.dev', disabled: false },
   { key: 'web', label: 'The web', disabled: true },
   { key: 'github', label: 'GitHub', disabled: true },
 ] as const;
-
-const Section = ({
-  title,
-  hint,
-  children,
-}: {
-  title: string;
-  hint?: string;
-  children: React.ReactNode;
-}): ReactElement => (
-  <FlexCol className="gap-3 border-b border-border-subtlest-tertiary py-5 last:border-b-0">
-    <FlexCol className="gap-0.5">
-      <Typography type={TypographyType.Body} bold>
-        {title}
-      </Typography>
-      {hint && (
-        <Typography
-          type={TypographyType.Footnote}
-          color={TypographyColor.Tertiary}
-        >
-          {hint}
-        </Typography>
-      )}
-    </FlexCol>
-    {children}
-  </FlexCol>
-);
 
 export const AgentSettingsPane = ({
   onDelete,
@@ -95,10 +43,8 @@ export const AgentSettingsPane = ({
   isDeleting: boolean;
 }): ReactElement => {
   const { interest, update, isUpdating, setSettingsOpen } = useAgent();
-  const [fomo, setFomo] = useState<number | null>(null);
   const [isConfirmingDelete, setConfirmingDelete] = useState(false);
   const isStopped = interest?.status === UserInterestStatus.Stopped;
-  const threshold = fomo ?? interest?.fomoThreshold ?? 0.5;
 
   return (
     <>
@@ -128,79 +74,24 @@ export const AgentSettingsPane = ({
 
       <div className="agent-scroll min-h-0 flex-1 overflow-y-auto px-5 tablet:px-8 laptop:px-10">
         <FlexCol className="mx-auto w-full max-w-[45rem] pb-8">
-          <Section
-            title="When it runs"
-            hint="How often the agent goes hunting for new content."
-          >
-            <Radio
-              name="agent-cadence"
-              value={interest?.cadence ?? UserInterestCadence.Daily}
-              options={cadenceOptions}
-              disabled={isUpdating || isStopped}
-              onChange={(cadence) => update({ cadence })}
-            />
-          </Section>
+          <CadenceSection
+            value={interest?.cadence ?? UserInterestCadence.Daily}
+            disabled={isUpdating || isStopped}
+            onChange={(cadence) => update({ cadence })}
+          />
 
-          <Section
-            title="FOMO vs quality"
-            hint={
-              threshold > 0.7
-                ? 'Only the very best makes it through.'
-                : 'You will see more, including the borderline stuff.'
-            }
-          >
-            <Slider
-              min={0}
-              max={1}
-              step={0.05}
-              value={[threshold]}
-              onValueChange={([value]) => setFomo(value)}
-              onValueCommit={([value]) => update({ fomoThreshold: value })}
-            />
-            <FlexRow className="justify-between">
-              <Typography
-                type={TypographyType.Caption1}
-                color={TypographyColor.Tertiary}
-              >
-                Show me everything
-              </Typography>
-              <Typography
-                type={TypographyType.Caption1}
-                color={TypographyColor.Tertiary}
-              >
-                Only the best
-              </Typography>
-            </FlexRow>
-          </Section>
+          <FomoSection
+            value={interest?.fomoThreshold ?? 0.5}
+            onChange={(fomoThreshold) => update({ fomoThreshold })}
+          />
 
-          <Section title="What it delivers">
-            {outputOptions.map(({ key, label, hint }) => (
-              <FlexCol key={key} className="gap-0.5">
-                <Switch
-                  inputId={`agent-output-${key}`}
-                  name={`agent-output-${key}`}
-                  checked={!!interest?.outputModes?.[key]}
-                  disabled={isUpdating}
-                  onToggle={() =>
-                    update({
-                      outputModes: { [key]: !interest?.outputModes?.[key] },
-                    })
-                  }
-                >
-                  {label}
-                </Switch>
-                <Typography
-                  type={TypographyType.Caption1}
-                  color={TypographyColor.Tertiary}
-                  className="pl-14"
-                >
-                  {hint}
-                </Typography>
-              </FlexCol>
-            ))}
-          </Section>
+          <OutputModesSection
+            value={interest?.outputModes}
+            disabled={isUpdating}
+            onChange={(outputModes) => update({ outputModes })}
+          />
 
-          <Section
+          <SettingsSection
             title="Where it looks"
             hint="Web and GitHub discovery are coming next."
           >
@@ -218,9 +109,9 @@ export const AgentSettingsPane = ({
                 {label}
               </Switch>
             ))}
-          </Section>
+          </SettingsSection>
 
-          <Section
+          <SettingsSection
             title="Delete this agent"
             hint="Its conversation and everything it found go with it. Pausing is in the settings menu if you only want it to stop hunting."
           >
@@ -256,7 +147,7 @@ export const AgentSettingsPane = ({
                 </Button>
               )}
             </FlexRow>
-          </Section>
+          </SettingsSection>
         </FlexCol>
       </div>
     </>

--- a/packages/shared/src/features/interests/hooks/useCreateInterest.ts
+++ b/packages/shared/src/features/interests/hooks/useCreateInterest.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthContext } from '../../../contexts/AuthContext';
 import { useToastNotification } from '../../../hooks/useToastNotification';
 import { generateQueryKey, RequestKey } from '../../../lib/query';
+import type { CreateInterestSettings } from '../../../graphql/interests';
 import { createInterest } from '../../../graphql/interests';
 import { interestQueryOptions } from '../queries';
 
@@ -15,7 +16,8 @@ export const useCreateInterest = ({
   const queryClient = useQueryClient();
 
   const { isPending, mutateAsync } = useMutation({
-    mutationFn: (query: string) => createInterest(query),
+    mutationFn: (input: { query: string; settings?: CreateInterestSettings }) =>
+      createInterest(input),
     onSuccess: async (interest) => {
       // Without priming, the page opened below mounts while the fetch is still
       // in flight and lands on an empty transcript.

--- a/packages/shared/src/graphql/interests.ts
+++ b/packages/shared/src/graphql/interests.ts
@@ -73,6 +73,14 @@ export type UpdateInterestInput = {
   outputModes?: Partial<InterestOutputModes>;
 };
 
+export type CreateInterestSettings = Omit<UpdateInterestInput, 'status'>;
+
+export const defaultCreateInterestSettings: CreateInterestSettings = {
+  cadence: UserInterestCadence.Hourly,
+  fomoThreshold: 0.5,
+  outputModes: { feed: true, post: true, digest: false, notification: true },
+};
+
 export type InterestFinding = {
   id: string;
   postId: string;
@@ -163,8 +171,8 @@ export const INTEREST_FINDINGS_QUERY = `
 `;
 
 export const CREATE_INTEREST_MUTATION = `
-  mutation CreateInterest($query: String!) {
-    createInterest(query: $query) {
+  mutation CreateInterest($query: String!, $settings: CreateInterestSettingsInput) {
+    createInterest(query: $query, settings: $settings) {
       ...UserInterestFragment
     }
   }
@@ -265,10 +273,16 @@ export const getInterestFindings = async (
   return res.interestFindings;
 };
 
-export const createInterest = async (query: string): Promise<UserInterest> => {
+export const createInterest = async ({
+  query,
+  settings,
+}: {
+  query: string;
+  settings?: CreateInterestSettings;
+}): Promise<UserInterest> => {
   const res = await gqlClient.request<{ createInterest: UserInterest }>(
     CREATE_INTEREST_MUTATION,
-    { query },
+    { query, settings },
   );
   return res.createInterest;
 };


### PR DESCRIPTION
## Changes

- `/agent` spawn screen gets an **Agent settings** disclosure below the prompt, with a live summary of the current picks (cadence + what it delivers)
- Expanding shows cadence, FOMO threshold, and output-mode controls; choices are held locally and sent with `createInterest(query, settings)`
- Cadence/FOMO/output sections extracted from `AgentSettingsPane` into shared controlled components (`AgentSettingsFields`), so both screens share one copy of the labels and behavior — the pane itself is unchanged behaviorally
- Sources and status are deliberately not on the spawn screen: web/GitHub are disabled placeholders and agents always spawn active

Requires dailydotdev/daily-api#4119 (settings arg on the mutation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://agent-spawn-settings.preview.app.daily.dev