### PR TITLE
fix(post): open the source article from the cover image and title

### DIFF
--- a/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
@@ -15,6 +15,17 @@ const freeformPost: Post = {
   contentHtml: '<p>Freeform body</p>',
 };
 
+// A squad post shared into another squad: the wrapper is type Share, but the
+// thing being opened is a freeform daily.dev post, not an external article.
+const sharedFreeformPost: Post = {
+  ...sharePost,
+  id: 'shared-freeform-id',
+  sharedPost: {
+    ...sharePost.sharedPost,
+    type: PostType.Freeform,
+  },
+} as Post;
+
 const renderCard = (postToRender: Post) =>
   render(
     <TestBootProvider client={new QueryClient()}>
@@ -49,6 +60,16 @@ describe('PostFocusCard opening the source article', () => {
 
     const title = screen.getByTestId('post-modal-title');
     expect(title.querySelector('a')).toHaveAttribute('href', post.permalink);
+  });
+
+  it('keeps the lightbox when a share wraps a native post', () => {
+    renderCard(sharedFreeformPost);
+
+    expect(screen.queryByTestId('post-cover-link')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('View cover image')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('post-modal-title').querySelector('a'),
+    ).toBeNull();
   });
 
   it('keeps the lightbox and a plain title on a native post', () => {

--- a/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
@@ -15,8 +15,6 @@ const freeformPost: Post = {
   contentHtml: '<p>Freeform body</p>',
 };
 
-// A squad post shared into another squad: the wrapper is type Share, but the
-// thing being opened is a freeform daily.dev post, not an external article.
 const sharedFreeformPost: Post = {
   ...sharePost,
   id: 'shared-freeform-id',
@@ -40,7 +38,6 @@ describe('PostFocusCard opening the source article', () => {
     const cover = screen.getByTestId('post-cover-link');
     expect(cover).toHaveAttribute('href', post.permalink);
     expect(cover).toHaveAttribute('target', '_blank');
-    // Duplicates the title link, so it stays out of the tab / AT order.
     expect(cover).toHaveAttribute('aria-hidden', 'true');
     expect(cover).toHaveAttribute('tabindex', '-1');
     expect(screen.queryByLabelText('View cover image')).not.toBeInTheDocument();

--- a/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import post, { sharePost } from '../../../../__tests__/fixture/post';
+import type { Post } from '../../../graphql/posts';
+import { PostType } from '../../../graphql/posts';
+import { Origin } from '../../../lib/log';
+import { PostFocusCard } from './PostFocusCard';
+
+const freeformPost: Post = {
+  ...post,
+  id: 'freeform-post-id',
+  type: PostType.Freeform,
+  contentHtml: '<p>Freeform body</p>',
+};
+
+const renderCard = (postToRender: Post) =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <PostFocusCard post={postToRender} origin={Origin.ArticlePage} />
+    </TestBootProvider>,
+  );
+
+describe('PostFocusCard opening the source article', () => {
+  it('links the cover to the source article on an external post', () => {
+    renderCard(post);
+
+    const cover = screen.getByTestId('post-cover-link');
+    expect(cover).toHaveAttribute('href', post.permalink);
+    expect(cover).toHaveAttribute('target', '_blank');
+    // Duplicates the title link, so it stays out of the tab / AT order.
+    expect(cover).toHaveAttribute('aria-hidden', 'true');
+    expect(cover).toHaveAttribute('tabindex', '-1');
+    expect(screen.queryByLabelText('View cover image')).not.toBeInTheDocument();
+  });
+
+  it('links the cover to the shared article on a share post', () => {
+    renderCard(sharePost);
+
+    expect(screen.getByTestId('post-cover-link')).toHaveAttribute(
+      'href',
+      sharePost.sharedPost?.permalink,
+    );
+  });
+
+  it('links the title to the source article on an external post', () => {
+    renderCard(post);
+
+    const title = screen.getByTestId('post-modal-title');
+    expect(title.querySelector('a')).toHaveAttribute('href', post.permalink);
+  });
+
+  it('keeps the lightbox and a plain title on a native post', () => {
+    renderCard(freeformPost);
+
+    expect(screen.queryByTestId('post-cover-link')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('View cover image')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('post-modal-title').querySelector('a'),
+    ).toBeNull();
+  });
+});

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -282,10 +282,6 @@ export const PostFocusCard = ({
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
   const readHref = getReadArticleHref(post);
-  // An external article to open: drives the title link, the cover link and the
-  // read button. Tested against `article` (the shared post when there is one)
-  // — a Share wrapping a freeform/welcome/collection is itself type Share, so
-  // testing the wrapper would treat those daily.dev posts as external articles.
   const canReadArticle = !!readHref && !isInternalReadType(article);
 
   useTrackPostView({ post });
@@ -472,17 +468,11 @@ export const PostFocusCard = ({
                   )}
                   data-testid="post-modal-title"
                 >
-                  {/* The biggest text target on the card, and the HN/Reddit
-                      convention — the title opens the source article. */}
                   {canReadArticle ? (
                     <a
                       href={readHref}
                       target="_blank"
                       rel="noopener"
-                      // Middle-click opens a background tab without firing
-                      // React's onClick, so log the read from onAuxClick too;
-                      // the selection guard keeps double-click-to-select a
-                      // word from navigating away.
                       {...combinedClicks<HTMLAnchorElement>(
                         withSelectionGuard(handleReadClick),
                       )}
@@ -494,16 +484,8 @@ export const PostFocusCard = ({
                     title
                   )}
                 </h1>
-                {/* Full-width tap target on mobile, hugs its label from tablet. */}
                 {renderReadButton('w-full tablet:w-fit')}
               </div>
-              {/* The cover is the biggest target on the card, so when there is
-                  a source article it opens it — same href, reader gate and read
-                  logging as the title and the read button. It duplicates the
-                  title link, so it stays out of the tab order and the
-                  accessibility tree rather than adding a third identical stop.
-                  Native posts have nothing to open, so there the cover keeps
-                  the zoom-in lightbox. */}
               {coverImage &&
                 (canReadArticle ? (
                   <a

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -34,7 +34,7 @@ import { getReadPostButtonIcon } from '../../cards/common/ReadArticleButton';
 import { PostUpvotesCommentsCount } from '../PostUpvotesCommentsCount';
 import { PostTagList } from '../tags/PostTagList';
 import { TruncateText } from '../../utilities';
-import { combinedClicks } from '../../../lib/click';
+import { combinedClicks, withSelectionGuard } from '../../../lib/click';
 import { useFeature } from '../../GrowthBookProvider';
 import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
 import {
@@ -282,10 +282,11 @@ export const PostFocusCard = ({
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
   const readHref = getReadArticleHref(post);
-  // An external article to open: drives the title link, the cover link and
-  // the read button. Native posts (freeform / welcome / collection) have
-  // nothing to open.
-  const canReadArticle = !!readHref && !isInternalReadType(post);
+  // An external article to open: drives the title link, the cover link and the
+  // read button. Tested against `article` (the shared post when there is one)
+  // — a Share wrapping a freeform/welcome/collection is itself type Share, so
+  // testing the wrapper would treat those daily.dev posts as external articles.
+  const canReadArticle = !!readHref && !isInternalReadType(article);
 
   useTrackPostView({ post });
 
@@ -338,7 +339,7 @@ export const PostFocusCard = ({
         target="_blank"
         rel="noopener"
         icon={isReaderVariant ? <EarthIcon /> : getReadPostButtonIcon(post)}
-        onClick={handleReadClick}
+        {...combinedClicks<HTMLAnchorElement>(handleReadClick)}
         variant={ButtonVariant.Primary}
         size={ButtonSize.Medium}
         className={className}
@@ -478,7 +479,13 @@ export const PostFocusCard = ({
                       href={readHref}
                       target="_blank"
                       rel="noopener"
-                      onClick={handleReadClick}
+                      // Middle-click opens a background tab without firing
+                      // React's onClick, so log the read from onAuxClick too;
+                      // the selection guard keeps double-click-to-select a
+                      // word from navigating away.
+                      {...combinedClicks<HTMLAnchorElement>(
+                        withSelectionGuard(handleReadClick),
+                      )}
                       className="transition-colors hover:text-text-link"
                     >
                       {title}
@@ -503,7 +510,7 @@ export const PostFocusCard = ({
                     href={readHref}
                     target="_blank"
                     rel="noopener"
-                    onClick={handleReadClick}
+                    {...combinedClicks<HTMLAnchorElement>(handleReadClick)}
                     aria-hidden
                     tabIndex={-1}
                     data-testid="post-cover-link"

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -282,6 +282,10 @@ export const PostFocusCard = ({
   const videoWrapperRef = useRef<HTMLDivElement>(null);
   const [isVideoExpanded, setIsVideoExpanded] = useState(false);
   const readHref = getReadArticleHref(post);
+  // An external article to open: drives the title link, the cover link and
+  // the read button. Native posts (freeform / welcome / collection) have
+  // nothing to open.
+  const canReadArticle = !!readHref && !isInternalReadType(post);
 
   useTrackPostView({ post });
 
@@ -327,7 +331,7 @@ export const PostFocusCard = ({
   // to the title regardless of the cover image height. The engagement bar lives
   // further down by the comment composer where the reader's cursor rests.
   const renderReadButton = (className: string): ReactElement | null =>
-    readHref && !isInternalReadType(post) ? (
+    canReadArticle ? (
       <Button
         tag="a"
         href={readHref}
@@ -336,11 +340,27 @@ export const PostFocusCard = ({
         icon={isReaderVariant ? <EarthIcon /> : getReadPostButtonIcon(post)}
         onClick={handleReadClick}
         variant={ButtonVariant.Primary}
-        size={ButtonSize.Small}
+        size={ButtonSize.Medium}
         className={className}
       >
         {getReadPostButtonText(post)}
       </Button>
+    ) : null;
+
+  const coverClassName =
+    'block h-fit w-24 shrink-0 overflow-hidden rounded-16 bg-background-subtle tablet:w-40';
+  const coverImage =
+    !isVideoType && article.image ? (
+      <LazyImage
+        eager
+        // Small square thumbnail below tablet; from tablet (656px) up it uses
+        // the original wide cover ratio (52% => 25/13).
+        className="aspect-square w-full tablet:aspect-[25/13]"
+        fallbackSrc={cloudinaryPostImageCoverPlaceholder}
+        fetchPriority="high"
+        imgAlt="Post cover image"
+        imgSrc={article.image}
+      />
     ) : null;
 
   return (
@@ -435,9 +455,8 @@ export const PostFocusCard = ({
             {!isShared && isCollection && (
               <p className="text-text-tertiary typo-footnote">Collection</p>
             )}
-            {/* Title and image are top-aligned columns. The cover image opens a
-                lightbox rather than navigating away. The read button lives in
-                the title column (right under the title) so it hugs the title
+            {/* Title and image are top-aligned columns. The read button lives
+                in the title column (right under the title) so it hugs the title
                 regardless of the image height — a short title next to a tall
                 image keeps the button close instead of dragging it down. */}
             <div className="flex min-w-0 flex-row items-start gap-4">
@@ -452,38 +471,65 @@ export const PostFocusCard = ({
                   )}
                   data-testid="post-modal-title"
                 >
-                  {title}
+                  {/* The biggest text target on the card, and the HN/Reddit
+                      convention — the title opens the source article. */}
+                  {canReadArticle ? (
+                    <a
+                      href={readHref}
+                      target="_blank"
+                      rel="noopener"
+                      onClick={handleReadClick}
+                      className="transition-colors hover:text-text-link"
+                    >
+                      {title}
+                    </a>
+                  ) : (
+                    title
+                  )}
                 </h1>
-                {renderReadButton('w-fit')}
+                {/* Full-width tap target on mobile, hugs its label from tablet. */}
+                {renderReadButton('w-full tablet:w-fit')}
               </div>
-              {!isVideoType && article.image && (
-                <button
-                  type="button"
-                  aria-label="View cover image"
-                  className="block h-fit w-24 shrink-0 cursor-zoom-in overflow-hidden rounded-16 bg-background-subtle tablet:w-40"
-                  onClick={(event) => {
-                    openModal({
-                      type: LazyModal.ImageView,
-                      props: {
-                        src: article.image as string,
-                        alt: 'Post cover image',
-                        originRect: getImageOriginRect(event.currentTarget),
-                      },
-                    });
-                  }}
-                >
-                  <LazyImage
-                    eager
-                    // Small square thumbnail below tablet; from tablet (656px)
-                    // up it uses the original wide cover ratio (52% => 25/13).
-                    className="aspect-square w-full tablet:aspect-[25/13]"
-                    fallbackSrc={cloudinaryPostImageCoverPlaceholder}
-                    fetchPriority="high"
-                    imgAlt="Post cover image"
-                    imgSrc={article.image}
-                  />
-                </button>
-              )}
+              {/* The cover is the biggest target on the card, so when there is
+                  a source article it opens it — same href, reader gate and read
+                  logging as the title and the read button. It duplicates the
+                  title link, so it stays out of the tab order and the
+                  accessibility tree rather than adding a third identical stop.
+                  Native posts have nothing to open, so there the cover keeps
+                  the zoom-in lightbox. */}
+              {coverImage &&
+                (canReadArticle ? (
+                  <a
+                    href={readHref}
+                    target="_blank"
+                    rel="noopener"
+                    onClick={handleReadClick}
+                    aria-hidden
+                    tabIndex={-1}
+                    data-testid="post-cover-link"
+                    className={classNames(coverClassName, 'cursor-pointer')}
+                  >
+                    {coverImage}
+                  </a>
+                ) : (
+                  <button
+                    type="button"
+                    aria-label="View cover image"
+                    className={classNames(coverClassName, 'cursor-zoom-in')}
+                    onClick={(event) => {
+                      openModal({
+                        type: LazyModal.ImageView,
+                        props: {
+                          src: article.image as string,
+                          alt: 'Post cover image',
+                          originRect: getImageOriginRect(event.currentTarget),
+                        },
+                      });
+                    }}
+                  >
+                    {coverImage}
+                  </button>
+                ))}
             </div>
           </div>
 


### PR DESCRIPTION
## Changes

Focused split of #6248, per @capJavert's review there — this carries **only** the source-opening fix, off current `main`. One file plus its spec, +153 / −37.

The readability redesign shrank the cover to a thumbnail and gave its click to a full-screen lightbox. That removed the big, learned target users tapped to reach the original article, leaving only a small `w-fit` "Read post" button.

Three entry points now open the source, all sharing `readHref`, the reader-install gate and the read logging (`handleReadClick`):

- **Cover image** — the biggest target on the card. Shared posts resolve through `getReadArticleHref`, so the cover follows `post.sharedPost` rather than the share wrapper.
- **Title** — the biggest text target, and the HN/Reddit convention.
- **Read button** — promoted to `ButtonSize.Medium` and full-width below tablet, so it is an easy tap target on mobile.

`canReadArticle` is extracted once and gates all three; the cover markup is defined once as `coverImage` / `coverClassName` and shared by both branches.

Native posts (freeform, welcome, collection) have no article to open, so there the title stays plain text and the cover keeps its zoom-in lightbox.

### Which post decides "is there an article to open"

`canReadArticle` tests `isInternalReadType` against **`article`** — the shared post when there is one — not against the wrapper. A Share wrapping a freeform / welcome / collection post is itself `type: Share`, so testing the wrapper would treat those daily.dev posts as external articles: the cover would lose its lightbox and both cover and title would link out to the `r/` redirect. `PostCardHeader` resolves the same question by inspecting the shared post. The second commit fixes this; its spec case fails without it.

Note this also corrects the pre-existing read button, which used the wrapper predicate on `main` and so rendered for shares of native posts.

### Clicks

All three entry points spread `combinedClicks`, because React's `onClick` does not fire for middle-click — without it, opening the title in a background tab skipped the read logging entirely and never reached the reader gate's own `event.button` branch. `ArticleLink` in this file and the equivalent button in `SharePostContent` already did this.

The title additionally wraps its handler in `withSelectionGuard`, so double-clicking a word to select it doesn't navigate away — matching `SharePostContent.tsx:163`.

### Accessibility

The cover link and the title link point at the same URL with the same accessible name, so the cover is `aria-hidden` + `tabIndex={-1}`: still a mouse/touch target, but not a third identical stop for keyboard and screen-reader users.

## Events

No new tracking events — every entry point reuses the existing read-article handler. Middle-clicks now log a read that previously went unrecorded.

## Experiment

No.

## Manual Testing

`PostFocusCard.spec.tsx` covers five branches: external article → cover and title link to `permalink`; share of an article → cover links to `sharedPost.permalink`; **share of a freeform post → lightbox kept, title plain**; native post → lightbox kept, title plain.

Also green locally: `packages/webapp/__tests__/PostPage.tsx` (51 tests), eslint, and the strict-typecheck guard on the changed files.

### Did you test the modified components media queries?
- [ ] MobileL (420px) — read button goes full-width, cover tap opens the article
- [ ] Tablet (656px) — read button hugs its label
- [ ] Laptop (1020px)

Also worth a look in preview:
- [ ] Reader enabled — cover, title and button all open the reader preview rather than an external tab
- [ ] Middle-click the title — opens a background tab and still logs the read
- [ ] Freeform post, and a share of a freeform post — both still open the lightbox

### Preview domain
https://claude-post-cover-opens-source.preview.app.daily.dev