### PR TITLE
feat: show community take on the legacy post layout

### DIFF
--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -18,7 +18,12 @@ import YoutubeVideo from '../video/YoutubeVideo';
 import { useTrackPostView } from '../../hooks/post/useTrackPostView';
 import { TruncateText } from '../utilities';
 import { useFeature } from '../GrowthBookProvider';
-import { feature } from '../../lib/featureManagement';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import {
+  feature,
+  featureCommunitySentiment,
+} from '../../lib/featureManagement';
+import { isDevelopment } from '../../lib/constants';
 import { LazyImage } from '../LazyImage';
 import { cloudinaryPostImageCoverPlaceholder } from '../../lib/image';
 import { withPostById } from './withPostById';
@@ -27,6 +32,10 @@ import { useSmartTitle } from '../../hooks/post/useSmartTitle';
 import { PostTagList } from './tags/PostTagList';
 import PostSourceInfo from './PostSourceInfo';
 import { useReaderInstallPromptGate } from '../../hooks/useReaderInstallPromptGate';
+import {
+  CommunitySentiment,
+  mapCommunitySentimentPost,
+} from './focus/CommunitySentiment';
 
 type PostContentRawProps = Omit<PostContentProps, 'post'> & { post: Post };
 
@@ -104,6 +113,20 @@ export function PostContentRaw({
   };
   const showCodeSnippets = useFeature(feature.showCodeSnippets);
   const { title } = useSmartTitle(post);
+  const communitySentimentData = post.communitySentiment
+    ? mapCommunitySentimentPost(post.communitySentiment)
+    : undefined;
+  // Conditional enrollment: only evaluate (and log exposure for) the
+  // community_sentiment experiment on posts that actually have a take, so
+  // take-less posts don't dilute the treatment/control split.
+  const { value: communitySentimentEnabled } = useConditionalFeature({
+    feature: featureCommunitySentiment,
+    shouldEvaluate: !!communitySentimentData,
+  });
+  const showCommunitySentiment =
+    isPostPage &&
+    !!communitySentimentData &&
+    (communitySentimentEnabled || isDevelopment);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const isVideoType = isVideoPost(post);
   const hasToc = (post.toc?.length ?? 0) > 0;
@@ -257,6 +280,9 @@ export function PostContentRaw({
             className={isCompactModalSpacing ? 'mb-4' : 'mb-6'}
             post={post}
           />
+        )}
+        {showCommunitySentiment && (
+          <CommunitySentiment data={communitySentimentData} className="mb-6" />
         )}
       </BasePostContent>
     </PostContainer>


### PR DESCRIPTION
## Problem

People reported not seeing community takes on posts that definitely have one.

The take is only rendered by `PostFocusCard`, which is mounted only when `usePostRedesign().showRedesign` is true. In GrowthBook, `post_redesign` has prod default `false` with a single force rule targeting `{"team": 1}` — so the surface is effectively team-only. The `community_sentiment` flag itself is fully on in prod and the API returns `Post.communitySentiment` ungated, so the data was there and just never rendered for anyone on the legacy layout.

## Change

Render `CommunitySentiment` in the legacy `PostContent` layout as well:

- full post page only (`isPostPage`), matching the redesign which hides it in the preview modal via `!onClose`
- same `useConditionalFeature` enrollment on `community_sentiment`, with `shouldEvaluate` bound to the post actually having a take so take-less posts don't dilute the treatment/control split
- `isDevelopment` escape hatch kept for local preview; the committed flag default stays `false`

Frontend-only — generation is unconditional, no backfill needed.

## Notes

- Modal behaviour is unchanged in both layouts. If we want takes in the feed preview modal too, that's a separate call (drop `!onClose` / `isPostPage`).
- Node/pnpm aren't available in this runtime, so lint/typecheck/tests weren't run locally — relying on CI.

🤖 Opened by Smith (AI) on behalf of Chris.


### Preview domain
https://feat-community-take-legacy-post.preview.app.daily.dev