### PR TITLE
fix(plus): exclude team plans from summer sale

### DIFF
--- a/packages/shared/src/contexts/payment/BasePaymentProvider.spec.tsx
+++ b/packages/shared/src/contexts/payment/BasePaymentProvider.spec.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect } from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { PurchaseType } from '../../graphql/paddle';
+import { useProductPricing } from '../../hooks/useProductPricing';
+import { BasePaymentProvider } from './BasePaymentProvider';
+import { usePaymentContext } from './context';
+
+jest.mock('../../hooks/useProductPricing', () => ({
+  useProductPricing: jest.fn(),
+}));
+
+jest.mock('../AuthContext', () => ({
+  useAuthContext: () => ({ isValidRegion: true }),
+}));
+
+const mockUseProductPricing = useProductPricing as jest.MockedFunction<
+  typeof useProductPricing
+>;
+
+const personalPriceId = 'pri_personal';
+const organizationPriceId = 'pri_organization';
+
+const CheckoutProbe = ({ priceId }: { priceId: string }) => {
+  const { openCheckout } = usePaymentContext();
+
+  useEffect(() => {
+    openCheckout?.({ priceId });
+  }, [openCheckout, priceId]);
+
+  return null;
+};
+
+describe('BasePaymentProvider sale discount', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies the sale discount to personal Plus pricing and checkout', async () => {
+    const openCheckout = jest.fn();
+    mockUseProductPricing.mockReturnValue({
+      data: [{ priceId: personalPriceId }],
+      isPending: false,
+    } as never);
+
+    render(
+      <BasePaymentProvider
+        openCheckout={openCheckout}
+        priceType={PurchaseType.Plus}
+        discountId="dsc_summer"
+      >
+        <CheckoutProbe priceId={personalPriceId} />
+      </BasePaymentProvider>,
+    );
+
+    expect(mockUseProductPricing).toHaveBeenCalledWith(
+      expect.objectContaining({ discountId: 'dsc_summer' }),
+    );
+    await waitFor(() =>
+      expect(openCheckout).toHaveBeenCalledWith(
+        expect.objectContaining({ discountId: 'dsc_summer' }),
+      ),
+    );
+  });
+
+  it('does not apply the sale discount to organization pricing or checkout', async () => {
+    const openCheckout = jest.fn();
+    mockUseProductPricing.mockReturnValue({
+      data: [{ priceId: organizationPriceId }],
+      isPending: false,
+    } as never);
+
+    render(
+      <BasePaymentProvider
+        openCheckout={openCheckout}
+        priceType={PurchaseType.Organization}
+        discountId="dsc_summer"
+      >
+        <CheckoutProbe priceId={organizationPriceId} />
+      </BasePaymentProvider>,
+    );
+
+    expect(mockUseProductPricing).toHaveBeenCalledWith(
+      expect.objectContaining({ discountId: undefined }),
+    );
+    await waitFor(() =>
+      expect(openCheckout).toHaveBeenCalledWith(
+        expect.objectContaining({ discountId: undefined }),
+      ),
+    );
+  });
+
+  it('does not apply the sale discount to a non-Plus price on the payment page', async () => {
+    const openCheckout = jest.fn();
+    mockUseProductPricing.mockReturnValue({
+      data: [{ priceId: personalPriceId }],
+      isPending: false,
+    } as never);
+
+    render(
+      <BasePaymentProvider
+        openCheckout={openCheckout}
+        priceType={PurchaseType.Plus}
+        discountId="dsc_summer"
+      >
+        <CheckoutProbe priceId={organizationPriceId} />
+      </BasePaymentProvider>,
+    );
+
+    await waitFor(() =>
+      expect(openCheckout).toHaveBeenCalledWith(
+        expect.objectContaining({ discountId: undefined }),
+      ),
+    );
+  });
+});

