### PR TITLE
feat(feed): add the feed hero section behind a flag

### DIFF
--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -2157,7 +2157,7 @@ describe('Feed ad cadence with highlight cards', () => {
     expect(order.slice(2).every((t) => t === 'postItem')).toBe(true);
   });
 
-  // The survivor keeps its index: the dropped ad no longer occupies a cell
+  // The survivor keeps index 12: the dropped ad no longer occupies a cell
   // against the cadence, so the next slot comes due one post later.
   it('drops the first ad slot when the surface shows one above the feed', async () => {
     const posts = Array.from({ length: 20 }, (_, i) => buildPost(`p${i}`));

--- a/packages/shared/src/components/Feed.spec.tsx
+++ b/packages/shared/src/components/Feed.spec.tsx
@@ -556,6 +556,64 @@ describe('Feed logged in', () => {
     ).toEqual(['postItem', 'postItem', 'highlightItem', 'postItem']);
   });
 
+  it('should drop feedV2 highlights when the surface shows them itself', async () => {
+    renderComponent(
+      [
+        {
+          request: {
+            query: FEED_V2_QUERY,
+            variables,
+          },
+          result: {
+            data: {
+              page: {
+                pageInfo: defaultFeedPage.pageInfo,
+                edges: [
+                  {
+                    node: {
+                      __typename: 'FeedPostItem',
+                      post: defaultFeedPage.edges[0].node,
+                      feedMeta: defaultFeedPage.edges[0].node.feedMeta ?? null,
+                    },
+                  },
+                  {
+                    node: {
+                      __typename: 'FeedHighlightsItem',
+                      feedMeta: null,
+                      highlights: [
+                        {
+                          id: 'highlight-1',
+                          channel: 'agents',
+                          headline: 'The first highlight',
+                          highlightedAt: '2026-04-05T09:00:00.000Z',
+                          post: {
+                            id: defaultFeedPage.edges[0].node.id,
+                            commentsPermalink:
+                              defaultFeedPage.edges[0].node.commentsPermalink,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      ],
+      defaultUser,
+      SharedFeedPage.MyFeed,
+      FEED_V2_QUERY,
+      { disableHighlightCards: true },
+    );
+
+    await waitForNock();
+
+    expect(await screen.findByTestId('postItem')).toBeInTheDocument();
+    expect(screen.queryByTestId('highlightItem')).not.toBeInTheDocument();
+    expect(screen.queryByText('Happening Now')).not.toBeInTheDocument();
+  });
+
   it('should send upvote mutation', async () => {
     let mutationCalled = false;
     renderComponent([
@@ -1889,6 +1947,7 @@ interface HighlightLayoutRenderParams {
   briefBannerPage?: number;
   staticAd?: { ad: Ad; index: number };
   disableAds?: boolean;
+  skipFirstAd?: boolean;
   user?: LoggedUser;
   isHorizontal?: boolean;
   feedName?: AllFeedPages;
@@ -1906,6 +1965,7 @@ const renderWithHighlightLayout = ({
   briefBannerPage,
   staticAd,
   disableAds,
+  skipFirstAd,
   user = defaultUser,
   isHorizontal,
   feedName = SharedFeedPage.MyFeed,
@@ -2012,6 +2072,7 @@ const renderWithHighlightLayout = ({
                   variables={variables}
                   staticAd={staticAd}
                   disableAds={disableAds}
+                  skipFirstAd={skipFirstAd}
                   isHorizontal={isHorizontal}
                 />
               </FeedContext.Provider>
@@ -2094,6 +2155,38 @@ describe('Feed ad cadence with highlight cards', () => {
     expect(order[0]).toBe('postItem');
     expect(order[1]).toBe('adItem');
     expect(order.slice(2).every((t) => t === 'postItem')).toBe(true);
+  });
+
+  // The survivor keeps its index: the dropped ad no longer occupies a cell
+  // against the cadence, so the next slot comes due one post later.
+  it('drops the first ad slot when the surface shows one above the feed', async () => {
+    const posts = Array.from({ length: 20 }, (_, i) => buildPost(`p${i}`));
+
+    renderWithHighlightLayout({
+      posts,
+      highlightEnabled: false,
+      skipFirstAd: true,
+    });
+
+    const order = await getFeedItemTestIds();
+    const adIndices = order
+      .map((type, index) => (type === 'adItem' ? index : -1))
+      .filter((index) => index >= 0);
+
+    expect(adIndices).toEqual([12]);
+  });
+
+  it('keeps both ad slots when nothing is shown above the feed', async () => {
+    const posts = Array.from({ length: 20 }, (_, i) => buildPost(`p${i}`));
+
+    renderWithHighlightLayout({ posts, highlightEnabled: false });
+
+    const order = await getFeedItemTestIds(2);
+    const adIndices = order
+      .map((type, index) => (type === 'adItem' ? index : -1))
+      .filter((index) => index >= 0);
+
+    expect(adIndices).toEqual([4, 12]);
   });
 
   // Same fixture, flag off: layout disabled → wide card collapses to 1 cell

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -102,6 +102,12 @@ export interface FeedProps<T>
   showSearch?: boolean;
   actionButtons?: ReactNode;
   disableAds?: boolean;
+  /** The surface shows the highlights itself, so keep them out of the grid. */
+  disableHighlightCards?: boolean;
+  /** The surface shows an ad above the feed, so drop the grid's first one. */
+  skipFirstAd?: boolean;
+  /** The surface leads with a featured card, so keep wide ones out of row one. */
+  deferWideCards?: boolean;
   staticAd?: { ad: Ad; index: number };
   disableAdRefresh?: boolean;
   allowFetchMore?: boolean;
@@ -211,6 +217,9 @@ export default function Feed<T>({
   shortcuts,
   actionButtons,
   disableAds,
+  disableHighlightCards,
+  skipFirstAd,
+  deferWideCards,
   staticAd,
   disableAdRefresh = false,
   allowFetchMore,
@@ -376,6 +385,9 @@ export default function Feed<T>({
       excludePinnedPosts,
       settings: {
         disableAds,
+        disableHighlightCards,
+        skipFirstAd,
+        deferWideCards,
         staticAd,
         adPostLength: isSquadFeed ? 2 : undefined,
         feedName,

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -104,6 +104,8 @@ export interface FeedProps<T>
   disableAds?: boolean;
   /** The surface shows the highlights itself, so keep them out of the grid. */
   disableHighlightCards?: boolean;
+  /** The surface owns the top slot, so the feed must not render or measure its own hero. */
+  disableTopHero?: boolean;
   /** The surface shows an ad above the feed, so drop the grid's first one. */
   skipFirstAd?: boolean;
   /** The surface leads with a featured card, so keep wide ones out of row one. */
@@ -218,6 +220,7 @@ export default function Feed<T>({
   actionButtons,
   disableAds,
   disableHighlightCards,
+  disableTopHero,
   skipFirstAd,
   deferWideCards,
   staticAd,
@@ -380,7 +383,7 @@ export default function Feed<T>({
       isBriefBannerEligible: !user?.isPlus && isMyFeed,
       engagementStripEligible: !isHorizontal && isEngagementAdFeed(feedName),
       firstSlotOffset: Number(eligibleFirstSlotCard !== null),
-      disableTopHero: isV2,
+      disableTopHero: isV2 || disableTopHero,
       isHorizontal,
       excludePinnedPosts,
       settings: {

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -14,22 +14,18 @@ import { LogEvent, Origin, TargetType } from '../lib/log';
 import type { SearchLogExtra } from '../lib/searchLog';
 import type { UseVotePost } from '../hooks';
 import { useFeedLayout } from '../hooks';
-import { CollectionList } from './cards/collection/CollectionList';
 import { FeedItemType } from './cards/common/common';
 import { AdGrid } from './cards/ad/AdGrid';
 import { AdList } from './cards/ad/AdList';
 import { SignalAdList } from './cards/ad/SignalAdList';
 import type { AdCardProps } from './cards/ad/common/common';
-import { FreeformGrid } from './cards/Freeform/FreeformGrid';
-import { FreeformList } from './cards/Freeform/FreeformList';
 import type { PostClick } from '../lib/click';
 import { ArticleList } from './cards/article/ArticleList';
 import { ArticleGrid } from './cards/article/ArticleGrid';
+import { PostTypeToGridCard } from './cards/common/gridCards';
 import type { FeaturedWideColSpan } from './cards/common/featuredWide';
 import { PostTypeToWideCard } from './cards/common/wideCards';
-import { ShareGrid } from './cards/share/ShareGrid';
-import { ShareList } from './cards/share/ShareList';
-import { CollectionGrid } from './cards/collection';
+import { PostTypeToListCard } from './cards/common/listCards';
 import type { UseBookmarkPost } from '../hooks/useBookmarkPost';
 import { AdActions } from '../lib/ads';
 import { useFeedCardContext } from '../features/posts/FeedCardContext';
@@ -38,7 +34,6 @@ import { AdMeasurement } from './cards/ad/common/AdMeasurement';
 import { AdViewability } from './cards/ad/common/AdViewability';
 import type { ViewabilityData } from '../features/monetization/viewability';
 import { viewabilityLogExtra } from '../features/monetization/viewability';
-import { BriefCard } from './cards/brief/BriefCard/BriefCard';
 import { ActivePostContextProvider } from '../contexts/ActivePostContext';
 import { LogExtraContextProvider } from '../contexts/LogExtraContext';
 import { SquadAdList } from './cards/ad/squad/SquadAdList';
@@ -50,10 +45,6 @@ import {
 } from '../lib/engagementAds';
 import { useEngagementAdsContext } from '../contexts/EngagementAdsContext';
 import { useLogContext } from '../contexts/LogContext';
-import PollGrid from './cards/poll/PollGrid';
-import { PollList } from './cards/poll/PollList';
-import { SocialTwitterGrid } from './cards/socialTwitter/SocialTwitterGrid';
-import { SocialTwitterList } from './cards/socialTwitter/SocialTwitterList';
 import { SignalList } from './cards/common/list/SignalList';
 import { OtherFeedPage } from '../lib/query';
 import { isSourceSquadOrMachine } from '../graphql/sources';
@@ -121,34 +112,6 @@ export function getFeedItemKey(item: FeedItem, index: number): string {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const PostTypeToTagCard: Record<PostType, React.ComponentType<any>> = {
-  [PostType.Article]: ArticleGrid,
-  [PostType.Share]: ShareGrid,
-  [PostType.Welcome]: FreeformGrid,
-  [PostType.Freeform]: FreeformGrid,
-  [PostType.VideoYouTube]: ArticleGrid,
-  [PostType.Collection]: CollectionGrid,
-  [PostType.Brief]: BriefCard,
-  [PostType.Poll]: PollGrid,
-  [PostType.SocialTwitter]: SocialTwitterGrid,
-  [PostType.Digest]: ArticleGrid,
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const PostTypeToTagList: Record<PostType, React.ComponentType<any>> = {
-  [PostType.Article]: ArticleList,
-  [PostType.Share]: ShareList,
-  [PostType.Welcome]: FreeformList,
-  [PostType.Freeform]: FreeformList,
-  [PostType.VideoYouTube]: ArticleList,
-  [PostType.Collection]: CollectionList,
-  [PostType.Brief]: BriefCard,
-  [PostType.Poll]: PollList,
-  [PostType.SocialTwitter]: SocialTwitterList,
-  [PostType.Digest]: ArticleList,
-};
-
 const getPostTypeForCard = (post?: Post): PostType => {
   if (!post) {
     return PostType.Article;
@@ -176,7 +139,7 @@ const getTags = ({
 }: GetTagsProps) => {
   const useListCards = isListFeedLayout || shouldUseListMode;
   const isSignalFeed = feedName === OtherFeedPage.AgentsVibes;
-  const listPostTag = isSignalFeed ? SignalList : PostTypeToTagList[postType];
+  const listPostTag = isSignalFeed ? SignalList : PostTypeToListCard[postType];
   const listPlaceholderTag = isSignalFeed
     ? SignalPlaceholderList
     : PlaceholderList;
@@ -185,7 +148,7 @@ const getTags = ({
   return {
     PostTag: useListCards
       ? listPostTag ?? ArticleList
-      : PostTypeToTagCard[postType] ?? ArticleGrid,
+      : PostTypeToGridCard[postType] ?? ArticleGrid,
     AdTag: useListCards ? listAdTag : AdGrid,
     SquadAdTag: useListCards ? SquadAdList : SquadAdGrid,
     PlaceholderTag: useListCards ? listPlaceholderTag : PlaceholderGrid,

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -394,9 +394,7 @@ export default function MainFeedLayout({
     shouldEvaluate: isMainFeedPage,
   });
   // The hero reports back rather than being asked: it only has a placement once
-  // its own column exists and an ad has come back for it. While it is showing
-  // one, the grid stands its first ad down so the reader does not meet two
-  // before the first post.
+  // its column exists and an ad has come back for it.
   const [isHeroAdVisible, setIsHeroAdVisible] = useState(false);
 
   const { isSearchPageLaptop } = useSearchResultsLayout();
@@ -813,11 +811,9 @@ export default function MainFeedLayout({
         {chipsNode}
       </div>
     ) : undefined;
-  // The v2 grid is inset inside the floating card and the hero is its sibling,
-  // not its child, so it has to repeat both the inset and the card border rules
-  // or it runs wider and brighter than every card under it. No bottom margin
-  // from `tablet` up, where the grid already opens with that same inset; mobile
-  // keeps one as the only separator the two have there.
+  // The hero is a sibling of the v2 grid, so it repeats the grid's inset and
+  // card border rules. No bottom margin from `tablet` up, where the grid
+  // already opens with that inset; mobile keeps one as the only separator.
   const isV2Grid = isV2 && !shouldUseListFeedLayout;
   const heroClassName = classNames(
     'w-full tablet:pt-6',
@@ -829,8 +825,7 @@ export default function MainFeedLayout({
         )
       : 'mb-8',
   );
-  // Left undefined when the hero is off so `Feed` keeps its own top slot for
-  // the reading reminder.
+  // Left undefined when the hero is off so `Feed` keeps its own top slot.
   const topContent = isFeedHeroEnabled ? (
     <>
       <FeedHero

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -394,8 +394,10 @@ export default function MainFeedLayout({
     shouldEvaluate: isMainFeedPage,
   });
   // The hero reports back rather than being asked: it only has a placement once
-  // its column exists and an ad has come back for it.
+  // its column exists and an ad has come back for it, and it renders nothing at
+  // all until its headlines resolve.
   const [isHeroAdVisible, setIsHeroAdVisible] = useState(false);
+  const [isHeroRendered, setIsHeroRendered] = useState(false);
 
   const { isSearchPageLaptop } = useSearchResultsLayout();
 
@@ -832,6 +834,7 @@ export default function MainFeedLayout({
         feedName={feedName}
         className={heroClassName}
         onAdVisibleChange={setIsHeroAdVisible}
+        onRenderedChange={setIsHeroRendered}
       />
       {chipsTopContent}
     </>
@@ -910,9 +913,15 @@ export default function MainFeedLayout({
               {...feedProps}
               shortcuts={shortcuts}
               topContent={topContent}
-              disableHighlightCards={isFeedHeroEnabled}
+              // The flag, not the hero's render: this placement logs an
+              // impression, so it has to be suppressed from the first paint
+              // rather than flickering in and out as the hero resolves.
+              disableTopHero={isFeedHeroEnabled}
+              // The render, so a hero that finds no headlines hands the
+              // highlights card and row one back to the grid.
+              disableHighlightCards={isHeroRendered}
               skipFirstAd={isHeroAdVisible}
-              deferWideCards={isFeedHeroEnabled}
+              deferWideCards={isHeroRendered}
               className={classNames(!isFinder && feedGutter)}
             />
           )

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -64,13 +64,14 @@ import {
   useViewSize,
   ViewSize,
 } from '../hooks';
-import { feedNameToHeading } from './feeds/FeedContainer';
+import { feedNameToHeading, v2FeedSideInsetClass } from './feeds/FeedContainer';
 import { pageHeaderClassName } from './layout/PageHeader';
 import {
   customFeedVersion,
   discussedFeedVersion,
   feature,
   featureFeedChips,
+  featureFeedHero,
   FeedChipsVariant,
   followingFeedVersion,
   latestFeedVersion,
@@ -78,6 +79,7 @@ import {
   upvotedFeedVersion,
 } from '../lib/featureManagement';
 import type { FeedContainerProps } from './feeds';
+import { FeedHero } from './feeds/hero/FeedHero';
 import { getFeedName } from '../lib/feed';
 import CommentFeed from './CommentFeed';
 import { COMMENT_FEED_QUERY } from '../graphql/comments';
@@ -384,6 +386,18 @@ export default function MainFeedLayout({
       ) : null,
     [showExploreChips, exploreCategories, feeds, isV2],
   );
+
+  const isMainFeedPage =
+    feedName === SharedFeedPage.MyFeed || feedName === SharedFeedPage.Popular;
+  const { value: isFeedHeroEnabled } = useConditionalFeature({
+    feature: featureFeedHero,
+    shouldEvaluate: isMainFeedPage,
+  });
+  // The hero reports back rather than being asked: it only has a placement once
+  // its own column exists and an ad has come back for it. While it is showing
+  // one, the grid stands its first ad down so the reader does not meet two
+  // before the first post.
+  const [isHeroAdVisible, setIsHeroAdVisible] = useState(false);
 
   const { isSearchPageLaptop } = useSearchResultsLayout();
 
@@ -791,6 +805,45 @@ export default function MainFeedLayout({
     }
     return '';
   }, [customFeedsData, feedName, router.query.slugOrId]);
+  const chipsTopContent =
+    (isExploreTag || shouldUseListFeedLayout) && chipsNode ? (
+      <div
+        className={classNames('mb-8 w-full', shouldUseListFeedLayout && 'mt-8')}
+      >
+        {chipsNode}
+      </div>
+    ) : undefined;
+  // The v2 grid is inset inside the floating card and the hero is its sibling,
+  // not its child, so it has to repeat both the inset and the card border rules
+  // or it runs wider and brighter than every card under it. No bottom margin
+  // from `tablet` up, where the grid already opens with that same inset; mobile
+  // keeps one as the only separator the two have there.
+  const isV2Grid = isV2 && !shouldUseListFeedLayout;
+  const heroClassName = classNames(
+    'w-full tablet:pt-6',
+    isV2Grid
+      ? classNames(
+          v2FeedSideInsetClass,
+          'mb-8 tablet:mb-0',
+          '[&_article:hover]:!border-border-subtlest-tertiary [&_article]:!border-border-subtlest-quaternary',
+        )
+      : 'mb-8',
+  );
+  // Left undefined when the hero is off so `Feed` keeps its own top slot for
+  // the reading reminder.
+  const topContent = isFeedHeroEnabled ? (
+    <>
+      <FeedHero
+        feedName={feedName}
+        className={heroClassName}
+        onAdVisibleChange={setIsHeroAdVisible}
+      />
+      {chipsTopContent}
+    </>
+  ) : (
+    chipsTopContent
+  );
+
   const v2ActionButtons = feedProps?.actionButtons;
   const showFeedV2PageHeader =
     isV2 &&
@@ -861,18 +914,10 @@ export default function MainFeedLayout({
             <Feed
               {...feedProps}
               shortcuts={shortcuts}
-              topContent={
-                (isExploreTag || shouldUseListFeedLayout) && chipsNode ? (
-                  <div
-                    className={classNames(
-                      'mb-8 w-full',
-                      shouldUseListFeedLayout && 'mt-8',
-                    )}
-                  >
-                    {chipsNode}
-                  </div>
-                ) : undefined
-              }
+              topContent={topContent}
+              disableHighlightCards={isFeedHeroEnabled}
+              skipFirstAd={isHeroAdVisible}
+              deferWideCards={isFeedHeroEnabled}
               className={classNames(!isFinder && feedGutter)}
             />
           )

--- a/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
@@ -11,11 +11,21 @@ import { useCardCover } from '../../../hooks/feed/useCardCover';
 import { stripHtmlTags } from '../../../lib/strings';
 import { HighlightChip } from '../common/HighlightChip';
 import type { FeaturedWideCardProps } from '../common/featuredWide';
-import { INNER_GRID_COLS } from '../common/featuredWide';
+import {
+  DESCRIPTION_CLASS_NAME,
+  featuredWideGridClass,
+  featuredWideTextColClass,
+  HERO_DESCRIPTION_CLASS_NAME,
+  HERO_DESCRIPTION_MAX_LINES,
+  HERO_TEXT_FIT_CLASS_NAME,
+  HERO_TITLE_CLASS_NAME,
+  TITLE_CLASS_NAME,
+} from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
 import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
+import { useFittedLineClamp } from '../../../hooks/useFittedLineClamp';
 
 export const FreeformFeaturedWideGridCard = forwardRef(
   function FreeformFeaturedWideGridCard(
@@ -34,6 +44,7 @@ export const FreeformFeaturedWideGridCard = forwardRef(
       eagerLoadImage = false,
       enableSourceHeader = false,
       wideColSpan = 2,
+      hero,
     }: FeaturedWideCardProps,
     ref: Ref<HTMLElement>,
   ): ReactElement {
@@ -42,6 +53,8 @@ export const FreeformFeaturedWideGridCard = forwardRef(
     const image = usePostImage(post);
     const significance = post.hero?.significance;
     const { overlay } = useCardCover({ post, onShare });
+    const hasMedia = !!image || !!overlay;
+    const textFit = useFittedLineClamp(HERO_DESCRIPTION_MAX_LINES);
     const description = useMemo(
       () => stripHtmlTags(post.contentHtml ?? '').trim(),
       [post.contentHtml],
@@ -61,16 +74,29 @@ export const FreeformFeaturedWideGridCard = forwardRef(
         <div
           className={classNames(
             'absolute inset-0 grid h-full min-h-0 gap-3 overflow-hidden laptop:gap-4',
-            image || overlay ? INNER_GRID_COLS[wideColSpan] : 'grid-cols-1',
+            featuredWideGridClass({ hasMedia, wideColSpan, hero }),
           )}
         >
-          <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
-            <FeaturedWideTextContainer>
+          <div
+            className={classNames(
+              'relative flex min-h-0 min-w-0 flex-col overflow-hidden',
+              featuredWideTextColClass({ hasMedia, hero }),
+            )}
+          >
+            <FeaturedWideTextContainer
+              ref={hero ? textFit.containerRef : undefined}
+              className={hero ? HERO_TEXT_FIT_CLASS_NAME : undefined}
+            >
               <SquadPostCardHeader
                 post={post}
                 enableSourceHeader={enableSourceHeader}
               />
-              <h3 className="mt-2 line-clamp-4 break-words font-bold text-text-primary typo-title1">
+              <h3
+                className={classNames(
+                  'mt-2 break-words font-bold text-text-primary',
+                  hero ? HERO_TITLE_CLASS_NAME : TITLE_CLASS_NAME,
+                )}
+              >
                 {title}
               </h3>
               <div className="mt-2 flex min-w-0 items-center gap-2">
@@ -87,7 +113,16 @@ export const FreeformFeaturedWideGridCard = forwardRef(
                 className="mt-1"
               />
               {!!description && (
-                <p className="mt-2 line-clamp-3 text-text-secondary typo-callout">
+                <p
+                  ref={hero ? textFit.textRef : undefined}
+                  // The measured fit replaces the class ceiling; inline because it is a
+                  // number rather than one of a handful of classes.
+                  style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
+                  className={classNames(
+                    'mt-2 text-text-secondary typo-callout',
+                    hero ? HERO_DESCRIPTION_CLASS_NAME : DESCRIPTION_CLASS_NAME,
+                  )}
+                >
                   {description}
                 </p>
               )}
@@ -101,11 +136,12 @@ export const FreeformFeaturedWideGridCard = forwardRef(
               onDownvoteClick={onDownvoteClick}
             />
           </div>
-          {(!!image || !!overlay) && (
+          {hasMedia && (
             <FeaturedWideImageColumn
               image={image}
               alt={post.title ?? ''}
               wideColSpan={wideColSpan}
+              hero={hero}
               overlay={overlay}
               eagerLoadImage={eagerLoadImage}
             />

--- a/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
@@ -115,8 +115,6 @@ export const FreeformFeaturedWideGridCard = forwardRef(
               {!!description && (
                 <p
                   ref={hero ? textFit.textRef : undefined}
-                  // The measured fit replaces the class ceiling; inline because it is a
-                  // number rather than one of a handful of classes.
                   style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
                   className={classNames(
                     'mt-2 text-text-secondary typo-callout',

--- a/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/Freeform/FreeformFeaturedWideGridCard.tsx
@@ -115,7 +115,7 @@ export const FreeformFeaturedWideGridCard = forwardRef(
               {!!description && (
                 <p
                   ref={hero ? textFit.textRef : undefined}
-                  style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
+                  style={hero ? textFit.style : undefined}
                   className={classNames(
                     'mt-2 text-text-secondary typo-callout',
                     hero ? HERO_DESCRIPTION_CLASS_NAME : DESCRIPTION_CLASS_NAME,

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
@@ -112,8 +112,6 @@ it('renders no chip when post has no highlight', () => {
 });
 
 describe('hero sizing', () => {
-  // The shared fixture has no summary, and the summary is the element under
-  // test here.
   const summarised: Post = { ...post, summary: 'What the post is about.' };
   const summaryOf = (): HTMLElement =>
     screen.getByText(summarised.summary as string);
@@ -122,8 +120,7 @@ describe('hero sizing', () => {
     renderComponent({ post: summarised, hero: true });
 
     const summary = summaryOf();
-    // Every element is `flex-shrink: 0` by default in base.css, so both have to
-    // opt back in or the actions are pushed out of the fixed-height card.
+    // `base.css` resets every element to `flex-shrink: 0`.
     expect(summary).toHaveClass('shrink');
     expect(summary.parentElement).toHaveClass('shrink', 'min-h-0');
   });

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.spec.tsx
@@ -7,6 +7,7 @@ import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import post from '../../../../__tests__/fixture/post';
 import type { PostCardProps } from '../common/common';
+import type { FeaturedWideColSpan } from '../common/featuredWide';
 import type { Post } from '../../../graphql/posts';
 import type { PostHero, PostHeroSignificance } from '../../../graphql/types';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
@@ -59,7 +60,9 @@ const makeHero = (significance: PostHeroSignificance | null): PostHero | null =>
     : null;
 
 const renderComponent = (
-  props: Partial<PostCardProps & { wideColSpan?: 2 | 3 | 4 }> = {},
+  props: Partial<
+    PostCardProps & { wideColSpan?: FeaturedWideColSpan; hero?: boolean }
+  > = {},
 ): RenderResult => {
   // HighlightChip short-circuits when the experiment flag is off; the
   // chip-label tests need it on, so override the GrowthBook value here.
@@ -106,4 +109,30 @@ it('renders no chip when post has no highlight', () => {
   expect(screen.queryByText('Breaking')).not.toBeInTheDocument();
   expect(screen.queryByText('Major')).not.toBeInTheDocument();
   expect(screen.queryByText('Notable')).not.toBeInTheDocument();
+});
+
+describe('hero sizing', () => {
+  // The shared fixture has no summary, and the summary is the element under
+  // test here.
+  const summarised: Post = { ...post, summary: 'What the post is about.' };
+  const summaryOf = (): HTMLElement =>
+    screen.getByText(summarised.summary as string);
+
+  it('lets the summary give way so the action row keeps its place', () => {
+    renderComponent({ post: summarised, hero: true });
+
+    const summary = summaryOf();
+    // Every element is `flex-shrink: 0` by default in base.css, so both have to
+    // opt back in or the actions are pushed out of the fixed-height card.
+    expect(summary).toHaveClass('shrink');
+    expect(summary.parentElement).toHaveClass('shrink', 'min-h-0');
+  });
+
+  it('leaves the in-feed card unable to shrink its summary', () => {
+    renderComponent({ post: summarised, wideColSpan: 2 });
+
+    const summary = summaryOf();
+    expect(summary).not.toHaveClass('shrink');
+    expect(summary.parentElement).not.toHaveClass('shrink');
+  });
 });

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
@@ -15,11 +15,21 @@ import { useCardCover } from '../../../hooks/feed/useCardCover';
 import { stripHtmlTags } from '../../../lib/strings';
 import { HighlightChip } from '../common/HighlightChip';
 import type { FeaturedWideCardProps } from '../common/featuredWide';
-import { INNER_GRID_COLS } from '../common/featuredWide';
+import {
+  DESCRIPTION_CLASS_NAME,
+  featuredWideGridClass,
+  featuredWideTextColClass,
+  HERO_DESCRIPTION_CLASS_NAME,
+  HERO_DESCRIPTION_MAX_LINES,
+  HERO_TEXT_FIT_CLASS_NAME,
+  HERO_TITLE_CLASS_NAME,
+  TITLE_CLASS_NAME,
+} from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
 import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
+import { useFittedLineClamp } from '../../../hooks/useFittedLineClamp';
 
 export const ArticleFeaturedWideGridCard = forwardRef(
   function ArticleFeaturedWideGridCard(
@@ -39,6 +49,7 @@ export const ArticleFeaturedWideGridCard = forwardRef(
       domProps = {},
       eagerLoadImage = false,
       wideColSpan = 2,
+      hero,
     }: FeaturedWideCardProps,
     ref: Ref<HTMLElement>,
   ): ReactElement {
@@ -48,6 +59,10 @@ export const ArticleFeaturedWideGridCard = forwardRef(
     const isVideoType = isVideoPost(post);
     const image = usePostImage(post);
     const { overlay } = useCardCover({ post, onShare });
+    const hasMedia = !!image || !!overlay;
+    // The headline keeps every line it needs; the summary takes what is left
+    // of the hero's fixed height, in whole lines.
+    const textFit = useFittedLineClamp(HERO_DESCRIPTION_MAX_LINES);
     const significance = post.hero?.significance;
     const isTweetPost =
       post.type === PostType.SocialTwitter ||
@@ -97,7 +112,10 @@ export const ArticleFeaturedWideGridCard = forwardRef(
 
     const standardContent = (
       <>
-        <FeaturedWideTextContainer>
+        <FeaturedWideTextContainer
+          ref={hero ? textFit.containerRef : undefined}
+          className={hero ? HERO_TEXT_FIT_CLASS_NAME : undefined}
+        >
           <PostCardHeader
             post={post}
             className="flex"
@@ -107,7 +125,12 @@ export const ArticleFeaturedWideGridCard = forwardRef(
             onReadArticleClick={onReadArticleClick}
             showFeedback={false}
           />
-          <h3 className="mt-2 line-clamp-4 break-words font-bold text-text-primary typo-title1">
+          <h3
+            className={classNames(
+              'mt-2 break-words font-bold text-text-primary',
+              hero ? HERO_TITLE_CLASS_NAME : TITLE_CLASS_NAME,
+            )}
+          >
             {title}
           </h3>
           <div className="mt-2 flex min-w-0 items-center gap-2">
@@ -122,7 +145,16 @@ export const ArticleFeaturedWideGridCard = forwardRef(
             className="mt-1"
           />
           {!!description && (
-            <p className="mt-2 line-clamp-3 text-text-secondary typo-callout">
+            <p
+              ref={hero ? textFit.textRef : undefined}
+              // The measured fit replaces the class ceiling; inline because it is a
+              // number rather than one of a handful of classes.
+              style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
+              className={classNames(
+                'mt-2 text-text-secondary typo-callout',
+                hero ? HERO_DESCRIPTION_CLASS_NAME : DESCRIPTION_CLASS_NAME,
+              )}
+            >
               {description}
             </p>
           )}
@@ -152,17 +184,23 @@ export const ArticleFeaturedWideGridCard = forwardRef(
         <div
           className={classNames(
             'absolute inset-0 grid h-full min-h-0 gap-3 overflow-hidden laptop:gap-4',
-            image || overlay ? INNER_GRID_COLS[wideColSpan] : 'grid-cols-1',
+            featuredWideGridClass({ hasMedia, wideColSpan, hero }),
           )}
         >
-          <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
+          <div
+            className={classNames(
+              'relative flex min-h-0 min-w-0 flex-col overflow-hidden',
+              featuredWideTextColClass({ hasMedia, hero }),
+            )}
+          >
             {showFeedback ? feedbackContent : standardContent}
           </div>
-          {(!!image || !!overlay) && (
+          {hasMedia && (
             <FeaturedWideImageColumn
               image={image}
               alt={post.title ?? ''}
               wideColSpan={wideColSpan}
+              hero={hero}
               overlay={overlay}
               isVideoType={isVideoType}
               eagerLoadImage={eagerLoadImage}

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
@@ -145,7 +145,7 @@ export const ArticleFeaturedWideGridCard = forwardRef(
           {!!description && (
             <p
               ref={hero ? textFit.textRef : undefined}
-              style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
+              style={hero ? textFit.style : undefined}
               className={classNames(
                 'mt-2 text-text-secondary typo-callout',
                 hero ? HERO_DESCRIPTION_CLASS_NAME : DESCRIPTION_CLASS_NAME,

--- a/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/article/ArticleFeaturedWideGridCard.tsx
@@ -60,8 +60,6 @@ export const ArticleFeaturedWideGridCard = forwardRef(
     const image = usePostImage(post);
     const { overlay } = useCardCover({ post, onShare });
     const hasMedia = !!image || !!overlay;
-    // The headline keeps every line it needs; the summary takes what is left
-    // of the hero's fixed height, in whole lines.
     const textFit = useFittedLineClamp(HERO_DESCRIPTION_MAX_LINES);
     const significance = post.hero?.significance;
     const isTweetPost =
@@ -147,8 +145,6 @@ export const ArticleFeaturedWideGridCard = forwardRef(
           {!!description && (
             <p
               ref={hero ? textFit.textRef : undefined}
-              // The measured fit replaces the class ceiling; inline because it is a
-              // number rather than one of a handful of classes.
               style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
               className={classNames(
                 'mt-2 text-text-secondary typo-callout',

--- a/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
@@ -12,11 +12,21 @@ import { useCardCover } from '../../../hooks/feed/useCardCover';
 import { CollectionCardHeader } from './CollectionCardHeader';
 import { HighlightChip } from '../common/HighlightChip';
 import type { FeaturedWideCardProps } from '../common/featuredWide';
-import { INNER_GRID_COLS } from '../common/featuredWide';
+import {
+  DESCRIPTION_CLASS_NAME,
+  featuredWideGridClass,
+  featuredWideTextColClass,
+  HERO_DESCRIPTION_CLASS_NAME,
+  HERO_DESCRIPTION_MAX_LINES,
+  HERO_TEXT_FIT_CLASS_NAME,
+  HERO_TITLE_CLASS_NAME,
+  TITLE_CLASS_NAME,
+} from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
 import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
+import { useFittedLineClamp } from '../../../hooks/useFittedLineClamp';
 
 export const CollectionFeaturedWideGridCard = forwardRef(
   function CollectionFeaturedWideGridCard(
@@ -34,6 +44,7 @@ export const CollectionFeaturedWideGridCard = forwardRef(
       domProps = {},
       eagerLoadImage = false,
       wideColSpan = 2,
+      hero,
     }: FeaturedWideCardProps,
     ref: Ref<HTMLElement>,
   ): ReactElement {
@@ -43,6 +54,8 @@ export const CollectionFeaturedWideGridCard = forwardRef(
     const significance = post.hero?.significance;
     const wasUpdated = isPostUpdated(post);
     const { overlay } = useCardCover({ post, onShare });
+    const hasMedia = !!image || !!overlay;
+    const textFit = useFittedLineClamp(HERO_DESCRIPTION_MAX_LINES);
 
     return (
       <FeaturedWideCardShell
@@ -58,13 +71,26 @@ export const CollectionFeaturedWideGridCard = forwardRef(
         <div
           className={classNames(
             'absolute inset-0 grid h-full min-h-0 gap-3 overflow-hidden laptop:gap-4',
-            image || overlay ? INNER_GRID_COLS[wideColSpan] : 'grid-cols-1',
+            featuredWideGridClass({ hasMedia, wideColSpan, hero }),
           )}
         >
-          <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
-            <FeaturedWideTextContainer>
+          <div
+            className={classNames(
+              'relative flex min-h-0 min-w-0 flex-col overflow-hidden',
+              featuredWideTextColClass({ hasMedia, hero }),
+            )}
+          >
+            <FeaturedWideTextContainer
+              ref={hero ? textFit.containerRef : undefined}
+              className={hero ? HERO_TEXT_FIT_CLASS_NAME : undefined}
+            >
               <CollectionCardHeader post={post} />
-              <h3 className="mt-2 line-clamp-4 break-words font-bold text-text-primary typo-title1">
+              <h3
+                className={classNames(
+                  'mt-2 break-words font-bold text-text-primary',
+                  hero ? HERO_TITLE_CLASS_NAME : TITLE_CLASS_NAME,
+                )}
+              >
                 {title}
               </h3>
               <div className="mt-2 flex min-w-0 items-center gap-2">
@@ -85,7 +111,16 @@ export const CollectionFeaturedWideGridCard = forwardRef(
                 className="mt-1"
               />
               {!!post.summary && (
-                <p className="mt-2 line-clamp-3 text-text-secondary typo-callout">
+                <p
+                  ref={hero ? textFit.textRef : undefined}
+                  // The measured fit replaces the class ceiling; inline because it is a
+                  // number rather than one of a handful of classes.
+                  style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
+                  className={classNames(
+                    'mt-2 text-text-secondary typo-callout',
+                    hero ? HERO_DESCRIPTION_CLASS_NAME : DESCRIPTION_CLASS_NAME,
+                  )}
+                >
                   {post.summary}
                 </p>
               )}
@@ -99,11 +134,12 @@ export const CollectionFeaturedWideGridCard = forwardRef(
               onDownvoteClick={onDownvoteClick}
             />
           </div>
-          {(!!image || !!overlay) && (
+          {hasMedia && (
             <FeaturedWideImageColumn
               image={image}
               alt={post.title ?? ''}
               wideColSpan={wideColSpan}
+              hero={hero}
               overlay={overlay}
               eagerLoadImage={eagerLoadImage}
             />

--- a/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
@@ -113,8 +113,6 @@ export const CollectionFeaturedWideGridCard = forwardRef(
               {!!post.summary && (
                 <p
                   ref={hero ? textFit.textRef : undefined}
-                  // The measured fit replaces the class ceiling; inline because it is a
-                  // number rather than one of a handful of classes.
                   style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
                   className={classNames(
                     'mt-2 text-text-secondary typo-callout',

--- a/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/collection/CollectionFeaturedWideGridCard.tsx
@@ -113,7 +113,7 @@ export const CollectionFeaturedWideGridCard = forwardRef(
               {!!post.summary && (
                 <p
                   ref={hero ? textFit.textRef : undefined}
-                  style={hero ? { WebkitLineClamp: textFit.lines } : undefined}
+                  style={hero ? textFit.style : undefined}
                   className={classNames(
                     'mt-2 text-text-secondary typo-callout',
                     hero ? HERO_DESCRIPTION_CLASS_NAME : DESCRIPTION_CLASS_NAME,

--- a/packages/shared/src/components/cards/common/Card.tsx
+++ b/packages/shared/src/components/cards/common/Card.tsx
@@ -54,6 +54,17 @@ const cardClassess =
 
 export const Card = classed('article', styles.card, cardClassess);
 
+/**
+ * A card without its chrome, for surfaces that sit on the page background
+ * rather than in the feed grid. Keeps the module class, which is what routes
+ * pointer events past the card body to the links inside it.
+ */
+export const FlatCard = classed(
+  'article',
+  styles.card,
+  'relative flex flex-col',
+);
+
 export const ClickableCard = classed('article', cardClassess);
 
 export const ChecklistCardComponent = classed(

--- a/packages/shared/src/components/cards/common/Card.tsx
+++ b/packages/shared/src/components/cards/common/Card.tsx
@@ -55,9 +55,8 @@ const cardClassess =
 export const Card = classed('article', styles.card, cardClassess);
 
 /**
- * A card without its chrome, for surfaces that sit on the page background
- * rather than in the feed grid. Keeps the module class, which is what routes
- * pointer events past the card body to the links inside it.
+ * A card without its chrome. Keeps the module class, which routes pointer
+ * events past the card body to the links inside it.
  */
 export const FlatCard = classed(
   'article',

--- a/packages/shared/src/components/cards/common/FeaturedWideImageColumn.tsx
+++ b/packages/shared/src/components/cards/common/FeaturedWideImageColumn.tsx
@@ -5,12 +5,19 @@ import { HIGH_PRIORITY_IMAGE_PROPS, Image, ImageType } from '../../image/Image';
 import { PlayIcon } from '../../icons';
 import { IconSize } from '../../Icon';
 import type { FeaturedWideColSpan } from './featuredWide';
-import { IMAGE_COL_SPAN } from './featuredWide';
+import { featuredWideImageColClass } from './featuredWide';
 
 export type FeaturedWideImageColumnProps = {
   image?: string;
   alt: string;
   wideColSpan: FeaturedWideColSpan;
+  /**
+   * The hero's treatment: container-query spans, and the cover cropped to fill
+   * its column inset with its own corners, the way the feed cards treat a
+   * cover. Off keeps the letterboxed image over the blurred backdrop the
+   * in-feed wide cards use.
+   */
+  hero?: boolean;
   overlay?: ReactNode;
   isVideoType?: boolean;
   eagerLoadImage?: boolean;
@@ -23,14 +30,16 @@ export const FeaturedWideImageColumn = ({
   overlay,
   isVideoType,
   eagerLoadImage,
+  hero,
 }: FeaturedWideImageColumnProps): ReactElement => (
   <div
     className={classNames(
-      'relative flex h-full min-w-0 items-center justify-center overflow-hidden rounded-r-16',
-      IMAGE_COL_SPAN[wideColSpan],
+      'relative flex h-full min-w-0 items-center justify-center overflow-hidden',
+      hero ? 'p-2' : 'rounded-r-16',
+      featuredWideImageColClass({ wideColSpan, hero }),
     )}
   >
-    {!!image && (
+    {!!image && !hero && (
       <Image
         aria-hidden
         alt=""
@@ -60,7 +69,8 @@ export const FeaturedWideImageColumn = ({
         src={image}
         type={ImageType.Post}
         className={classNames(
-          'relative size-full object-contain',
+          'relative size-full',
+          hero ? 'rounded-12 object-cover' : 'object-contain',
           !!overlay && 'opacity-16',
         )}
         {...(eagerLoadImage ? HIGH_PRIORITY_IMAGE_PROPS : {})}

--- a/packages/shared/src/components/cards/common/FeaturedWideImageColumn.tsx
+++ b/packages/shared/src/components/cards/common/FeaturedWideImageColumn.tsx
@@ -12,10 +12,8 @@ export type FeaturedWideImageColumnProps = {
   alt: string;
   wideColSpan: FeaturedWideColSpan;
   /**
-   * The hero's treatment: container-query spans, and the cover cropped to fill
-   * its column inset with its own corners, the way the feed cards treat a
-   * cover. Off keeps the letterboxed image over the blurred backdrop the
-   * in-feed wide cards use.
+   * Container-query spans, and the cover cropped to fill its column. Off keeps
+   * the letterboxed image over a blurred backdrop.
    */
   hero?: boolean;
   overlay?: ReactNode;

--- a/packages/shared/src/components/cards/common/FeaturedWideTextContainer.tsx
+++ b/packages/shared/src/components/cards/common/FeaturedWideTextContainer.tsx
@@ -1,8 +1,22 @@
-import type { ReactElement, ReactNode } from 'react';
-import React from 'react';
+import type { ReactElement, ReactNode, Ref } from 'react';
+import React, { forwardRef } from 'react';
+import classNames from 'classnames';
 
-export const FeaturedWideTextContainer = ({
-  children,
-}: {
-  children: ReactNode;
-}): ReactElement => <div className="mx-4 flex flex-col">{children}</div>;
+export const FeaturedWideTextContainer = forwardRef(
+  function FeaturedWideTextContainer(
+    {
+      className,
+      children,
+    }: {
+      className?: string;
+      children: ReactNode;
+    },
+    ref: Ref<HTMLDivElement>,
+  ): ReactElement {
+    return (
+      <div ref={ref} className={classNames('mx-4 flex flex-col', className)}>
+        {children}
+      </div>
+    );
+  },
+);

--- a/packages/shared/src/components/cards/common/featuredWide.ts
+++ b/packages/shared/src/components/cards/common/featuredWide.ts
@@ -4,7 +4,57 @@ export type FeaturedWideColSpan = 2 | 3 | 4;
 
 export type FeaturedWideCardProps = PostCardProps & {
   wideColSpan?: FeaturedWideColSpan;
+  /**
+   * The standalone hero treatment: the cover is cropped to fill its column
+   * instead of being letterboxed, and the text trades headline size for lines
+   * because it runs in a third of the card's width. The in-feed wide cards
+   * share a row with normal cards and keep the original sizes.
+   */
+  hero?: boolean;
 };
+
+export const TITLE_CLASS_NAME = 'line-clamp-4 typo-title1';
+export const HERO_TITLE_CLASS_NAME = 'line-clamp-5 typo-title2';
+export const DESCRIPTION_CLASS_NAME = 'line-clamp-3';
+
+/**
+ * The hero's card height is fixed, so a headline that runs to five lines would
+ * otherwise push the action row out through the bottom edge. `base.css` resets
+ * every element to `flex-shrink: 0`, so this block and the summary opt back in:
+ * the summary is the only shrinkable child, which makes it the one that gives
+ * way while the headline above it keeps every line. `grow` so the block's floor
+ * is the action row rather than wherever its own copy happens to end, which is
+ * what `useFittedLineClamp` measures down to.
+ */
+export const HERO_TEXT_FIT_CLASS_NAME = 'min-h-0 shrink grow overflow-hidden';
+
+/**
+ * Six is the ceiling, not the count — the measured fit replaces it whenever the
+ * headline above leaves room for fewer. Kept as a class so the first paint,
+ * before anything has been measured, is already close.
+ */
+export const HERO_DESCRIPTION_CLASS_NAME = 'line-clamp-6 min-h-0 shrink';
+export const HERO_DESCRIPTION_MAX_LINES = 6;
+
+/**
+ * The hero card sizes itself against its own width rather than the viewport's:
+ * the section is capped at the feed grid's width, which follows the reader's
+ * card-count setting, so a wide monitor showing three cards gives this card
+ * half the room a five-card feed does.
+ *
+ * Narrow, the cover sits under the copy; from 40rem it takes a column beside
+ * it; from 52rem the copy keeps two of five for the 40/60 split. Needs
+ * `@container/wide` on an ancestor — the carousel slide provides it, which is
+ * why in-feed wide cards keep their prop-driven spans.
+ */
+const HERO_INNER_GRID_CLASS_NAME =
+  'grid-cols-1 grid-rows-[minmax(0,1fr)_10rem] @[40rem]/wide:grid-cols-2 @[40rem]/wide:grid-rows-[minmax(0,1fr)] @[52rem]/wide:grid-cols-5';
+
+const HERO_TEXT_COL_CLASS_NAME =
+  'col-span-1 row-start-1 @[52rem]/wide:col-span-2';
+
+const HERO_IMAGE_COL_CLASS_NAME =
+  'col-span-1 row-start-2 @[40rem]/wide:row-start-1 @[52rem]/wide:col-span-3';
 
 export const INNER_GRID_COLS: Record<FeaturedWideColSpan, string> = {
   2: 'grid-cols-2',
@@ -17,3 +67,37 @@ export const IMAGE_COL_SPAN: Record<FeaturedWideColSpan, string> = {
   3: 'col-span-2',
   4: 'col-span-3',
 };
+
+type FeaturedWideLayout = {
+  hasMedia: boolean;
+  wideColSpan: FeaturedWideColSpan;
+  hero?: boolean;
+};
+
+export const featuredWideGridClass = ({
+  hasMedia,
+  wideColSpan,
+  hero,
+}: FeaturedWideLayout): string => {
+  if (!hasMedia) {
+    return 'grid-cols-1';
+  }
+
+  return hero ? HERO_INNER_GRID_CLASS_NAME : INNER_GRID_COLS[wideColSpan];
+};
+
+/**
+ * Only the hero states a span: with a single image column beside it the text
+ * takes one column by default, which is what every other span comes to.
+ */
+export const featuredWideTextColClass = ({
+  hasMedia,
+  hero,
+}: Pick<FeaturedWideLayout, 'hasMedia' | 'hero'>): string | undefined =>
+  hasMedia && hero ? HERO_TEXT_COL_CLASS_NAME : undefined;
+
+export const featuredWideImageColClass = ({
+  wideColSpan,
+  hero,
+}: Pick<FeaturedWideLayout, 'wideColSpan' | 'hero'>): string =>
+  hero ? HERO_IMAGE_COL_CLASS_NAME : IMAGE_COL_SPAN[wideColSpan];

--- a/packages/shared/src/components/cards/common/featuredWide.ts
+++ b/packages/shared/src/components/cards/common/featuredWide.ts
@@ -4,12 +4,7 @@ export type FeaturedWideColSpan = 2 | 3 | 4;
 
 export type FeaturedWideCardProps = PostCardProps & {
   wideColSpan?: FeaturedWideColSpan;
-  /**
-   * The standalone hero treatment: the cover is cropped to fill its column
-   * instead of being letterboxed, and the text trades headline size for lines
-   * because it runs in a third of the card's width. The in-feed wide cards
-   * share a row with normal cards and keep the original sizes.
-   */
+  /** The standalone hero treatment, sized from the card's own width. */
   hero?: boolean;
 };
 
@@ -18,34 +13,22 @@ export const HERO_TITLE_CLASS_NAME = 'line-clamp-5 typo-title2';
 export const DESCRIPTION_CLASS_NAME = 'line-clamp-3';
 
 /**
- * The hero's card height is fixed, so a headline that runs to five lines would
- * otherwise push the action row out through the bottom edge. `base.css` resets
- * every element to `flex-shrink: 0`, so this block and the summary opt back in:
- * the summary is the only shrinkable child, which makes it the one that gives
- * way while the headline above it keeps every line. `grow` so the block's floor
- * is the action row rather than wherever its own copy happens to end, which is
- * what `useFittedLineClamp` measures down to.
+ * `base.css` resets every element to `flex-shrink: 0`, so the text block has to
+ * opt back in; the summary is then the only shrinkable child, and gives way
+ * before the headline does. `grow` puts the block's floor at the action row,
+ * which is what `useFittedLineClamp` measures down to.
  */
 export const HERO_TEXT_FIT_CLASS_NAME = 'min-h-0 shrink grow overflow-hidden';
 
-/**
- * Six is the ceiling, not the count — the measured fit replaces it whenever the
- * headline above leaves room for fewer. Kept as a class so the first paint,
- * before anything has been measured, is already close.
- */
+/** A ceiling for the first paint; `useFittedLineClamp` replaces it once measured. */
 export const HERO_DESCRIPTION_CLASS_NAME = 'line-clamp-6 min-h-0 shrink';
 export const HERO_DESCRIPTION_MAX_LINES = 6;
 
 /**
- * The hero card sizes itself against its own width rather than the viewport's:
- * the section is capped at the feed grid's width, which follows the reader's
- * card-count setting, so a wide monitor showing three cards gives this card
- * half the room a five-card feed does.
- *
- * Narrow, the cover sits under the copy; from 40rem it takes a column beside
- * it; from 52rem the copy keeps two of five for the 40/60 split. Needs
- * `@container/wide` on an ancestor — the carousel slide provides it, which is
- * why in-feed wide cards keep their prop-driven spans.
+ * Container queries, not viewport ones: the hero is only ever as wide as the
+ * reader's feed grid, so a wide monitor set to three cards gives this card half
+ * the room a five-card feed does. Needs `@container/wide` on an ancestor, which
+ * the carousel slide provides.
  */
 const HERO_INNER_GRID_CLASS_NAME =
   'grid-cols-1 grid-rows-[minmax(0,1fr)_10rem] @[40rem]/wide:grid-cols-2 @[40rem]/wide:grid-rows-[minmax(0,1fr)] @[52rem]/wide:grid-cols-5';
@@ -86,10 +69,7 @@ export const featuredWideGridClass = ({
   return hero ? HERO_INNER_GRID_CLASS_NAME : INNER_GRID_COLS[wideColSpan];
 };
 
-/**
- * Only the hero states a span: with a single image column beside it the text
- * takes one column by default, which is what every other span comes to.
- */
+/** Only the hero states a span; every other layout's text column defaults to 1. */
 export const featuredWideTextColClass = ({
   hasMedia,
   hero,

--- a/packages/shared/src/components/cards/common/gridCards.ts
+++ b/packages/shared/src/components/cards/common/gridCards.ts
@@ -1,0 +1,23 @@
+import type React from 'react';
+import { PostType } from '../../../graphql/posts';
+import { ArticleGrid } from '../article/ArticleGrid';
+import { ShareGrid } from '../share/ShareGrid';
+import { FreeformGrid } from '../Freeform/FreeformGrid';
+import { CollectionGrid } from '../collection/CollectionGrid';
+import PollGrid from '../poll/PollGrid';
+import { SocialTwitterGrid } from '../socialTwitter/SocialTwitterGrid';
+import { BriefCard } from '../brief/BriefCard/BriefCard';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const PostTypeToGridCard: Record<PostType, React.ComponentType<any>> = {
+  [PostType.Article]: ArticleGrid,
+  [PostType.Share]: ShareGrid,
+  [PostType.Welcome]: FreeformGrid,
+  [PostType.Freeform]: FreeformGrid,
+  [PostType.VideoYouTube]: ArticleGrid,
+  [PostType.Collection]: CollectionGrid,
+  [PostType.Brief]: BriefCard,
+  [PostType.Poll]: PollGrid,
+  [PostType.SocialTwitter]: SocialTwitterGrid,
+  [PostType.Digest]: ArticleGrid,
+};

--- a/packages/shared/src/components/cards/common/listCards.ts
+++ b/packages/shared/src/components/cards/common/listCards.ts
@@ -1,0 +1,23 @@
+import type React from 'react';
+import { PostType } from '../../../graphql/posts';
+import { ArticleList } from '../article/ArticleList';
+import { ShareList } from '../share/ShareList';
+import { FreeformList } from '../Freeform/FreeformList';
+import { CollectionList } from '../collection/CollectionList';
+import { PollList } from '../poll/PollList';
+import { SocialTwitterList } from '../socialTwitter/SocialTwitterList';
+import { BriefCard } from '../brief/BriefCard/BriefCard';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const PostTypeToListCard: Record<PostType, React.ComponentType<any>> = {
+  [PostType.Article]: ArticleList,
+  [PostType.Share]: ShareList,
+  [PostType.Welcome]: FreeformList,
+  [PostType.Freeform]: FreeformList,
+  [PostType.VideoYouTube]: ArticleList,
+  [PostType.Collection]: CollectionList,
+  [PostType.Brief]: BriefCard,
+  [PostType.Poll]: PollList,
+  [PostType.SocialTwitter]: SocialTwitterList,
+  [PostType.Digest]: ArticleList,
+};

--- a/packages/shared/src/components/cards/highlight/HighlightCards.spec.tsx
+++ b/packages/shared/src/components/cards/highlight/HighlightCards.spec.tsx
@@ -62,6 +62,20 @@ describe('Highlight cards', () => {
     expect(screen.getByText('Read all')).toBeInTheDocument();
   });
 
+  // The hero passes `compact`; the in-feed cards do not, and must keep the
+  // row they had before it existed.
+  it('keeps the in-feed row bordered, with the timestamp on its own line', () => {
+    render(<HighlightGrid highlights={highlights} />);
+
+    const row = screen.getByRole('link', { name: /the first highlight/i });
+
+    expect(row).toHaveClass('border-b');
+    expect(row.className).not.toMatch(/after:/);
+    expect(
+      screen.getByText('The first highlight').querySelector('time'),
+    ).toBeNull();
+  });
+
   it('should trigger the highlight callbacks without blocking navigation', async () => {
     const onHighlightClick = jest.fn();
     const onReadAllClick = jest.fn();

--- a/packages/shared/src/components/cards/highlight/common.tsx
+++ b/packages/shared/src/components/cards/highlight/common.tsx
@@ -27,10 +27,12 @@ const getHighlightUrl = (highlight: PostHighlight): string =>
 export const ReadAllHighlightsFooter = ({
   highlightId,
   onClick,
+  compact,
   className,
 }: {
   highlightId?: string;
   onClick?: () => void;
+  compact?: boolean;
   className?: string;
 }): ReactElement => {
   const href = getHighlightsUrl(highlightId);
@@ -39,7 +41,10 @@ export const ReadAllHighlightsFooter = ({
       <Link href={href}>
         <a
           aria-label="Read all highlights"
-          className="bg-surface-float/70 flex h-8 w-full items-center rounded-10 px-3 backdrop-blur-xl"
+          className={classNames(
+            'flex h-8 w-full items-center',
+            !compact && 'bg-surface-float/70 rounded-10 px-3 backdrop-blur-xl',
+          )}
           href={href}
           onClick={() => onClick?.()}
         >
@@ -65,26 +70,37 @@ const HighlightRow = ({
   highlight,
   index,
   onHighlightClick,
+  compact,
 }: {
   highlight: PostHighlight;
   index: number;
   onHighlightClick?: (highlight: PostHighlight, position: number) => void;
+  compact?: boolean;
 }): ReactElement => {
   return (
     <Link href={getHighlightUrl(highlight)}>
       <a
-        className="flex w-full flex-col gap-0 rounded-8 border-b border-border-subtlest-tertiary px-3 py-2 text-left transition-colors hover:bg-surface-hover focus-visible:bg-surface-hover"
+        className={classNames(
+          // Drawn rather than bordered: a `border-b` follows the row's corner
+          // radius and curves up at both ends, reading as a half-open box
+          // around every headline instead of a list.
+          'relative flex w-full flex-col gap-0 text-left transition-colors after:absolute after:bottom-0 after:h-px after:bg-border-subtlest-tertiary last:after:hidden hover:bg-surface-hover focus-visible:bg-surface-hover',
+          compact
+            ? 'rounded-12 px-4 py-3 after:inset-x-4'
+            : 'rounded-8 px-3 py-2 after:inset-x-3',
+        )}
         href={getHighlightUrl(highlight)}
         onClick={() => onHighlightClick?.(highlight, index + 1)}
       >
         <span className="break-words font-bold text-text-primary typo-callout">
           {highlight.headline}
+          {/* In the headline's own text flow rather than on a line of its own,
+              so it trails the last word and wraps with it. */}
+          <span className="font-normal text-text-tertiary typo-footnote">
+            <span aria-hidden> · </span>
+            <RelativeTime dateTime={highlight.highlightedAt} maxHoursAgo={72} />
+          </span>
         </span>
-        <RelativeTime
-          dateTime={highlight.highlightedAt}
-          maxHoursAgo={72}
-          className="mt-0.5 text-text-tertiary typo-footnote"
-        />
       </a>
     </Link>
   );
@@ -95,16 +111,34 @@ export const HighlightCardContent = ({
   onHighlightClick,
   onReadAllClick,
   variant,
-}: HighlightCardProps & { variant: 'grid' | 'list' }): ReactElement => {
-  const headerClassName =
-    variant === 'list'
-      ? 'flex items-center pb-4'
-      : 'flex items-center px-4 py-4';
-  const contentClassName =
-    variant === 'list'
-      ? 'flex flex-col gap-2'
-      : 'no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto px-2.5 pb-1 pt-0';
-  const footerClassName = variant === 'list' ? 'pt-1.5' : 'px-1 pb-1';
+  compact,
+}: HighlightCardProps & {
+  variant: 'grid' | 'list';
+  /** Flush against its container, for a surface without card chrome. */
+  compact?: boolean;
+}): ReactElement => {
+  const isFlushGrid = variant === 'grid' && compact;
+  const headerClassName = classNames(
+    'flex items-center',
+    variant === 'list' && 'pb-4',
+    variant === 'grid' && (isFlushGrid ? 'px-4 pb-2' : 'px-4 py-4'),
+  );
+  const contentClassName = classNames(
+    variant === 'list' && 'flex flex-col gap-2',
+    variant === 'grid' &&
+      'no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto pt-0',
+    variant === 'grid' && !isFlushGrid && 'px-2.5 pb-1',
+    // Only from `laptop`, where the column has a fixed height and the list
+    // actually scrolls: the fade stops the pinned footer slicing a row flat.
+    isFlushGrid &&
+      'laptop:[mask-image:linear-gradient(to_bottom,black_calc(100%-1.25rem),transparent)]',
+  );
+  const footerClassName = classNames(
+    variant === 'list' && 'pt-1.5',
+    // The bottom inset matches the ad card's padding, so the two columns finish
+    // on one line rather than 12px apart.
+    variant === 'grid' && (isFlushGrid ? 'px-4 pb-3 pt-2' : 'px-1 pb-1'),
+  );
   const firstHighlight = highlights[0];
 
   return (
@@ -127,12 +161,14 @@ export const HighlightCardContent = ({
             highlight={highlight}
             index={index}
             onHighlightClick={onHighlightClick}
+            compact={compact}
           />
         ))}
       </div>
       <ReadAllHighlightsFooter
         highlightId={firstHighlight?.id}
         onClick={onReadAllClick}
+        compact={isFlushGrid}
         className={footerClassName}
       />
     </>

--- a/packages/shared/src/components/cards/highlight/common.tsx
+++ b/packages/shared/src/components/cards/highlight/common.tsx
@@ -77,28 +77,42 @@ const HighlightRow = ({
   onHighlightClick?: (highlight: PostHighlight, position: number) => void;
   compact?: boolean;
 }): ReactElement => {
+  const timestamp = (
+    <RelativeTime
+      dateTime={highlight.highlightedAt}
+      maxHoursAgo={72}
+      className={
+        compact ? undefined : 'mt-0.5 text-text-tertiary typo-footnote'
+      }
+    />
+  );
+
   return (
     <Link href={getHighlightUrl(highlight)}>
       <a
         className={classNames(
-          // Drawn, not bordered: a `border-b` follows the row's corner radius
-          // and curves up at both ends.
-          'relative flex w-full flex-col gap-0 text-left transition-colors after:absolute after:bottom-0 after:h-px after:bg-border-subtlest-tertiary last:after:hidden hover:bg-surface-hover focus-visible:bg-surface-hover',
+          'flex w-full flex-col gap-0 text-left transition-colors hover:bg-surface-hover focus-visible:bg-surface-hover',
           compact
-            ? 'rounded-12 px-4 py-3 after:inset-x-4'
-            : 'rounded-8 px-3 py-2 after:inset-x-3',
+            ? // Drawn, not bordered: a `border-b` follows the row's corner
+              // radius and curves up at both ends.
+              'relative rounded-12 px-4 py-3 after:absolute after:inset-x-4 after:bottom-0 after:h-px after:bg-border-subtlest-tertiary last:after:hidden'
+            : 'rounded-8 border-b border-border-subtlest-tertiary px-3 py-2',
         )}
         href={getHighlightUrl(highlight)}
         onClick={() => onHighlightClick?.(highlight, index + 1)}
       >
         <span className="break-words font-bold text-text-primary typo-callout">
           {highlight.headline}
-          {/* In the headline's text flow, so it trails and wraps with it. */}
-          <span className="font-normal text-text-tertiary typo-footnote">
-            <span aria-hidden> · </span>
-            <RelativeTime dateTime={highlight.highlightedAt} maxHoursAgo={72} />
-          </span>
+          {/* Compact trails the headline in its own text flow, so it wraps
+              with the last word rather than taking a line of its own. */}
+          {!!compact && (
+            <span className="font-normal text-text-tertiary typo-footnote">
+              <span aria-hidden> · </span>
+              {timestamp}
+            </span>
+          )}
         </span>
+        {!compact && timestamp}
       </a>
     </Link>
   );

--- a/packages/shared/src/components/cards/highlight/common.tsx
+++ b/packages/shared/src/components/cards/highlight/common.tsx
@@ -81,9 +81,8 @@ const HighlightRow = ({
     <Link href={getHighlightUrl(highlight)}>
       <a
         className={classNames(
-          // Drawn rather than bordered: a `border-b` follows the row's corner
-          // radius and curves up at both ends, reading as a half-open box
-          // around every headline instead of a list.
+          // Drawn, not bordered: a `border-b` follows the row's corner radius
+          // and curves up at both ends.
           'relative flex w-full flex-col gap-0 text-left transition-colors after:absolute after:bottom-0 after:h-px after:bg-border-subtlest-tertiary last:after:hidden hover:bg-surface-hover focus-visible:bg-surface-hover',
           compact
             ? 'rounded-12 px-4 py-3 after:inset-x-4'
@@ -94,8 +93,7 @@ const HighlightRow = ({
       >
         <span className="break-words font-bold text-text-primary typo-callout">
           {highlight.headline}
-          {/* In the headline's own text flow rather than on a line of its own,
-              so it trails the last word and wraps with it. */}
+          {/* In the headline's text flow, so it trails and wraps with it. */}
           <span className="font-normal text-text-tertiary typo-footnote">
             <span aria-hidden> · </span>
             <RelativeTime dateTime={highlight.highlightedAt} maxHoursAgo={72} />
@@ -128,15 +126,14 @@ export const HighlightCardContent = ({
     variant === 'grid' &&
       'no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-y-auto pt-0',
     variant === 'grid' && !isFlushGrid && 'px-2.5 pb-1',
-    // Only from `laptop`, where the column has a fixed height and the list
-    // actually scrolls: the fade stops the pinned footer slicing a row flat.
+    // Only where the column has a fixed height and actually scrolls: the fade
+    // stops the pinned footer slicing a row flat.
     isFlushGrid &&
       'laptop:[mask-image:linear-gradient(to_bottom,black_calc(100%-1.25rem),transparent)]',
   );
   const footerClassName = classNames(
     variant === 'list' && 'pt-1.5',
-    // The bottom inset matches the ad card's padding, so the two columns finish
-    // on one line rather than 12px apart.
+    // Matches the ad card's padding, so the columns finish on one line.
     variant === 'grid' && (isFlushGrid ? 'px-4 pb-3 pt-2' : 'px-1 pb-1'),
   );
   const firstHighlight = highlights[0];

--- a/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
@@ -16,11 +16,21 @@ import { DeletedPostId } from '../../../lib/constants';
 import { stripHtmlTags } from '../../../lib/strings';
 import { HighlightChip } from '../common/HighlightChip';
 import type { FeaturedWideCardProps } from '../common/featuredWide';
-import { INNER_GRID_COLS } from '../common/featuredWide';
+import {
+  DESCRIPTION_CLASS_NAME,
+  featuredWideGridClass,
+  featuredWideTextColClass,
+  HERO_DESCRIPTION_CLASS_NAME,
+  HERO_DESCRIPTION_MAX_LINES,
+  HERO_TEXT_FIT_CLASS_NAME,
+  HERO_TITLE_CLASS_NAME,
+  TITLE_CLASS_NAME,
+} from '../common/featuredWide';
 import { FeaturedWideCardShell } from '../common/FeaturedWideCardShell';
 import { FeaturedWideImageColumn } from '../common/FeaturedWideImageColumn';
 import { FeaturedWideActions } from '../common/FeaturedWideActions';
 import { FeaturedWideTextContainer } from '../common/FeaturedWideTextContainer';
+import { useFittedLineClamp } from '../../../hooks/useFittedLineClamp';
 
 export const ShareFeaturedWideGridCard = forwardRef(
   function ShareFeaturedWideGridCard(
@@ -40,6 +50,7 @@ export const ShareFeaturedWideGridCard = forwardRef(
       domProps = {},
       eagerLoadImage = false,
       wideColSpan = 2,
+      hero,
     }: FeaturedWideCardProps,
     ref: Ref<HTMLElement>,
   ): ReactElement {
@@ -58,6 +69,8 @@ export const ShareFeaturedWideGridCard = forwardRef(
       ? stripHtmlTags(sharedPost?.contentHtml ?? post.contentHtml ?? '').trim()
       : '';
     const { overlay } = useCardCover({ post, onShare });
+    const hasMedia = !!image || !!overlay;
+    const textFit = useFittedLineClamp(HERO_DESCRIPTION_MAX_LINES);
 
     return (
       <FeaturedWideCardShell
@@ -74,11 +87,19 @@ export const ShareFeaturedWideGridCard = forwardRef(
         <div
           className={classNames(
             'absolute inset-0 grid h-full min-h-0 gap-3 overflow-hidden laptop:gap-4',
-            image || overlay ? INNER_GRID_COLS[wideColSpan] : 'grid-cols-1',
+            featuredWideGridClass({ hasMedia, wideColSpan, hero }),
           )}
         >
-          <div className="relative flex min-h-0 min-w-0 flex-col overflow-hidden">
-            <FeaturedWideTextContainer>
+          <div
+            className={classNames(
+              'relative flex min-h-0 min-w-0 flex-col overflow-hidden',
+              featuredWideTextColClass({ hasMedia, hero }),
+            )}
+          >
+            <FeaturedWideTextContainer
+              ref={hero ? textFit.containerRef : undefined}
+              className={hero ? HERO_TEXT_FIT_CLASS_NAME : undefined}
+            >
               <PostCardHeader
                 post={post}
                 className="flex"
@@ -88,7 +109,12 @@ export const ShareFeaturedWideGridCard = forwardRef(
                 onReadArticleClick={onReadArticleClick}
               />
               {(!isSharedTweet || post.title) && (
-                <h3 className="mt-2 line-clamp-4 break-words font-bold text-text-primary typo-title1">
+                <h3
+                  className={classNames(
+                    'mt-2 break-words font-bold text-text-primary',
+                    hero ? HERO_TITLE_CLASS_NAME : TITLE_CLASS_NAME,
+                  )}
+                >
                   {title}
                 </h3>
               )}
@@ -122,7 +148,20 @@ export const ShareFeaturedWideGridCard = forwardRef(
               ) : (
                 <>
                   {!!sharedSummary && (
-                    <p className="mt-2 line-clamp-3 text-text-secondary typo-callout">
+                    <p
+                      ref={hero ? textFit.textRef : undefined}
+                      // The measured fit replaces the class ceiling; inline because it is a
+                      // number rather than one of a handful of classes.
+                      style={
+                        hero ? { WebkitLineClamp: textFit.lines } : undefined
+                      }
+                      className={classNames(
+                        'mt-2 text-text-secondary typo-callout',
+                        hero
+                          ? HERO_DESCRIPTION_CLASS_NAME
+                          : DESCRIPTION_CLASS_NAME,
+                      )}
+                    >
                       {sharedSummary}
                     </p>
                   )}
@@ -143,11 +182,12 @@ export const ShareFeaturedWideGridCard = forwardRef(
               onDownvoteClick={onDownvoteClick}
             />
           </div>
-          {(!!image || !!overlay) && (
+          {hasMedia && (
             <FeaturedWideImageColumn
               image={image}
               alt={sharedTitle || post.title || ''}
               wideColSpan={wideColSpan}
+              hero={hero}
               overlay={overlay}
               isVideoType={isVideoType}
               eagerLoadImage={eagerLoadImage}

--- a/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
@@ -150,8 +150,6 @@ export const ShareFeaturedWideGridCard = forwardRef(
                   {!!sharedSummary && (
                     <p
                       ref={hero ? textFit.textRef : undefined}
-                      // The measured fit replaces the class ceiling; inline because it is a
-                      // number rather than one of a handful of classes.
                       style={
                         hero ? { WebkitLineClamp: textFit.lines } : undefined
                       }

--- a/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
+++ b/packages/shared/src/components/cards/share/ShareFeaturedWideGridCard.tsx
@@ -150,9 +150,7 @@ export const ShareFeaturedWideGridCard = forwardRef(
                   {!!sharedSummary && (
                     <p
                       ref={hero ? textFit.textRef : undefined}
-                      style={
-                        hero ? { WebkitLineClamp: textFit.lines } : undefined
-                      }
+                      style={hero ? textFit.style : undefined}
                       className={classNames(
                         'mt-2 text-text-secondary typo-callout',
                         hero

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -55,9 +55,8 @@ export interface FeedContainerProps {
 }
 
 /**
- * The v2 grid sits inset inside the floating card. Anything the feed renders in
- * its top slot is a sibling of that grid, not a child, so it has to carry the
- * same side inset or it runs wider than the cards underneath it.
+ * Exported because anything in the feed's top slot is a sibling of the grid,
+ * not a child, and has to carry the same inset to line up with it.
  */
 export const v2FeedSideInsetClass = 'tablet:px-2 laptop:px-6';
 const v2FeedInsetClass = `${v2FeedSideInsetClass} tablet:py-2 laptop:py-6`;

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -54,6 +54,14 @@ export interface FeedContainerProps {
   disableListFrame?: boolean;
 }
 
+/**
+ * The v2 grid sits inset inside the floating card. Anything the feed renders in
+ * its top slot is a sibling of that grid, not a child, so it has to carry the
+ * same side inset or it runs wider than the cards underneath it.
+ */
+export const v2FeedSideInsetClass = 'tablet:px-2 laptop:px-6';
+const v2FeedInsetClass = `${v2FeedSideInsetClass} tablet:py-2 laptop:py-6`;
+
 const listGapClass = 'gap-2';
 const gridGapClass = 'gap-8';
 const feedGapPx = {
@@ -381,7 +389,7 @@ export const FeedContainer = ({
                   // mock. The page-header strip above sets its own
                   // bottom border, so cards sit p-6 inside the floating
                   // card on all four sides.
-                  'tablet:p-2 laptop:p-6 [&_article:hover]:!border-border-subtlest-tertiary [&_article]:!border-border-subtlest-quaternary',
+                  `${v2FeedInsetClass} [&_article:hover]:!border-border-subtlest-tertiary [&_article]:!border-border-subtlest-quaternary`,
                 // Inner inset for the bordered list frame. With the frame gone
                 // there is nothing to inset from, so the cards run the full
                 // width of the column like the page header above them.

--- a/packages/shared/src/components/feeds/hero/FeedHero.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHero.tsx
@@ -44,12 +44,7 @@ export const FeedHero = ({
   /** For the headline click events, which the in-feed card also reports. */
   feedName: string;
   className?: string;
-  /**
-   * Told whether the hero ended up showing a placement, so the feed below can
-   * stand its own first ad down. Only the hero knows: it turns on the column
-   * the ad needs, and the ad still has to come back before there is one to
-   * stand down for.
-   */
+  /** Lets the feed below stand its own first ad down while the hero shows one. */
   onAdVisibleChange?: (isVisible: boolean) => void;
 }): ReactElement | null => {
   const { user, tokenRefreshed } = useAuthContext();
@@ -59,7 +54,7 @@ export const FeedHero = ({
   const { toggleBookmark } = useBookmarkPost();
   const [, copyLink] = useCopyLink();
 
-  const { ad, placement, shape } = useFeedHeroAd(true);
+  const { ad, placement, shape } = useFeedHeroAd();
 
   const { data: headlines } = useQuery({
     ...majorHeadlinesQueryOptions({ first: HIGHLIGHT_COUNT }),
@@ -98,13 +93,11 @@ export const FeedHero = ({
     return postIds.map((id) => byId.get(id)).filter(Boolean) as Post[];
   }, [featured, postIds]);
 
-  // The hero renders nothing without posts, so it is showing no ad either.
   const adPlacement = posts.length > 0 ? placement : 'none';
   const isAdShown = adPlacement !== 'none';
 
-  // Stacked, the section leads with one story as a list card and the headline
-  // list carries the rest, so the lead is dropped from the list rather than
-  // appearing twice a few pixels apart.
+  // Stacked, the lead story is already a card above the list, so drop it from
+  // the list rather than showing it twice a few pixels apart.
   const railHighlights =
     shape.layout === 'stacked' ? highlights.slice(1) : highlights;
 

--- a/packages/shared/src/components/feeds/hero/FeedHero.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHero.tsx
@@ -31,6 +31,9 @@ import { useFeedHeroAd } from './useFeedHeroAd';
 
 const HIGHLIGHT_COUNT = 6;
 const FEATURED_POST_COUNT = 4;
+// Distinct from `Origin.Feed` so the experiment can tell the hero's clicks and
+// impressions apart from the grid's. Matches the ad events' own origin.
+const HERO_ORIGIN = 'feed hero';
 
 /**
  * The carousel and the Happening Now list are the same headlines: the top few
@@ -40,12 +43,19 @@ export const FeedHero = ({
   feedName,
   className,
   onAdVisibleChange,
+  onRenderedChange,
 }: {
   /** For the headline click events, which the in-feed card also reports. */
   feedName: string;
   className?: string;
   /** Lets the feed below stand its own first ad down while the hero shows one. */
   onAdVisibleChange?: (isVisible: boolean) => void;
+  /**
+   * Whether the hero found anything to show. It returns `null` without posts,
+   * and the grid has to take back the highlights card and its first-row wide
+   * cards when it does, or the reader gets neither.
+   */
+  onRenderedChange?: (isRendered: boolean) => void;
 }): ReactElement | null => {
   const { user, tokenRefreshed } = useAuthContext();
   const { logEvent } = useLogContext();
@@ -93,7 +103,8 @@ export const FeedHero = ({
     return postIds.map((id) => byId.get(id)).filter(Boolean) as Post[];
   }, [featured, postIds]);
 
-  const adPlacement = posts.length > 0 ? placement : 'none';
+  const isRendered = posts.length > 0;
+  const adPlacement = isRendered ? placement : 'none';
   const isAdShown = adPlacement !== 'none';
 
   // Stacked, the lead story is already a card above the list, so drop it from
@@ -108,7 +119,7 @@ export const FeedHero = ({
       }
 
       logEvent(
-        adLogEvent(action, ad, { extra: { origin: 'feed hero', ...extra } }),
+        adLogEvent(action, ad, { extra: { origin: HERO_ORIGIN, ...extra } }),
       );
     },
     [ad, logEvent],
@@ -135,6 +146,10 @@ export const FeedHero = ({
   }, [isAdShown, onAdVisibleChange]);
 
   useEffect(() => {
+    onRenderedChange?.(isRendered);
+  }, [isRendered, onRenderedChange]);
+
+  useEffect(() => {
     // Gated on `isAdShown`, not just on the ad existing: logging here while the
     // hero renders nothing would mark the cached ad LOGGED and swallow the
     // impression for the render that actually puts it on screen.
@@ -151,7 +166,7 @@ export const FeedHero = ({
       onPostClick: (post: Post) =>
         logEvent(
           postLogEvent(LogEvent.Click, post, {
-            extra: { origin: Origin.Feed },
+            extra: { origin: HERO_ORIGIN },
           }),
         ),
       onUpvoteClick: (post: Post, origin = Origin.Feed) =>
@@ -173,7 +188,7 @@ export const FeedHero = ({
     ],
   );
 
-  if (!posts.length) {
+  if (!isRendered) {
     return null;
   }
 
@@ -186,6 +201,13 @@ export const FeedHero = ({
       adPlacement={adPlacement}
       shape={shape}
       cardProps={cardProps}
+      onPostImpression={(post) =>
+        logEvent(
+          postLogEvent(LogEvent.Impression, post, {
+            extra: { origin: HERO_ORIGIN },
+          }),
+        )
+      }
       onHighlightClick={(highlight, position) =>
         logHighlightsClick('highlight_click', highlight, position)
       }

--- a/packages/shared/src/components/feeds/hero/FeedHero.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHero.tsx
@@ -1,0 +1,206 @@
+import type { ReactElement } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { Post } from '../../../graphql/posts';
+import type { Connection } from '../../../graphql/common';
+import { gqlClient } from '../../../graphql/common';
+import {
+  FEED_BY_IDS_QUERY,
+  supportedTypesForPrivateSources,
+} from '../../../graphql/feed';
+import type { PostHighlight } from '../../../graphql/highlights';
+import { majorHeadlinesQueryOptions } from '../../../graphql/highlights';
+import type { ViewabilityData } from '../../../features/monetization/viewability';
+import { viewabilityLogExtra } from '../../../features/monetization/viewability';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useLogContext } from '../../../contexts/LogContext';
+import { useVotePost } from '../../../hooks';
+import { useBookmarkPost } from '../../../hooks/useBookmarkPost';
+import { useCopyLink } from '../../../hooks/useCopy';
+import { ImpressionStatus } from '../../../hooks/feed/useLogImpression';
+import {
+  adLogEvent,
+  feedHighlightsLogEvent,
+  usePostLogEvent,
+} from '../../../lib/feed';
+import { AdActions } from '../../../lib/ads';
+import { LogEvent, Origin } from '../../../lib/log';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import { FeedHeroSection } from './FeedHeroSection';
+import { useFeedHeroAd } from './useFeedHeroAd';
+
+const HIGHLIGHT_COUNT = 6;
+const FEATURED_POST_COUNT = 4;
+
+/**
+ * The carousel and the Happening Now list are the same headlines: the top few
+ * get their full post fetched for a card, the rest stay as rows.
+ */
+export const FeedHero = ({
+  feedName,
+  className,
+  onAdVisibleChange,
+}: {
+  /** For the headline click events, which the in-feed card also reports. */
+  feedName: string;
+  className?: string;
+  /**
+   * Told whether the hero ended up showing a placement, so the feed below can
+   * stand its own first ad down. Only the hero knows: it turns on the column
+   * the ad needs, and the ad still has to come back before there is one to
+   * stand down for.
+   */
+  onAdVisibleChange?: (isVisible: boolean) => void;
+}): ReactElement | null => {
+  const { user, tokenRefreshed } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const postLogEvent = usePostLogEvent();
+  const { toggleUpvote, toggleDownvote } = useVotePost();
+  const { toggleBookmark } = useBookmarkPost();
+  const [, copyLink] = useCopyLink();
+
+  const { ad, placement, shape } = useFeedHeroAd(true);
+
+  const { data: headlines } = useQuery({
+    ...majorHeadlinesQueryOptions({ first: HIGHLIGHT_COUNT }),
+    enabled: tokenRefreshed,
+  });
+  const highlights = useMemo(
+    () => headlines?.majorHeadlines?.edges?.map(({ node }) => node) ?? [],
+    [headlines],
+  );
+
+  const postIds = useMemo(
+    () => highlights.slice(0, FEATURED_POST_COUNT).map(({ post }) => post.id),
+    [highlights],
+  );
+
+  const { data: featured } = useQuery({
+    queryKey: generateQueryKey(RequestKey.FeedByIds, user, 'hero', ...postIds),
+    queryFn: () =>
+      gqlClient.request<{ page: Connection<Post> }>(FEED_BY_IDS_QUERY, {
+        first: postIds.length,
+        postIds,
+        loggedIn: !!user,
+        supportedTypes: supportedTypesForPrivateSources,
+      }),
+    enabled: tokenRefreshed && postIds.length > 0,
+    staleTime: StaleTime.Default,
+  });
+
+  // `feedByIds` answers in its own order, so re-key by id to keep the carousel
+  // in the same order as the headlines beside it.
+  const posts = useMemo(() => {
+    const byId = new Map(
+      featured?.page?.edges?.map(({ node }) => [node.id, node]) ?? [],
+    );
+
+    return postIds.map((id) => byId.get(id)).filter(Boolean) as Post[];
+  }, [featured, postIds]);
+
+  // The hero renders nothing without posts, so it is showing no ad either.
+  const adPlacement = posts.length > 0 ? placement : 'none';
+  const isAdShown = adPlacement !== 'none';
+
+  // Stacked, the section leads with one story as a list card and the headline
+  // list carries the rest, so the lead is dropped from the list rather than
+  // appearing twice a few pixels apart.
+  const railHighlights =
+    shape.layout === 'stacked' ? highlights.slice(1) : highlights;
+
+  const onAdAction = useCallback(
+    (action: AdActions, extra?: Record<string, unknown>) => {
+      if (!ad) {
+        return;
+      }
+
+      logEvent(
+        adLogEvent(action, ad, { extra: { origin: 'feed hero', ...extra } }),
+      );
+    },
+    [ad, logEvent],
+  );
+
+  const logHighlightsClick = useCallback(
+    (action: string, clickedHighlight?: PostHighlight, position?: number) =>
+      logEvent(
+        feedHighlightsLogEvent(LogEvent.Click, {
+          feedName,
+          action,
+          position,
+          count: railHighlights.length,
+          clickedHighlight,
+          highlightIds: railHighlights.map(({ id }) => id),
+          origin: Origin.Feed,
+        }),
+      ),
+    [feedName, logEvent, railHighlights],
+  );
+
+  useEffect(() => {
+    onAdVisibleChange?.(isAdShown);
+  }, [isAdShown, onAdVisibleChange]);
+
+  useEffect(() => {
+    // Gated on `isAdShown`, not just on the ad existing: logging here while the
+    // hero renders nothing would mark the cached ad LOGGED and swallow the
+    // impression for the render that actually puts it on screen.
+    if (!ad || !isAdShown || ad.impressionStatus === ImpressionStatus.LOGGED) {
+      return;
+    }
+
+    onAdAction(AdActions.Impression);
+    ad.impressionStatus = ImpressionStatus.LOGGED;
+  }, [ad, isAdShown, onAdAction]);
+
+  const cardProps = useMemo(
+    () => ({
+      onPostClick: (post: Post) =>
+        logEvent(
+          postLogEvent(LogEvent.Click, post, {
+            extra: { origin: Origin.Feed },
+          }),
+        ),
+      onUpvoteClick: (post: Post, origin = Origin.Feed) =>
+        toggleUpvote({ payload: post, origin }),
+      onDownvoteClick: (post: Post, origin = Origin.Feed) =>
+        toggleDownvote({ payload: post, origin }),
+      onBookmarkClick: (post: Post, origin = Origin.Feed) =>
+        toggleBookmark({ post, origin }),
+      onCopyLinkClick: (_: React.MouseEvent, post: Post) =>
+        copyLink({ link: post.commentsPermalink }),
+    }),
+    [
+      copyLink,
+      logEvent,
+      postLogEvent,
+      toggleBookmark,
+      toggleDownvote,
+      toggleUpvote,
+    ],
+  );
+
+  if (!posts.length) {
+    return null;
+  }
+
+  return (
+    <FeedHeroSection
+      className={className}
+      posts={posts}
+      highlights={railHighlights}
+      ad={isAdShown ? ad : undefined}
+      adPlacement={adPlacement}
+      shape={shape}
+      cardProps={cardProps}
+      onHighlightClick={(highlight, position) =>
+        logHighlightsClick('highlight_click', highlight, position)
+      }
+      onReadAllClick={() => logHighlightsClick('read_all_click')}
+      onAdLinkClick={() => onAdAction(AdActions.Click)}
+      onAdViewable={(_, data: ViewabilityData) =>
+        onAdAction(AdActions.Viewable, viewabilityLogExtra(data))
+      }
+    />
+  );
+};

--- a/packages/shared/src/components/feeds/hero/FeedHeroAdCard.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroAdCard.tsx
@@ -1,0 +1,126 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Ad } from '../../../graphql/posts';
+import type { ViewabilityData } from '../../../features/monetization/viewability';
+import { FlatCard } from '../../cards/common/Card';
+import AdLink from '../../cards/ad/common/AdLink';
+import AdAttribution from '../../cards/ad/common/AdAttribution';
+import { AdFavicon } from '../../cards/ad/common/AdFavicon';
+import { AdImage } from '../../cards/ad/common/AdImage';
+import { AdPixel } from '../../cards/ad/common/AdPixel';
+import { AdMeasurement } from '../../cards/ad/common/AdMeasurement';
+import { AdViewability } from '../../cards/ad/common/AdViewability';
+import { RemoveAd } from '../../cards/ad/common/RemoveAd';
+import { AdvertiseLink } from '../../cards/ad/common/AdvertiseLink';
+import PostTags from '../../cards/common/PostTags';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { Image } from '../../image/Image';
+import classed from '../../../lib/classed';
+import { useAdLabel } from '../../../features/monetization/useAdLabel';
+import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
+import { TargetId } from '../../../lib/log';
+
+// `CardImage`'s own height and treatment, so the creative comes out the shape
+// the reader has already seen four of on the row below.
+const AdCover = classed(Image, 'h-40 w-full rounded-12 object-cover');
+
+interface FeedHeroAdCardProps {
+  ad: Ad;
+  onLinkClick?: (ad: Ad) => unknown;
+  onViewable?: (ad: Ad, data: ViewabilityData) => void;
+  className?: string;
+}
+
+/**
+ * The rail's ad, built to read as another big article rather than a compact
+ * widget. It follows the featured card beside it in both order and scale: the
+ * advertiser mark, the headline, its tags, the disclosure where the card puts
+ * its date, then the cover at the grid card's fixed 160px.
+ *
+ * The two controls sit below the card rather than inside it, the way "Read all"
+ * sits below the headline list, so the hover highlight covers what the card
+ * links to and stops short of the buttons that go somewhere else.
+ */
+export const FeedHeroAdCard = ({
+  ad,
+  onLinkClick,
+  onViewable,
+  className,
+}: FeedHeroAdCardProps): ReactElement => {
+  const { isPlus } = usePlusSubscription();
+  const { showAdvertiseLink } = useAdLabel();
+  const matchingTags = ad.matchingTags ?? [];
+
+  return (
+    <div className={classNames('flex min-h-0 flex-1 flex-col', className)}>
+      <FlatCard
+        data-testid="feedHeroAdCard"
+        className={classNames(
+          // The card radius the feed and the highlights card use, not the rail
+          // rows' smaller one. It takes the column's height but stops above the
+          // controls, which are the hover surface's edge.
+          'min-h-0 flex-1 rounded-16 px-4 py-3 transition-colors hover:bg-surface-hover',
+        )}
+      >
+        <AdLink ad={ad} onLinkClick={onLinkClick} />
+        <AdFavicon ad={ad} className="!m-0 shrink-0" />
+        {/* `typo-title3` is `CardTitle`'s size — what every post in the grid
+            gives its headline. */}
+        <span className="mt-3 line-clamp-3 break-words font-bold text-text-primary typo-title3">
+          {ad.description}
+        </span>
+        {/* `CardSpace`'s job: the copy takes the column's slack so the cover
+            below keeps its fixed height. */}
+        <div className="min-h-0 flex-1" />
+        {matchingTags.length > 0 && (
+          <PostTags
+            post={{ tags: matchingTags.slice(0, 6) }}
+            className="mt-2 [&>*]:!my-0"
+          />
+        )}
+        <AdAttribution
+          ad={ad}
+          className={{
+            main: 'mt-1 min-w-0 truncate !text-text-tertiary',
+            typo: 'typo-footnote',
+          }}
+        />
+        {!!ad.image && (
+          <AdImage ad={ad} ImageComponent={AdCover} className="!mb-0 !mt-4" />
+        )}
+        {/* Out of flow so the column's spacing doesn't reserve a row for it. */}
+        <div aria-hidden className="pointer-events-none absolute inset-0">
+          <AdPixel pixel={ad.pixel} />
+        </div>
+        <AdMeasurement ad={ad} />
+        <AdViewability ad={ad} onViewable={(data) => onViewable?.(ad, data)} />
+      </FlatCard>
+      {/* Outside the card, so hovering them does not light the creative up as
+          though it were the link. The creative's own call to action is left out
+          too: a third button wraps this row onto two lines in a 270px column,
+          and the card is already the click target.
+
+          The negative margins cancel the 12px `ButtonSize.Small` pads with, so
+          what lines up with the cover and the copy above is the label rather
+          than the button's box. */}
+      <div className="flex min-w-0 shrink-0 items-center justify-between gap-2 px-4 pb-3 pt-2">
+        {showAdvertiseLink && (
+          <AdvertiseLink
+            targetId={TargetId.AdCard}
+            buttonStyle
+            size={ButtonSize.Small}
+            className="-ml-3"
+          />
+        )}
+        {!isPlus && (
+          <RemoveAd
+            variant={ButtonVariant.Tertiary}
+            size={ButtonSize.Small}
+            className="!ml-0 -mr-3 !font-normal typo-footnote"
+          />
+        )}
+      </div>
+    </div>
+  );
+};

--- a/packages/shared/src/components/feeds/hero/FeedHeroAdCard.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroAdCard.tsx
@@ -21,8 +21,7 @@ import { useAdLabel } from '../../../features/monetization/useAdLabel';
 import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
 import { TargetId } from '../../../lib/log';
 
-// `CardImage`'s own height and treatment, so the creative comes out the shape
-// the reader has already seen four of on the row below.
+// `CardImage`'s own height, so the creative matches the covers on the row below.
 const AdCover = classed(Image, 'h-40 w-full rounded-12 object-cover');
 
 interface FeedHeroAdCardProps {
@@ -33,14 +32,9 @@ interface FeedHeroAdCardProps {
 }
 
 /**
- * The rail's ad, built to read as another big article rather than a compact
- * widget. It follows the featured card beside it in both order and scale: the
- * advertiser mark, the headline, its tags, the disclosure where the card puts
- * its date, then the cover at the grid card's fixed 160px.
- *
- * The two controls sit below the card rather than inside it, the way "Read all"
- * sits below the headline list, so the hover highlight covers what the card
- * links to and stops short of the buttons that go somewhere else.
+ * The rail's ad, following the featured card beside it in order and scale. The
+ * two controls sit below the card rather than inside it, so the hover highlight
+ * covers what the card links to and stops short of buttons that go elsewhere.
  */
 export const FeedHeroAdCard = ({
   ad,
@@ -57,21 +51,15 @@ export const FeedHeroAdCard = ({
       <FlatCard
         data-testid="feedHeroAdCard"
         className={classNames(
-          // The card radius the feed and the highlights card use, not the rail
-          // rows' smaller one. It takes the column's height but stops above the
-          // controls, which are the hover surface's edge.
           'min-h-0 flex-1 rounded-16 px-4 py-3 transition-colors hover:bg-surface-hover',
         )}
       >
         <AdLink ad={ad} onLinkClick={onLinkClick} />
         <AdFavicon ad={ad} className="!m-0 shrink-0" />
-        {/* `typo-title3` is `CardTitle`'s size — what every post in the grid
-            gives its headline. */}
         <span className="mt-3 line-clamp-3 break-words font-bold text-text-primary typo-title3">
           {ad.description}
         </span>
-        {/* `CardSpace`'s job: the copy takes the column's slack so the cover
-            below keeps its fixed height. */}
+        {/* The copy takes the column's slack so the cover keeps its height. */}
         <div className="min-h-0 flex-1" />
         {matchingTags.length > 0 && (
           <PostTags
@@ -97,13 +85,8 @@ export const FeedHeroAdCard = ({
         <AdViewability ad={ad} onViewable={(data) => onViewable?.(ad, data)} />
       </FlatCard>
       {/* Outside the card, so hovering them does not light the creative up as
-          though it were the link. The creative's own call to action is left out
-          too: a third button wraps this row onto two lines in a 270px column,
-          and the card is already the click target.
-
-          The negative margins cancel the 12px `ButtonSize.Small` pads with, so
-          what lines up with the cover and the copy above is the label rather
-          than the button's box. */}
+          though it were the link. The negative margins cancel the padding
+          `ButtonSize.Small` adds, so the labels line up with the copy above. */}
       <div className="flex min-w-0 shrink-0 items-center justify-between gap-2 px-4 pb-3 pt-2">
         {showAdvertiseLink && (
           <AdvertiseLink

--- a/packages/shared/src/components/feeds/hero/FeedHeroCarousel.spec.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroCarousel.spec.tsx
@@ -101,8 +101,6 @@ describe('FeedHeroCarousel split', () => {
     ).toHaveLength(titles.length);
   });
 
-  // Half a section is about a feed column wide, so the featured post takes the
-  // card the feed itself would give it rather than the wide card.
   it('uses the standard card, not the wide one', () => {
     renderComponent(posts, 'split');
 

--- a/packages/shared/src/components/feeds/hero/FeedHeroCarousel.spec.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroCarousel.spec.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import type { RenderResult } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import basePost from '../../../../__tests__/fixture/post';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import type { Post } from '../../../graphql/posts';
+import { FeedHeroCarousel } from './FeedHeroCarousel';
+import type { FeedHeroLayout } from './feedHeroShape';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest
+    .mocked(useRouter)
+    .mockImplementation(() => ({ pathname: '/' } as unknown as NextRouter));
+});
+
+const titles = ['First hero post', 'Second hero post', 'Third hero post'];
+
+const posts: Post[] = titles.map((title, index) => ({
+  ...basePost,
+  id: `hero-${index}`,
+  title,
+}));
+
+const renderComponent = (
+  carouselPosts: Post[] = posts,
+  layout: FeedHeroLayout = 'stacked',
+): RenderResult =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <FeedHeroCarousel posts={carouselPosts} layout={layout} />
+    </TestBootProvider>,
+  );
+
+const getTitle = (title: string) =>
+  screen.getByRole('heading', { name: title });
+
+describe('FeedHeroCarousel stacked', () => {
+  it('leads with the first post at full width', () => {
+    renderComponent();
+
+    expect(getTitle(titles[0])).toBeInTheDocument();
+  });
+
+  it('leaves the rest of the posts to the headline list', () => {
+    renderComponent();
+
+    expect(
+      screen.queryByRole('heading', { name: titles[1] }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('heading', { name: titles[2] }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('has nothing to page, so no indicators, arrows or autoplay', () => {
+    renderComponent();
+
+    expect(
+      screen.queryByRole('button', { name: /^Show featured post/ }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /^Next:/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId('carouselProgress')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing without posts', () => {
+    const { container } = renderComponent([]);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('FeedHeroCarousel wide', () => {
+  it('pages through every post once the section has columns', () => {
+    renderComponent(posts, 'wide');
+
+    expect(
+      screen.getByRole('button', { name: `Next: ${titles[1]}` }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole('button', { name: /^Show featured post/ }),
+    ).toHaveLength(titles.length);
+  });
+});
+
+describe('FeedHeroCarousel split', () => {
+  it('pages through every post', () => {
+    renderComponent(posts, 'split');
+
+    expect(
+      screen.getAllByRole('button', { name: /^Show featured post/ }),
+    ).toHaveLength(titles.length);
+  });
+
+  // Half a section is about a feed column wide, so the featured post takes the
+  // card the feed itself would give it rather than the wide card.
+  it('uses the standard card, not the wide one', () => {
+    renderComponent(posts, 'split');
+
+    expect(getTitle(titles[0])).toBeInTheDocument();
+    expect(
+      screen.getByRole('region', { name: 'Featured posts' }),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties, ReactElement } from 'react';
 import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useSwipeable } from 'react-swipeable';
+import { useInView } from 'react-intersection-observer';
 import type { Post } from '../../../graphql/posts';
 import type { FeaturedWideCardProps } from '../../cards/common/featuredWide';
 import { PostTypeToWideCard } from '../../cards/common/wideCards';
@@ -45,17 +46,20 @@ export const FeedHeroCarousel = ({
   // Slides the reader has actually been shown. Only the active one is visible,
   // so the rest are deliberately never counted.
   const logged = useRef(new Set<string>());
+  // The same threshold the grid's cards use, so a hero impression and a card
+  // impression mean the same thing when the two are compared.
+  const { ref: inViewRef, inView } = useInView({ threshold: 0.5 });
   const active = posts.length ? wrapIndex(slide.index, posts.length) : 0;
   const shown = layout === 'stacked' ? posts[0] : posts[active];
 
   useEffect(() => {
-    if (!shown || logged.current.has(shown.id)) {
+    if (!inView || !shown || logged.current.has(shown.id)) {
       return;
     }
 
     logged.current.add(shown.id);
     onPostImpression?.(shown);
-  }, [shown, onPostImpression]);
+  }, [inView, shown, onPostImpression]);
 
   const total = posts.length;
 
@@ -107,6 +111,7 @@ export const FeedHeroCarousel = ({
 
     return (
       <section
+        ref={inViewRef}
         aria-label="Featured post"
         className={classNames('flex min-w-0 flex-col', className)}
       >
@@ -155,6 +160,7 @@ export const FeedHeroCarousel = ({
 
   return (
     <section
+      ref={inViewRef}
       aria-label="Featured posts"
       aria-roledescription="carousel"
       className={classNames(
@@ -207,7 +213,13 @@ export const FeedHeroCarousel = ({
                         '--feed-hero-carousel-duration': `${autoplayMs}ms`,
                       } as CSSProperties
                     }
-                    className="feed-hero-carousel-progress block h-full w-full rounded-max bg-text-primary group-focus-within/hero:[animation-play-state:paused] group-hover/hero:[animation-play-state:paused]"
+                    className={classNames(
+                      'feed-hero-carousel-progress block h-full w-full rounded-max bg-text-primary group-focus-within/hero:[animation-play-state:paused] group-hover/hero:[animation-play-state:paused]',
+                      // Off screen the rotation would burn through all four
+                      // posts unseen, and take the ad column's neighbour with
+                      // it.
+                      !inView && '[animation-play-state:paused]',
+                    )}
                     onAnimationEnd={() => moveTo(active + 1)}
                   />
                 )}

--- a/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
@@ -1,0 +1,219 @@
+import type { CSSProperties, ReactElement } from 'react';
+import React, { useState } from 'react';
+import classNames from 'classnames';
+import type { Post } from '../../../graphql/posts';
+import type { FeaturedWideCardProps } from '../../cards/common/featuredWide';
+import { PostTypeToWideCard } from '../../cards/common/wideCards';
+import { ArticleFeaturedWideGridCard } from '../../cards/article/ArticleFeaturedWideGridCard';
+import { PostTypeToGridCard } from '../../cards/common/gridCards';
+import { PostTypeToListCard } from '../../cards/common/listCards';
+import { ArticleList } from '../../cards/article/ArticleList';
+import { ArticleGrid } from '../../cards/article/ArticleGrid';
+import type { FeedHeroLayout } from './feedHeroShape';
+import { Button } from '../../buttons/Button';
+import { ButtonSize, ButtonVariant } from '../../buttons/common';
+import { Tooltip } from '../../tooltip/Tooltip';
+import { ArrowIcon } from '../../icons';
+
+export type FeedHeroCarouselProps = Omit<FeaturedWideCardProps, 'post'> & {
+  posts: Post[];
+  autoplayMs?: number;
+  /**
+   * The section's shape. Passed in rather than measured here so the card and
+   * the layout around it come from one number: read apart, a viewport
+   * breakpoint and a container query disagreed, and a list card stretched down
+   * a 30rem column was the result.
+   */
+  layout?: FeedHeroLayout;
+  className?: string;
+};
+
+const wrapIndex = (index: number, total: number): number =>
+  (index + total) % total;
+
+export const FeedHeroCarousel = ({
+  posts,
+  autoplayMs = 6000,
+  layout = 'stacked',
+  className,
+  ...cardProps
+}: FeedHeroCarouselProps): ReactElement | null => {
+  const [slide, setSlide] = useState<{ index: number; from: number | null }>({
+    index: 0,
+    from: null,
+  });
+  const [isManualChange, setIsManualChange] = useState(false);
+  if (!posts.length) {
+    return null;
+  }
+
+  // One column: the lead story as a list card, with the headline list under it,
+  // so the section is the same kind of thing as the rows beneath it. There is
+  // no paging here — a slide has to stop short of the edge for the next one to
+  // peek, and at these widths that left every card too narrow to read. The
+  // stories it would have paged through are the headline list's first rows.
+  if (layout === 'stacked') {
+    const [lead] = posts;
+    const LeadCard = PostTypeToListCard[lead.type] ?? ArticleList;
+
+    return (
+      <section
+        aria-label="Featured post"
+        className={classNames('flex min-w-0 flex-col', className)}
+      >
+        <LeadCard post={lead} {...cardProps} />
+      </section>
+    );
+  }
+
+  const total = posts.length;
+  const active = wrapIndex(slide.index, total);
+
+  const moveTo = (position: number) => {
+    if (wrapIndex(position, total) === active) {
+      return;
+    }
+    setSlide({ index: position, from: active });
+  };
+
+  const goTo = (position: number) => {
+    setIsManualChange(true);
+    moveTo(position);
+  };
+
+  const post = posts[active];
+  const outgoing = slide.from === null ? null : posts[slide.from];
+  // Half a section is about the width of a feed column, so the featured post
+  // takes the card the feed itself would give it. The wide card's own layout
+  // has nothing left to trade at that size and its copy clips mid-sentence.
+  const isWide = layout === 'wide';
+  const cardFor = (item: Post) => {
+    if (isWide) {
+      return PostTypeToWideCard[item.type] ?? ArticleFeaturedWideGridCard;
+    }
+
+    return PostTypeToGridCard[item.type] ?? ArticleGrid;
+  };
+  const Card = cardFor(post);
+  // `hero` is the wide card's own prop; the standard card has no use for it.
+  const wideProps = isWide ? { hero: true } : {};
+  const previous = posts[wrapIndex(active - 1, total)];
+  const next = posts[wrapIndex(active + 1, total)];
+
+  // The slide being replaced stays mounted on top of the new one until its
+  // fade finishes, so the two cross over instead of the card popping.
+  let outgoingSlide: ReactElement | null = null;
+  if (outgoing) {
+    const OutgoingCard = cardFor(outgoing);
+    outgoingSlide = (
+      <div
+        key={outgoing.id}
+        aria-hidden
+        data-testid="carouselOutgoing"
+        className="feed-hero-slide-out pointer-events-none col-start-1 row-start-1 flex flex-col @container/wide"
+        onAnimationEnd={(event) => {
+          if (event.target !== event.currentTarget) {
+            return;
+          }
+          setSlide((current) => ({ ...current, from: null }));
+        }}
+      >
+        <OutgoingCard post={outgoing} {...wideProps} {...cardProps} />
+      </div>
+    );
+  }
+
+  return (
+    <section
+      aria-label="Featured posts"
+      aria-roledescription="carousel"
+      className={classNames(
+        // The bottom inset is the one the other two columns already carry — the
+        // rail on its "Read all" footer, the ad through its card padding — so
+        // this column's controls finish on their line rather than 12px below.
+        'group/hero flex min-h-0 min-w-0 flex-col gap-3 pb-3',
+        className,
+      )}
+    >
+      <div
+        // `overflow-hidden` makes this box the last word on a slide's height:
+        // every post type renders its own card, and one that wants more than
+        // the row would paint over the controls underneath.
+        className="grid min-h-0 flex-1 overflow-hidden"
+        // Announcing every automatic rotation would talk over the reader, so
+        // only a change the user asked for is live.
+        aria-live={isManualChange ? 'polite' : 'off'}
+      >
+        {outgoingSlide}
+        <div
+          key={post.id}
+          // The card sizes its own split against this box, not the viewport:
+          // the hero is only ever as wide as the reader's feed grid.
+          className="feed-hero-slide-in col-start-1 row-start-1 flex flex-col @container/wide"
+        >
+          <Card post={post} {...wideProps} {...cardProps} />
+        </div>
+      </div>
+      {total > 1 && (
+        <div className="flex items-center gap-3">
+          <div className="flex flex-1 items-center gap-1.5">
+            {posts.map((item, position) => (
+              <button
+                key={item.id}
+                type="button"
+                aria-label={`Show featured post ${position + 1}`}
+                aria-current={position === active}
+                onClick={() => goTo(position)}
+                className={classNames(
+                  'h-1.5 overflow-hidden rounded-max bg-border-subtlest-primary transition-all',
+                  position === active
+                    ? 'w-6'
+                    : 'w-1.5 hover:bg-text-quaternary',
+                )}
+              >
+                {position === active && (
+                  <span
+                    key={active}
+                    data-testid="carouselProgress"
+                    style={
+                      {
+                        '--feed-hero-carousel-duration': `${autoplayMs}ms`,
+                      } as CSSProperties
+                    }
+                    className="feed-hero-carousel-progress block h-full w-full rounded-max bg-text-primary group-focus-within/hero:[animation-play-state:paused] group-hover/hero:[animation-play-state:paused]"
+                    onAnimationEnd={() => {
+                      setIsManualChange(false);
+                      moveTo(active + 1);
+                    }}
+                  />
+                )}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-1">
+            <Tooltip content={previous.title}>
+              <Button
+                type="button"
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={<ArrowIcon className="-rotate-90" />}
+                onClick={() => goTo(active - 1)}
+                aria-label={`Previous: ${previous.title}`}
+              />
+            </Tooltip>
+            <Tooltip content={next.title}>
+              <Button
+                type="button"
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={<ArrowIcon className="rotate-90" />}
+                onClick={() => goTo(active + 1)}
+                aria-label={`Next: ${next.title}`}
+              />
+            </Tooltip>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};

--- a/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactElement } from 'react';
-import React, { useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
+import { useSwipeable } from 'react-swipeable';
 import type { Post } from '../../../graphql/posts';
 import type { FeaturedWideCardProps } from '../../cards/common/featuredWide';
 import { PostTypeToWideCard } from '../../cards/common/wideCards';
@@ -20,6 +21,8 @@ export type FeedHeroCarouselProps = Omit<FeaturedWideCardProps, 'post'> & {
   autoplayMs?: number;
   /** Passed in, not measured, so the card and the layout share one number. */
   layout?: FeedHeroLayout;
+  /** Called once per post brought on screen, so clicks have a denominator. */
+  onPostImpression?: (post: Post) => void;
   className?: string;
 };
 
@@ -30,6 +33,7 @@ export const FeedHeroCarousel = ({
   posts,
   autoplayMs = 6000,
   layout = 'stacked',
+  onPostImpression,
   className,
   ...cardProps
 }: FeedHeroCarouselProps): ReactElement | null => {
@@ -38,6 +42,58 @@ export const FeedHeroCarousel = ({
     from: null,
   });
   const [isManualChange, setIsManualChange] = useState(false);
+  // Slides the reader has actually been shown. Only the active one is visible,
+  // so the rest are deliberately never counted.
+  const logged = useRef(new Set<string>());
+  const active = posts.length ? wrapIndex(slide.index, posts.length) : 0;
+  const shown = layout === 'stacked' ? posts[0] : posts[active];
+
+  useEffect(() => {
+    if (!shown || logged.current.has(shown.id)) {
+      return;
+    }
+
+    logged.current.add(shown.id);
+    onPostImpression?.(shown);
+  }, [shown, onPostImpression]);
+
+  const total = posts.length;
+
+  const moveTo = (position: number) => {
+    if (!total || wrapIndex(position, total) === active) {
+      return;
+    }
+    setSlide({ index: position, from: active });
+  };
+
+  const goTo = (position: number) => {
+    setIsManualChange(true);
+    moveTo(position);
+  };
+
+  // A touch laptop gets the grid layouts but no swipe from the dots and arrows
+  // alone, so the same gesture the rest of the app's carousels accept.
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () => goTo(active + 1),
+    onSwipedRight: () => goTo(active - 1),
+    preventScrollOnSwipe: false,
+    trackMouse: false,
+  });
+
+  // The region is only live for the slide a manual change brings in. Reset on
+  // a timer rather than on the next automatic advance, which never arrives
+  // while the reader is hovering or focused — and would leave every later
+  // rotation announcing itself.
+  useEffect(() => {
+    if (!isManualChange) {
+      return undefined;
+    }
+
+    const timeout = setTimeout(() => setIsManualChange(false), 1000);
+
+    return () => clearTimeout(timeout);
+  }, [isManualChange, active]);
+
   if (!posts.length) {
     return null;
   }
@@ -58,21 +114,6 @@ export const FeedHeroCarousel = ({
       </section>
     );
   }
-
-  const total = posts.length;
-  const active = wrapIndex(slide.index, total);
-
-  const moveTo = (position: number) => {
-    if (wrapIndex(position, total) === active) {
-      return;
-    }
-    setSlide({ index: position, from: active });
-  };
-
-  const goTo = (position: number) => {
-    setIsManualChange(true);
-    moveTo(position);
-  };
 
   const post = posts[active];
   const outgoing = slide.from === null ? null : posts[slide.from];
@@ -124,6 +165,7 @@ export const FeedHeroCarousel = ({
       )}
     >
       <div
+        {...swipeHandlers}
         // `overflow-hidden` makes this box the last word on a slide's height:
         // a card wanting more would paint over the controls underneath.
         className="grid min-h-0 flex-1 overflow-hidden"
@@ -166,10 +208,7 @@ export const FeedHeroCarousel = ({
                       } as CSSProperties
                     }
                     className="feed-hero-carousel-progress block h-full w-full rounded-max bg-text-primary group-focus-within/hero:[animation-play-state:paused] group-hover/hero:[animation-play-state:paused]"
-                    onAnimationEnd={() => {
-                      setIsManualChange(false);
-                      moveTo(active + 1);
-                    }}
+                    onAnimationEnd={() => moveTo(active + 1)}
                   />
                 )}
               </button>

--- a/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroCarousel.tsx
@@ -18,12 +18,7 @@ import { ArrowIcon } from '../../icons';
 export type FeedHeroCarouselProps = Omit<FeaturedWideCardProps, 'post'> & {
   posts: Post[];
   autoplayMs?: number;
-  /**
-   * The section's shape. Passed in rather than measured here so the card and
-   * the layout around it come from one number: read apart, a viewport
-   * breakpoint and a container query disagreed, and a list card stretched down
-   * a 30rem column was the result.
-   */
+  /** Passed in, not measured, so the card and the layout share one number. */
   layout?: FeedHeroLayout;
   className?: string;
 };
@@ -47,11 +42,9 @@ export const FeedHeroCarousel = ({
     return null;
   }
 
-  // One column: the lead story as a list card, with the headline list under it,
-  // so the section is the same kind of thing as the rows beneath it. There is
-  // no paging here — a slide has to stop short of the edge for the next one to
-  // peek, and at these widths that left every card too narrow to read. The
-  // stories it would have paged through are the headline list's first rows.
+  // No paging at one column: a slide has to stop short of the edge for the
+  // next to peek, which left every card too narrow to read. The stories it
+  // would have paged through are the headline list's first rows.
   if (layout === 'stacked') {
     const [lead] = posts;
     const LeadCard = PostTypeToListCard[lead.type] ?? ArticleList;
@@ -83,9 +76,6 @@ export const FeedHeroCarousel = ({
 
   const post = posts[active];
   const outgoing = slide.from === null ? null : posts[slide.from];
-  // Half a section is about the width of a feed column, so the featured post
-  // takes the card the feed itself would give it. The wide card's own layout
-  // has nothing left to trade at that size and its copy clips mid-sentence.
   const isWide = layout === 'wide';
   const cardFor = (item: Post) => {
     if (isWide) {
@@ -95,13 +85,12 @@ export const FeedHeroCarousel = ({
     return PostTypeToGridCard[item.type] ?? ArticleGrid;
   };
   const Card = cardFor(post);
-  // `hero` is the wide card's own prop; the standard card has no use for it.
   const wideProps = isWide ? { hero: true } : {};
   const previous = posts[wrapIndex(active - 1, total)];
   const next = posts[wrapIndex(active + 1, total)];
 
-  // The slide being replaced stays mounted on top of the new one until its
-  // fade finishes, so the two cross over instead of the card popping.
+  // The outgoing slide stays mounted until its fade ends, so the two cross
+  // over instead of the card popping.
   let outgoingSlide: ReactElement | null = null;
   if (outgoing) {
     const OutgoingCard = cardFor(outgoing);
@@ -128,17 +117,15 @@ export const FeedHeroCarousel = ({
       aria-label="Featured posts"
       aria-roledescription="carousel"
       className={classNames(
-        // The bottom inset is the one the other two columns already carry — the
-        // rail on its "Read all" footer, the ad through its card padding — so
-        // this column's controls finish on their line rather than 12px below.
+        // The bottom inset the other two columns already carry, so all three
+        // finish on one line.
         'group/hero flex min-h-0 min-w-0 flex-col gap-3 pb-3',
         className,
       )}
     >
       <div
         // `overflow-hidden` makes this box the last word on a slide's height:
-        // every post type renders its own card, and one that wants more than
-        // the row would paint over the controls underneath.
+        // a card wanting more would paint over the controls underneath.
         className="grid min-h-0 flex-1 overflow-hidden"
         // Announcing every automatic rotation would talk over the reader, so
         // only a change the user asked for is live.
@@ -147,8 +134,6 @@ export const FeedHeroCarousel = ({
         {outgoingSlide}
         <div
           key={post.id}
-          // The card sizes its own split against this box, not the viewport:
-          // the hero is only ever as wide as the reader's feed grid.
           className="feed-hero-slide-in col-start-1 row-start-1 flex flex-col @container/wide"
         >
           <Card post={post} {...wideProps} {...cardProps} />

--- a/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
@@ -11,10 +11,7 @@ import { FeedHeroCarousel } from './FeedHeroCarousel';
 import type { FeedHeroAdPlacement, FeedHeroShape } from './feedHeroShape';
 import { feedHeroShape } from './feedHeroShape';
 
-/**
- * Written out rather than built, because Tailwind only generates the classes it
- * can see. Six is the grid's own ceiling — `FeedContext`'s widest setting.
- */
+/** Written out, not built: Tailwind only generates the classes it can see. */
 const gridColsClass: Partial<Record<number, string>> = {
   2: 'grid-cols-2',
   3: 'grid-cols-3',
@@ -34,10 +31,6 @@ interface FeedHeroSectionProps {
   posts: Post[];
   highlights: PostHighlight[];
   ad?: Ad;
-  /**
-   * Where the section is putting the ad. Decided by the caller from the same
-   * shape passed in here, so the column and what goes in it cannot disagree.
-   */
   adPlacement?: FeedHeroAdPlacement;
   /** The section's row, measured against the feed grid's column count. */
   shape?: FeedHeroShape;
@@ -64,8 +57,6 @@ export function FeedHeroSection({
 }: FeedHeroSectionProps): ReactElement {
   const adProps = { onLinkClick: onAdLinkClick, onViewable: onAdViewable };
   const { columns, featuredSpan, railSpan, layout } = shape;
-  // One column stacks: no grid to hold columns apart, and no row height, since
-  // the list card and the headline list each take what they need.
   const isStacked = layout === 'stacked';
 
   return (
@@ -76,16 +67,12 @@ export function FeedHeroSection({
           isStacked
             ? 'flex flex-col gap-6'
             : classNames(
-                // The grid's own gap, so the hero's columns land on the
-                // columns underneath rather than near them.
+                // The feed grid's own gap, so the columns line up with it.
                 'grid gap-8',
                 gridColsClass[columns],
-                // The featured card's height plus the 3.5rem the paging
-                // controls and their gaps need under it. A single column is
-                // the narrow case, where the title wraps furthest and the card
-                // runs to its `max-h-cardLarge` ceiling; across two or more it
-                // settles 3rem shorter, and the row gives that back to the
-                // first feed row rather than holding a gap open.
+                // The card's height plus the 3.5rem the paging controls need
+                // under it. One column wraps the title furthest and runs to
+                // `max-h-cardLarge`; wider, the card settles 3rem shorter.
                 layout === 'wide'
                   ? 'grid-rows-[27.5rem]'
                   : 'grid-rows-[30.5rem]',

--- a/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
@@ -1,0 +1,123 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import type { Ad, Post } from '../../../graphql/posts';
+import type { PostHighlight } from '../../../graphql/highlights';
+import type { ViewabilityData } from '../../../features/monetization/viewability';
+import type { FeaturedWideCardProps } from '../../cards/common/featuredWide';
+import { HighlightCardContent } from '../../cards/highlight/common';
+import { FeedHeroAdCard } from './FeedHeroAdCard';
+import { FeedHeroCarousel } from './FeedHeroCarousel';
+import type { FeedHeroAdPlacement, FeedHeroShape } from './feedHeroShape';
+import { feedHeroShape } from './feedHeroShape';
+
+/**
+ * Written out rather than built, because Tailwind only generates the classes it
+ * can see. Six is the grid's own ceiling — `FeedContext`'s widest setting.
+ */
+const gridColsClass: Partial<Record<number, string>> = {
+  2: 'grid-cols-2',
+  3: 'grid-cols-3',
+  4: 'grid-cols-4',
+  5: 'grid-cols-5',
+  6: 'grid-cols-6',
+};
+
+const colSpanClass: Partial<Record<number, string>> = {
+  1: 'col-span-1',
+  2: 'col-span-2',
+  3: 'col-span-3',
+  4: 'col-span-4',
+};
+
+interface FeedHeroSectionProps {
+  posts: Post[];
+  highlights: PostHighlight[];
+  ad?: Ad;
+  /**
+   * Where the section is putting the ad. Decided by the caller from the same
+   * shape passed in here, so the column and what goes in it cannot disagree.
+   */
+  adPlacement?: FeedHeroAdPlacement;
+  /** The section's row, measured against the feed grid's column count. */
+  shape?: FeedHeroShape;
+  cardProps?: Omit<FeaturedWideCardProps, 'post'>;
+  onAdLinkClick?: (ad: Ad) => unknown;
+  onAdViewable?: (ad: Ad, data: ViewabilityData) => void;
+  onHighlightClick?: (highlight: PostHighlight, position: number) => void;
+  onReadAllClick?: () => void;
+  className?: string;
+}
+
+export function FeedHeroSection({
+  posts,
+  highlights,
+  ad,
+  adPlacement = 'none',
+  shape = feedHeroShape(1),
+  cardProps,
+  onAdLinkClick,
+  onAdViewable,
+  onHighlightClick,
+  onReadAllClick,
+  className,
+}: FeedHeroSectionProps): ReactElement {
+  const adProps = { onLinkClick: onAdLinkClick, onViewable: onAdViewable };
+  const { columns, featuredSpan, railSpan, layout } = shape;
+  // One column stacks: no grid to hold columns apart, and no row height, since
+  // the list card and the headline list each take what they need.
+  const isStacked = layout === 'stacked';
+
+  return (
+    <div className={classNames('w-full', className)}>
+      <section
+        className={classNames(
+          'w-full',
+          isStacked
+            ? 'flex flex-col gap-6'
+            : classNames(
+                // The grid's own gap, so the hero's columns land on the
+                // columns underneath rather than near them.
+                'grid gap-8',
+                gridColsClass[columns],
+                // The featured card's height plus the 3.5rem the paging
+                // controls and their gaps need under it. A single column is
+                // the narrow case, where the title wraps furthest and the card
+                // runs to its `max-h-cardLarge` ceiling; across two or more it
+                // settles 3rem shorter, and the row gives that back to the
+                // first feed row rather than holding a gap open.
+                layout === 'wide'
+                  ? 'grid-rows-[27.5rem]'
+                  : 'grid-rows-[30.5rem]',
+              ),
+        )}
+      >
+        <FeedHeroCarousel
+          posts={posts}
+          layout={layout}
+          className={isStacked ? undefined : colSpanClass[featuredSpan]}
+          {...cardProps}
+        />
+        <aside
+          className={classNames(
+            'group flex min-h-0 min-w-0 flex-col overflow-hidden',
+            !isStacked && colSpanClass[railSpan],
+          )}
+        >
+          <HighlightCardContent
+            highlights={highlights}
+            onHighlightClick={onHighlightClick}
+            onReadAllClick={onReadAllClick}
+            variant="grid"
+            compact
+          />
+        </aside>
+        {!!ad && adPlacement === 'column' && (
+          <aside className="col-span-1 flex min-h-0 min-w-0 flex-col overflow-hidden">
+            <FeedHeroAdCard ad={ad} {...adProps} />
+          </aside>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
@@ -35,6 +35,8 @@ interface FeedHeroSectionProps {
   /** The section's row, measured against the feed grid's column count. */
   shape?: FeedHeroShape;
   cardProps?: Omit<FeaturedWideCardProps, 'post'>;
+  /** Called once per post the carousel actually brings on screen. */
+  onPostImpression?: (post: Post) => void;
   onAdLinkClick?: (ad: Ad) => unknown;
   onAdViewable?: (ad: Ad, data: ViewabilityData) => void;
   onHighlightClick?: (highlight: PostHighlight, position: number) => void;
@@ -49,6 +51,7 @@ export function FeedHeroSection({
   adPlacement = 'none',
   shape = feedHeroShape(1),
   cardProps,
+  onPostImpression,
   onAdLinkClick,
   onAdViewable,
   onHighlightClick,
@@ -57,7 +60,10 @@ export function FeedHeroSection({
 }: FeedHeroSectionProps): ReactElement {
   const adProps = { onLinkClick: onAdLinkClick, onViewable: onAdViewable };
   const { columns, featuredSpan, railSpan, layout } = shape;
-  const isStacked = layout === 'stacked';
+  // A column count with no class written out would render an unclassed grid —
+  // one implicit column with `col-span-3` children overflowing it. Stacking is
+  // a layout the reader can still use.
+  const isStacked = layout === 'stacked' || !gridColsClass[columns];
 
   return (
     <div className={classNames('w-full', className)}>
@@ -82,6 +88,7 @@ export function FeedHeroSection({
         <FeedHeroCarousel
           posts={posts}
           layout={layout}
+          onPostImpression={onPostImpression}
           className={isStacked ? undefined : colSpanClass[featuredSpan]}
           {...cardProps}
         />

--- a/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
+++ b/packages/shared/src/components/feeds/hero/FeedHeroSection.tsx
@@ -11,7 +11,11 @@ import { FeedHeroCarousel } from './FeedHeroCarousel';
 import type { FeedHeroAdPlacement, FeedHeroShape } from './feedHeroShape';
 import { feedHeroShape } from './feedHeroShape';
 
-/** Written out, not built: Tailwind only generates the classes it can see. */
+/**
+ * Written out, not built: Tailwind only generates the classes it can see. Must
+ * cover every count up to `MAX_HERO_COLUMNS`, which is what `feedHeroShape`
+ * stacks above — `feedHeroShape.spec.ts` pins the two together.
+ */
 const gridColsClass: Partial<Record<number, string>> = {
   2: 'grid-cols-2',
   3: 'grid-cols-3',
@@ -60,10 +64,7 @@ export function FeedHeroSection({
 }: FeedHeroSectionProps): ReactElement {
   const adProps = { onLinkClick: onAdLinkClick, onViewable: onAdViewable };
   const { columns, featuredSpan, railSpan, layout } = shape;
-  // A column count with no class written out would render an unclassed grid —
-  // one implicit column with `col-span-3` children overflowing it. Stacking is
-  // a layout the reader can still use.
-  const isStacked = layout === 'stacked' || !gridColsClass[columns];
+  const isStacked = layout === 'stacked';
 
   return (
     <div className={classNames('w-full', className)}>

--- a/packages/shared/src/components/feeds/hero/feedHeroShape.spec.ts
+++ b/packages/shared/src/components/feeds/hero/feedHeroShape.spec.ts
@@ -1,9 +1,7 @@
 import { feedHeroShape } from './feedHeroShape';
 
 describe('feedHeroShape', () => {
-  // The row has to come out exactly as wide as the grid under it, or the
-  // section's edges land next to the feed's instead of on them. One column is
-  // not in this: the section stacks there rather than laying out on a grid.
+  // One column is excluded: it stacks rather than laying out on a grid.
   it.each([2, 3, 4, 5, 6])('fills all %i columns', (columns) => {
     const { featuredSpan, railSpan, adSpan } = feedHeroShape(columns);
 
@@ -17,8 +15,6 @@ describe('feedHeroShape', () => {
     });
   });
 
-  // Whatever the count says: a grid hero over a list feed reads as two
-  // different things stacked on each other.
   it.each([2, 3, 4, 5, 6])(
     'stacks a %i-column feed that renders as a list',
     (columns) => {
@@ -34,15 +30,11 @@ describe('feedHeroShape', () => {
     expect(feedHeroShape(2)).toMatchObject({ featuredSpan: 1, railSpan: 1 });
   });
 
-  // One column is a feed card, which is what the standard card is drawn for;
-  // the wide card only earns its shape back across two.
   it('takes the standard card at one column and the wide card beyond it', () => {
     expect(feedHeroShape(2).layout).toBe('split');
     expect(feedHeroShape(3).layout).toBe('wide');
   });
 
-  // Below four columns the feed keeps the placement and shows it in its own
-  // slot rather than the hero squeezing a different-shaped one in.
   it('spares the ad a column only once there are four', () => {
     expect(feedHeroShape(3)).toMatchObject({ adSpan: 0, adPlacement: 'none' });
     expect(feedHeroShape(4)).toMatchObject({
@@ -51,8 +43,6 @@ describe('feedHeroShape', () => {
     });
   });
 
-  // The featured card takes the slack as the grid widens, up to the point
-  // where the headline list has earned a second column too.
   it('widens the featured card, then the rail', () => {
     expect(feedHeroShape(4)).toMatchObject({ featuredSpan: 2, railSpan: 1 });
     expect(feedHeroShape(5)).toMatchObject({ featuredSpan: 3, railSpan: 1 });

--- a/packages/shared/src/components/feeds/hero/feedHeroShape.spec.ts
+++ b/packages/shared/src/components/feeds/hero/feedHeroShape.spec.ts
@@ -1,4 +1,4 @@
-import { feedHeroShape } from './feedHeroShape';
+import { feedHeroShape, MAX_HERO_COLUMNS } from './feedHeroShape';
 
 describe('feedHeroShape', () => {
   // One column is excluded: it stacks rather than laying out on a grid.
@@ -6,6 +6,22 @@ describe('feedHeroShape', () => {
     const { featuredSpan, railSpan, adSpan } = feedHeroShape(columns);
 
     expect(featuredSpan + railSpan + adSpan).toBe(columns);
+  });
+
+  // The section writes its column classes out by hand and stops at this count.
+  // A shape that laid out beyond it would ask for classes that do not exist.
+  it('lays out on every column count the section has classes for', () => {
+    for (let columns = 2; columns <= MAX_HERO_COLUMNS; columns += 1) {
+      expect(feedHeroShape(columns).layout).not.toBe('stacked');
+    }
+  });
+
+  it('stacks a count past the widest row the section can class', () => {
+    expect(feedHeroShape(MAX_HERO_COLUMNS + 1)).toMatchObject({
+      columns: 1,
+      layout: 'stacked',
+      adPlacement: 'none',
+    });
   });
 
   it('stacks the phone, where there is one column to share', () => {

--- a/packages/shared/src/components/feeds/hero/feedHeroShape.spec.ts
+++ b/packages/shared/src/components/feeds/hero/feedHeroShape.spec.ts
@@ -1,0 +1,61 @@
+import { feedHeroShape } from './feedHeroShape';
+
+describe('feedHeroShape', () => {
+  // The row has to come out exactly as wide as the grid under it, or the
+  // section's edges land next to the feed's instead of on them. One column is
+  // not in this: the section stacks there rather than laying out on a grid.
+  it.each([2, 3, 4, 5, 6])('fills all %i columns', (columns) => {
+    const { featuredSpan, railSpan, adSpan } = feedHeroShape(columns);
+
+    expect(featuredSpan + railSpan + adSpan).toBe(columns);
+  });
+
+  it('stacks the phone, where there is one column to share', () => {
+    expect(feedHeroShape(1)).toMatchObject({
+      layout: 'stacked',
+      adPlacement: 'none',
+    });
+  });
+
+  // Whatever the count says: a grid hero over a list feed reads as two
+  // different things stacked on each other.
+  it.each([2, 3, 4, 5, 6])(
+    'stacks a %i-column feed that renders as a list',
+    (columns) => {
+      expect(feedHeroShape(columns, true)).toMatchObject({
+        columns: 1,
+        layout: 'stacked',
+        adPlacement: 'none',
+      });
+    },
+  );
+
+  it('gives the rail a column of its own from two columns up', () => {
+    expect(feedHeroShape(2)).toMatchObject({ featuredSpan: 1, railSpan: 1 });
+  });
+
+  // One column is a feed card, which is what the standard card is drawn for;
+  // the wide card only earns its shape back across two.
+  it('takes the standard card at one column and the wide card beyond it', () => {
+    expect(feedHeroShape(2).layout).toBe('split');
+    expect(feedHeroShape(3).layout).toBe('wide');
+  });
+
+  // Below four columns the feed keeps the placement and shows it in its own
+  // slot rather than the hero squeezing a different-shaped one in.
+  it('spares the ad a column only once there are four', () => {
+    expect(feedHeroShape(3)).toMatchObject({ adSpan: 0, adPlacement: 'none' });
+    expect(feedHeroShape(4)).toMatchObject({
+      adSpan: 1,
+      adPlacement: 'column',
+    });
+  });
+
+  // The featured card takes the slack as the grid widens, up to the point
+  // where the headline list has earned a second column too.
+  it('widens the featured card, then the rail', () => {
+    expect(feedHeroShape(4)).toMatchObject({ featuredSpan: 2, railSpan: 1 });
+    expect(feedHeroShape(5)).toMatchObject({ featuredSpan: 3, railSpan: 1 });
+    expect(feedHeroShape(6)).toMatchObject({ featuredSpan: 3, railSpan: 2 });
+  });
+});

--- a/packages/shared/src/components/feeds/hero/feedHeroShape.ts
+++ b/packages/shared/src/components/feeds/hero/feedHeroShape.ts
@@ -1,0 +1,73 @@
+/**
+ * Where the section puts the placement. `column` is the full card in a column
+ * of its own; `none` hands it back to the feed, which places it exactly as it
+ * does with no hero at all.
+ */
+export type FeedHeroAdPlacement = 'none' | 'column';
+
+/**
+ * Which card the featured post takes.
+ *
+ * `stacked` is one column: the lead story as a list card with the headline list
+ * under it, which is what the feed's own list view gets. `split` is one feed
+ * column wide, which takes the platform's standard card — the wide card's own
+ * layout has nothing left to trade at that size and its copy clips mid-
+ * sentence. `wide` is two columns or more, where the wide card earns its shape
+ * back.
+ */
+export type FeedHeroLayout = 'stacked' | 'split' | 'wide';
+
+export type FeedHeroShape = {
+  /** Columns in the hero's row — the feed grid's own count. */
+  columns: number;
+  featuredSpan: number;
+  railSpan: number;
+  /** 0 when the ad has no column of its own. */
+  adSpan: number;
+  layout: FeedHeroLayout;
+  adPlacement: FeedHeroAdPlacement;
+};
+
+/**
+ * The hero's row, laid out on the feed grid's columns instead of on thresholds
+ * of its own, so the section reflows when the feed does and its column edges
+ * land on the grid's rather than beside them.
+ *
+ * The rail holds a single column until there are enough to spare it a second,
+ * and the ad earns one from four columns up — below that the feed keeps the
+ * placement rather than the hero squeezing it in. The featured card takes
+ * whatever is left, which is what makes the row come out exactly as wide as the
+ * grid beneath it however many columns that is.
+ *
+ * A feed rendering as a list takes the one-column shape whatever its column
+ * count says, so the section reads as the same kind of thing as the rows under
+ * it.
+ */
+export const feedHeroShape = (
+  columns: number,
+  isList = false,
+): FeedHeroShape => {
+  if (isList || columns <= 1) {
+    return {
+      columns: 1,
+      featuredSpan: 1,
+      railSpan: 1,
+      adSpan: 0,
+      layout: 'stacked',
+      adPlacement: 'none',
+    };
+  }
+
+  const adSpan = columns >= 4 ? 1 : 0;
+  const railSpan = columns >= 6 ? 2 : 1;
+  const featuredSpan = columns - railSpan - adSpan;
+
+  return {
+    columns,
+    featuredSpan,
+    railSpan,
+    adSpan,
+    layout: featuredSpan > 1 ? 'wide' : 'split',
+    adPlacement: adSpan > 0 ? 'column' : 'none',
+  };
+};

--- a/packages/shared/src/components/feeds/hero/feedHeroShape.ts
+++ b/packages/shared/src/components/feeds/hero/feedHeroShape.ts
@@ -8,6 +8,13 @@ export type FeedHeroAdPlacement = 'none' | 'column';
  */
 export type FeedHeroLayout = 'stacked' | 'split' | 'wide';
 
+/**
+ * Widest row the section has column classes written out for — Tailwind only
+ * generates what it can see, so `FeedHeroSection`'s maps stop here too. A count
+ * beyond it stacks rather than laying out on classes that do not exist.
+ */
+export const MAX_HERO_COLUMNS = 6;
+
 export type FeedHeroShape = {
   /** Columns in the hero's row — the feed grid's own count. */
   columns: number;
@@ -29,7 +36,7 @@ export const feedHeroShape = (
   columns: number,
   isList = false,
 ): FeedHeroShape => {
-  if (isList || columns <= 1) {
+  if (isList || columns <= 1 || columns > MAX_HERO_COLUMNS) {
     return {
       columns: 1,
       featuredSpan: 1,

--- a/packages/shared/src/components/feeds/hero/feedHeroShape.ts
+++ b/packages/shared/src/components/feeds/hero/feedHeroShape.ts
@@ -1,19 +1,10 @@
-/**
- * Where the section puts the placement. `column` is the full card in a column
- * of its own; `none` hands it back to the feed, which places it exactly as it
- * does with no hero at all.
- */
+/** `none` hands the placement back to the feed, which shows it in its own slot. */
 export type FeedHeroAdPlacement = 'none' | 'column';
 
 /**
- * Which card the featured post takes.
- *
- * `stacked` is one column: the lead story as a list card with the headline list
- * under it, which is what the feed's own list view gets. `split` is one feed
- * column wide, which takes the platform's standard card — the wide card's own
- * layout has nothing left to trade at that size and its copy clips mid-
- * sentence. `wide` is two columns or more, where the wide card earns its shape
- * back.
+ * Which card the featured post takes: `stacked` a list card, `split` the
+ * standard grid card, `wide` the featured-wide card. The wide card's copy
+ * clips mid-sentence at one column, which is why `split` exists.
  */
 export type FeedHeroLayout = 'stacked' | 'split' | 'wide';
 
@@ -29,19 +20,10 @@ export type FeedHeroShape = {
 };
 
 /**
- * The hero's row, laid out on the feed grid's columns instead of on thresholds
- * of its own, so the section reflows when the feed does and its column edges
- * land on the grid's rather than beside them.
- *
- * The rail holds a single column until there are enough to spare it a second,
- * and the ad earns one from four columns up — below that the feed keeps the
- * placement rather than the hero squeezing it in. The featured card takes
- * whatever is left, which is what makes the row come out exactly as wide as the
- * grid beneath it however many columns that is.
- *
- * A feed rendering as a list takes the one-column shape whatever its column
- * count says, so the section reads as the same kind of thing as the rows under
- * it.
+ * The hero's row, laid out on the feed grid's own column count rather than on
+ * viewport thresholds, so the section reflows when the feed does and its column
+ * edges land on the grid's. The featured card takes what the rail and the ad
+ * leave, which is what keeps the row exactly as wide as the grid beneath it.
  */
 export const feedHeroShape = (
   columns: number,

--- a/packages/shared/src/components/feeds/hero/useFeedHeroAd.ts
+++ b/packages/shared/src/components/feeds/hero/useFeedHeroAd.ts
@@ -13,39 +13,29 @@ import { feedHeroShape } from './feedHeroShape';
 export type FeedHeroAdSlot = {
   ad?: Ad;
   placement: FeedHeroAdPlacement;
-  /**
-   * The section's row. The carousel needs it too — it picks the featured card
-   * from the same number of columns the card is given, so the two cannot end
-   * up disagreeing about how much room there is.
-   */
+  /** The section's row, so the card and the layout around it share one number. */
   shape: FeedHeroShape;
 };
 
 /**
- * The hero's ad. The feed underneath drops its own first placement whenever the
- * hero has somewhere to put one, so the reader never meets two before the first
- * post — and gets it back the moment the hero does not.
- *
- * Whether there is somewhere comes from the grid's column count, which is there
- * on the first render, rather than from measuring the section: a load that
- * paints straight at its final size never fires a resize to measure on.
+ * The hero's ad. Whether there is room comes from the grid's column count,
+ * which is there on the first render — measuring the section instead missed a
+ * load that painted straight at its final size and so never fired a resize.
  */
-export const useFeedHeroAd = (enabled: boolean): FeedHeroAdSlot => {
+export const useFeedHeroAd = (): FeedHeroAdSlot => {
   const { user, tokenRefreshed } = useAuthContext();
   const { isPlus } = usePlusSubscription();
   const { numCards } = useContext(FeedContext);
-  // The same call the feed makes, so the two agree on what a list is: below
-  // laptop, and on laptop up whenever the reader has list mode on.
+  // The same call the feed makes, so the two agree on what a list is.
   const { shouldUseListFeedLayout } = useFeedLayout();
-  // `.eco` regardless of the reader's spaciness, because that is the count the
-  // grid itself renders with — see `FeedContainer`.
+  // `.eco` regardless of the reader's spaciness: the count the grid renders
+  // with — see `FeedContainer`.
   const shape = feedHeroShape(numCards.eco, shouldUseListFeedLayout);
 
   const { data: ad } = useAdQuery({
     placement: AdPlacement.Feed,
     queryKey: generateQueryKey(RequestKey.Ads, user, 'feed-hero'),
-    enabled:
-      enabled && tokenRefreshed && !isPlus && shape.adPlacement !== 'none',
+    enabled: tokenRefreshed && !isPlus && shape.adPlacement !== 'none',
     staleTime: StaleTime.OneHour,
   });
 

--- a/packages/shared/src/components/feeds/hero/useFeedHeroAd.ts
+++ b/packages/shared/src/components/feeds/hero/useFeedHeroAd.ts
@@ -1,0 +1,57 @@
+import { useContext } from 'react';
+import type { Ad } from '../../../graphql/posts';
+import { useAdQuery } from '../../../features/monetization/useAdQuery';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import FeedContext from '../../../contexts/FeedContext';
+import { useFeedLayout } from '../../../hooks/useFeedLayout';
+import { usePlusSubscription } from '../../../hooks/usePlusSubscription';
+import { AdPlacement } from '../../../lib/ads';
+import { generateQueryKey, RequestKey, StaleTime } from '../../../lib/query';
+import type { FeedHeroAdPlacement, FeedHeroShape } from './feedHeroShape';
+import { feedHeroShape } from './feedHeroShape';
+
+export type FeedHeroAdSlot = {
+  ad?: Ad;
+  placement: FeedHeroAdPlacement;
+  /**
+   * The section's row. The carousel needs it too — it picks the featured card
+   * from the same number of columns the card is given, so the two cannot end
+   * up disagreeing about how much room there is.
+   */
+  shape: FeedHeroShape;
+};
+
+/**
+ * The hero's ad. The feed underneath drops its own first placement whenever the
+ * hero has somewhere to put one, so the reader never meets two before the first
+ * post — and gets it back the moment the hero does not.
+ *
+ * Whether there is somewhere comes from the grid's column count, which is there
+ * on the first render, rather than from measuring the section: a load that
+ * paints straight at its final size never fires a resize to measure on.
+ */
+export const useFeedHeroAd = (enabled: boolean): FeedHeroAdSlot => {
+  const { user, tokenRefreshed } = useAuthContext();
+  const { isPlus } = usePlusSubscription();
+  const { numCards } = useContext(FeedContext);
+  // The same call the feed makes, so the two agree on what a list is: below
+  // laptop, and on laptop up whenever the reader has list mode on.
+  const { shouldUseListFeedLayout } = useFeedLayout();
+  // `.eco` regardless of the reader's spaciness, because that is the count the
+  // grid itself renders with — see `FeedContainer`.
+  const shape = feedHeroShape(numCards.eco, shouldUseListFeedLayout);
+
+  const { data: ad } = useAdQuery({
+    placement: AdPlacement.Feed,
+    queryKey: generateQueryKey(RequestKey.Ads, user, 'feed-hero'),
+    enabled:
+      enabled && tokenRefreshed && !isPlus && shape.adPlacement !== 'none',
+    staleTime: StaleTime.OneHour,
+  });
+
+  return {
+    ad: ad ?? undefined,
+    placement: ad ? shape.adPlacement : 'none',
+    shape,
+  };
+};

--- a/packages/shared/src/components/post/read/ReadAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/read/ReadAdSlot.spec.tsx
@@ -117,10 +117,12 @@ describe('ReadAdSlot', () => {
     setSlots({ '3': { id: '1234567890', type: 'display' } });
     render(<ReadAdSlot slot={3} format={ReadAdFormat.MediumRectangle} eager />);
 
-    // Left on `auto`, a 300px-wide slot is free to answer with a 300x600.
+    // Left on `auto`, a 300px-wide slot is free to answer with a 300x600;
+    // left on the phone default, the ins stretches to the screen width and
+    // overflows the card.
     const ins = screen.getByTestId('adsense-slot-3');
     expect(ins).toHaveAttribute('data-ad-format', 'rectangle');
-    expect(ins).not.toHaveAttribute('data-full-width-responsive');
+    expect(ins).toHaveAttribute('data-full-width-responsive', 'false');
   });
 
   it('keeps banners horizontal so a rectangle cannot fill them', () => {
@@ -232,6 +234,7 @@ describe('ReadAdSlot', () => {
     );
     expect(ins).toHaveStyle({ width: '300px', height: '250px' });
     expect(ins).not.toHaveAttribute('data-ad-format');
+    expect(ins).toHaveAttribute('data-full-width-responsive', 'false');
   });
 
   it('never renders for logged-in users', () => {

--- a/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
@@ -14,9 +14,9 @@ export interface ReadTopLeaderboardProps {
   released?: boolean;
   slot?: number;
   /**
-   * The twin the phone requests instead of `slot`, so phone and desktop fill
-   * report under their own slot numbers. Must come from the same surface's
-   * map as `slot`, or the twin would ride the other surface's flag gating.
+   * The fixed 320x50 twin the phone requests instead of the responsive
+   * unit. Must come from the same surface's map as `slot`, or the twin
+   * would ride the other surface's flag gating.
    */
   phoneSlot?: number;
   surface?: 'read' | 'organic';
@@ -27,7 +27,7 @@ export interface ReadTopLeaderboardProps {
  * Top leaderboard (slot 2), first thing in the article column. The column is
  * 745px wide inside its padding at the layout's full width, so a 728px
  * leaderboard renders at its booked size within the page rather than spanning
- * it; narrower viewports get a 320x50 or 320x100 mobile banner instead.
+ * it; narrower viewports get the 320x50 mobile banner instead.
  *
  * Stays pinned for the first ten seconds of scrolling, then releases and
  * scrolls away with the page. Sticky rather than fixed so it only pins within
@@ -68,10 +68,9 @@ export function ReadTopLeaderboard({
           'z-2 laptop:sticky laptop:top-[var(--sticky-header-offset)]',
       )}
     >
-      {/* Two breakpoint twins of one unit, both horizontal responsive: the
-          phone's 320px cap leaves room for the mobile banners only, tablet+
-          gets the 728x90. Expandable and video creatives are blocked on the
-          unit account-side, not here — see READ_SLOT.topLeaderboardPhone.
+      {/* Two breakpoint twins of one unit: the phone requests a fixed
+          320x50 (see READ_SLOT.topLeaderboardPhone), tablet+ keeps the
+          responsive 728x90.
           Neither is eager: an eager push from a display:none twin would
           initialise the visible one out of order, and both sit at the top of
           the page where the intersection observer fires on first paint
@@ -79,7 +78,7 @@ export function ReadTopLeaderboard({
       <ReadAdSlot
         slot={phoneSlot}
         surface={surface}
-        format={ReadAdFormat.Leaderboard}
+        format={ReadAdFormat.MobileBanner}
         className="tablet:hidden"
         refreshes
       />

--- a/packages/shared/src/components/post/read/slots.ts
+++ b/packages/shared/src/components/post/read/slots.ts
@@ -23,15 +23,14 @@ export const READ_SLOT = {
   /** Half page closing the rail — the page's only sticky unit. */
   railBottomSticky: 19,
   /**
-   * The top leaderboard's phone twin: the same AdSense unit, requested
-   * separately so phone and desktop fill split by slot number in our events.
-   * It was a fixed 320x100 after a responsive request came back as expandable
-   * video and pinned half the screen inside the phone-sticky header block,
-   * but 320x100 alone has too little inventory and the header sat empty on
-   * most phones. It is a horizontal responsive request again (320x50 and
-   * 320x100 both serve) with expandable and video creatives blocked on the
-   * unit in the AdSense account, which is the only place that can rule them
-   * out: the <ins> can shape a request, not filter formats.
+   * The top leaderboard's phone twin: the same AdSense unit requested at a
+   * fixed 320x50, the smallest standard banner. Fixed rather than responsive
+   * because a responsive request can come back as expandable video, which
+   * inside the phone-sticky header block once pinned half the screen, and
+   * because on a phone user agent AdSense stretches a responsive ins to the
+   * full screen width regardless of the wrapper. 320x50 over the earlier
+   * 320x100: it is the best-filled mobile size and takes the least of the
+   * pinned header.
    */
   topLeaderboardPhone: 20,
 } as const;
@@ -105,13 +104,12 @@ export const MAX_CONTENT_ADS_PER_SECTION = 4;
  */
 export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   [READ_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  // Same responsive request as the desktop twin: FORMAT_SPEC caps the phone
-  // at 320px and `horizontal` keeps rectangles out, so only the mobile
-  // banners fit. See READ_SLOT.topLeaderboardPhone for why this is not fixed.
-  // TODO(vas): in AdSense, block "Expandable" and "Video" under Blocking
-  // controls > Ad serving for unit 9942870945 before shipping — the fixed
-  // size was the only thing keeping expandables out of the pinned header.
-  [READ_SLOT.topLeaderboardPhone]: { id: '9942870945', type: 'display' },
+  [READ_SLOT.topLeaderboardPhone]: {
+    id: '9942870945',
+    type: 'display',
+    width: 320,
+    height: 50,
+  },
   // The three MPU placements below share existing Display units while the
   // dedicated ones don't exist: Google's per-unit reporting blends them, but
   // our first-party events split by slot number, so per-placement RPM stays
@@ -154,7 +152,7 @@ export const ORGANIC_SLOT = {
   topLeaderboard: 15,
   /** Rail unit below the direct-sold ad widget. */
   railAfterDirectAd: 16,
-  /** The organic leaderboard's responsive phone twin — see slot 20. */
+  /** The organic leaderboard's fixed 320x50 phone twin — see slot 20. */
   topLeaderboardPhone: 21,
   /** MPU repeated through the TLDR, same cadence as the articles page. */
   inContentMpu: 22,
@@ -170,7 +168,12 @@ export const ORGANIC_SLOT = {
 // (Display 300x250) in AdSense and swap the ids for per-placement RPM.
 export const ORGANIC_ADSENSE_SLOTS: AdsenseSlots = {
   [ORGANIC_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  [ORGANIC_SLOT.topLeaderboardPhone]: { id: '9942870945', type: 'display' },
+  [ORGANIC_SLOT.topLeaderboardPhone]: {
+    id: '9942870945',
+    type: 'display',
+    width: 320,
+    height: 50,
+  },
   [ORGANIC_SLOT.railAfterDirectAd]: { id: '6921226982', type: 'display' },
   // Shared units, same trade as the articles map: Google's per-unit rows
   // blend, first-party events split by slot number.

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -21,6 +21,7 @@ export enum ProgrammaticAdFormat {
   MediumRectangle = 'mediumRectangle',
   Rectangle = 'rectangle',
   HalfPage = 'halfPage',
+  MobileBanner = 'mobileBanner',
   Native = 'native',
 }
 
@@ -58,10 +59,12 @@ type FormatSpec = {
 };
 
 export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
-  // Leaderboard on desktop, large mobile banner on a phone.
+  // Leaderboard on desktop; the phone header is the MobileBanner twin below.
+  // The phone cap stays so a Leaderboard left visible on a phone still comes
+  // back as a banner rather than whatever else fits the column.
   [ProgrammaticAdFormat.Leaderboard]: {
     label: 'Leaderboard',
-    size: '728x90 · 320x50 / 320x100 mobile',
+    size: '728x90 · 320x100 mobile',
     minHeight: 'min-h-[136px] tablet:min-h-[126px]',
     maxWidth: 'max-w-[320px] tablet:max-w-[728px]',
     shape: 'horizontal',
@@ -91,6 +94,17 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
     minHeight: 'min-h-[356px]',
     maxWidth: 'max-w-[300px]',
     shape: 'vertical',
+  },
+  // The phone header unit, booked at the fixed 320x50: the smallest standard
+  // size, so the pinned header block takes the least of a phone screen, and a
+  // fixed request can only return its exact size — no expandable or video
+  // creative can answer it, which a responsive request could not rule out.
+  [ProgrammaticAdFormat.MobileBanner]: {
+    label: 'Mobile banner',
+    size: '320x50',
+    minHeight: 'min-h-[86px]',
+    maxWidth: 'max-w-[320px]',
+    shape: 'horizontal',
   },
   [ProgrammaticAdFormat.Native]: {
     label: 'Native',
@@ -158,17 +172,31 @@ function getInsAttributes(
   }
 
   if (config.width && config.height) {
+    // The opt-out applies here too: the units are responsive on the AdSense
+    // side, and without it a phone user agent had the tag rewrite a fixed
+    // 320x50 into a 390x390 with a negative margin, the same full-width
+    // expansion as below.
     return {
       style: {
         display: 'inline-block',
         width: config.width,
         height: config.height,
       },
+      'data-full-width-responsive': 'false',
     };
   }
 
   if (shape) {
-    return { style: { display: 'block' }, 'data-ad-format': shape };
+    // Off explicitly: for a phone user agent AdSense defaults full-width
+    // responsive ON and stretches the ins to the screen width, past the
+    // wrapper's IAB cap — a 390px ins overflowing a 300px card, and a 390x390
+    // request for a horizontal unit that nothing fills. Off, the ins takes
+    // the wrapper's width and the shape decides the height.
+    return {
+      style: { display: 'block' },
+      'data-ad-format': shape,
+      'data-full-width-responsive': 'false',
+    };
   }
 
   return {

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -206,6 +206,24 @@ export type FeedReturnType = {
 type UseFeedSettingParams = {
   adPostLength?: number;
   disableAds?: boolean;
+  /**
+   * Set when the surface already shows the highlights somewhere else (the feed
+   * hero), so the grid doesn't repeat them in a card.
+   */
+  disableHighlightCards?: boolean;
+  /**
+   * Set when the surface shows an ad of its own above the feed (the feed hero),
+   * so the reader doesn't meet two of them before the first post. The queue is
+   * still consumed in order: the slot is dropped, not the creative that would
+   * have filled it.
+   */
+  skipFirstAd?: boolean;
+  /**
+   * Set when the surface already leads with a full-size featured card (the feed
+   * hero), so the grid doesn't open with a second one directly beneath it. The
+   * first row stays all single-column cards; wide ones resume below it.
+   */
+  deferWideCards?: boolean;
   feedName?: string;
   staticAd?: { ad: Ad; index: number };
   /** Set on search feeds so every fetch can be logged as a search execution. */
@@ -571,7 +589,7 @@ export default function useFeed<T>(
       const adRepeat = adTemplate?.adRepeat ?? pageSize + 1;
       const adJitter = adTemplate?.adJitter ?? 0;
 
-      const adPage = getAdSlotIndex({
+      const slot = getAdSlotIndex({
         index,
         adStart,
         adRepeat,
@@ -579,7 +597,15 @@ export default function useFeed<T>(
         seed: adJitterSeedRef.current ?? '',
       });
 
-      if (adPage === undefined) {
+      if (slot === undefined) {
+        return undefined;
+      }
+
+      // Shifted rather than skipped, so the creative the first slot would have
+      // shown moves down to the second instead of being fetched and discarded.
+      const adPage = settings?.skipFirstAd ? slot - 1 : slot;
+
+      if (adPage < 0) {
         return undefined;
       }
 
@@ -618,6 +644,7 @@ export default function useFeed<T>(
       adTemplate?.adJitter,
       adsUpdatedAt,
       pageSize,
+      settings?.skipFirstAd,
     ],
   );
 
@@ -662,6 +689,7 @@ export default function useFeed<T>(
         startIndex: heroCardsConfig.startIndex,
         widenableTypes,
         firstSlotOffset: effectiveFirstSlotOffset,
+        minWideCardRow: settings?.deferWideCards ? 1 : 0,
       });
 
       const staticAd = settings?.staticAd;
@@ -707,7 +735,7 @@ export default function useFeed<T>(
           }
 
           if (node.itemType === 'highlight') {
-            if (!node.highlights.length) {
+            if (!node.highlights.length || settings?.disableHighlightCards) {
               return;
             }
             pushAndAdvance({
@@ -760,6 +788,7 @@ export default function useFeed<T>(
     feedQuery.dataUpdatedAt,
     placeholdersPerPage,
     getAd,
+    settings?.disableHighlightCards,
     settings?.staticAd,
     heroCardsConfig,
     virtualizedNumCards,
@@ -770,6 +799,7 @@ export default function useFeed<T>(
     widenableTypes,
     excludePinnedPosts,
     effectiveFirstSlotOffset,
+    settings?.deferWideCards,
   ]);
 
   const placements = useMemo(
@@ -785,6 +815,7 @@ export default function useFeed<T>(
         fullRowInsertionBeforeIndex,
         cadence,
         firstSlotOffset: effectiveFirstSlotOffset,
+        minWideCardRow: settings?.deferWideCards ? 1 : 0,
       }),
     [
       items,
@@ -796,6 +827,7 @@ export default function useFeed<T>(
       cadence,
       widenableTypes,
       effectiveFirstSlotOffset,
+      settings?.deferWideCards,
     ],
   );
 

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -206,23 +206,11 @@ export type FeedReturnType = {
 type UseFeedSettingParams = {
   adPostLength?: number;
   disableAds?: boolean;
-  /**
-   * Set when the surface already shows the highlights somewhere else (the feed
-   * hero), so the grid doesn't repeat them in a card.
-   */
+  /** The surface shows the highlights itself, so keep them out of the grid. */
   disableHighlightCards?: boolean;
-  /**
-   * Set when the surface shows an ad of its own above the feed (the feed hero),
-   * so the reader doesn't meet two of them before the first post. The queue is
-   * still consumed in order: the slot is dropped, not the creative that would
-   * have filled it.
-   */
+  /** The surface shows an ad above the feed, so drop the grid's first slot. */
   skipFirstAd?: boolean;
-  /**
-   * Set when the surface already leads with a full-size featured card (the feed
-   * hero), so the grid doesn't open with a second one directly beneath it. The
-   * first row stays all single-column cards; wide ones resume below it.
-   */
+  /** The surface leads with a featured card, so keep wide ones out of row one. */
   deferWideCards?: boolean;
   feedName?: string;
   staticAd?: { ad: Ad; index: number };

--- a/packages/shared/src/hooks/useFittedLineClamp.spec.ts
+++ b/packages/shared/src/hooks/useFittedLineClamp.spec.ts
@@ -1,0 +1,100 @@
+import { act, renderHook } from '@testing-library/react';
+import { useFittedLineClamp } from './useFittedLineClamp';
+
+const LINE_HEIGHT = 20;
+const MAX_LINES = 6;
+
+let notify: (() => void) | undefined;
+
+beforeEach(() => {
+  notify = undefined;
+
+  Object.defineProperty(global, 'ResizeObserver', {
+    writable: true,
+    value: jest.fn().mockImplementation((callback: () => void) => {
+      notify = callback;
+
+      return {
+        observe: jest.fn(),
+        unobserve: jest.fn(),
+        disconnect: jest.fn(),
+      };
+    }),
+  });
+
+  jest
+    .spyOn(window, 'getComputedStyle')
+    // `line-height` resolves even on a box that is not rendered, so the hook's
+    // own guard cannot stand in for keeping the element in flow.
+    .mockImplementation(
+      () =>
+        ({
+          lineHeight: `${LINE_HEIGHT}px`,
+          paddingBottom: '0px',
+        } as CSSStyleDeclaration),
+    );
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+/** A container whose floor sits `room` pixels below where the text starts. */
+const attach = (
+  result: { current: ReturnType<typeof useFittedLineClamp> },
+  room: number,
+) => {
+  const container = document.createElement('div');
+  const text = document.createElement('p');
+
+  container.getBoundingClientRect = () => ({ bottom: room } as DOMRect);
+  text.getBoundingClientRect = () => ({ top: 0 } as DOMRect);
+
+  act(() => {
+    result.current.containerRef(container);
+    result.current.textRef(text);
+  });
+};
+
+describe('useFittedLineClamp', () => {
+  it('clamps to the whole lines that fit', () => {
+    const { result } = renderHook(() => useFittedLineClamp(MAX_LINES));
+    attach(result, LINE_HEIGHT * 3);
+
+    expect(result.current.lines).toBe(3);
+    expect(result.current.style).toEqual({ WebkitLineClamp: 3 });
+  });
+
+  it('never exceeds the ceiling however much room there is', () => {
+    const { result } = renderHook(() => useFittedLineClamp(MAX_LINES));
+    attach(result, LINE_HEIGHT * 50);
+
+    expect(result.current.lines).toBe(MAX_LINES);
+  });
+
+  // `display: none` reports a 0x0 box at the origin, which measures as a full
+  // viewport of room, brings the text back, and oscillates. The box has to stay
+  // in flow for the next measurement to read the same geometry.
+  it('hides the text without removing it from layout when nothing fits', () => {
+    const { result } = renderHook(() => useFittedLineClamp(MAX_LINES));
+    attach(result, 0);
+
+    expect(result.current.lines).toBe(0);
+    // Exactly one declaration: `display` here would take the box out of flow.
+    expect(Object.keys(result.current.style)).toEqual(['visibility']);
+    expect(result.current.style).toEqual({ visibility: 'hidden' });
+  });
+
+  it('settles at zero instead of oscillating once hidden', () => {
+    const { result } = renderHook(() => useFittedLineClamp(MAX_LINES));
+    attach(result, 0);
+
+    expect(result.current.lines).toBe(0);
+
+    // The element is still in flow, so a re-measure reads the same geometry.
+    act(() => notify?.());
+
+    expect(result.current.lines).toBe(0);
+    expect(result.current.style).toEqual({ visibility: 'hidden' });
+  });
+});

--- a/packages/shared/src/hooks/useFittedLineClamp.ts
+++ b/packages/shared/src/hooks/useFittedLineClamp.ts
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 interface FittedLineClamp {
   /** The box the text has to fit inside. */
@@ -7,6 +8,12 @@ interface FittedLineClamp {
   textRef: (node: HTMLElement | null) => void;
   /** Whole lines that fit, never more than `maxLines`. */
   lines: number;
+  /**
+   * Apply to the text. `-webkit-line-clamp: 0` is invalid and would be dropped,
+   * leaving the text unclamped for its `overflow-hidden` parent to slice
+   * through a glyph row — so no room at all hides the block instead.
+   */
+  style: CSSProperties;
 }
 
 /**
@@ -67,5 +74,10 @@ export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
       setText(node);
     }, []),
     lines,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    style: useMemo(
+      () => (lines > 0 ? { WebkitLineClamp: lines } : { display: 'none' }),
+      [lines],
+    ),
   };
 };

--- a/packages/shared/src/hooks/useFittedLineClamp.ts
+++ b/packages/shared/src/hooks/useFittedLineClamp.ts
@@ -11,7 +11,11 @@ interface FittedLineClamp {
   /**
    * Apply to the text. `-webkit-line-clamp: 0` is invalid and would be dropped,
    * leaving the text unclamped for its `overflow-hidden` parent to slice
-   * through a glyph row — so no room at all hides the block instead.
+   * through a glyph row, so no room at all hides the block instead.
+   *
+   * `visibility`, not `display`: the measurement reads this element's own top
+   * edge, and `display: none` reports a 0x0 box at the origin — which measures
+   * as a full viewport of room, brings the text back, and oscillates.
    */
   style: CSSProperties;
 }
@@ -66,6 +70,11 @@ export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
     return () => observer.disconnect();
   }, [container, text, maxLines]);
 
+  const style = useMemo<CSSProperties>(
+    () => (lines > 0 ? { WebkitLineClamp: lines } : { visibility: 'hidden' }),
+    [lines],
+  );
+
   return {
     containerRef: useCallback((node: HTMLElement | null) => {
       setContainer(node);
@@ -74,10 +83,6 @@ export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
       setText(node);
     }, []),
     lines,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    style: useMemo(
-      () => (lines > 0 ? { WebkitLineClamp: lines } : { display: 'none' }),
-      [lines],
-    ),
+    style,
   };
 };

--- a/packages/shared/src/hooks/useFittedLineClamp.ts
+++ b/packages/shared/src/hooks/useFittedLineClamp.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface FittedLineClamp {
+  /** The box the text has to fit inside. */
+  containerRef: (node: HTMLElement | null) => void;
+  /** The text itself, which must be the last thing in that box. */
+  textRef: (node: HTMLElement | null) => void;
+  /** Whole lines that fit, never more than `maxLines`. */
+  lines: number;
+}
+
+/**
+ * How many whole lines of a block still fit the room left under everything
+ * above it.
+ *
+ * A fixed line count cannot do this: the text starts wherever the copy above it
+ * happens to end, and clamping to a count that no longer fits lets the box clip
+ * the overflow — a row of glyphs sliced through the middle rather than a
+ * paragraph that stops. `-webkit-line-clamp` takes a number, not a height, and
+ * the free space is only known once the flex column above has been laid out, so
+ * it is measured here and handed back as that number.
+ *
+ * Reducing the count only makes the text shorter, and the text is the last
+ * child, so where it starts does not move and the measurement cannot chase
+ * itself.
+ */
+export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
+  // Nodes as state rather than refs so the effect re-runs when they attach:
+  // the card renders no summary at all until the post arrives.
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const [text, setText] = useState<HTMLElement | null>(null);
+  const [lines, setLines] = useState(maxLines);
+
+  useEffect(() => {
+    if (!container || !text || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const measure = () => {
+      const style = getComputedStyle(text);
+      const lineHeight = parseFloat(style.lineHeight);
+
+      // `normal` gives no number to divide by. Leaving the count alone keeps
+      // the CSS clamp, which is the behaviour without this hook at all.
+      if (!lineHeight) {
+        return;
+      }
+
+      const bottom =
+        container.getBoundingClientRect().bottom -
+        parseFloat(getComputedStyle(container).paddingBottom || '0');
+      const available = bottom - text.getBoundingClientRect().top;
+
+      setLines(
+        Math.max(0, Math.min(maxLines, Math.floor(available / lineHeight))),
+      );
+    };
+
+    // The container's own height moves the floor; the text's moves the ceiling,
+    // and the copy above it can rewrap without either box changing size.
+    const observer = new ResizeObserver(measure);
+
+    observer.observe(container);
+    observer.observe(text);
+    measure();
+
+    return () => observer.disconnect();
+  }, [container, text, maxLines]);
+
+  return {
+    containerRef: useCallback((node: HTMLElement | null) => {
+      setContainer(node);
+    }, []),
+    textRef: useCallback((node: HTMLElement | null) => {
+      setText(node);
+    }, []),
+    lines,
+  };
+};

--- a/packages/shared/src/hooks/useFittedLineClamp.ts
+++ b/packages/shared/src/hooks/useFittedLineClamp.ts
@@ -11,22 +11,16 @@ interface FittedLineClamp {
 
 /**
  * How many whole lines of a block still fit the room left under everything
- * above it.
+ * above it. `-webkit-line-clamp` takes a number, not a height, and the free
+ * space is only known once the flex column above has been laid out, so it is
+ * measured and handed back as that number. Clamping to a count that no longer
+ * fits would let the box clip a row of glyphs through the middle.
  *
- * A fixed line count cannot do this: the text starts wherever the copy above it
- * happens to end, and clamping to a count that no longer fits lets the box clip
- * the overflow — a row of glyphs sliced through the middle rather than a
- * paragraph that stops. `-webkit-line-clamp` takes a number, not a height, and
- * the free space is only known once the flex column above has been laid out, so
- * it is measured here and handed back as that number.
- *
- * Reducing the count only makes the text shorter, and the text is the last
- * child, so where it starts does not move and the measurement cannot chase
- * itself.
+ * Safe against feedback: the text is the last child, so shortening it does not
+ * move where it starts.
  */
 export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
-  // Nodes as state rather than refs so the effect re-runs when they attach:
-  // the card renders no summary at all until the post arrives.
+  // Nodes as state, not refs, so the effect re-runs when they attach.
   const [container, setContainer] = useState<HTMLElement | null>(null);
   const [text, setText] = useState<HTMLElement | null>(null);
   const [lines, setLines] = useState(maxLines);
@@ -40,8 +34,7 @@ export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
       const style = getComputedStyle(text);
       const lineHeight = parseFloat(style.lineHeight);
 
-      // `normal` gives no number to divide by. Leaving the count alone keeps
-      // the CSS clamp, which is the behaviour without this hook at all.
+      // `normal` gives no number to divide by; leave the CSS clamp in charge.
       if (!lineHeight) {
         return;
       }
@@ -56,8 +49,7 @@ export const useFittedLineClamp = (maxLines: number): FittedLineClamp => {
       );
     };
 
-    // The container's own height moves the floor; the text's moves the ceiling,
-    // and the copy above it can rewrap without either box changing size.
+    // The container's height moves the floor, the text's moves the ceiling.
     const observer = new ResizeObserver(measure);
 
     observer.observe(container);

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -271,6 +271,10 @@ export const featureHeroCards = new Feature<HeroCardsConfig>('hero_cards', {
   },
 });
 
+// Experiment: a hero section above the feed — a carousel of the current
+// headlines, with the Happening Now list and a direct ad placement beside it.
+export const featureFeedHero = new Feature('feed_hero', false);
+
 // Experiment: skip layout/paint for off-screen feed cards via CSS
 // `content-visibility: auto` to keep long feeds responsive.
 export const featureFeedContentVisibility = new Feature(

--- a/packages/shared/src/lib/feedHighlightColSpan.spec.ts
+++ b/packages/shared/src/lib/feedHighlightColSpan.spec.ts
@@ -422,6 +422,7 @@ describe('computePlacements', () => {
     minSpacing: 10,
     startIndex: 0,
     widenableTypes: ALL_WIDENABLE,
+    minWideCardRow: 0,
   };
 
   const colSpans = (items: FeedItem[], o = opts) =>
@@ -512,6 +513,39 @@ describe('computePlacements', () => {
     expect(colSpans(items, { ...opts, startIndex: 4 })).toEqual([
       1, 1, 1, 1, 4,
     ]);
+  });
+
+  describe('minWideCardRow', () => {
+    // `startIndex` counts items, so at four columns item 0 is still in the
+    // opening row. A surface that leads with its own featured card needs the
+    // floor stated in rows.
+    it('keeps wide cards out of the rows below the floor', () => {
+      const items = Array.from({ length: 6 }, () =>
+        makePostItem(makePost({ significance: 'breaking' })),
+      );
+
+      expect(colSpans(items, { ...opts, minSpacing: 0 })).toEqual([
+        4, 4, 4, 4, 4, 4,
+      ]);
+      expect(
+        colSpans(items, { ...opts, minSpacing: 0, minWideCardRow: 1 }),
+      ).toEqual([1, 1, 1, 1, 4, 4]);
+    });
+
+    it('measures the floor in rows, not items', () => {
+      const items = Array.from({ length: 6 }, (_, index) =>
+        makePostItem(makePost(index === 5 ? { significance: 'breaking' } : {})),
+      );
+      // Five single-column cards fill row 0 and spill into row 1, so the sixth
+      // is past the floor and widens — to the 3 columns left in its row, since
+      // the fit-to-row clamp still applies.
+      const placements = computePlacements(items, {
+        ...opts,
+        minWideCardRow: 1,
+      });
+
+      expect(placements[5]).toEqual({ colSpan: 3, row: 1, column: 1 });
+    });
   });
 
   it('caps wide cards to one per ten items', () => {

--- a/packages/shared/src/lib/feedHighlightColSpan.spec.ts
+++ b/packages/shared/src/lib/feedHighlightColSpan.spec.ts
@@ -516,9 +516,6 @@ describe('computePlacements', () => {
   });
 
   describe('minWideCardRow', () => {
-    // `startIndex` counts items, so at four columns item 0 is still in the
-    // opening row. A surface that leads with its own featured card needs the
-    // floor stated in rows.
     it('keeps wide cards out of the rows below the floor', () => {
       const items = Array.from({ length: 6 }, () =>
         makePostItem(makePost({ significance: 'breaking' })),
@@ -536,9 +533,8 @@ describe('computePlacements', () => {
       const items = Array.from({ length: 6 }, (_, index) =>
         makePostItem(makePost(index === 5 ? { significance: 'breaking' } : {})),
       );
-      // Five single-column cards fill row 0 and spill into row 1, so the sixth
-      // is past the floor and widens — to the 3 columns left in its row, since
-      // the fit-to-row clamp still applies.
+      // Five cards fill row 0 and spill into row 1, so the sixth widens — to
+      // the 3 columns left in its row, since the fit-to-row clamp applies.
       const placements = computePlacements(items, {
         ...opts,
         minWideCardRow: 1,

--- a/packages/shared/src/lib/feedHighlightColSpan.ts
+++ b/packages/shared/src/lib/feedHighlightColSpan.ts
@@ -59,6 +59,13 @@ export interface PlacementBuilderOptions {
   startIndex: number;
   widenableTypes: ReadonlySet<PostType>;
   firstSlotOffset?: number;
+  /**
+   * First grid row a wide card may occupy. `startIndex` gates on the item
+   * index, which at five columns still lets one land in the opening row, so a
+   * surface that already leads with a full-size card above the grid (the feed
+   * hero) needs the floor stated in rows instead.
+   */
+  minWideCardRow?: number;
 }
 
 /**
@@ -167,6 +174,7 @@ export const createPlacementBuilder = ({
   startIndex,
   widenableTypes,
   firstSlotOffset = 0,
+  minWideCardRow = 0,
 }: PlacementBuilderOptions): PlacementBuilder => {
   const layoutEnabled = isEnabled && !isMobile && !isList && numCards > 1;
   const safeNumCards = Math.max(numCards, 1);
@@ -210,6 +218,9 @@ export const createPlacementBuilder = ({
           return 1;
         }
         if (itemIdx < startIndex) {
+          return 1;
+        }
+        if (row < minWideCardRow) {
           return 1;
         }
         if (itemIdx - lastLargeIndex < minSpacing) {

--- a/packages/shared/src/lib/feedHighlightColSpan.ts
+++ b/packages/shared/src/lib/feedHighlightColSpan.ts
@@ -60,10 +60,8 @@ export interface PlacementBuilderOptions {
   widenableTypes: ReadonlySet<PostType>;
   firstSlotOffset?: number;
   /**
-   * First grid row a wide card may occupy. `startIndex` gates on the item
-   * index, which at five columns still lets one land in the opening row, so a
-   * surface that already leads with a full-size card above the grid (the feed
-   * hero) needs the floor stated in rows instead.
+   * First grid row a wide card may occupy. `startIndex` gates on item index,
+   * which at five columns still lets one land in the opening row.
    */
   minWideCardRow?: number;
 }

--- a/packages/shared/src/styles/utilities.css
+++ b/packages/shared/src/styles/utilities.css
@@ -340,6 +340,70 @@
   }
 }
 
+@keyframes feed-hero-slide-in {
+  from {
+    opacity: 0;
+    transform: scale(0.985);
+  }
+
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes feed-hero-slide-out {
+  from {
+    opacity: 1;
+  }
+
+  to {
+    opacity: 0;
+  }
+}
+
+.feed-hero-slide-in {
+  animation: feed-hero-slide-in 420ms cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.feed-hero-slide-out {
+  animation: feed-hero-slide-out 320ms ease-out both;
+}
+
+/* Near-zero rather than `none`: the outgoing slide is unmounted on its own
+   `animationend`, which never arrives if the animation is removed outright. */
+@media (prefers-reduced-motion: reduce) {
+  .feed-hero-slide-in,
+  .feed-hero-slide-out {
+    animation-duration: 1ms;
+  }
+}
+
+@keyframes feed-hero-carousel-progress {
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+}
+
+/* The slide advances on this animation's `animationend`, so pausing it also
+   pauses the rotation and reduced motion stops the carousel altogether. */
+.feed-hero-carousel-progress {
+  transform-origin: left center;
+  animation: feed-hero-carousel-progress
+    var(--feed-hero-carousel-duration, 6s) linear forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feed-hero-carousel-progress {
+    animation: none;
+    transform: scaleX(1);
+  }
+}
+
 .feed-highlights-new-item-border-bottom {
   border-style: solid;
   border-width: 0 0 0.0625rem;

--- a/packages/storybook/stories/features/feed/FeedHero.stories.tsx
+++ b/packages/storybook/stories/features/feed/FeedHero.stories.tsx
@@ -1,0 +1,478 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import { fn } from 'storybook/test';
+import { ArticleGrid } from '@dailydotdev/shared/src/components/cards/article/ArticleGrid';
+import { ExploreChipsBar } from '@dailydotdev/shared/src/components/feeds/ExploreChipsBar';
+import { FeedHeroAdCard } from '@dailydotdev/shared/src/components/feeds/hero/FeedHeroAdCard';
+import { FeedHeroCarousel } from '@dailydotdev/shared/src/components/feeds/hero/FeedHeroCarousel';
+import { FeedHeroSection } from '@dailydotdev/shared/src/components/feeds/hero/FeedHeroSection';
+import { feedHeroShape } from '@dailydotdev/shared/src/components/feeds/hero/feedHeroShape';
+import {
+  adWithLongCopy,
+  adWithoutAdvertiser,
+  adWithoutCta,
+  adWithoutImage,
+  adWithoutTags,
+  cardHandlers,
+  exploreCategories,
+  feedPosts,
+  FeedHeroProviders,
+  heroAd,
+  heroPosts,
+  highlights,
+  longTitleHeroPost,
+  mixedTypeHeroPosts,
+  noImageHeroPost,
+  readHeroPost,
+} from './feedHero.mocks';
+
+const Page = ({ children }: { children: ReactNode }): ReactElement => (
+  <FeedHeroProviders>
+    <div className="min-h-screen bg-background-default p-4 laptop:p-8">
+      {/* A four-card feed, the narrowest one the ad column appears in. */}
+      <div className="mx-auto flex max-w-[91rem] flex-col gap-8">
+        {children}
+      </div>
+    </div>
+  </FeedHeroProviders>
+);
+
+const Case = ({
+  title,
+  note,
+  width,
+  children,
+}: {
+  title: string;
+  note?: string;
+  width?: string;
+  children: ReactNode;
+}): ReactElement => (
+  <section className="flex flex-col gap-2">
+    <h3 className="font-bold text-text-primary typo-callout">{title}</h3>
+    {!!note && <p className="text-text-tertiary typo-footnote">{note}</p>}
+    <div style={width ? { width, maxWidth: '100%' } : undefined}>
+      {children}
+    </div>
+  </section>
+);
+
+const FeedGrid = (): ReactElement => (
+  <div className="grid grid-cols-1 gap-6 tablet:grid-cols-2 laptop:grid-cols-3">
+    {feedPosts.map((post) => (
+      <ArticleGrid key={post.id} post={post} {...cardHandlers} />
+    ))}
+  </div>
+);
+
+const meta: Meta = {
+  title: 'Features/Feed/Hero',
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj;
+
+export const FullLayout: Story = {
+  name: 'Hero + all posts',
+  render: () => (
+    <Page>
+      <FeedHeroSection
+        posts={heroPosts}
+        highlights={highlights}
+        ad={heroAd}
+        adPlacement="column"
+        shape={feedHeroShape(4)}
+        cardProps={cardHandlers}
+        onAdLinkClick={fn()}
+        onHighlightClick={fn()}
+        onReadAllClick={fn()}
+      />
+      <div className="flex flex-col gap-4">
+        <ExploreChipsBar categories={exploreCategories} />
+        <FeedGrid />
+      </div>
+    </Page>
+  ),
+};
+
+export const HeroOnly: Story = {
+  name: 'Hero section',
+  render: () => (
+    <Page>
+      <FeedHeroSection
+        posts={heroPosts}
+        highlights={highlights}
+        ad={heroAd}
+        adPlacement="column"
+        shape={feedHeroShape(4)}
+        cardProps={cardHandlers}
+      />
+    </Page>
+  ),
+};
+
+// The hero lays out on the feed grid's own columns, so its stage is a column
+// count rather than a width — the same count the grid under it is using, which
+// `FeedContext` derives from the viewport, the sidebar's state and the reader's
+// card-count setting together. The widths here are only what that many columns
+// come to at a typical window; the shape does not depend on them.
+const FEED_STAGES = [
+  {
+    columns: 2,
+    px: 720,
+    note: 'the featured post takes one column — the feed card at its own size — and the feed below keeps the ad',
+  },
+  {
+    columns: 3,
+    px: 980,
+    note: 'the featured card takes two columns and turns wide; a third for the ad would leave every column too narrow, so the feed keeps it',
+  },
+  {
+    columns: 4,
+    px: 1250,
+    note: 'the ad earns a column, at the 270px the card was drawn for',
+  },
+  {
+    columns: 5,
+    px: 1560,
+    note: 'the slack goes to the featured card',
+  },
+  {
+    columns: 6,
+    px: 1880,
+    note: 'wide enough that the headline list earns a second column too',
+  },
+];
+
+export const WideFeed: Story = {
+  name: 'Hero at each stage',
+  render: () => (
+    <FeedHeroProviders>
+      <div className="flex min-h-screen flex-col gap-10 bg-background-default p-8">
+        {FEED_STAGES.map(({ columns, px, note }) => {
+          const shape = feedHeroShape(columns);
+
+          return (
+            <section key={columns} className="flex flex-col gap-2">
+              <h3 className="font-bold text-text-primary typo-callout">
+                {columns} columns · about {px}px of feed
+              </h3>
+              <p className="text-text-tertiary typo-footnote">{note}</p>
+              <div style={{ width: px, maxWidth: '100%' }}>
+                <FeedHeroSection
+                  posts={heroPosts}
+                  highlights={highlights}
+                  ad={adWithoutCta}
+                  adPlacement={shape.adPlacement}
+                  shape={shape}
+                  cardProps={cardHandlers}
+                />
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </FeedHeroProviders>
+  ),
+};
+
+// Each breakpoint gets its own iframe so Tailwind's media queries resolve
+// against a real viewport width, not a resized container.
+const BREAKPOINTS = [
+  { label: 'Mobile', width: 390, height: 900 },
+  { label: 'Tablet', width: 768, height: 900 },
+  { label: 'Laptop', width: 1024, height: 760 },
+  { label: 'Desktop', width: 1440, height: 760 },
+];
+
+export const Responsive: Story = {
+  name: 'Responsive breakpoints',
+  render: (args, { globals }) => (
+    <div className="flex flex-col gap-6 bg-background-default p-6">
+      <p className="text-text-tertiary typo-callout">
+        The four-column shape rendered at each breakpoint, so what these show is
+        the section holding that shape as the window narrows — not which shape a
+        window picks. That comes from the feed grid&apos;s column count, which
+        no story can set from a viewport: see &ldquo;Hero at each stage&rdquo;
+        for the stages themselves, and &ldquo;Hero in list view&rdquo; for the
+        one-column list shape.
+      </p>
+      <div className="flex flex-wrap items-start gap-6">
+        {BREAKPOINTS.map(({ label, width, height }) => (
+          <div key={label} className="flex flex-col gap-2">
+            <span className="font-bold text-text-primary typo-footnote">
+              {label} · {width}px
+            </span>
+            <iframe
+              title={`${label} preview`}
+              src={`iframe.html?id=features-feed-hero--hero-only&globals=theme:${
+                globals.theme ?? 'light'
+              }`}
+              width={width}
+              height={height}
+              className="rounded-16 border border-border-subtlest-tertiary"
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  ),
+};
+
+// Phone widths that actually ship, the narrowest one anything still has to
+// work at, and a tablet — the list shape is not only a phone's.
+const LIST_WIDTHS = [
+  { label: 'Small phone', px: 320 },
+  { label: 'iPhone', px: 390 },
+  { label: 'Large phone', px: 430 },
+  { label: 'Tablet', px: 720 },
+];
+
+export const TouchLayout: Story = {
+  name: 'Hero in list view',
+  render: () => (
+    <FeedHeroProviders>
+      <div className="flex min-h-screen flex-col gap-10 bg-background-default p-6">
+        <p className="max-w-[40rem] text-text-tertiary typo-callout">
+          Wherever the feed renders as a list — every width below laptop, and
+          laptop up with list mode on — the section takes the same shape: the
+          lead story as a list card, the headline list under it. Before this a
+          tablet ran a two-card hero over a list, and list mode at a wide window
+          ran a three-column one. There is no paging: a slide has to stop short
+          of the edge for the next one to peek, which is what says “carousel”,
+          and at these widths that left every card too narrow to read. The
+          stories it would have paged through are the list’s first rows anyway,
+          and the placement goes back to the feed.
+        </p>
+        {LIST_WIDTHS.map(({ label, px }) => (
+          <section key={px} className="flex flex-col gap-2">
+            <h3 className="font-bold text-text-primary typo-callout">
+              {label} · {px}px
+            </h3>
+            <div
+              style={{ width: px }}
+              className="border border-border-subtlest-tertiary"
+            >
+              <FeedHeroSection
+                posts={heroPosts}
+                highlights={highlights.slice(1)}
+                cardProps={cardHandlers}
+              />
+            </div>
+          </section>
+        ))}
+      </div>
+    </FeedHeroProviders>
+  ),
+};
+
+export const HeroStates: Story = {
+  name: 'Hero section states',
+  render: () => (
+    <Page>
+      <Case
+        title="With the ad column"
+        note="The placement takes a fourth column beside the headline list."
+      >
+        <FeedHeroSection
+          posts={heroPosts}
+          highlights={highlights}
+          ad={heroAd}
+          adPlacement="column"
+          shape={feedHeroShape(4)}
+          cardProps={cardHandlers}
+        />
+      </Case>
+      <Case
+        title="No ad column"
+        note="Nothing served, or a feed too narrow to seat one. The section drops to three columns and ends at the headline list; the feed below keeps its own first-row placement."
+      >
+        <FeedHeroSection
+          posts={heroPosts}
+          highlights={highlights}
+          shape={feedHeroShape(3)}
+          cardProps={cardHandlers}
+        />
+      </Case>
+      <Case
+        title="A single featured post"
+        note="Indicators and paging controls are hidden."
+      >
+        <FeedHeroSection
+          posts={heroPosts.slice(0, 1)}
+          highlights={highlights}
+          ad={heroAd}
+          adPlacement="column"
+          shape={feedHeroShape(4)}
+          cardProps={cardHandlers}
+        />
+      </Case>
+      <Case
+        title="Headline long enough to fill the column"
+        note="The summary gives up lines so the action row keeps its place instead of being clipped off the bottom of the card."
+      >
+        <FeedHeroSection
+          posts={[longTitleHeroPost]}
+          highlights={highlights}
+          ad={heroAd}
+          adPlacement="column"
+          shape={feedHeroShape(4)}
+          cardProps={cardHandlers}
+        />
+      </Case>
+      <Case
+        title="Two highlights"
+        note="The list is short enough that nothing scrolls."
+      >
+        <FeedHeroSection
+          posts={heroPosts}
+          highlights={highlights.slice(0, 2)}
+          ad={heroAd}
+          adPlacement="column"
+          shape={feedHeroShape(4)}
+          cardProps={cardHandlers}
+        />
+      </Case>
+    </Page>
+  ),
+};
+
+export const Carousel: Story = {
+  name: 'Carousel cases',
+  render: () => (
+    <Page>
+      <Case
+        title="Mixed post types"
+        note="Page through it: article, squad share, collection and freeform each render their own featured-wide card."
+      >
+        <FeedHeroCarousel
+          posts={mixedTypeHeroPosts}
+          layout="wide"
+          {...cardHandlers}
+        />
+      </Case>
+      <Case
+        title="Fast autoplay"
+        note="Two seconds per slide instead of six, so the indicator fill is easy to watch. Hovering or focusing the carousel pauses it."
+      >
+        <FeedHeroCarousel
+          posts={heroPosts}
+          layout="wide"
+          autoplayMs={2000}
+          {...cardHandlers}
+        />
+      </Case>
+      <Case
+        title="Read and bookmarked"
+        note="Carries the same read/bookmark treatment as any feed card."
+      >
+        <FeedHeroCarousel
+          posts={[readHeroPost]}
+          layout="wide"
+          {...cardHandlers}
+        />
+      </Case>
+      <Case
+        title="No cover image"
+        note="The card falls back to a single column."
+      >
+        <FeedHeroCarousel
+          posts={[noImageHeroPost]}
+          layout="wide"
+          {...cardHandlers}
+        />
+      </Case>
+      <Case
+        title="Narrow card — cover below the copy"
+        note="Under 40rem the split stops being worth it and the cover moves under the headline. The card decides this from its own width, so it holds whatever the reader's card-count setting leaves the hero."
+        width="30rem"
+      >
+        <FeedHeroCarousel posts={heroPosts} layout="wide" {...cardHandlers} />
+      </Case>
+      <Case
+        title="Even split"
+        note="From 40rem the cover takes a column beside the copy."
+        width="44rem"
+      >
+        <FeedHeroCarousel posts={heroPosts} layout="wide" {...cardHandlers} />
+      </Case>
+      <Case
+        title="40/60"
+        note="From 52rem the copy keeps two of five columns."
+        width="60rem"
+      >
+        <FeedHeroCarousel posts={heroPosts} layout="wide" {...cardHandlers} />
+      </Case>
+    </Page>
+  ),
+};
+
+export const AdPlacement: Story = {
+  name: 'Ad placement cases',
+  render: () => (
+    <Page>
+      <Case
+        title="In its own column"
+        note="Column width (19rem) on the section's height. Copy, then the disclosure in the headline rows' timestamp colour, then tags, then a cover that takes whatever height the copy leaves."
+        width="19rem"
+      >
+        <div className="h-[27.5rem]">
+          <FeedHeroAdCard ad={heroAd} onLinkClick={fn()} />
+        </div>
+      </Case>
+      <Case title="No matching tags" width="19rem">
+        <div className="h-[27.5rem]">
+          <FeedHeroAdCard ad={adWithoutTags} onLinkClick={fn()} />
+        </div>
+      </Case>
+      <Case
+        title="No cover image"
+        note="Nothing left to absorb the column's height, so the action row falls to the bottom on its own."
+        width="19rem"
+      >
+        <div className="h-[27.5rem]">
+          <FeedHeroAdCard ad={adWithoutImage} onLinkClick={fn()} />
+        </div>
+      </Case>
+      <Case
+        title="Advertiser hidden"
+        note="No referral link, so the disclosure is a bare “Promoted”."
+        width="19rem"
+      >
+        <div className="h-[27.5rem]">
+          <FeedHeroAdCard ad={adWithoutAdvertiser} onLinkClick={fn()} />
+        </div>
+      </Case>
+      <Case
+        title="Long copy"
+        note="Title clamps at three lines; the tag row keeps what fits."
+        width="19rem"
+      >
+        <div className="h-[27.5rem]">
+          <FeedHeroAdCard ad={adWithLongCopy} onLinkClick={fn()} />
+        </div>
+      </Case>
+      <Case
+        title="No call to action"
+        note="Only “Remove” is left in the action row."
+        width="19rem"
+      >
+        <div className="h-[27.5rem]">
+          <FeedHeroAdCard ad={adWithoutCta} onLinkClick={fn()} />
+        </div>
+      </Case>
+      <Case
+        title="Auto height"
+        note="Off the section's row the cover has no slack to take, so the card ends at its content instead of stretching."
+        width="19rem"
+      >
+        <FeedHeroAdCard ad={heroAd} onLinkClick={fn()} />
+      </Case>
+    </Page>
+  ),
+};

--- a/packages/storybook/stories/features/feed/feedHero.mocks.tsx
+++ b/packages/storybook/stories/features/feed/feedHero.mocks.tsx
@@ -1,0 +1,487 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import { fn } from 'storybook/test';
+import type { Ad, Post } from '@dailydotdev/shared/src/graphql/posts';
+import { PostType, UserVote } from '@dailydotdev/shared/src/graphql/posts';
+import type { Source } from '@dailydotdev/shared/src/graphql/sources';
+import { SourceType } from '@dailydotdev/shared/src/graphql/sources';
+import type { PostHighlight } from '@dailydotdev/shared/src/graphql/highlights';
+import type { ExploreCategory } from '@dailydotdev/shared/src/components/feeds/exploreCategories';
+import { featureHeroCards } from '@dailydotdev/shared/src/lib/featureManagement';
+import { FeatureOverrides } from '../../../mock/GrowthBookProvider';
+import ExtensionProviders from '../../extension/_providers';
+
+const hoursAgo = (hours: number): string =>
+  new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+const createSource = (id: string, name: string): Source => ({
+  id,
+  handle: id,
+  name,
+  permalink: `https://app.daily.dev/sources/${id}`,
+  image: `https://media.daily.dev/image/upload/t_logo,f_auto/v1/logos/${id}`,
+  type: SourceType.Machine,
+  public: true,
+});
+
+const sources = {
+  tds: createSource('tds', 'Towards Data Science'),
+  tc: createSource('tc', 'TechCrunch'),
+  ph: createSource('ph', 'Product Hunt'),
+  tkdodo: createSource('tkdodo', 'TkDodo'),
+};
+
+const placeholder = (index: number): string =>
+  `https://media.daily.dev/image/upload/f_auto/v1/placeholders/${index}`;
+
+const basePost = {
+  numUpvotes: 128,
+  numComments: 24,
+  bookmarked: false,
+  read: false,
+  upvoted: false,
+  commented: false,
+  userState: { vote: UserVote.None, flags: { feedbackDismiss: false } },
+};
+
+export const heroPosts: Post[] = [
+  {
+    ...basePost,
+    id: 'hero-1',
+    type: PostType.Article,
+    title:
+      'React 20 ships the compiler by default — what breaks and what to do',
+    summary:
+      'The compiler is no longer opt-in. Memoization hooks become no-ops, refs behave differently inside effects, and a handful of popular libraries need a patch release before you upgrade.',
+    permalink: 'https://api.daily.dev/r/hero-1',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-1',
+    createdAt: hoursAgo(3),
+    readTime: 9,
+    image: placeholder(1),
+    source: sources.tds,
+    tags: ['react', 'javascript', 'webdev'],
+    numUpvotes: 842,
+    numComments: 96,
+    hero: {
+      id: 'hero-sig-1',
+      headline: 'React 20 ships the compiler by default',
+      significance: 'breaking',
+      size: 2,
+      highlightedAt: hoursAgo(3),
+    },
+  },
+  {
+    ...basePost,
+    id: 'hero-2',
+    type: PostType.Article,
+    title:
+      'Postgres 19 makes logical replication usable for zero-downtime migrations',
+    summary:
+      'Sequences finally replicate, DDL is carried across publications, and failover slots survive a promotion — the three gaps that used to force a maintenance window.',
+    permalink: 'https://api.daily.dev/r/hero-2',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-2',
+    createdAt: hoursAgo(7),
+    readTime: 12,
+    image: placeholder(2),
+    source: sources.tc,
+    tags: ['postgres', 'databases', 'devops'],
+    numUpvotes: 511,
+    numComments: 48,
+    hero: {
+      id: 'hero-sig-2',
+      headline: 'Postgres 19 lands zero-downtime logical replication',
+      significance: 'major',
+      size: 2,
+      highlightedAt: hoursAgo(7),
+    },
+  },
+  {
+    ...basePost,
+    id: 'hero-3',
+    type: PostType.Article,
+    title: 'We replaced our GraphQL gateway with a 400-line Rust proxy',
+    summary:
+      'p99 dropped from 340ms to 28ms and the on-call pager went quiet. A walkthrough of what the gateway was actually doing, and why almost none of it was needed.',
+    permalink: 'https://api.daily.dev/r/hero-3',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-3',
+    createdAt: hoursAgo(14),
+    readTime: 15,
+    image: placeholder(3),
+    source: sources.tkdodo,
+    tags: ['rust', 'graphql', 'performance'],
+    numUpvotes: 1204,
+    numComments: 187,
+    hero: {
+      id: 'hero-sig-3',
+      headline: 'A 400-line Rust proxy replaced a GraphQL gateway',
+      significance: 'breakout',
+      size: 2,
+      highlightedAt: hoursAgo(14),
+    },
+  },
+  {
+    ...basePost,
+    id: 'hero-4',
+    type: PostType.Article,
+    title:
+      'The agent benchmark everyone quotes has been measuring the wrong thing',
+    summary:
+      'A reproduction of the headline numbers, the prompt leak that inflated them, and a rerun on a clean split that puts every model within four points of each other.',
+    permalink: 'https://api.daily.dev/r/hero-4',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-4',
+    createdAt: hoursAgo(20),
+    readTime: 11,
+    image: placeholder(4),
+    source: sources.ph,
+    tags: ['ai', 'machine-learning', 'agents'],
+    numUpvotes: 933,
+    numComments: 142,
+    hero: {
+      id: 'hero-sig-4',
+      headline: 'The agent benchmark everyone quotes is broken',
+      significance: 'notable',
+      size: 2,
+      highlightedAt: hoursAgo(20),
+    },
+  },
+];
+
+export const feedPosts: Post[] = [
+  {
+    ...basePost,
+    id: 'feed-1',
+    type: PostType.Article,
+    title: 'Stop reaching for useEffect: a decision tree',
+    summary: 'Six common effects and where each one actually belongs.',
+    permalink: 'https://api.daily.dev/r/feed-1',
+    commentsPermalink: 'https://app.daily.dev/posts/feed-1',
+    createdAt: hoursAgo(5),
+    readTime: 6,
+    image: placeholder(5),
+    source: sources.tkdodo,
+    tags: ['react', 'hooks'],
+  },
+  {
+    ...basePost,
+    id: 'feed-2',
+    type: PostType.Article,
+    title: 'Shipping a monorepo with pnpm workspaces and Turborepo in 2026',
+    summary:
+      'Caching, task graphs, and the traps that make CI slower, not faster.',
+    permalink: 'https://api.daily.dev/r/feed-2',
+    commentsPermalink: 'https://app.daily.dev/posts/feed-2',
+    createdAt: hoursAgo(9),
+    readTime: 10,
+    image: placeholder(6),
+    source: sources.tds,
+    tags: ['monorepo', 'pnpm', 'ci'],
+  },
+  {
+    ...basePost,
+    id: 'feed-3',
+    type: PostType.Article,
+    title: 'A practical guide to CSS container queries',
+    summary: 'Component-level breakpoints without a single media query.',
+    permalink: 'https://api.daily.dev/r/feed-3',
+    commentsPermalink: 'https://app.daily.dev/posts/feed-3',
+    createdAt: hoursAgo(11),
+    readTime: 7,
+    image: placeholder(1),
+    source: sources.tc,
+    tags: ['css', 'frontend'],
+  },
+  {
+    ...basePost,
+    id: 'feed-4',
+    type: PostType.Article,
+    title: 'What a year of on-call taught us about alert design',
+    summary:
+      'Every alert that woke someone up, categorized and mostly deleted.',
+    permalink: 'https://api.daily.dev/r/feed-4',
+    commentsPermalink: 'https://app.daily.dev/posts/feed-4',
+    createdAt: hoursAgo(16),
+    readTime: 8,
+    image: placeholder(2),
+    source: sources.ph,
+    tags: ['sre', 'observability'],
+  },
+  {
+    ...basePost,
+    id: 'feed-5',
+    type: PostType.Article,
+    title: 'Type-safe environment variables without a build step',
+    summary: 'Zod, a tiny loader, and failing fast on boot.',
+    permalink: 'https://api.daily.dev/r/feed-5',
+    commentsPermalink: 'https://app.daily.dev/posts/feed-5',
+    createdAt: hoursAgo(22),
+    readTime: 5,
+    image: placeholder(3),
+    source: sources.tkdodo,
+    tags: ['typescript', 'zod'],
+  },
+  {
+    ...basePost,
+    id: 'feed-6',
+    type: PostType.Article,
+    title: 'Reading the SQLite source to understand WAL mode',
+    summary: 'What the checkpointer does, and why your writes stall.',
+    permalink: 'https://api.daily.dev/r/feed-6',
+    commentsPermalink: 'https://app.daily.dev/posts/feed-6',
+    createdAt: hoursAgo(28),
+    readTime: 14,
+    image: placeholder(4),
+    source: sources.tds,
+    tags: ['sqlite', 'databases'],
+  },
+];
+
+export const highlights: PostHighlight[] = [
+  {
+    id: 'highlight-1',
+    channel: 'frontend',
+    headline: 'React 20 makes the compiler the default in every new app',
+    highlightedAt: hoursAgo(1),
+    post: {
+      id: 'hero-1',
+      commentsPermalink: 'https://app.daily.dev/posts/hero-1',
+    },
+  },
+  {
+    id: 'highlight-2',
+    channel: 'ai',
+    headline: 'OpenAI and Anthropic both ship agent sandboxes on the same day',
+    highlightedAt: hoursAgo(2),
+    post: {
+      id: 'highlight-post-2',
+      commentsPermalink: 'https://app.daily.dev/posts/highlight-post-2',
+    },
+  },
+  {
+    id: 'highlight-3',
+    channel: 'devops',
+    headline: 'Cloudflare outage takes down half the JS ecosystem CDNs',
+    highlightedAt: hoursAgo(4),
+    post: {
+      id: 'highlight-post-3',
+      commentsPermalink: 'https://app.daily.dev/posts/highlight-post-3',
+    },
+  },
+  {
+    id: 'highlight-4',
+    channel: 'languages',
+    headline: 'TypeScript 7 preview lands with the Go-based compiler',
+    highlightedAt: hoursAgo(9),
+    post: {
+      id: 'highlight-post-4',
+      commentsPermalink: 'https://app.daily.dev/posts/highlight-post-4',
+    },
+  },
+  {
+    id: 'highlight-5',
+    channel: 'security',
+    headline: 'Another postinstall supply-chain attack hits 40 npm packages',
+    highlightedAt: hoursAgo(13),
+    post: {
+      id: 'highlight-post-5',
+      commentsPermalink: 'https://app.daily.dev/posts/highlight-post-5',
+    },
+  },
+];
+
+export const heroAd: Ad = {
+  company: 'Vercel',
+  source: 'Vercel',
+  tagLine: 'Ship your Next.js app in seconds',
+  description:
+    'Zero-config deploys, a preview URL on every push, and analytics that come with it.',
+  image: 'https://media.daily.dev/image/upload/f_auto/v1/placeholders/5',
+  link: 'https://vercel.com',
+  referralLink: 'https://vercel.com',
+  companyLogo: 'https://svgl.app/library/vercel.svg',
+  callToAction: 'Start deploying',
+  adDomain: 'vercel.com',
+  providerId: 'sb-provider',
+  matchingTags: ['nextjs', 'react', 'devops'],
+};
+
+export const adWithoutTags: Ad = { ...heroAd, matchingTags: undefined };
+
+/** Plenty of live creatives ship no call to action, leaving only "Remove". */
+export const adWithoutCta: Ad = {
+  ...heroAd,
+  company: 'Fastmail',
+  source: 'Fastmail',
+  description: "A Calendar That's Yours. Not Google's.",
+  callToAction: undefined,
+};
+
+export const adWithoutImage: Ad = { ...heroAd, image: undefined as never };
+
+export const adWithoutAdvertiser: Ad = {
+  ...heroAd,
+  referralLink: undefined,
+  companyLogo: undefined,
+};
+
+export const adWithLongCopy: Ad = {
+  ...heroAd,
+  company: 'Observability Cloud Platform',
+  source: 'Observability Cloud Platform',
+  description:
+    'Distributed tracing, log search, RUM and synthetic checks in one place, with alerts that route straight to the on-call engineer who owns the service.',
+  matchingTags: ['observability', 'sre', 'monitoring', 'devops'],
+};
+
+export const exploreCategories: ExploreCategory[] = [
+  { id: 'ai', label: 'AI', path: '/explore/ai', tag: 'ai' },
+  { id: 'react', label: 'React', path: '/explore/react', tag: 'react' },
+  {
+    id: 'typescript',
+    label: 'TypeScript',
+    path: '/explore/typescript',
+    tag: 'typescript',
+  },
+  { id: 'devops', label: 'DevOps', path: '/explore/devops', tag: 'devops' },
+  { id: 'rust', label: 'Rust', path: '/explore/rust', tag: 'rust' },
+  { id: 'career', label: 'Career', path: '/explore/career', tag: 'career' },
+  {
+    id: 'databases',
+    label: 'Databases',
+    path: '/explore/databases',
+    tag: 'databases',
+  },
+  {
+    id: 'security',
+    label: 'Security',
+    path: '/explore/security',
+    tag: 'security',
+  },
+  { id: 'webdev', label: 'Web dev', path: '/explore/webdev', tag: 'webdev' },
+  {
+    id: 'open-source',
+    label: 'Open source',
+    path: '/explore/open-source',
+    tag: 'open-source',
+  },
+];
+
+const squadSource: Source = {
+  ...createSource('avengers', 'Frontend Avengers'),
+  type: SourceType.Squad,
+};
+
+export const mixedTypeHeroPosts: Post[] = [
+  heroPosts[0],
+  {
+    ...basePost,
+    id: 'hero-share',
+    type: PostType.Share,
+    title: 'This is the clearest explanation of the compiler I have read',
+    permalink: 'https://api.daily.dev/r/hero-share',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-share',
+    createdAt: hoursAgo(4),
+    image: placeholder(5),
+    source: squadSource,
+    tags: ['react', 'javascript'],
+    sharedPost: {
+      id: 'shared-1',
+      title: 'React 20 ships the compiler by default',
+      summary:
+        'A walkthrough of the compiler output, the hooks it makes redundant, and the migration path for a large app.',
+      image: placeholder(1),
+      readTime: 9,
+      permalink: 'https://api.daily.dev/r/shared-1',
+      commentsPermalink: 'https://app.daily.dev/posts/shared-1',
+      createdAt: hoursAgo(6),
+      private: false,
+      type: PostType.Article,
+      tags: ['react'],
+      source: sources.tds,
+    },
+  },
+  {
+    ...basePost,
+    id: 'hero-collection',
+    type: PostType.Collection,
+    title: 'Everything we know about the npm supply-chain attack',
+    summary:
+      'Six reports on the same incident, merged into one timeline: what was published, which packages pulled it in, and how to check your lockfile.',
+    permalink: 'https://api.daily.dev/r/hero-collection',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-collection',
+    createdAt: hoursAgo(8),
+    readTime: 6,
+    image: placeholder(2),
+    source: sources.tc,
+    tags: ['security', 'npm'],
+    collectionSources: [sources.tc, sources.ph, sources.tds],
+    numCollectionSources: 6,
+  },
+  {
+    ...basePost,
+    id: 'hero-freeform',
+    type: PostType.Freeform,
+    title: 'We cut our CI bill by 70% — here is the full breakdown',
+    permalink: 'https://api.daily.dev/r/hero-freeform',
+    commentsPermalink: 'https://app.daily.dev/posts/hero-freeform',
+    createdAt: hoursAgo(12),
+    readTime: 4,
+    image: placeholder(3),
+    source: squadSource,
+    tags: ['ci', 'devops'],
+    contentHtml:
+      '<p>Three changes did most of the work: caching the pnpm store, splitting the test matrix by package, and dropping the nightly full build.</p>',
+  },
+];
+
+export const readHeroPost: Post = {
+  ...heroPosts[0],
+  id: 'hero-read',
+  read: true,
+  bookmarked: true,
+};
+
+export const noImageHeroPost: Post = {
+  ...heroPosts[1],
+  id: 'hero-no-image',
+  image: undefined as never,
+};
+
+export const longTitleHeroPost: Post = {
+  ...heroPosts[0],
+  id: 'hero-long-title',
+  title:
+    'MTIA 300: Meta’s First Training Chip with Built-in NICs and Communication-Offloading Engines',
+  summary:
+    'Meta introduces MTIA 300, its first training-optimized chip built specifically for recommendation and ranking models, featuring built-in NIC chiplets and dedicated communication-offloading engines. Unlike GPUs, where collective operations contend with compute for memory bandwidth, MTIA 300 runs them on separate silicon so a training step never stalls waiting on the network.',
+};
+
+export const cardHandlers = {
+  onPostClick: fn(),
+  onPostAuxClick: fn(),
+  onUpvoteClick: fn(),
+  onDownvoteClick: fn(),
+  onCommentClick: fn(),
+  onBookmarkClick: fn(),
+  onCopyLinkClick: fn(),
+  onShare: fn(),
+  onReadArticleClick: fn(),
+};
+
+export const FeedHeroProviders = ({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement => (
+  <ExtensionProviders>
+    <FeatureOverrides
+      values={{
+        [featureHeroCards.id]: {
+          ...featureHeroCards.defaultValue,
+          enabled: true,
+        },
+      }}
+    >
+      {children}
+    </FeatureOverrides>
+  </ExtensionProviders>
+);


### PR DESCRIPTION
## What

A hero section above My Feed and Popular: a carousel of the current headlines, the Happening Now list beside it, and an ad in a column of its own.

Behind `feed_hero`, default off.

## Layout

The section lays out on **the feed grid's own column count** rather than on viewport thresholds of its own, so it reflows exactly when the feed does and its column edges land on the grid's rather than beside them.

| Columns | Featured | Rail | Ad |
| --- | --- | --- | --- |
| 1 (or any list feed) | lead story as a list card | headlines below it | feed keeps it |
| 2 | 1 (standard card) | 1 | feed keeps it |
| 3 | 2 (wide card) | 1 | feed keeps it |
| 4–5 | the remainder | 1 | 1 |
| 6 | the remainder | 2 | 1 |

A feed rendering as a list takes the stacked shape whatever its column count says, so the section reads as the same kind of thing as the rows under it.

## The featured card

The existing featured-wide cards gain a `hero` prop. The cover fills its column instead of being letterboxed, and the card sizes its split from container queries on **its own width** — the hero is only ever as wide as the reader's feed grid, so a wide monitor set to three cards gives it half the room a five-card feed does. Under 40rem the cover moves under the copy; from 52rem the copy keeps two of five for the 40/60 split.

The card height is fixed, so the summary is clamped to the whole lines actually left under the headline (`useFittedLineClamp`). The action row keeps its place under a headline of any length, and the copy stops on a line rather than being sliced through the middle.

## Making room in the feed

Three new `Feed` settings, all off unless the hero is on:

- `disableHighlightCards` — the hero already shows those headlines, so the grid does not repeat them.
- `skipFirstAd` — the hero seats a placement, so the grid stands its first one down and the reader does not meet two before the first post. The slot is *shifted*, not dropped: the creative moves to the next slot instead of being fetched and discarded.
- `deferWideCards` — the hero already leads with a full-size card, so the grid's first row stays single-column.

`skipFirstAd` follows the hero's actual placement, which only exists once its column exists *and* an ad has come back for it — so the feed gets its own placement back whenever the hero has none.

## Also

`PostTypeToTagCard` / `PostTypeToTagList` move out of `FeedItemComponent` into `cards/common/gridCards.ts` and `listCards.ts`, so the hero uses the same mapping rather than a second copy of it.

Headline clicks in the hero report the same `feedHighlightsLogEvent` the in-feed highlights card does, so the events do not disappear when the flag is on.

## Data

One `feedHero` query returns both the featured posts and the Happening Now headlines, so the section paints on a single round trip. Its post selection is built from the same `feedPostNodeSelection` the feed's connection fragment uses, so the hero's cards carry exactly the grid's payload and cannot silently fall a field behind it. Headlines refresh on the same one-minute window the in-feed highlights card uses.

Vote and bookmark on a hero card go through `useFeedHeroPostActions`, which patches the hero's own query the way `useFeedVotePost` / `useFeedBookmarkPost` patch the grid's — an optimistic write, keyed mutations so the hero's own subscription does not double-apply it, and a subscription so a vote from the post page still lands. Every hero event (click, impression, vote, bookmark, ad) carries `Origin.FeedHero`, so the experiment can separate hero engagement from the grid's.

## Implementation notes

**Why `useFittedLineClamp` rather than static `line-clamp-N` per container band.** The line count does not follow the card's width band — it follows how many lines the *headline above it* took, which varies per post at the same width. A static clamp would have to assume a worst-case headline and short-change every post with a shorter one, or assume the best case and clip. `-webkit-line-clamp` takes a number, not a height, so the free space has to be measured once the flex column above is laid out.

**Why a third carousel rather than extending `containers/Carousel`.** The overlap is "show one of N with dots"; the differences are structural. That one is a translate filmstrip with items in normal flow at `w-[inherit]`, with an unbounded index whose edges call `onClose`/`onEnd`. The hero crossfades two stacked slides in a fixed-height grid row, fills a column of variable width, and wraps. Extending it would mean a second positioning model, a second height model and different index semantics, with `SquadTour`, `PromotionTour` and `QuestOfferCarousel` exposed to the change. Unifying them is worth doing — as its own PR.

## Heads-up for the reading-reminder placement

While `feed_hero` is on, `MainFeedLayout` passes `disableTopHero`, so the `TopHero` reading-reminder placement renders — and logs — nothing for the variant cohort on `/`, including sessions where the hero itself found no headlines. That is deliberate (an impression for a CTA nobody saw is worse), but it is a denominator change in a different experiment. Whoever owns that placement should know before their next readout rather than after.

## Known behaviour

Only the highlights *card* is removed from the grid, not the underlying posts, so a headline can appear in the carousel and again as a card below it. Deliberate: filtering client-side would silently shrink the first page and skew the hero-versus-grid comparison the experiment exists to make. If product wants them deduped it belongs in the feed query.

## Testing

- `feedHeroShape.spec.ts` — every column count fills its row exactly; list feeds stack.
- `FeedHeroCarousel.spec.tsx` — stacked leads with one story and pages nothing; split and wide page through all of them.
- `Feed.spec.tsx` — highlights dropped, and the first ad slot dropped while the survivor keeps its index.
- `feedHighlightColSpan.spec.ts` — the wide-card row floor is measured in rows, not items.
- Storybook: `Features/Feed/Hero`.

### Preview domain
https://claude-hero-carousel-layout-e5e0.preview.app.daily.dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)

