### PR TITLE
fix: show community takes in post modals

### DIFF
--- a/packages/shared/__tests__/fixture/post.ts
+++ b/packages/shared/__tests__/fixture/post.ts
@@ -25,6 +25,46 @@ const post: Post = {
   type: PostType.Article,
 };
 
+export const postWithCommunitySentiment: Post = {
+  ...post,
+  communitySentiment: {
+    breakdown: { positive: 62, mixed: 24, critical: 14 },
+    tldr: 'Most agree it is worth reading.',
+    postCount: 2,
+    sources: ['Hacker News', 'Lobsters'],
+    pros: ['Clear explanation'],
+    cons: ['Skips some trade-offs'],
+    bySource: [
+      {
+        source: 'Hacker News',
+        lean: 'positive',
+        note: 'Mostly supportive',
+        url: 'https://news.ycombinator.com/item?id=1',
+      },
+    ],
+    hottestDebate: 'Whether the advice applies broadly.',
+    openQuestions: ['How does it behave at scale?'],
+    highlights: [
+      {
+        quote: 'This helped clarify the trade-off.',
+        author: 'someone',
+        source: 'Hacker News',
+        url: 'https://news.ycombinator.com/item?id=2',
+        metrics: { points: 214, replies: 88 },
+      },
+    ],
+    discussions: [
+      {
+        provider: 'hackernews',
+        url: 'https://news.ycombinator.com/item?id=1',
+        points: 214,
+        commentsCount: 88,
+      },
+    ],
+    updatedAt: '2026-07-18T00:00:00.000Z',
+  },
+};
+
 export const sharePost: Post = {
   id: '5nLQHVNHi',
   title: 'Good read about react-query',

--- a/packages/shared/src/components/post/PostContent.spec.tsx
+++ b/packages/shared/src/components/post/PostContent.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import { render, screen } from '@testing-library/react';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import { postWithCommunitySentiment } from '../../../__tests__/fixture/post';
+import { Origin } from '../../lib/log';
+import { featureCommunitySentiment } from '../../lib/featureManagement';
+import { PostContentRaw } from './PostContent';
+
+const renderContent = (gb?: GrowthBook) =>
+  render(
+    <TestBootProvider client={new QueryClient()} gb={gb}>
+      <PostContentRaw
+        post={postWithCommunitySentiment}
+        origin={Origin.ArticleModal}
+        onClose={jest.fn()}
+      />
+    </TestBootProvider>,
+  );
+
+describe('PostContent community sentiment', () => {
+  it('renders in the classic post modal when the flag is enabled', () => {
+    const gb = new GrowthBook();
+    gb.setFeatures({
+      [featureCommunitySentiment.id]: {
+        defaultValue: true,
+      },
+    });
+
+    renderContent(gb);
+
+    expect(
+      screen.getByRole('region', { name: 'What the community thinks' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Most agree it is worth reading.')).toBeVisible();
+  });
+
+  it('stays hidden in the classic post modal when the flag is disabled', () => {
+    renderContent();
+
+    expect(
+      screen.queryByRole('region', { name: 'What the community thinks' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -124,9 +124,7 @@ export function PostContentRaw({
     shouldEvaluate: !!communitySentimentData,
   });
   const showCommunitySentiment =
-    isPostPage &&
-    !!communitySentimentData &&
-    (communitySentimentEnabled || isDevelopment);
+    !!communitySentimentData && (communitySentimentEnabled || isDevelopment);
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const isVideoType = isVideoPost(post);
   const hasToc = (post.toc?.length ?? 0) > 0;
@@ -282,7 +280,10 @@ export function PostContentRaw({
           />
         )}
         {showCommunitySentiment && (
-          <CommunitySentiment data={communitySentimentData} className="mb-6" />
+          <CommunitySentiment
+            data={communitySentimentData}
+            className={isCompactModalSpacing ? 'mb-4' : 'mb-6'}
+          />
         )}
       </BasePostContent>
     </PostContainer>

--- a/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.spec.tsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
 import { render, screen } from '@testing-library/react';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
-import post, { sharePost } from '../../../../__tests__/fixture/post';
+import post, {
+  postWithCommunitySentiment,
+  sharePost,
+} from '../../../../__tests__/fixture/post';
 import type { Post } from '../../../graphql/posts';
 import { PostType } from '../../../graphql/posts';
 import { Origin } from '../../../lib/log';
+import { featureCommunitySentiment } from '../../../lib/featureManagement';
 import { PostFocusCard } from './PostFocusCard';
 
 const freeformPost: Post = {
@@ -24,10 +29,20 @@ const sharedFreeformPost: Post = {
   },
 } as Post;
 
-const renderCard = (postToRender: Post) =>
+const renderCard = (
+  postToRender: Post,
+  options: {
+    gb?: GrowthBook;
+    onClose?: () => void;
+  } = {},
+) =>
   render(
-    <TestBootProvider client={new QueryClient()}>
-      <PostFocusCard post={postToRender} origin={Origin.ArticlePage} />
+    <TestBootProvider client={new QueryClient()} gb={options.gb}>
+      <PostFocusCard
+        post={postToRender}
+        origin={Origin.ArticlePage}
+        onClose={options.onClose}
+      />
     </TestBootProvider>,
   );
 
@@ -77,5 +92,31 @@ describe('PostFocusCard opening the source article', () => {
     expect(
       screen.getByTestId('post-modal-title').querySelector('a'),
     ).toBeNull();
+  });
+});
+
+describe('PostFocusCard community sentiment', () => {
+  it('renders in the post modal when the flag is enabled', () => {
+    const gb = new GrowthBook();
+    gb.setFeatures({
+      [featureCommunitySentiment.id]: {
+        defaultValue: true,
+      },
+    });
+
+    renderCard(postWithCommunitySentiment, { gb, onClose: jest.fn() });
+
+    expect(
+      screen.getByRole('region', { name: 'What the community thinks' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Most agree it is worth reading.')).toBeVisible();
+  });
+
+  it('stays hidden in the post modal when the flag is disabled', () => {
+    renderCard(postWithCommunitySentiment, { onClose: jest.fn() });
+
+    expect(
+      screen.queryByRole('region', { name: 'What the community thinks' }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -264,14 +264,11 @@ export const PostFocusCard = ({
     feature: featureCommunitySentiment,
     shouldEvaluate: !!communitySentimentData,
   });
-  // Only on the full post page, not the preview modal (which passes
-  // `onClose`), and only when the post actually has a take. `isDevelopment`
-  // lets the surface be previewed locally without flipping the committed
-  // (always-`false`) flag default.
+  // Only when the post actually has a take. `isDevelopment` lets the surface be
+  // previewed locally without flipping the committed (always-`false`) flag
+  // default.
   const showCommunitySentiment =
-    !onClose &&
-    !!communitySentimentData &&
-    (communitySentimentEnabled || isDevelopment);
+    !!communitySentimentData && (communitySentimentEnabled || isDevelopment);
   const focusCommentRef = useRef<() => void>(() => {});
   const discussionRef = useRef<HTMLDivElement>(null);
   // The video is a small floating preview on tablet/desktop and expands to the


### PR DESCRIPTION
## Changes

- Show Community take in classic and redesigned post modals when the existing community_sentiment flag is enabled and the post has a take.
- Keep the same conditional enrollment behavior so posts without a take do not evaluate the flag.
- Use compact modal spacing for the Community take block in classic post modals.
- Add regression coverage for enabled and disabled flag states in modal contexts.

## Scope

- Rendering is still data-gated on the optional Post.communitySentiment field; no post without that payload can show the section or evaluate the flag.
- Classic article/video-style modals read the take from the modal post itself.
- Redesigned share modals keep the existing PostFocusCard normalization and show the underlying shared article's take when sharedPost.communitySentiment is present.

## Events

No new tracking events.

## Experiment

No new experiment. This changes exposure for the existing community_sentiment experiment: modal viewers of posts with takes were previously eligible/evaluated without seeing the surface, and after this deploy they will see it when assigned treatment. The analysis start date should be reset to this deploy, or the experiment should be restarted, so results do not blend the old and new exposure regimes.

## Manual Testing

- [x] pnpm exec eslint __tests__/fixture/post.ts src/components/post/PostContent.tsx src/components/post/PostContent.spec.tsx src/components/post/focus/PostFocusCard.tsx src/components/post/focus/PostFocusCard.spec.tsx --max-warnings 0
- [x] NODE_ENV=test pnpm exec jest src/components/post/PostContent.spec.tsx src/components/post/focus/PostFocusCard.spec.tsx --runInBand
- [x] node ./scripts/typecheck-strict-changed.js