--- a/packages/shared/src/contexts/payment/BasePaymentProvider.tsx
+++ b/packages/shared/src/contexts/payment/BasePaymentProvider.tsx
@@ -36,23 +36,33 @@ export const BasePaymentProvider = ({
 }: PropsWithChildren<BasePaymentProviderProps>): ReactElement => {
   const { isValidRegion: isPlusAvailable } = useAuthContext();
   const { pricing: funnelPricing } = useFunnelPaymentPricingContext() ?? {};
+  const saleDiscountId =
+    priceType === PurchaseType.Plus ? discountId : undefined;
   const { data: plusPricing, isPending: isPricesPending } = useProductPricing({
     type: priceType,
     enabled: !funnelPricing?.length,
-    discountId,
+    discountId: saleDiscountId,
   });
   const data = funnelPricing?.length ? funnelPricing : plusPricing;
 
   const openCheckoutWithDiscount = useCallback<OpenCheckoutFn>(
-    (props) =>
+    (props) => {
+      const isSaleEligiblePrice =
+        priceType === PurchaseType.Plus &&
+        data?.some(({ priceId }) => priceId === props.priceId);
+
       openCheckout({
         ...props,
-        // Gifting buys a separate one-off product, not a subscription, so a
-        // subscription sale must not follow the buyer into the gift checkout.
+        // The sale only covers personal Plus prices. Gifting and organization
+        // subscriptions must not inherit its Paddle discount.
         discountId:
-          props.discountId ?? (props.giftToUserId ? undefined : discountId),
-      }),
-    [openCheckout, discountId],
+          props.discountId ??
+          (props.giftToUserId || !isSaleEligiblePrice
+            ? undefined
+            : saleDiscountId),
+      });
+    },
+    [openCheckout, priceType, data, saleDiscountId],
   );
 
   const giftOneYear = useMemo(

--- a/packages/shared/src/contexts/payment/context.ts
+++ b/packages/shared/src/contexts/payment/context.ts
@@ -49,9 +49,8 @@ export interface PaymentContextProviderProps<T = unknown, E = unknown> {
   successCallback?: (event: T) => void;
   initialPriceType?: PurchaseType;
   /**
-   * Paddle discount applied to both the previewed prices and checkout for
-   * everything under this provider. Opt-in per surface: the onboarding funnel
-   * mounts its own provider without it and keeps its own discount logic.
+   * Paddle discount applied to personal Plus previews and checkouts under this
+   * provider. Organization and gift purchases are excluded.
    */
   discountId?: string;
 }

--- a/packages/webapp/__tests__/PlusPaymentPage.spec.tsx
+++ b/packages/webapp/__tests__/PlusPaymentPage.spec.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { usePaymentContext } from '@dailydotdev/shared/src/contexts/payment/context';
 import { usePlusSale } from '@dailydotdev/shared/src/hooks/usePlusSale';
 import {
-  useProductPricing,
   useProductPricingByIds,
 } from '@dailydotdev/shared/src/hooks/useProductPricing';
 import type { ProductPricingPreview } from '@dailydotdev/shared/src/graphql/paddle';
@@ -22,7 +21,6 @@ jest.mock('@dailydotdev/shared/src/hooks/usePlusSale', () => ({
 }));
 
 jest.mock('@dailydotdev/shared/src/hooks/useProductPricing', () => ({
-  useProductPricing: jest.fn(),
   useProductPricingByIds: jest.fn(),
 }));
 
@@ -50,9 +48,6 @@ const mockUsePaymentContext = usePaymentContext as jest.MockedFunction<
   typeof usePaymentContext
 >;
 const mockUsePlusSale = usePlusSale as jest.MockedFunction<typeof usePlusSale>;
-const mockUseProductPricing = useProductPricing as jest.MockedFunction<
-  typeof useProductPricing
->;
 const mockUseProductPricingByIds =
   useProductPricingByIds as jest.MockedFunction<typeof useProductPricingByIds>;
 const mockUseViewSize = useViewSize as jest.MockedFunction<typeof useViewSize>;
@@ -71,11 +66,9 @@ const price = (formatted: string, priceId: string) =>
 const renderPage = ({
   discountId,
   query = { pid: personal },
-  teamPricing = [price('$150', team)],
 }: {
   discountId?: string;
   query?: Record<string, string>;
-  teamPricing?: ProductPricingPreview[];
 }) => {
   mockUseRouter.mockReturnValue({
     query,
@@ -88,7 +81,6 @@ const renderPage = ({
     productOptions: [price('$16', personal)],
   } as never);
   mockUsePlusSale.mockReturnValue({ discountId } as never);
-  mockUseProductPricing.mockReturnValue({ data: teamPricing } as never);
   mockUseProductPricingByIds.mockReturnValue({
     data: [price('$32', personal), price('$300', team)],
   } as never);
@@ -124,20 +116,9 @@ describe('PlusPaymentPage plan details', () => {
     expect(await screen.findByTestId('plan-details')).toHaveTextContent('$32');
   });
 
-  it('keeps the panel for a team plan, which the provider does not preview', async () => {
+  it('shows the undiscounted amount for a team plan during a sale', async () => {
     renderPage({ discountId: 'dsc_summer', query: { pid: team } });
 
-    expect(await screen.findByTestId('plan-details')).toHaveTextContent('$150');
-    expect(mockUseProductPricing).toHaveBeenCalledWith(
-      expect.objectContaining({ discountId: 'dsc_summer', enabled: true }),
-    );
-  });
-
-  it('only asks for team prices when the personal list misses the plan', () => {
-    renderPage({ discountId: 'dsc_summer' });
-
-    expect(mockUseProductPricing).toHaveBeenCalledWith(
-      expect.objectContaining({ enabled: false }),
-    );
+    expect(await screen.findByTestId('plan-details')).toHaveTextContent('$300');
   });
 });

--- a/packages/webapp/pages/plus/payment.tsx
+++ b/packages/webapp/pages/plus/payment.tsx
@@ -13,10 +13,8 @@ import {
 } from '@dailydotdev/shared/src/components/typography/Typography';
 import dynamic from 'next/dynamic';
 import {
-  useProductPricing,
   useProductPricingByIds,
 } from '@dailydotdev/shared/src/hooks/useProductPricing';
-import { PurchaseType } from '@dailydotdev/shared/src/graphql/paddle';
 import { PlusCheckoutContainer } from '@dailydotdev/shared/src/components/plus/PlusCheckoutContainer';
 import { usePlusSale } from '@dailydotdev/shared/src/hooks/usePlusSale';
 import { getPlusLayout } from '../../components/layouts/PlusLayout/PlusLayout';
@@ -40,17 +38,11 @@ const PlusPaymentPage = (): ReactElement => {
     ids: [pid as string],
     loadMetadata: true,
   });
-  // Gifting buys a one-off product the subscription sale doesn't cover.
-  const isDiscounted = !!discountId && !gift;
-  const isPersonalPlan = productOptions?.some(({ priceId }) => priceId === pid);
-  // The provider previews personal plans, so a team purchase needs its own
-  // discounted preview: pricingPreviewByIds takes no discount, and quoting its
-  // list price next to a discounted Paddle total is what misleads the buyer.
-  const { data: teamPricing } = useProductPricing({
-    type: PurchaseType.Organization,
-    discountId,
-    enabled: isDiscounted && !isPersonalPlan,
-  });
+  // The sale only covers personal Plus plans, not gifts or Team plans.
+  const isDiscountedPersonalPlan =
+    !!discountId &&
+    !gift &&
+    productOptions?.some(({ priceId }) => priceId === pid);
 
   useEffect(() => {
     if (!isPaddleReady) {
@@ -74,9 +66,7 @@ const PlusPaymentPage = (): ReactElement => {
     }
   }, [pid, router]);
 
-  const pricing = isDiscounted
-    ? [...(productOptions ?? []), ...(teamPricing ?? [])]
-    : productPricing;
+  const pricing = isDiscountedPersonalPlan ? productOptions : productPricing;
   const selectedProduct = pricing?.find(({ priceId }) => priceId === pid);
 
   return (


### PR DESCRIPTION
## Summary

- scope the summer-sale discount to personal Plus pricing and checkout
- keep Team plan details at their undiscounted price on the payment page
- prevent Team price IDs from inheriting the personal Plus discount
- add coverage for personal, organization, and payment-page checkout paths

## Context

The sale discount is not eligible for organization prices. Opening `/plus?type=team` sent the sale discount to `pricingPreview`, causing Paddle to return `transaction_discount_not_eligible`. With no Team pricing loaded, changing quantity then sent an empty price ID to Paddle checkout.

Related: [ENG-1985](https://linear.app/dailydev/issue/ENG-1985/feedback-bug-report-user-unable-to-purchase-team-subscription-due-to)

## Testing

- Added unit coverage for discount scoping in `BasePaymentProvider`
- Updated payment-page coverage to assert Team plans remain undiscounted
- Tests not run locally because the execution environment does not include Node/pnpm


### Preview domain
https://fix-plus-sale-team-checkout.preview.app.daily.dev