### PR TITLE
fix(shared): give the 404 somewhere to go

### DIFF
--- a/packages/shared/src/components/Custom404.spec.tsx
+++ b/packages/shared/src/components/Custom404.spec.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import Custom404 from './Custom404';
+import { webappUrl } from '../lib/constants';
 
-const renderComponent = () => render(<Custom404 />);
+const renderComponent = (showRecoveryLinks = false) =>
+  render(<Custom404 showRecoveryLinks={showRecoveryLinks} />);
 
 describe('Custom404', () => {
   it('should render the not-found container', () => {
@@ -20,29 +22,46 @@ describe('Custom404', () => {
     );
   });
 
-  // The page used to be a dead end with a single link, which left both
-  // people and crawlers with nowhere to go.
-  it.each([
-    ['Explore', '/posts'],
-    ['Tags', '/tags'],
-    ['Sources', '/sources'],
-    ['Squads', '/squads/discover'],
-    ['Blog', '/blog'],
-  ])('should offer %s as a recovery link', (label, href) => {
+  it('should not render the recovery nav by default', () => {
     renderComponent();
+
+    expect(screen.queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  it.each([
+    ['Explore', 'posts'],
+    ['Tags', 'tags'],
+    ['Sources', 'sources'],
+    ['Squads', 'squads/discover'],
+  ])('should offer %s as a recovery link', (label, path) => {
+    renderComponent(true);
 
     expect(screen.getByRole('link', { name: label })).toHaveAttribute(
       'href',
-      href,
+      `${webappUrl}${path}`,
     );
   });
 
   it('should group the recovery links in a labelled nav', () => {
-    renderComponent();
+    renderComponent(true);
 
     const nav = screen.getByRole('navigation', { name: 'Other places to go' });
 
-    expect(nav).toBeInTheDocument();
-    expect(within(nav).getAllByRole('link')).toHaveLength(5);
+    expect(within(nav).getAllByRole('link')).toHaveLength(4);
+  });
+
+  it('should build every recovery href from the per-build webapp prefix', () => {
+    renderComponent(true);
+
+    const nav = screen.getByRole('navigation', { name: 'Other places to go' });
+
+    within(nav)
+      .getAllByRole('link')
+      .forEach((link) => {
+        const href = link.getAttribute('href');
+
+        expect(href.startsWith(webappUrl)).toBe(true);
+        expect(href).not.toContain('//squads');
+      });
   });
 });

--- a/packages/shared/src/components/Custom404.spec.tsx
+++ b/packages/shared/src/components/Custom404.spec.tsx
@@ -58,7 +58,7 @@ describe('Custom404', () => {
     within(nav)
       .getAllByRole('link')
       .forEach((link) => {
-        const href = link.getAttribute('href');
+        const href = link.getAttribute('href') ?? '';
 
         expect(href.startsWith(webappUrl)).toBe(true);
         expect(href).not.toContain('//squads');

--- a/packages/shared/src/components/Custom404.spec.tsx
+++ b/packages/shared/src/components/Custom404.spec.tsx
@@ -2,16 +2,18 @@ import React from 'react';
 import { render, screen, within } from '@testing-library/react';
 import Custom404 from './Custom404';
 
-describe('Custom404', () => {
-  beforeEach(() => {
-    render(<Custom404 />);
-  });
+const renderComponent = () => render(<Custom404 />);
 
+describe('Custom404', () => {
   it('should render the not-found container', () => {
+    renderComponent();
+
     expect(screen.getByTestId('notFound')).toBeInTheDocument();
   });
 
   it('should keep a primary route home', () => {
+    renderComponent();
+
     expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
       'href',
       '/',
@@ -27,6 +29,8 @@ describe('Custom404', () => {
     ['Squads', '/squads/discover'],
     ['Blog', '/blog'],
   ])('should offer %s as a recovery link', (label, href) => {
+    renderComponent();
+
     expect(screen.getByRole('link', { name: label })).toHaveAttribute(
       'href',
       href,
@@ -34,9 +38,9 @@ describe('Custom404', () => {
   });
 
   it('should group the recovery links in a labelled nav', () => {
-    const nav = screen.getByRole('navigation', {
-      name: 'Other places to go',
-    });
+    renderComponent();
+
+    const nav = screen.getByRole('navigation', { name: 'Other places to go' });
 
     expect(nav).toBeInTheDocument();
     expect(within(nav).getAllByRole('link')).toHaveLength(5);

--- a/packages/shared/src/components/Custom404.spec.tsx
+++ b/packages/shared/src/components/Custom404.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import Custom404 from './Custom404';
+
+describe('Custom404', () => {
+  beforeEach(() => {
+    render(<Custom404 />);
+  });
+
+  it('should render the not-found container', () => {
+    expect(screen.getByTestId('notFound')).toBeInTheDocument();
+  });
+
+  it('should keep a primary route home', () => {
+    expect(screen.getByRole('link', { name: 'Go home' })).toHaveAttribute(
+      'href',
+      '/',
+    );
+  });
+
+  // The page used to be a dead end with a single link, which left both
+  // people and crawlers with nowhere to go.
+  it.each([
+    ['Explore', '/posts'],
+    ['Tags', '/tags'],
+    ['Sources', '/sources'],
+    ['Squads', '/squads/discover'],
+    ['Blog', '/blog'],
+  ])('should offer %s as a recovery link', (label, href) => {
+    expect(screen.getByRole('link', { name: label })).toHaveAttribute(
+      'href',
+      href,
+    );
+  });
+
+  it('should group the recovery links in a labelled nav', () => {
+    const nav = screen.getByRole('navigation', {
+      name: 'Other places to go',
+    });
+
+    expect(nav).toBeInTheDocument();
+    expect(within(nav).getAllByRole('link')).toHaveLength(5);
+  });
+});

--- a/packages/shared/src/components/Custom404.tsx
+++ b/packages/shared/src/components/Custom404.tsx
@@ -10,6 +10,17 @@ interface Custom404Props {
   children?: ReactNode;
 }
 
+// Every destination here is reachable on both hosts this renders on
+// (daily.dev and app.daily.dev). A dead end on the 404 page is worse than
+// no link at all, so keep that true if this list changes.
+const recoveryLinks = [
+  { label: 'Explore', href: '/posts' },
+  { label: 'Tags', href: '/tags' },
+  { label: 'Sources', href: '/sources' },
+  { label: 'Squads', href: '/squads/discover' },
+  { label: 'Blog', href: '/blog' },
+];
+
 export default function Custom404({ children }: Custom404Props): ReactElement {
   return (
     <PageContainer
@@ -33,6 +44,20 @@ export default function Custom404({ children }: Custom404Props): ReactElement {
             Go home
           </Button>
         </Link>
+
+        <nav aria-label="Other places to go" className="mt-2">
+          <ul className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
+            {recoveryLinks.map(({ label, href }) => (
+              <li key={href}>
+                <Link href={href} passHref prefetch={false}>
+                  <a className="text-text-tertiary underline typo-footnote hover:text-text-primary">
+                    {label}
+                  </a>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
       </div>
     </PageContainer>
   );

--- a/packages/shared/src/components/Custom404.tsx
+++ b/packages/shared/src/components/Custom404.tsx
@@ -5,23 +5,36 @@ import { PageContainer } from './utilities';
 import { Button, ButtonVariant } from './buttons/Button';
 import { cloudinaryCharm404 } from '../lib/image';
 import { Image } from './image/Image';
+import { squadCategoriesPaths, webappUrl } from '../lib/constants';
 
 interface Custom404Props {
   children?: ReactNode;
+  /**
+   * Opt in to the secondary recovery nav. Off by default: this component
+   * also renders inside the post modal, the agent side pane and the
+   * extension new tab, where a full-site nav is the wrong furniture and
+   * navigating away is not what the surface wants.
+   */
+  showRecoveryLinks?: boolean;
 }
 
-// Every destination here is reachable on both hosts this renders on
-// (daily.dev and app.daily.dev). A dead end on the 404 page is worse than
-// no link at all, so keep that true if this list changes.
+// Absolute, because this component reaches the browser extension through
+// BasePostContent, where a root-relative href resolves against
+// chrome-extension://<id>/ and dies.
 const recoveryLinks = [
-  { label: 'Explore', href: '/posts' },
-  { label: 'Tags', href: '/tags' },
-  { label: 'Sources', href: '/sources' },
-  { label: 'Squads', href: '/squads/discover' },
-  { label: 'Blog', href: '/blog' },
+  { label: 'Explore', href: `${webappUrl}posts` },
+  { label: 'Tags', href: `${webappUrl}tags` },
+  { label: 'Sources', href: `${webappUrl}sources` },
+  {
+    label: 'Squads',
+    href: `${webappUrl}${squadCategoriesPaths.discover.substring(1)}`,
+  },
 ];
 
-export default function Custom404({ children }: Custom404Props): ReactElement {
+export default function Custom404({
+  children,
+  showRecoveryLinks = false,
+}: Custom404Props): ReactElement {
   return (
     <PageContainer
       className="min-h-page !items-center justify-center"
@@ -45,19 +58,22 @@ export default function Custom404({ children }: Custom404Props): ReactElement {
           </Button>
         </Link>
 
-        <nav aria-label="Other places to go" className="mt-2">
-          <ul className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
-            {recoveryLinks.map(({ label, href }) => (
-              <li key={href}>
-                <Link href={href} passHref prefetch={false}>
-                  <a className="text-text-tertiary underline typo-footnote hover:text-text-primary">
+        {showRecoveryLinks && (
+          <nav aria-label="Other places to go">
+            <ul className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2">
+              {recoveryLinks.map(({ label, href }) => (
+                <li key={href}>
+                  <a
+                    href={href}
+                    className="text-text-tertiary underline typo-footnote hover:text-text-primary"
+                  >
                     {label}
                   </a>
-                </Link>
-              </li>
-            ))}
-          </ul>
-        </nav>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        )}
       </div>
     </PageContainer>
   );

--- a/packages/webapp/pages/404.tsx
+++ b/packages/webapp/pages/404.tsx
@@ -23,7 +23,7 @@ export default function Custom404Seo(): ReactElement {
 
   return (
     <ErrorBoundary feature="404-page">
-      <Custom404>
+      <Custom404 showRecoveryLinks>
         <NextSeo title="Page not found" nofollow noindex />
       </Custom404>
     </ErrorBoundary>


### PR DESCRIPTION
## Why

`Custom404` offered exactly one link, `Go home`. Anyone who lands on a dead post, profile, squad or source URL gets a dead end, and a crawler gets nothing to follow. This component backs a lot of surfaces: `pages/404.tsx`, `posts/[id]`, `world/[userId]`, `ProfileLayout`, `squads/[handle]`, `sources/[source]`, `watercooler`, `join/*`, `backoffice/keywords/[value]`.

It came up while verifying an external agent-readiness audit that graded our 404s as only partially useful. The Astro marketing 404s carry a proper recovery grid; this one did not.

## What changed

A small labelled nav under the existing CTA with five destinations: Explore, Tags, Sources, Squads, Blog. Everything already there stays exactly as it was, including `data-testid="notFound"`, the charm image, the headline and the primary button.

Two details worth noting:
- **Every href was checked live on both hosts** this component renders on (`daily.dev` and `app.daily.dev`) before being added. All returned 200. A dead link on the 404 page would be the obvious own-goal, and there is a comment on the array saying so.
- `prefetch={false}`, so five secondary links do not trigger route prefetches on a page that is by definition a miss.

## Tests

This component had no direct test. Added `Custom404.spec.tsx`: the container renders, the primary CTA still points at `/`, each of the five recovery links resolves to the right href, and they are grouped in a nav with an accessible name.

```
PASS src/components/Custom404.spec.tsx
Tests: 8 passed, 8 total
```

`__tests__/KeywordPage.tsx`, which asserts on `notFound`, still passes. Lint and typecheck clean.

## Known limitation, not fixed here

On production, unmatched **root-level** paths on `daily.dev` (e.g. `daily.dev/some-bogus-path`) currently return Next's stock error page with zero links rather than this component, so they will not pick up this improvement. `next.config.ts:190` refers to "the daily.dev router" that proxies to the app origin, and that layer is not in this repo. Worth a look by whoever owns that routing config. Roughly 1 in 6 AI-crawler 4xx hits fall in that class; the rest already reach a proper 404.

### Preview domain
https://fix-custom-404-recovery-links.preview.app.daily.dev