### PR TITLE
feat(pixels): add Quora Pixel tracking

### DIFF
--- a/packages/webapp/components/Pixels.tsx
+++ b/packages/webapp/components/Pixels.tsx
@@ -13,6 +13,7 @@ const GA_TRACKING_ID = 'G-VTGLXD7QSN';
 const TWITTER_TRACKING_ID = 'o6izs';
 const REDDIT_TRACKING_ID = 't2_j1li1n7e';
 const TIKTOK_TRACKING_ID = 'CO2RCPBC77U37LT1TAIG';
+const QUORA_TRACKING_ID = '72971829a9ca45dcbfbb5921213cbb56';
 
 export type PixelProps = {
   instanceId?: string;
@@ -325,6 +326,55 @@ const TiktokTracking = (): ReactElement => {
   );
 };
 
+const QuoraTracking = (): ReactElement => {
+  return (
+    <>
+      <Script
+        id="quora-pixel"
+        strategy="afterInteractive"
+        data-quora-id={QUORA_TRACKING_ID}
+      >
+        {`(function() {
+  const QUORA_PIXEL_ID = document.currentScript.getAttribute('data-quora-id');
+
+  function initializeQuoraPixel(q, e, v, n, t, s) {
+    if (q.qp) return;
+    n = q.qp = function() {
+      n.qp ? n.qp.apply(n, arguments) : n.queue.push(arguments);
+    };
+    n.queue = [];
+    t = document.createElement(e);
+    t.async = !0;
+    t.src = v;
+    s = document.getElementsByTagName(e)[0];
+    s.parentNode.insertBefore(t, s);
+  }
+
+  initializeQuoraPixel(
+    window,
+    'script',
+    'https://a.quora.com/qevents.js',
+  );
+
+  window.qp('init', QUORA_PIXEL_ID);
+
+  window.qp('track', 'ViewContent');
+})();
+      `}
+      </Script>
+      <noscript>
+        <img
+          alt="Quora Pixel"
+          height="1"
+          width="1"
+          style={{ display: 'none' }}
+          src={`https://q.quora.com/_/ad/${QUORA_TRACKING_ID}/pixel?tag=ViewContent&noscript=1`}
+        />
+      </noscript>
+    </>
+  );
+};
+
 export const EXPERIENCE_TO_SENIORITY: Record<
   keyof typeof UserExperienceLevel,
   string
@@ -364,6 +414,7 @@ export const Pixels = (): ReactElement => {
           <TiktokTracking />
           <TwitterTracking />
           <RedditTracking />
+          <QuoraTracking />
         </>
       )}
     </>

--- a/packages/webapp/context/PixelsContext.tsx
+++ b/packages/webapp/context/PixelsContext.tsx
@@ -59,6 +59,10 @@ function WebPixelsProvider({
       if (typeof globalThis.ttq?.track === 'function') {
         globalThis.ttq.track('CompletePayment', { value: 1 });
       }
+
+      if (typeof globalThis.qp === 'function') {
+        globalThis.qp('track', 'CompleteRegistration');
+      }
     },
     trackPayment() {
       // if (typeof globalThis.gtag === 'function') {

--- a/packages/webapp/context/PixelsContext.tsx
+++ b/packages/webapp/context/PixelsContext.tsx
@@ -59,10 +59,6 @@ function WebPixelsProvider({
       if (typeof globalThis.ttq?.track === 'function') {
         globalThis.ttq.track('CompletePayment', { value: 1 });
       }
-
-      if (typeof globalThis.qp === 'function') {
-        globalThis.qp('track', 'CompleteRegistration');
-      }
     },
     trackPayment() {
       // if (typeof globalThis.gtag === 'function') {

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -200,14 +200,12 @@ const strictSkipList = new Set([
   'packages/shared/src/components/cards/ad/squad/SquadAdList.tsx',
   'packages/shared/src/components/cards/ad/squad/common.ts',
   'packages/shared/src/components/cards/squad/SquadGrid.tsx',
-  // Quora-pixel branch — touched only to add the Quora tracking script and
-  // its signup conversion event. The strict violations (untyped globalThis
-  // pixel globals like fbq/twq/rdt/ttq, ReactElement vs null returns) are the
-  // files' established idiom across every vendor and predate this change; the
-  // new qp access follows it. Typing the pixel globals belongs in a dedicated
-  // cleanup PR.
+  // Quora-pixel branch — touched only to add the Quora tracking script.
+  // The strict violations (untyped globalThis pixel globals like fbq/gtag,
+  // ReactElement vs null returns) are the file's established idiom across
+  // every vendor and predate this change. Typing the pixel globals belongs
+  // in a dedicated cleanup PR.
   'packages/webapp/components/Pixels.tsx',
-  'packages/webapp/context/PixelsContext.tsx',
   // Tool-page-signals branch — touched only to add an `onError` toast to the
   // comment/edit mutations (surfacing the server's ForbiddenError message
   // instead of failing silently). Pre-existing strict violations (optional

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -200,6 +200,14 @@ const strictSkipList = new Set([
   'packages/shared/src/components/cards/ad/squad/SquadAdList.tsx',
   'packages/shared/src/components/cards/ad/squad/common.ts',
   'packages/shared/src/components/cards/squad/SquadGrid.tsx',
+  // Quora-pixel branch — touched only to add the Quora tracking script and
+  // its signup conversion event. The strict violations (untyped globalThis
+  // pixel globals like fbq/twq/rdt/ttq, ReactElement vs null returns) are the
+  // files' established idiom across every vendor and predate this change; the
+  // new qp access follows it. Typing the pixel globals belongs in a dedicated
+  // cleanup PR.
+  'packages/webapp/components/Pixels.tsx',
+  'packages/webapp/context/PixelsContext.tsx',
   // Tool-page-signals branch — touched only to add an `onError` toast to the
   // comment/edit mutations (surfacing the server's ForbiddenError message
   // instead of failing silently). Pre-existing strict violations (optional


### PR DESCRIPTION
## Changes

- Add a `QuoraTracking` component to `Pixels.tsx` following the existing Reddit/TikTok pattern: loads Quora's `qevents.js`, fires `qp('init', ...)` and `qp('track', 'ViewContent')`, with the `<noscript>` fallback image. Rendered inside the existing consent-gated block since Quora has no consent API.
- Add `Pixels.tsx` to the strict typecheck skip list — the surfaced violations (untyped `globalThis` pixel globals, `ReactElement` vs `null` returns) are the file's pre-existing idiom across all vendors; typing the pixel globals belongs in a dedicated cleanup PR.

Base pixel only — no signup conversion event for now.

## Notes

- Pixel only loads in production for identified users with marketing consent, same as the other vendor pixels.
- Verify post-deploy via the network tab (`qevents.js` + `q.quora.com` beacons) or Quora's Pixel Helper extension.

### Preview domain
https://feat-quora-pixel.preview.app.daily.dev