### PR TITLE
feat(agent): scroll and highlight the notified run in the workspace

### DIFF
--- a/packages/shared/src/features/interests/chat.ts
+++ b/packages/shared/src/features/interests/chat.ts
@@ -17,6 +17,11 @@ export type AgentAttachment = {
   detail?: string;
 };
 
+export type AgentTurnHighlight = {
+  id: string;
+  isActive: boolean;
+};
+
 export type AgentMessage = {
   id: string;
   role: 'user' | 'agent';

--- a/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
@@ -9,7 +9,7 @@ import * as copy from '../../../hooks/useCopy';
 import * as lazyModal from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../../components/modals/common/types';
 import { Origin } from '../../../lib/log';
-import type { AgentMessage } from '../chat';
+import type { AgentMessage, AgentTurnHighlight } from '../chat';
 import { AgentProvider, useAgent } from '../AgentContext';
 import { AgentChatSection } from './AgentChatSection';
 
@@ -41,6 +41,15 @@ const renderTranscript = () =>
     <TestBootProvider client={new QueryClient()}>
       <AgentProvider id="a1" isDemo initialMessages={[reply]}>
         <AgentChatSection />
+      </AgentProvider>
+    </TestBootProvider>,
+  );
+
+const renderHighlightedTranscript = (highlight: AgentTurnHighlight) =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <AgentProvider id="a1" isDemo initialMessages={[reply]}>
+        <AgentChatSection highlight={highlight} />
       </AgentProvider>
     </TestBootProvider>,
   );
@@ -357,5 +366,30 @@ describe('a post link in the reply text', () => {
     fireEvent.click(link);
 
     expect(screen.getByTestId('active-post')).toHaveTextContent('none');
+  });
+});
+
+describe('a deep-linked turn', () => {
+  it('gets an addressable id and the highlight ring while active', () => {
+    renderHighlightedTranscript({ id: 'm1', isActive: true });
+
+    const turn = document.getElementById('agent-turn-m1');
+    expect(turn).not.toBeNull();
+    expect(turn).toHaveClass('border-accent-cabbage-default');
+  });
+
+  it('keeps the frame but drops the tint once faded', () => {
+    renderHighlightedTranscript({ id: 'm1', isActive: false });
+
+    const turn = document.getElementById('agent-turn-m1');
+    expect(turn).toHaveClass('border-transparent');
+    expect(turn).not.toHaveClass('border-accent-cabbage-default');
+  });
+
+  it('marks no turn when the target is not in the transcript', () => {
+    renderHighlightedTranscript({ id: 'other-run', isActive: true });
+
+    expect(document.getElementById('agent-turn-m1')).toBeNull();
+    expect(document.getElementById('agent-turn-other-run')).toBeNull();
   });
 });

