### PR TITLE
fix: open shared articles in reader

### DIFF
--- a/packages/shared/src/components/modals/ReaderInstallPromptModal.tsx
+++ b/packages/shared/src/components/modals/ReaderInstallPromptModal.tsx
@@ -46,6 +46,7 @@ import { requestFrameEmbeddingPermissionFromPage } from '../../features/extensio
 
 interface ReaderInstallPromptModalProps extends LazyModalCommonProps {
   post: Post;
+  targetPost?: Post;
   /**
    * Close handler for the surface that owns the Read post click (e.g. the
    * classic post modal). Fired alongside the prompt's own dismiss paths
@@ -245,6 +246,7 @@ function BlurredArticleBackdrop(): ReactElement {
 
 function ReaderInstallPromptModal({
   post,
+  targetPost = post,
   isOpen,
   onRequestClose,
   onCloseParent,
@@ -306,7 +308,7 @@ function ReaderInstallPromptModal({
     ? 'Install Chrome extension'
     : 'Install Edge extension';
   const browser = isChromeBrowser ? 'chrome' : 'edge';
-  const host = getPostHost(post);
+  const host = getPostHost(targetPost);
   const faviconSrc = useFaviconSrc(host);
   const displayUrl = getDisplayUrl(host);
 
@@ -334,7 +336,7 @@ function ReaderInstallPromptModal({
   const [embedStatus, setEmbedStatus] =
     useState<ExtensionSiteEmbedStatus>('idle');
   const hasOpenedReaderRef = useRef(false);
-  const isTargetEmbeddable = isEmbeddableSiteTarget(post.permalink ?? '');
+  const isTargetEmbeddable = isEmbeddableSiteTarget(targetPost.permalink ?? '');
   const canRequestPermissions =
     !!embedExtensionId && isTargetEmbeddable && hasInstalledExtension;
 
@@ -349,9 +351,9 @@ function ReaderInstallPromptModal({
     // (e.g. the classic post modal behind it).
     openModal({
       type: LazyModal.ReaderPreview,
-      props: { post, onCloseParent },
+      props: { post, targetPost, onCloseParent },
     });
-  }, [closeModal, onCloseParent, openModal, post]);
+  }, [closeModal, onCloseParent, openModal, post, targetPost]);
 
   // `preparing-tab` arrives once `PermissionsReady` has fired (the user has
   // either just granted access or had it from a previous session). Transition
@@ -428,8 +430,12 @@ function ReaderInstallPromptModal({
       event_name: LogEvent.ClickReaderInstallSkip,
       extra: JSON.stringify({ browser, post_id: post.id }),
     });
-    if (post.permalink) {
-      globalThis.window?.open(post.permalink, '_blank', 'noopener,noreferrer');
+    if (targetPost.permalink) {
+      globalThis.window?.open(
+        targetPost.permalink,
+        '_blank',
+        'noopener,noreferrer',
+      );
     }
     onRequestClose({} as MouseEvent<HTMLButtonElement>);
   };
@@ -443,8 +449,12 @@ function ReaderInstallPromptModal({
       event_name: LogEvent.ClickReaderInstallSkip,
       extra: JSON.stringify({ browser, post_id: post.id }),
     });
-    if (post.permalink) {
-      globalThis.window?.open(post.permalink, '_blank', 'noopener,noreferrer');
+    if (targetPost.permalink) {
+      globalThis.window?.open(
+        targetPost.permalink,
+        '_blank',
+        'noopener,noreferrer',
+      );
     }
     onRequestClose(event);
   };
@@ -480,7 +490,7 @@ function ReaderInstallPromptModal({
             <div className="z-10 relative flex min-h-0 w-full flex-1 flex-col">
               <ExtensionSiteEmbed
                 extensionId={embedExtensionId}
-                targetUrl={post.permalink ?? ''}
+                targetUrl={targetPost.permalink ?? ''}
                 enabled
                 className="h-full w-full"
                 permissionFrameTitle="Embedded browsing permissions"

--- a/packages/shared/src/components/modals/ReaderPostModal.tsx
+++ b/packages/shared/src/components/modals/ReaderPostModal.tsx
@@ -16,6 +16,7 @@ import useDebounceFn from '../../hooks/useDebounceFn';
 interface ReaderPostModalProps extends ModalProps, PassedPostNavigationProps {
   id: string;
   post: Post;
+  targetPost?: Post;
 }
 
 export default function ReaderPostModal({
@@ -26,6 +27,7 @@ export default function ReaderPostModal({
   onNextPost,
   postPosition,
   post,
+  targetPost,
   ...props
 }: ReaderPostModalProps): ReactElement {
   const usePostReferrer =
@@ -74,6 +76,7 @@ export default function ReaderPostModal({
     >
       <ReaderPostLayout
         post={post}
+        targetPost={targetPost}
         postPosition={postPosition}
         onPreviousPost={onPreviousPost}
         onNextPost={onNextPost}

--- a/packages/shared/src/components/modals/ReaderPreviewLazyModal.tsx
+++ b/packages/shared/src/components/modals/ReaderPreviewLazyModal.tsx
@@ -7,6 +7,7 @@ import ReaderPostModal from './ReaderPostModal';
 
 interface ReaderPreviewLazyModalProps extends LazyModalCommonProps {
   post: Post;
+  targetPost?: Post;
   /**
    * Close handler for the surface that owns the original Read post click
    * (e.g. the classic post modal). Forwarded from the install prompt so
@@ -19,6 +20,7 @@ interface ReaderPreviewLazyModalProps extends LazyModalCommonProps {
 
 function ReaderPreviewLazyModal({
   post,
+  targetPost,
   isOpen,
   onRequestClose,
   onCloseParent,
@@ -32,6 +34,7 @@ function ReaderPreviewLazyModal({
     <ReaderPostModal
       id={post.id}
       post={post}
+      targetPost={targetPost}
       isOpen={isOpen}
       onRequestClose={onRequestCloseWithParent}
       postPosition={PostPosition.Only}

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -251,7 +251,7 @@ export const PostFocusCard = ({
   const { onReadClick: onReaderInstallGateClick } =
     useReaderInstallPromptGate(post);
   const { isReaderEnabled } = useReaderModalEligibility();
-  const isReaderVariant = isReaderEnabled && post.type === PostType.Article;
+  const isReaderVariant = isReaderEnabled && article.type === PostType.Article;
   const showCodeSnippets = useFeature(feature.showCodeSnippets);
   const communitySentimentData = article.communitySentiment
     ? mapCommunitySentimentPost(article.communitySentiment)

--- a/packages/shared/src/components/post/reader/ArticleReaderFrame.tsx
+++ b/packages/shared/src/components/post/reader/ArticleReaderFrame.tsx
@@ -11,6 +11,7 @@ import { TargetId } from '../../../lib/log';
 type ArticleReaderFrameProps = {
   post: Post;
   targetUrl: string | null;
+  previewHost?: string;
   isEmbeddable: boolean;
   className?: string;
   onClose?: () => void;
@@ -38,6 +39,7 @@ type ArticleReaderFrameProps = {
 export function ArticleReaderFrame({
   post,
   targetUrl,
+  previewHost,
   isEmbeddable,
   className,
   onClose,
@@ -91,7 +93,7 @@ export function ArticleReaderFrame({
     >
       <PostArticlePreviewEmbed
         targetUrl={targetUrl}
-        previewHost={post.domain ?? undefined}
+        previewHost={previewHost}
         leftHeaderActions={leftHeaderActions ?? undefined}
         rightHeaderActions={
           <ReaderHeaderActionGroup

--- a/packages/shared/src/components/post/reader/ReaderPostLayout.tsx
+++ b/packages/shared/src/components/post/reader/ReaderPostLayout.tsx
@@ -37,6 +37,7 @@ const SHELL_MAX_WIDTH = 'min(96vw, 100rem)';
 
 type ReaderPostLayoutProps = {
   post: Post;
+  targetPost?: Post;
   postPosition?: PostPosition;
   onPreviousPost?: () => void;
   onNextPost?: () => void;
@@ -57,6 +58,7 @@ type ReaderPostLayoutProps = {
 
 export function ReaderPostLayout({
   post: initialPost,
+  targetPost = initialPost,
   postPosition,
   onPreviousPost,
   onNextPost,
@@ -70,12 +72,12 @@ export function ReaderPostLayout({
   // icons keep showing the initial prop's state.
   const { post: cachedPost } = usePostById({ id: initialPost?.id });
   const post = cachedPost ?? initialPost;
-  const { targetUrl, isEmbeddable } = useIframeEmbed(post.permalink);
+  const { targetUrl, isEmbeddable } = useIframeEmbed(targetPost.permalink);
   const { logEvent } = useLogContext();
   const { openNewTab } = useContext(SettingsContext);
   const surface = isPostPage ? Origin.ArticlePage : Origin.ArticleModal;
   const onReadArticle = useReadArticle({ post, origin: surface });
-  const readArticleHref = getReadArticleHref(post);
+  const readArticleHref = getReadArticleHref(targetPost);
   const hasEmbed = !!targetUrl && isEmbeddable;
 
   useEffect(() => {
@@ -203,6 +205,7 @@ export function ReaderPostLayout({
                   <ArticleReaderFrame
                     post={post}
                     targetUrl={targetUrl}
+                    previewHost={targetPost.domain}
                     isEmbeddable={isEmbeddable}
                     fallbackScrollRef={fallbackScrollRef}
                     className="min-h-0 flex-1"

--- a/packages/shared/src/hooks/useReaderInstallPromptGate.spec.tsx
+++ b/packages/shared/src/hooks/useReaderInstallPromptGate.spec.tsx
@@ -1,0 +1,75 @@
+import { act, renderHook } from '@testing-library/react';
+import type { MouseEvent } from 'react';
+import { PostType } from '../graphql/posts';
+import type { Post } from '../graphql/posts';
+import { LazyModal } from '../components/modals/common/types';
+import { useReaderInstallPromptGate } from './useReaderInstallPromptGate';
+
+const mockOpenModal = jest.fn();
+const mockUpdateFlag = jest.fn();
+const mockUseReaderModalEligibility = jest.fn();
+
+jest.mock('./useLazyModal', () => ({
+  useLazyModal: () => ({ openModal: mockOpenModal }),
+}));
+
+jest.mock('../contexts/SettingsContext', () => ({
+  useSettingsContext: () => ({ updateFlag: mockUpdateFlag }),
+}));
+
+jest.mock('../components/post/reader/hooks/useReaderModalEligibility', () => ({
+  useReaderModalEligibility: () => mockUseReaderModalEligibility(),
+}));
+
+const article = {
+  id: 'article-id',
+  image: 'https://example.com/article.png',
+  commentsPermalink: '/posts/article-id',
+  permalink: 'https://example.com/article',
+  type: PostType.Article,
+} as Post;
+
+const sharedPost = {
+  id: 'share-id',
+  image: 'https://example.com/share.png',
+  commentsPermalink: '/posts/share-id',
+  type: PostType.Share,
+  sharedPost: article,
+} as Post;
+
+const createClickEvent = (): MouseEvent =>
+  ({
+    button: 0,
+    preventDefault: jest.fn(),
+    stopPropagation: jest.fn(),
+  } as unknown as MouseEvent);
+
+describe('useReaderInstallPromptGate', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseReaderModalEligibility.mockReturnValue({
+      isReaderEnabled: true,
+      canShowReaderInstallPrompt: false,
+    });
+  });
+
+  it('opens the shared article in the reader instead of following its external link', () => {
+    const { result } = renderHook(() => useReaderInstallPromptGate(sharedPost));
+    const event = createClickEvent();
+
+    act(() => {
+      expect(result.current.onReadClick(event)).toBe(true);
+    });
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+    expect(mockOpenModal).toHaveBeenCalledWith({
+      type: LazyModal.ReaderPreview,
+      props: {
+        post: sharedPost,
+        targetPost: article,
+        onCloseParent: undefined,
+      },
+    });
+  });
+});

--- a/packages/shared/src/hooks/useReaderInstallPromptGate.ts
+++ b/packages/shared/src/hooks/useReaderInstallPromptGate.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 import { useLazyModal } from './useLazyModal';
 import { LazyModal } from '../components/modals/common/types';
 import type { Post } from '../graphql/posts';
-import { PostType } from '../graphql/posts';
+import { getPostReadTarget, PostType } from '../graphql/posts';
 import { useReaderModalEligibility } from '../components/post/reader/hooks/useReaderModalEligibility';
 import { useSettingsContext } from '../contexts/SettingsContext';
 
@@ -42,15 +42,16 @@ export function useReaderInstallPromptGate(
   const { isReaderEnabled, canShowReaderInstallPrompt } =
     useReaderModalEligibility();
   const { updateFlag } = useSettingsContext();
+  const readerPost = post ? getPostReadTarget(post).target : undefined;
 
   const isGated =
-    !!post &&
-    READER_GATE_ELIGIBLE_TYPES.has(post.type) &&
+    !!readerPost &&
+    READER_GATE_ELIGIBLE_TYPES.has(readerPost.type) &&
     (isReaderEnabled || canShowReaderInstallPrompt);
 
   const onReadClick = useCallback(
     (event: MouseEvent): boolean => {
-      if (!isGated || !post) {
+      if (!isGated || !post || !readerPost) {
         return false;
       }
       // Preserve cmd/ctrl/shift/middle-click escape hatches so power users
@@ -70,18 +71,26 @@ export function useReaderInstallPromptGate(
       if (isReaderEnabled) {
         openModal({
           type: LazyModal.ReaderPreview,
-          props: { post, onCloseParent },
+          props: { post, targetPost: readerPost, onCloseParent },
         });
       } else {
         updateFlag('readerInstallPromptSeen', true);
         openModal({
           type: LazyModal.ReaderInstallPrompt,
-          props: { post, onCloseParent },
+          props: { post, targetPost: readerPost, onCloseParent },
         });
       }
       return true;
     },
-    [isGated, isReaderEnabled, onCloseParent, openModal, post, updateFlag],
+    [
+      isGated,
+      isReaderEnabled,
+      onCloseParent,
+      openModal,
+      post,
+      readerPost,
+      updateFlag,
+    ],
   );
 
   return { isGated, onReadClick };


### PR DESCRIPTION
## Summary
- resolve a shared post to its underlying article before evaluating the reader gate
- open that article in the reader preview or install prompt
- cover the shared-post regression

## Validation
- `NODE_ENV=test pnpm --filter shared exec jest src/hooks/useReaderInstallPromptGate.spec.tsx --runInBand`
- `node ./scripts/typecheck-strict-changed.js`
- `pnpm --filter shared lint`
- `pnpm --filter webapp test`

### Preview domain
https://fix-reader-shared-post.preview.app.daily.dev