### PR TITLE
fix: hydrate post in focus card so community takes show in modals

### DIFF
--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -61,6 +61,7 @@ import {
   CommunitySentiment,
   mapCommunitySentimentPost,
 } from './CommunitySentiment';
+import { withPostById } from '../withPostById';
 
 const PostCodeSnippets = dynamic(() =>
   import(/* webpackChunkName: "postCodeSnippets" */ '../PostCodeSnippets').then(
@@ -216,7 +217,7 @@ const VideoSummary = ({ summary }: { summary: string }): ReactElement => {
   );
 };
 
-export const PostFocusCard = ({
+const PostFocusCardRaw = ({
   post,
   origin,
   leftVariant,
@@ -643,3 +644,9 @@ export const PostFocusCard = ({
     </article>
   );
 };
+
+// Feed cards only carry the `FeedPostInfo` fields, so when the card is opened
+// from a feed (post modal) fields such as `communitySentiment` are missing.
+// Wrapping with `withPostById` hydrates the post from the by-id query (cache
+// hit on the post page, where the post is already fetched).
+export const PostFocusCard = withPostById(PostFocusCardRaw);


### PR DESCRIPTION
## Problem

Community takes show on the post page but never in the post modal opened from a feed (e.g. /sources/hn).

## Root cause

#6520 removed the isPostPage / !onClose gating, so gating is no longer the blocker — the **data** is.

- Post page: usePostById -> POST_BY_ID_QUERY -> SharedPostInfo, which selects communitySentiment. OK
- Post modal: Feed.tsx passes selectedPost straight from the feed items, and the feed query only selects FeedPostInfo — which has **no communitySentiment field**. PostFocusCard therefore always sees post.communitySentiment === undefined and renders nothing.

The legacy PostContent does not have this problem because it is exported as withPostById(PostContentRaw), which refetches the post by id and replaces the partial feed object. PostFocusCard (used by the redesign Article/Share/Collection modals) was not wrapped.

## Fix

Wrap PostFocusCard with withPostById, the same hydration pattern used by PostContent, CollectionPostContent, SquadPostContent. On the post page the post is already in the query cache (cache hit, no extra request); in the modal it hydrates the missing SharedPostInfo-only fields.

Alternative considered: adding communitySentiment to FEED_POST_INFO_FRAGMENT. Rejected — large nested payload (breakdown, highlights, discussions, bySource) multiplied by every card in every feed response.

---
Investigated and authored with Smith (AI). No local typecheck/test run was possible in this environment, so please let CI confirm.

### Preview domain
https://fix-community-sentiment-modal-hy.preview.app.daily.dev