--- a/packages/shared/src/features/interests/components/AgentChatSection.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement, ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import Markdown from '../../../components/Markdown';
 import { Tooltip } from '../../../components/tooltip/Tooltip';
 import {
@@ -30,7 +31,7 @@ import { useCopyText } from '../../../hooks/useCopy';
 import { DateFormat } from '../../../components/utilities/DateFormat';
 import { TimeFormatType } from '../../../lib/dateFormat';
 import type { Post } from '../../../graphql/posts';
-import type { AgentBlock, AgentMessage } from '../chat';
+import type { AgentBlock, AgentMessage, AgentTurnHighlight } from '../chat';
 import { FEEDBACK_MARKER_REGEX } from '../chat';
 import { webappUrl } from '../../../lib/constants';
 import { useAgent } from '../AgentContext';
@@ -379,13 +380,16 @@ const MessageRow = ({
   onFeedClick,
   onPostLinkClick,
   activePostId,
+  highlight,
 }: {
   message: AgentMessage;
   onPostClick: (post: Post) => void;
   onFeedClick: (label: string, posts: Post[]) => void;
   onPostLinkClick: (postId: string) => void;
   activePostId?: string;
+  highlight?: AgentTurnHighlight;
 }): ReactElement => {
+  const isHighlightTarget = highlight?.id === message.id;
   if (message.role === 'user') {
     return (
       <FlexCol className="agent-turn-in items-end gap-1">
@@ -409,7 +413,18 @@ const MessageRow = ({
   }
 
   return (
-    <FlexCol className="agent-turn-in group min-w-0 gap-2">
+    <FlexCol
+      id={isHighlightTarget ? `agent-turn-${message.id}` : undefined}
+      className={classNames(
+        'agent-turn-in group min-w-0 gap-2',
+        isHighlightTarget &&
+          '-m-3 rounded-16 border p-3 transition-colors duration-700',
+        isHighlightTarget &&
+          (highlight.isActive
+            ? 'border-accent-cabbage-default'
+            : 'border-transparent'),
+      )}
+    >
       {message.isScheduled && (
         <FlexRow className="items-center gap-1.5 text-text-quaternary">
           <TimerIcon size={IconSize.XXSmall} />
@@ -444,7 +459,11 @@ const MessageRow = ({
   );
 };
 
-export const AgentChatSection = (): ReactElement => {
+export const AgentChatSection = ({
+  highlight,
+}: {
+  highlight?: AgentTurnHighlight;
+}): ReactElement => {
   const {
     messages,
     openContentTarget,
@@ -461,6 +480,7 @@ export const AgentChatSection = (): ReactElement => {
         <MessageRow
           key={message.id}
           message={message}
+          highlight={highlight}
           onPostClick={(post) =>
             openContentTarget({ type: 'post', postId: post.id, post })
           }

--- a/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
@@ -13,6 +13,7 @@ import {
   mockMatchMedia,
 } from '../../../../__tests__/helpers/media';
 import usePersistentContext from '../../../hooks/usePersistentContext';
+import type { AgentMessage } from '../chat';
 import { AgentProvider, useAgent } from '../AgentContext';
 import { AgentWorkspace } from './AgentWorkspace';
 
@@ -41,7 +42,13 @@ const stubStore = (initial?: number) => {
 
 type Agent = ReturnType<typeof useAgent>;
 
-const renderWorkspace = () => {
+const renderWorkspace = ({
+  initialMessages = [],
+  runId,
+}: {
+  initialMessages?: AgentMessage[];
+  runId?: string;
+} = {}) => {
   const agent: { current: Agent } = { current: undefined as never };
 
   const Probe = () => {
@@ -52,8 +59,13 @@ const renderWorkspace = () => {
 
   render(
     <TestBootProvider client={new QueryClient()}>
-      <AgentProvider id="a1" isDemo initialMessages={[]}>
-        <AgentWorkspace items={[]} onDelete={jest.fn()} isDeleting={false} />
+      <AgentProvider id="a1" isDemo initialMessages={initialMessages}>
+        <AgentWorkspace
+          items={[]}
+          onDelete={jest.fn()}
+          isDeleting={false}
+          runId={runId}
+        />
         <Probe />
       </AgentProvider>
     </TestBootProvider>,
@@ -303,6 +315,66 @@ describe('AgentWorkspace transcript', () => {
     scrollTo(0);
 
     expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+    jest.useRealTimers();
+  });
+});
+
+describe('AgentWorkspace run deep-link', () => {
+  const runReply: AgentMessage = {
+    id: 'run-1',
+    role: 'agent',
+    at: new Date(0).toISOString(),
+    blocks: [{ type: 'text', html: '<p>Fresh findings landed.</p>' }],
+  };
+
+  const scrollIntoView = jest.fn();
+
+  beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+  });
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { scrollIntoView?: unknown })
+      .scrollIntoView;
+  });
+
+  it('scrolls the focused turn into view and highlights it', async () => {
+    stubStore(600);
+    renderWorkspace({ initialMessages: [runReply], runId: 'run-1' });
+
+    await waitFor(() =>
+      expect(scrollIntoView).toHaveBeenCalledWith({
+        block: 'center',
+        inline: 'nearest',
+      }),
+    );
+    expect(document.getElementById('agent-turn-run-1')).toHaveClass(
+      'border-accent-cabbage-default',
+    );
+  });
+
+  it('drops the highlight tint after the fade delay', () => {
+    jest.useFakeTimers();
+    stubStore(600);
+    renderWorkspace({ initialMessages: [runReply], runId: 'run-1' });
+
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(document.getElementById('agent-turn-run-1')).toHaveClass(
+      'border-transparent',
+    );
+    jest.useRealTimers();
+  });
+
+  it('falls back to the tail when the run is not in the transcript', () => {
+    jest.useFakeTimers();
+    stubStore(600);
+    renderWorkspace({ initialMessages: [runReply], runId: 'gone' });
+
+    act(() => jest.runOnlyPendingTimers());
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+    expect(document.getElementById('agent-turn-run-1')).toBeNull();
     jest.useRealTimers();
   });
 });

--- a/packages/shared/src/features/interests/components/AgentWorkspace.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.tsx
@@ -11,6 +11,7 @@ import { ArrowIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
 import usePersistentContext from '../../../hooks/usePersistentContext';
 import { useAgentShellHeight } from '../shell';
+import type { AgentTurnHighlight } from '../chat';
 import type { AgentFeedItem } from '../hooks/useAgentFeed';
 import { useAgent } from '../AgentContext';
 import { AgentWorkspaceHeader } from './AgentWorkspaceHeader';
@@ -25,17 +26,20 @@ import { AgentSettingsPane } from './AgentSettingsPane';
 // Both columns floor at a mobile-width panel.
 const minPanelWidth = 384;
 const defaultPaneWidth = 480;
+const highlightFadeDelay = 3000;
 
 export const AgentWorkspace = ({
   items,
   onDelete,
   isDeleting,
   isStandalone,
+  runId,
 }: {
   items: AgentFeedItem[];
   onDelete: () => void;
   isDeleting: boolean;
   isStandalone?: boolean;
+  runId?: string;
 }): ReactElement => {
   const { isSettingsOpen, openContent, messages, summaryPosts } = useAgent();
   const shellHeight = useAgentShellHeight(isStandalone);
@@ -121,6 +125,39 @@ export const AgentWorkspace = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isTailPending]);
 
+  const [turnHighlight, setTurnHighlight] = useState<AgentTurnHighlight | null>(
+    runId ? { id: runId, isActive: true } : null,
+  );
+  const hasFocusedTurnRef = useRef(false);
+  const hasFocusTarget = !!runId && messages.some(({ id }) => id === runId);
+
+  useEffect(() => {
+    if (!hasFocusTarget || hasFocusedTurnRef.current) {
+      return undefined;
+    }
+
+    hasFocusedTurnRef.current = true;
+    const frame = requestAnimationFrame(() => {
+      document
+        .getElementById(`agent-turn-${runId}`)
+        ?.scrollIntoView({ block: 'center', inline: 'nearest' });
+      isPinnedRef.current = false;
+      setIsAwayFromBottom(true);
+    });
+    const fadeTimeout = window.setTimeout(
+      () =>
+        setTurnHighlight(
+          (current) => current && { ...current, isActive: false },
+        ),
+      highlightFadeDelay,
+    );
+
+    return () => {
+      cancelAnimationFrame(frame);
+      window.clearTimeout(fadeTimeout);
+    };
+  }, [hasFocusTarget, runId]);
+
   useEffect(() => {
     const measure = () => {
       const workspace = workspaceRef.current;
@@ -195,7 +232,7 @@ export const AgentWorkspace = ({
                     findingsCount={items.length}
                     postsCount={summaryPosts.length}
                   />
-                  <AgentChatSection />
+                  <AgentChatSection highlight={turnHighlight ?? undefined} />
                 </FlexCol>
               </div>
             </div>

--- a/packages/webapp/pages/agent/[id].tsx
+++ b/packages/webapp/pages/agent/[id].tsx
@@ -21,7 +21,13 @@ import { getLayout } from '../../components/layouts/MainLayout';
 import ProtectedPage from '../../components/ProtectedPage';
 import { getPageSeoTitles } from '../../components/layouts/utils';
 
-const LiveAgentPage = ({ id }: { id: string }): ReactElement | null => {
+const LiveAgentPage = ({
+  id,
+  runId,
+}: {
+  id: string;
+  runId?: string;
+}): ReactElement | null => {
   const router = useRouter();
   const { user, isAuthReady } = useAuthContext();
   const { value: showAgent } = useConditionalFeature({
@@ -88,6 +94,7 @@ const LiveAgentPage = ({ id }: { id: string }): ReactElement | null => {
             // not also reject unhandled.
             onDelete={() => deleteInterest(id).catch(() => undefined)}
             isDeleting={isDeleting}
+            runId={runId}
           />
         )}
       </AgentProvider>
@@ -103,7 +110,14 @@ const Page = (): ReactElement | null => {
     return null;
   }
 
-  return <LiveAgentPage id={router.query.id as string} />;
+  return (
+    <LiveAgentPage
+      id={router.query.id as string}
+      runId={
+        typeof router.query.run === 'string' ? router.query.run : undefined
+      }
+    />
+  );
 };
 
 const getAgentLayout: typeof getLayout = (...props) =>


### PR DESCRIPTION
Counterpart to dailydotdev/daily-api#4145. The interest content notification now targets `/agent/{id}?run={runId}`; this makes the workspace consume it.

- `pages/agent/[id].tsx` reads `?run=` and passes it as `runId` to `AgentWorkspace`
- when the run's turn is in the loaded history, a one-shot effect scrolls it to center (overriding the initial follow-tail pin by queueing its rAF later in the same frame) and un-pins so later replies don't yank the reader away
- the focused turn gets an `agent-turn-{id}` anchor and a comment-style `border-accent-cabbage-default` ring that fades to transparent after 3s (`transition-colors`); non-focused turns keep their original DOM
- the focus effect keys on a derived `hasFocusTarget` boolean instead of `messages`, so its rAF/timeout cleanup runs only on unmount — a history poll can't cancel the pending fade
- no `?run=` (or run not in the loaded page) → behavior unchanged; the param is kept on the URL so a reload re-runs the scroll+fade, same as comment permalinks

Deploy after the API PR (both directions are safe — older clients just ignore the param).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://interest-run-deeplink.preview.app.daily.dev