### PR TITLE
fix(shared): show pending state while deleting squads

### DIFF
--- a/packages/shared/src/components/modals/Prompt.spec.tsx
+++ b/packages/shared/src/components/modals/Prompt.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { PromptOptions } from '../../hooks/usePrompt';
-import { PROMPT_KEY } from '../../hooks/usePrompt';
+import { PROMPT_KEY, usePrompt } from '../../hooks/usePrompt';
 import { PromptElement } from './Prompt';
 
 const renderPrompt = (options: PromptOptions) => {
@@ -12,6 +13,7 @@ const renderPrompt = (options: PromptOptions) => {
     options,
     onSuccess: jest.fn(),
     onFail: jest.fn(),
+    onError: jest.fn(),
   });
 
   return render(
@@ -20,6 +22,53 @@ const renderPrompt = (options: PromptOptions) => {
     </QueryClientProvider>,
   );
 };
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve: () => resolve(),
+    reject: (error: Error) => reject(error),
+  };
+};
+
+const renderPromptController = () => {
+  const client = new QueryClient();
+  const controller: {
+    showPrompt?: ReturnType<typeof usePrompt>['showPrompt'];
+  } = {};
+
+  const TestComponent = () => {
+    const { showPrompt } = usePrompt();
+    controller.showPrompt = showPrompt;
+
+    return <PromptElement ariaHideApp={false} />;
+  };
+
+  render(
+    <QueryClientProvider client={client}>
+      <TestComponent />
+    </QueryClientProvider>,
+  );
+
+  return {
+    client,
+    controller: controller as {
+      showPrompt: ReturnType<typeof usePrompt>['showPrompt'];
+    },
+  };
+};
+
+const waitForPromptReady = (client: QueryClient) =>
+  waitFor(() =>
+    expect(client.getQueryState(PROMPT_KEY)?.fetchStatus).toBe('idle'),
+  );
 
 describe('PromptElement', () => {
   it('does not render cancel button when cancelButton is null', () => {
@@ -46,5 +95,76 @@ describe('PromptElement', () => {
     expect(
       screen.getByRole('button', { name: 'Continue' }),
     ).toBeInTheDocument();
+  });
+
+  it('keeps prompt mounted and disables actions while async confirm is pending', async () => {
+    const deferred = createDeferred();
+    const onConfirm = jest.fn(() => deferred.promise);
+    const { client, controller } = renderPromptController();
+    await waitForPromptReady(client);
+
+    let promptResult: Promise<boolean>;
+    act(() => {
+      promptResult = controller.showPrompt({
+        title: 'Confirm action',
+        okButton: { title: 'Continue' },
+        onConfirm,
+      });
+    });
+
+    const okButton = await screen.findByRole('button', { name: 'Continue' });
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+
+    await userEvent.click(okButton);
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(okButton).toHaveAttribute('aria-busy', 'true');
+    expect(okButton).toBeDisabled();
+    expect(cancelButton).toBeDisabled();
+    expect(screen.getByText('Confirm action')).toBeInTheDocument();
+
+    await userEvent.click(okButton);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    await expect(promptResult!).resolves.toBe(true);
+    await waitFor(() =>
+      expect(screen.queryByText('Confirm action')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('closes prompt and rejects when async confirm fails', async () => {
+    const deferred = createDeferred();
+    const { client, controller } = renderPromptController();
+    await waitForPromptReady(client);
+
+    let promptResult: Promise<boolean>;
+    act(() => {
+      promptResult = controller.showPrompt({
+        title: 'Confirm action',
+        okButton: { title: 'Continue' },
+        onConfirm: () => deferred.promise,
+      });
+    });
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Continue' }),
+    );
+
+    const error = new Error('failed');
+    const promptRejection = expect(promptResult!).rejects.toBe(error);
+    await act(async () => {
+      deferred.reject(error);
+      await deferred.promise.catch(() => undefined);
+    });
+
+    await promptRejection;
+    await waitFor(() =>
+      expect(screen.queryByText('Confirm action')).not.toBeInTheDocument(),
+    );
   });
 });

--- a/packages/shared/src/components/modals/Prompt.spec.tsx
+++ b/packages/shared/src/components/modals/Prompt.spec.tsx
@@ -97,7 +97,7 @@ describe('PromptElement', () => {
     ).toBeInTheDocument();
   });
 
-  it('keeps prompt mounted and disables actions while async confirm is pending', async () => {
+  it('keeps prompt mounted and disables confirm while async confirm is pending', async () => {
     const deferred = createDeferred();
     const onConfirm = jest.fn(() => deferred.promise);
     const { client, controller } = renderPromptController();
@@ -113,14 +113,12 @@ describe('PromptElement', () => {
     });
 
     const okButton = await screen.findByRole('button', { name: 'Continue' });
-    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
 
     await userEvent.click(okButton);
 
     expect(onConfirm).toHaveBeenCalledTimes(1);
     expect(okButton).toHaveAttribute('aria-busy', 'true');
     expect(okButton).toBeDisabled();
-    expect(cancelButton).toBeDisabled();
     expect(screen.getByText('Confirm action')).toBeInTheDocument();
 
     await userEvent.click(okButton);
@@ -137,7 +135,7 @@ describe('PromptElement', () => {
     );
   });
 
-  it('closes prompt and rejects when async confirm fails', async () => {
+  it('allows dismissing the prompt while async confirm is pending', async () => {
     const deferred = createDeferred();
     const { client, controller } = renderPromptController();
     await waitForPromptReady(client);
@@ -155,14 +153,48 @@ describe('PromptElement', () => {
       await screen.findByRole('button', { name: 'Continue' }),
     );
 
-    const error = new Error('failed');
-    const promptRejection = expect(promptResult!).rejects.toBe(error);
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancelButton).not.toBeDisabled();
+
+    await userEvent.click(cancelButton);
+
+    await expect(promptResult!).resolves.toBe(false);
+    await waitFor(() =>
+      expect(screen.queryByText('Confirm action')).not.toBeInTheDocument(),
+    );
+
     await act(async () => {
-      deferred.reject(error);
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    expect(screen.queryByText('Confirm action')).not.toBeInTheDocument();
+  });
+
+  it('closes prompt and resolves false when async confirm fails', async () => {
+    const deferred = createDeferred();
+    const { client, controller } = renderPromptController();
+    await waitForPromptReady(client);
+
+    let promptResult: Promise<boolean>;
+    act(() => {
+      promptResult = controller.showPrompt({
+        title: 'Confirm action',
+        okButton: { title: 'Continue' },
+        onConfirm: () => deferred.promise,
+      });
+    });
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Continue' }),
+    );
+
+    await act(async () => {
+      deferred.reject(new Error('failed'));
       await deferred.promise.catch(() => undefined);
     });
 
-    await promptRejection;
+    await expect(promptResult!).resolves.toBe(false);
     await waitFor(() =>
       expect(screen.queryByText('Confirm action')).not.toBeInTheDocument(),
     );

--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -73,11 +73,12 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
       .catch(() => settle(onError));
   };
 
+  const cancelButtonProps = cancelButton ?? {};
   const cancelActionButtonProps = {
     variant: ButtonVariant.Secondary,
-    ...cancelButton,
+    ...cancelButtonProps,
     onClick: handleFail,
-    className: classNames('w-full tablet:w-auto', cancelButton.className),
+    className: classNames('w-full tablet:w-auto', cancelButtonProps.className),
   } as ButtonProps<'button'>;
   const okActionButtonProps = {
     variant: ButtonVariant.Primary,
@@ -113,7 +114,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
         <Buttons className={className.buttons}>
           {cancelButton !== null && (
             <Button {...cancelActionButtonProps}>
-              {cancelButton.title ?? 'Cancel'}
+              {cancelButtonProps.title ?? 'Cancel'}
             </Button>
           )}
           {okButton !== null && (

--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -1,8 +1,9 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import { usePrompt } from '../../hooks/usePrompt';
-import { Button, ButtonVariant } from '../buttons/Button';
+import type { ButtonProps } from '../buttons/Button';
+import { Button, ButtonIconPosition, ButtonVariant } from '../buttons/Button';
 import classed from '../../lib/classed';
 import type { ModalProps } from './common/Modal';
 import { Modal } from './common/Modal';
@@ -19,11 +20,13 @@ const Buttons = classed(
 
 export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
   const { prompt } = usePrompt();
+  const [isPending, setIsPending] = useState(false);
+
   if (!prompt || !prompt.options) {
     return null;
   }
   const { options } = prompt;
-  const { onFail, onSuccess } = prompt;
+  const { onError, onFail, onSuccess } = prompt;
   const {
     title,
     description,
@@ -35,17 +38,97 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
     className = {},
     shouldCloseOnOverlayClick,
   } = options;
+  const { onConfirm } = options;
+  const {
+    className: cancelButtonClassName,
+    color: cancelButtonColor,
+    disabled: cancelButtonDisabled,
+    icon: cancelButtonIcon,
+    iconPosition: cancelButtonIconPosition,
+    title: cancelButtonTitle,
+    variant: cancelButtonVariant,
+    ...cancelButtonProps
+  } = cancelButton ?? {};
+  const {
+    className: okButtonClassName,
+    color: okButtonColor,
+    disabled: okButtonDisabled,
+    icon: okButtonIcon,
+    iconPosition: okButtonIconPosition,
+    loading: okButtonLoading,
+    title: okButtonTitle,
+    variant: okButtonVariant,
+    ...okButtonProps
+  } = okButton ?? {};
+  const handleFail = () => {
+    if (isPending) {
+      return;
+    }
+
+    onFail();
+  };
+  const handleSuccess = () => {
+    if (isPending) {
+      return;
+    }
+
+    if (!onConfirm) {
+      onSuccess();
+      return;
+    }
+
+    setIsPending(true);
+    Promise.resolve(onConfirm())
+      .then(() => {
+        setIsPending(false);
+        onSuccess();
+      })
+      .catch((error) => {
+        setIsPending(false);
+        onError(error);
+      });
+  };
+  const cancelActionButtonProps = {
+    ...cancelButtonProps,
+    variant: cancelButtonVariant ?? ButtonVariant.Secondary,
+    ...(cancelButtonColor ? { color: cancelButtonColor } : {}),
+    ...(cancelButtonIcon
+      ? {
+          icon: cancelButtonIcon,
+          iconPosition: cancelButtonIconPosition ?? ButtonIconPosition.Left,
+        }
+      : {}),
+    onClick: handleFail,
+    disabled: isPending || !!cancelButtonDisabled,
+    className: classNames('w-full tablet:w-auto', cancelButtonClassName),
+  } as ButtonProps<'button'>;
+  const okActionButtonProps = {
+    ...okButtonProps,
+    variant: okButtonVariant ?? ButtonVariant.Primary,
+    ...(okButtonColor ? { color: okButtonColor } : {}),
+    ...(okButtonIcon
+      ? {
+          icon: okButtonIcon,
+          iconPosition: okButtonIconPosition ?? ButtonIconPosition.Left,
+        }
+      : {}),
+    onClick: handleSuccess,
+    disabled: isPending || !!okButtonDisabled,
+    loading: isPending || !!okButtonLoading,
+    className: classNames('w-full tablet:w-auto', okButtonClassName),
+  } as ButtonProps<'button'>;
+
   return (
     <Modal
       isOpen
       kind={Modal.Kind.FlexibleCenter}
       size={promptSize}
-      onRequestClose={onFail}
+      onRequestClose={handleFail}
       className={className.modal}
       overlayClassName="!z-max"
       isDrawerOnMobile
       drawerProps={{ displayCloseButton: false, appendOnRoot: true }}
-      shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
+      shouldCloseOnOverlayClick={isPending ? false : shouldCloseOnOverlayClick}
       {...props}
     >
       <Modal.Body>
@@ -59,33 +142,12 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
         {content}
         <Buttons className={className.buttons}>
           {cancelButton !== null && (
-            <Button
-              variant={cancelButton.variant ?? ButtonVariant.Secondary}
-              color={cancelButton.color}
-              icon={cancelButton.icon}
-              iconPosition={cancelButton.iconPosition}
-              onClick={onFail}
-              {...cancelButton}
-              className={classNames(
-                'w-full tablet:w-auto',
-                cancelButton.className,
-              )}
-            >
-              {cancelButton?.title ?? 'Cancel'}
+            <Button {...cancelActionButtonProps}>
+              {cancelButtonTitle ?? 'Cancel'}
             </Button>
           )}
           {okButton !== null && (
-            <Button
-              variant={okButton.variant ?? ButtonVariant.Primary}
-              color={okButton.color}
-              icon={okButton.icon}
-              iconPosition={okButton.iconPosition}
-              onClick={onSuccess}
-              {...okButton}
-              className={classNames('w-full tablet:w-auto', okButton.className)}
-            >
-              {okButton?.title ?? 'Ok'}
-            </Button>
+            <Button {...okActionButtonProps}>{okButtonTitle ?? 'Ok'}</Button>
           )}
         </Buttons>
       </Modal.Body>

--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -1,9 +1,8 @@
 import type { ReactElement } from 'react';
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import classNames from 'classnames';
 import { usePrompt } from '../../hooks/usePrompt';
-import type { ButtonProps } from '../buttons/Button';
-import { Button, ButtonIconPosition, ButtonVariant } from '../buttons/Button';
+import { Button, ButtonVariant } from '../buttons/Button';
 import classed from '../../lib/classed';
 import type { ModalProps } from './common/Modal';
 import { Modal } from './common/Modal';
@@ -20,51 +19,30 @@ const Buttons = classed(
 
 export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
   const { prompt } = usePrompt();
-  const [isPending, setIsPending] = useState(false);
+  const confirmingPrompt = useRef<typeof prompt>(null);
+  const [isConfirming, setIsConfirming] = useState(false);
 
   if (!prompt || !prompt.options) {
     return null;
   }
-  const { options } = prompt;
   const { onError, onFail, onSuccess } = prompt;
+  const { options } = prompt;
   const {
     title,
     description,
     icon,
     content,
+    onConfirm,
     promptSize = Modal.Size.Small,
     cancelButton = {},
     okButton = {},
     className = {},
     shouldCloseOnOverlayClick,
   } = options;
-  const { onConfirm } = options;
-  const {
-    className: cancelButtonClassName,
-    color: cancelButtonColor,
-    disabled: cancelButtonDisabled,
-    icon: cancelButtonIcon,
-    iconPosition: cancelButtonIconPosition,
-    title: cancelButtonTitle,
-    variant: cancelButtonVariant,
-    ...cancelButtonProps
-  } = cancelButton ?? {};
-  const {
-    className: okButtonClassName,
-    color: okButtonColor,
-    disabled: okButtonDisabled,
-    icon: okButtonIcon,
-    iconPosition: okButtonIconPosition,
-    loading: okButtonLoading,
-    title: okButtonTitle,
-    variant: okButtonVariant,
-    ...okButtonProps
-  } = okButton ?? {};
+  const isPending = isConfirming && confirmingPrompt.current === prompt;
   const handleFail = () => {
-    if (isPending) {
-      return;
-    }
-
+    confirmingPrompt.current = null;
+    setIsConfirming(false);
     onFail();
   };
   const handleSuccess = () => {
@@ -77,46 +55,22 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
       return;
     }
 
-    setIsPending(true);
+    const settle = (callback: () => void) => {
+      if (confirmingPrompt.current !== prompt) {
+        return;
+      }
+
+      confirmingPrompt.current = null;
+      setIsConfirming(false);
+      callback();
+    };
+
+    confirmingPrompt.current = prompt;
+    setIsConfirming(true);
     Promise.resolve(onConfirm())
-      .then(() => {
-        setIsPending(false);
-        onSuccess();
-      })
-      .catch((error) => {
-        setIsPending(false);
-        onError(error);
-      });
+      .then(() => settle(onSuccess))
+      .catch(() => settle(onError));
   };
-  const cancelActionButtonProps = {
-    ...cancelButtonProps,
-    variant: cancelButtonVariant ?? ButtonVariant.Secondary,
-    ...(cancelButtonColor ? { color: cancelButtonColor } : {}),
-    ...(cancelButtonIcon
-      ? {
-          icon: cancelButtonIcon,
-          iconPosition: cancelButtonIconPosition ?? ButtonIconPosition.Left,
-        }
-      : {}),
-    onClick: handleFail,
-    disabled: isPending || !!cancelButtonDisabled,
-    className: classNames('w-full tablet:w-auto', cancelButtonClassName),
-  } as ButtonProps<'button'>;
-  const okActionButtonProps = {
-    ...okButtonProps,
-    variant: okButtonVariant ?? ButtonVariant.Primary,
-    ...(okButtonColor ? { color: okButtonColor } : {}),
-    ...(okButtonIcon
-      ? {
-          icon: okButtonIcon,
-          iconPosition: okButtonIconPosition ?? ButtonIconPosition.Left,
-        }
-      : {}),
-    onClick: handleSuccess,
-    disabled: isPending || !!okButtonDisabled,
-    loading: isPending || !!okButtonLoading,
-    className: classNames('w-full tablet:w-auto', okButtonClassName),
-  } as ButtonProps<'button'>;
 
   return (
     <Modal
@@ -128,7 +82,7 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
       overlayClassName="!z-max"
       isDrawerOnMobile
       drawerProps={{ displayCloseButton: false, appendOnRoot: true }}
-      shouldCloseOnOverlayClick={isPending ? false : shouldCloseOnOverlayClick}
+      shouldCloseOnOverlayClick={shouldCloseOnOverlayClick}
       {...props}
     >
       <Modal.Body>
@@ -142,12 +96,35 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
         {content}
         <Buttons className={className.buttons}>
           {cancelButton !== null && (
-            <Button {...cancelActionButtonProps}>
-              {cancelButtonTitle ?? 'Cancel'}
+            <Button
+              variant={cancelButton.variant ?? ButtonVariant.Secondary}
+              color={cancelButton.color}
+              icon={cancelButton.icon}
+              iconPosition={cancelButton.iconPosition}
+              {...cancelButton}
+              onClick={handleFail}
+              className={classNames(
+                'w-full tablet:w-auto',
+                cancelButton.className,
+              )}
+            >
+              {cancelButton.title ?? 'Cancel'}
             </Button>
           )}
           {okButton !== null && (
-            <Button {...okActionButtonProps}>{okButtonTitle ?? 'Ok'}</Button>
+            <Button
+              variant={okButton.variant ?? ButtonVariant.Primary}
+              color={okButton.color}
+              icon={okButton.icon}
+              iconPosition={okButton.iconPosition}
+              {...okButton}
+              onClick={handleSuccess}
+              disabled={isPending || okButton.disabled}
+              loading={isPending || okButton.loading}
+              className={classNames('w-full tablet:w-auto', okButton.className)}
+            >
+              {okButton.title ?? 'Ok'}
+            </Button>
           )}
         </Buttons>
       </Modal.Body>

--- a/packages/shared/src/components/modals/Prompt.tsx
+++ b/packages/shared/src/components/modals/Prompt.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import React, { useRef, useState } from 'react';
 import classNames from 'classnames';
 import { usePrompt } from '../../hooks/usePrompt';
+import type { ButtonProps } from '../buttons/Button';
 import { Button, ButtonVariant } from '../buttons/Button';
 import classed from '../../lib/classed';
 import type { ModalProps } from './common/Modal';
@@ -72,6 +73,21 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
       .catch(() => settle(onError));
   };
 
+  const cancelActionButtonProps = {
+    variant: ButtonVariant.Secondary,
+    ...cancelButton,
+    onClick: handleFail,
+    className: classNames('w-full tablet:w-auto', cancelButton.className),
+  } as ButtonProps<'button'>;
+  const okActionButtonProps = {
+    variant: ButtonVariant.Primary,
+    ...okButton,
+    onClick: handleSuccess,
+    disabled: isPending || okButton.disabled,
+    loading: isPending || okButton.loading,
+    className: classNames('w-full tablet:w-auto', okButton.className),
+  } as ButtonProps<'button'>;
+
   return (
     <Modal
       isOpen
@@ -96,35 +112,12 @@ export function PromptElement(props: Partial<ModalProps>): ReactElement | null {
         {content}
         <Buttons className={className.buttons}>
           {cancelButton !== null && (
-            <Button
-              variant={cancelButton.variant ?? ButtonVariant.Secondary}
-              color={cancelButton.color}
-              icon={cancelButton.icon}
-              iconPosition={cancelButton.iconPosition}
-              {...cancelButton}
-              onClick={handleFail}
-              className={classNames(
-                'w-full tablet:w-auto',
-                cancelButton.className,
-              )}
-            >
+            <Button {...cancelActionButtonProps}>
               {cancelButton.title ?? 'Cancel'}
             </Button>
           )}
           {okButton !== null && (
-            <Button
-              variant={okButton.variant ?? ButtonVariant.Primary}
-              color={okButton.color}
-              icon={okButton.icon}
-              iconPosition={okButton.iconPosition}
-              {...okButton}
-              onClick={handleSuccess}
-              disabled={isPending || okButton.disabled}
-              loading={isPending || okButton.loading}
-              className={classNames('w-full tablet:w-auto', okButton.className)}
-            >
-              {okButton.title ?? 'Ok'}
-            </Button>
+            <Button {...okActionButtonProps}>{okButton.title ?? 'Ok'}</Button>
           )}
         </Buttons>
       </Modal.Body>

--- a/packages/shared/src/components/squads/SquadHeaderMenu.spec.tsx
+++ b/packages/shared/src/components/squads/SquadHeaderMenu.spec.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { generateTestSquad } from '../../../__tests__/fixture/squads';
+import type { MenuItemProps } from '../dropdown/common';
+import type { Boot } from '../../lib/boot';
+import { BOOT_QUERY_KEY } from '../../contexts/common';
+import { SourcePermissions } from '../../graphql/sources';
+import { deleteSquad } from '../../graphql/squads';
+import { PROMPT_KEY } from '../../hooks/usePrompt';
+import { PromptElement } from '../modals/Prompt';
+import SquadHeaderMenu from './SquadHeaderMenu';
+
+const mockReplace = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/',
+    push: jest.fn(),
+    replace: mockReplace,
+  }),
+}));
+
+jest.mock('../../graphql/squads', () => ({
+  ...(jest.requireActual('../../graphql/squads') as Record<string, unknown>),
+  deleteSquad: jest.fn(),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuthContext: () => ({
+    isLoggedIn: true,
+  }),
+}));
+
+jest.mock('../../contexts/LogContext', () => ({
+  useLogContext: () => ({
+    logEvent: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useLazyModal', () => ({
+  useLazyModal: () => ({
+    openModal: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/useSquadInvitation', () => ({
+  useSquadInvitation: () => ({
+    logAndCopyLink: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks/contentPreference/useContentPreference', () => ({
+  useContentPreference: () => ({
+    follow: jest.fn(),
+    unfollow: jest.fn(),
+  }),
+}));
+
+jest.mock('../../hooks', () => ({
+  ...(jest.requireActual('../../hooks') as Record<string, unknown>),
+  useLeaveSquad: () => jest.fn(),
+  useSquadNavigation: () => ({
+    editSquad: jest.fn(),
+  }),
+}));
+
+jest.mock('../dropdown/DropdownMenu', () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode }) =>
+    children,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuOptions: ({ options }: { options: MenuItemProps[] }) => (
+    <div>
+      {options.map(({ label, action }) => (
+        <button key={label} onClick={action} type="button">
+          {label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+const mockedDeleteSquad = jest.mocked(deleteSquad);
+
+describe('SquadHeaderMenu', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps the delete prompt visible while the delete request is pending', async () => {
+    const squad = generateTestSquad({
+      currentMember: {
+        ...generateTestSquad().currentMember!,
+        permissions: [SourcePermissions.Delete],
+      },
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    queryClient.setQueryData<Boot>(BOOT_QUERY_KEY, { squads: [squad] } as Boot);
+    mockedDeleteSquad.mockReturnValue(new Promise(() => undefined));
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SquadHeaderMenu squad={squad} />
+        <PromptElement ariaHideApp={false} />
+      </QueryClientProvider>,
+    );
+    await waitFor(() =>
+      expect(queryClient.getQueryState(PROMPT_KEY)?.fetchStatus).toBe('idle'),
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Squad' }));
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Yes, delete Squad' }),
+    );
+
+    const promptButton = screen.getByRole('button', {
+      name: 'Yes, delete Squad',
+    });
+    expect(promptButton).toHaveAttribute('aria-busy', 'true');
+    expect(promptButton).toBeDisabled();
+    expect(screen.getByText(`Delete ${squad.name}`)).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/squads/settings/SquadDangerZone.tsx
+++ b/packages/shared/src/components/squads/settings/SquadDangerZone.tsx
@@ -29,7 +29,7 @@ const Important = () => (
 
 export function SquadDangerZone({ squad }: SquadDangerZoneProps): ReactElement {
   const router = useRouter();
-  const { onDeleteSquad } = useDeleteSquad({
+  const { isPending, onDeleteSquad } = useDeleteSquad({
     squad,
     callback: () => router.replace('/'),
   });
@@ -47,6 +47,8 @@ export function SquadDangerZone({ squad }: SquadDangerZoneProps): ReactElement {
           'Allow your Squad name to become available to anyone.',
         ]}
         important={<Important />}
+        buttonDisabled={isPending}
+        buttonLoading={isPending}
       />
     </SquadSettingsSection>
   );

--- a/packages/shared/src/hooks/useDeleteSquad.spec.tsx
+++ b/packages/shared/src/hooks/useDeleteSquad.spec.tsx
@@ -171,9 +171,7 @@ describe('useDeleteSquad', () => {
   it('does not report a failure when the post-delete callback rejects', async () => {
     const squad = generateTestSquad();
     mockedDeleteSquad.mockResolvedValue(undefined);
-    const callback = jest
-      .fn()
-      .mockRejectedValue(new Error('Route Cancelled'));
+    const callback = jest.fn().mockRejectedValue(new Error('Route Cancelled'));
     const { queryClient } = renderDeleteSquad(squad, callback);
     await waitForPromptReady(queryClient);
 

--- a/packages/shared/src/hooks/useDeleteSquad.spec.tsx
+++ b/packages/shared/src/hooks/useDeleteSquad.spec.tsx
@@ -167,4 +167,32 @@ describe('useDeleteSquad', () => {
       ).not.toBeInTheDocument(),
     );
   });
+
+  it('does not report a failure when the post-delete callback rejects', async () => {
+    const squad = generateTestSquad();
+    mockedDeleteSquad.mockResolvedValue(undefined);
+    const callback = jest
+      .fn()
+      .mockRejectedValue(new Error('Route Cancelled'));
+    const { queryClient } = renderDeleteSquad(squad, callback);
+    await waitForPromptReady(queryClient);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Squad' }));
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Yes, delete Squad' }),
+    );
+
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Yes, delete Squad' }),
+      ).not.toBeInTheDocument(),
+    );
+    expect(queryClient.getQueryData(TOAST_NOTIF_KEY)).toBeUndefined();
+    expect(
+      queryClient
+        .getQueryData<Boot>(BOOT_QUERY_KEY)
+        ?.squads.map((item) => item.id),
+    ).toEqual(['other-squad']);
+  });
 });

--- a/packages/shared/src/hooks/useDeleteSquad.spec.tsx
+++ b/packages/shared/src/hooks/useDeleteSquad.spec.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { generateTestSquad } from '../../__tests__/fixture/squads';
+import type { Squad } from '../graphql/sources';
+import { BOOT_QUERY_KEY } from '../contexts/common';
+import type { Boot } from '../lib/boot';
+import { TOAST_NOTIF_KEY } from './useToastNotification';
+import { DEFAULT_ERROR } from '../graphql/common';
+import { PromptElement } from '../components/modals/Prompt';
+import { useDeleteSquad } from './useDeleteSquad';
+import { deleteSquad } from '../graphql/squads';
+import { PROMPT_KEY } from './usePrompt';
+
+jest.mock('../graphql/squads', () => ({
+  deleteSquad: jest.fn(),
+}));
+
+jest.mock('../contexts/LogContext', () => ({
+  useLogContext: () => ({
+    logEvent: jest.fn(),
+  }),
+}));
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    pathname: '/',
+  }),
+}));
+
+const mockedDeleteSquad = jest.mocked(deleteSquad);
+
+const createDeferred = () => {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {
+    promise,
+    resolve,
+    reject,
+  };
+};
+
+const renderDeleteSquad = (squad: Squad, callback = jest.fn()) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  queryClient.setQueryData<Boot>(BOOT_QUERY_KEY, {
+    squads: [squad, generateTestSquad({ id: 'other-squad' })],
+  } as Boot);
+
+  const TestComponent = () => {
+    const { isPending, onDeleteSquad } = useDeleteSquad({ callback, squad });
+
+    return (
+      <>
+        <button
+          aria-busy={isPending}
+          disabled={isPending}
+          onClick={onDeleteSquad}
+          type="button"
+        >
+          Delete Squad
+        </button>
+        <PromptElement ariaHideApp={false} />
+      </>
+    );
+  };
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <TestComponent />
+    </QueryClientProvider>,
+  );
+
+  return { callback, queryClient };
+};
+
+const waitForPromptReady = (queryClient: QueryClient) =>
+  waitFor(() =>
+    expect(queryClient.getQueryState(PROMPT_KEY)?.fetchStatus).toBe('idle'),
+  );
+
+describe('useDeleteSquad', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('keeps delete actions pending until delete completes, then prunes boot cache and calls callback once', async () => {
+    const squad = generateTestSquad();
+    const deferred = createDeferred();
+    mockedDeleteSquad.mockReturnValue(deferred.promise);
+    const { callback, queryClient } = renderDeleteSquad(squad);
+    await waitForPromptReady(queryClient);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Squad' }));
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Yes, delete Squad' }),
+    );
+
+    const dangerZoneButton = screen.getByRole('button', {
+      name: 'Delete Squad',
+    });
+    const promptButton = screen.getByRole('button', {
+      name: 'Yes, delete Squad',
+    });
+
+    await waitFor(() => {
+      expect(dangerZoneButton).toHaveAttribute('aria-busy', 'true');
+      expect(dangerZoneButton).toBeDisabled();
+    });
+    expect(promptButton).toHaveAttribute('aria-busy', 'true');
+    expect(promptButton).toBeDisabled();
+
+    await userEvent.click(promptButton);
+    expect(mockedDeleteSquad).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve();
+      await deferred.promise;
+    });
+
+    await waitFor(() => expect(callback).toHaveBeenCalledTimes(1));
+    expect(
+      queryClient
+        .getQueryData<Boot>(BOOT_QUERY_KEY)
+        ?.squads.map((item) => item.id),
+    ).toEqual(['other-squad']);
+  });
+
+  it('shows an error toast and does not prune cache or call callback when delete fails', async () => {
+    const squad = generateTestSquad();
+    const deferred = createDeferred();
+    mockedDeleteSquad.mockReturnValue(deferred.promise);
+    const { callback, queryClient } = renderDeleteSquad(squad);
+    await waitForPromptReady(queryClient);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Squad' }));
+    await userEvent.click(
+      await screen.findByRole('button', { name: 'Yes, delete Squad' }),
+    );
+
+    await act(async () => {
+      deferred.reject(new Error('failed'));
+      await deferred.promise.catch(() => undefined);
+    });
+
+    await waitFor(() =>
+      expect(queryClient.getQueryData(TOAST_NOTIF_KEY)).toMatchObject({
+        message: DEFAULT_ERROR,
+      }),
+    );
+    expect(callback).not.toHaveBeenCalled();
+    expect(
+      queryClient
+        .getQueryData<Boot>(BOOT_QUERY_KEY)
+        ?.squads.map((item) => item.id),
+    ).toEqual([squad.id, 'other-squad']);
+    await waitFor(() =>
+      expect(
+        screen.queryByRole('button', { name: 'Yes, delete Squad' }),
+      ).not.toBeInTheDocument(),
+    );
+  });
+});

--- a/packages/shared/src/hooks/useDeleteSquad.spec.tsx
+++ b/packages/shared/src/hooks/useDeleteSquad.spec.tsx
@@ -186,7 +186,7 @@ describe('useDeleteSquad', () => {
         screen.queryByRole('button', { name: 'Yes, delete Squad' }),
       ).not.toBeInTheDocument(),
     );
-    expect(queryClient.getQueryData(TOAST_NOTIF_KEY)).toBeUndefined();
+    expect(queryClient.getQueryData(TOAST_NOTIF_KEY)).toBeFalsy();
     expect(
       queryClient
         .getQueryData<Boot>(BOOT_QUERY_KEY)

--- a/packages/shared/src/hooks/useDeleteSquad.ts
+++ b/packages/shared/src/hooks/useDeleteSquad.ts
@@ -1,4 +1,5 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useMutation } from '@tanstack/react-query';
 import { deleteSquad } from '../graphql/squads';
 import type { Squad } from '../graphql/sources';
 import type { PromptOptions } from './usePrompt';
@@ -7,14 +8,17 @@ import { useBoot } from './useBoot';
 import { useLogContext } from '../contexts/LogContext';
 import { LogEvent } from '../lib/log';
 import { ButtonColor } from '../components/buttons/Button';
+import { useToastNotification } from './useToastNotification';
+import { DEFAULT_ERROR } from '../graphql/common';
 
 interface UseDeleteSquadModal {
   onDeleteSquad: () => void;
+  isPending: boolean;
 }
 
 type UseDeleteSquadProps = {
   squad: Squad;
-  callback?: (params?: unknown) => void;
+  callback?: (params?: unknown) => Promise<unknown> | unknown;
 };
 
 export const useDeleteSquad = ({
@@ -24,10 +28,22 @@ export const useDeleteSquad = ({
   const { logEvent } = useLogContext();
   const { showPrompt } = usePrompt();
   const { deleteSquad: deleteCachedSquad } = useBoot();
+  const { displayToast } = useToastNotification();
 
-  // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const onDeleteSquad = async () => {
+  const { mutateAsync: deleteSquadMutation, isPending } = useMutation({
+    mutationFn: async () => {
+      logEvent({
+        event_name: LogEvent.DeleteSquad,
+        extra: JSON.stringify({ squad: squad.id! }),
+      });
+      await deleteSquad(squad.id!);
+      deleteCachedSquad(squad.id!);
+      await callback?.();
+    },
+    onError: () => displayToast(DEFAULT_ERROR),
+  });
+
+  const onDeleteSquad = useCallback(async () => {
     const options: PromptOptions = {
       title: `Delete ${squad.name}`,
       description: squad.active
@@ -37,17 +53,14 @@ export const useDeleteSquad = ({
         title: 'Yes, delete Squad',
         color: ButtonColor.Ketchup,
       },
+      onConfirm: deleteSquadMutation,
     };
-    if (await showPrompt(options)) {
-      logEvent({
-        event_name: LogEvent.DeleteSquad,
-        extra: JSON.stringify({ squad: squad.id! }),
-      });
-      await deleteSquad(squad.id!);
-      deleteCachedSquad(squad.id!);
-      await callback?.();
-    }
-  };
 
-  return useMemo(() => ({ onDeleteSquad }), [onDeleteSquad]);
+    await showPrompt(options).catch(() => false);
+  }, [deleteSquadMutation, showPrompt, squad.active, squad.name]);
+
+  return useMemo(
+    () => ({ isPending, onDeleteSquad }),
+    [isPending, onDeleteSquad],
+  );
 };

--- a/packages/shared/src/hooks/useDeleteSquad.ts
+++ b/packages/shared/src/hooks/useDeleteSquad.ts
@@ -38,7 +38,7 @@ export const useDeleteSquad = ({
       });
       await deleteSquad(squad.id!);
       deleteCachedSquad(squad.id!);
-      await callback?.();
+      await Promise.resolve(callback?.()).catch(() => undefined);
     },
     onError: () => displayToast(DEFAULT_ERROR),
   });
@@ -56,7 +56,7 @@ export const useDeleteSquad = ({
       onConfirm: deleteSquadMutation,
     };
 
-    await showPrompt(options).catch(() => false);
+    await showPrompt(options);
   }, [deleteSquadMutation, showPrompt, squad.active, squad.name]);
 
   return useMemo(

--- a/packages/shared/src/hooks/usePrompt.ts
+++ b/packages/shared/src/hooks/usePrompt.ts
@@ -33,7 +33,7 @@ type Prompt = {
   options: PromptOptions | null;
   onSuccess: () => void;
   onFail: () => void;
-  onError: (error: unknown) => void;
+  onError: () => void;
 };
 
 type PromptState = Prompt | null;
@@ -57,20 +57,16 @@ export function usePrompt(): UsePromptRet {
 
   const showPrompt = useCallback(
     (promptOptions: PromptOptions): Promise<boolean> =>
-      new Promise((resolve, reject) => {
+      new Promise((resolve) => {
         const closeWith = (result: boolean) => {
           resolve(result);
-          setPrompt(null);
-        };
-        const failWith = (error: unknown) => {
-          reject(error);
           setPrompt(null);
         };
         const newPrompt: Prompt = {
           options: promptOptions,
           onFail: () => closeWith(false),
           onSuccess: () => closeWith(true),
-          onError: failWith,
+          onError: () => closeWith(false),
         };
         setPrompt(newPrompt);
       }),

--- a/packages/shared/src/hooks/usePrompt.ts
+++ b/packages/shared/src/hooks/usePrompt.ts
@@ -15,6 +15,7 @@ export type PromptOptions = {
   title: string;
   icon?: ReactNode;
   description?: string | ReactNode;
+  onConfirm?: () => Promise<unknown> | unknown;
   okButton?: PromptButtonProps;
   cancelButton?: PromptButtonProps | null;
   content?: ReactNode;
@@ -32,6 +33,7 @@ type Prompt = {
   options: PromptOptions | null;
   onSuccess: () => void;
   onFail: () => void;
+  onError: (error: unknown) => void;
 };
 
 type PromptState = Prompt | null;
@@ -55,15 +57,20 @@ export function usePrompt(): UsePromptRet {
 
   const showPrompt = useCallback(
     (promptOptions: PromptOptions): Promise<boolean> =>
-      new Promise((resolve) => {
+      new Promise((resolve, reject) => {
         const closeWith = (result: boolean) => {
           resolve(result);
+          setPrompt(null);
+        };
+        const failWith = (error: unknown) => {
+          reject(error);
           setPrompt(null);
         };
         const newPrompt: Prompt = {
           options: promptOptions,
           onFail: () => closeWith(false),
           onSuccess: () => closeWith(true),
+          onError: failWith,
         };
         setPrompt(newPrompt);
       }),


### PR DESCRIPTION
## Summary
- Add optional async confirm handling to shared prompts so destructive actions can keep the modal open while work is pending.
- Move squad deletion through a mutation that awaits network deletion, boot-cache pruning, and navigation callback in order.
- Surface pending state in the Squad settings danger zone and keep the header-menu confirmation prompt visible in flight.

## Key decisions
- Kept the existing `showPrompt(options): Promise<boolean>` contract additive and non-throwing: a failed `onConfirm` closes the prompt and resolves `false`, so no caller needs a `catch`.
- Close the prompt and show the existing generic error toast on failure instead of adding inline retry UI.
- Did not add a client timeout, but cancel / ESC / overlay close stay available while the confirm is in flight, so a hung delete never traps the user. Dismissing only hides the prompt; the mutation keeps running and still reports through its own toast/navigation.
- The pending flag is scoped to the prompt instance, so a prompt that replaces a pending one does not inherit its disabled/loading state.
- Post-delete `callback` (navigation) failures are not mapped to a delete failure — a cancelled `router.replace` no longer produces a false error toast.

## Verification
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/modals/Prompt.spec.tsx src/hooks/useDeleteSquad.spec.tsx src/components/squads/SquadHeaderMenu.spec.tsx --runInBand`
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec eslint src/hooks/usePrompt.ts src/components/modals/Prompt.tsx src/hooks/useDeleteSquad.ts src/components/squads/settings/SquadDangerZone.tsx src/components/modals/Prompt.spec.tsx src/hooks/useDeleteSquad.spec.tsx src/components/squads/SquadHeaderMenu.spec.tsx --max-warnings 0`
- `node ./scripts/typecheck-strict-changed.js`
- Follow-up commit relies on CI for `lint_shared` / `typecheck_strict_changed` / `test_shared`.

Issue: https://linear.app/dailydev/issue/ENG-1945/feedback-ux-issue-deleting-squads-lacks-a-processing-ui-causing-user

Closes ENG-1945

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1945-feedback-ux-issue-delet.preview.app.daily.dev
