### PR TITLE
fix(cookies): stop the LGPD banner from showing worldwide

### DIFF
--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -147,8 +147,6 @@ export const Iubenda = (): ReactElement | null => {
       gdprAppliesGlobally: false,
       googleAdditionalConsentMode: true,
       inlineDelay: 100,
-      // iubenda defaults this to true, which asks for LGPD consent (and shows
-      // the banner) worldwide instead of in Brazil only
       lgpdAppliesGlobally: false,
       perPurposeConsent: true,
       siteId: Number(siteId),

--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -147,6 +147,9 @@ export const Iubenda = (): ReactElement | null => {
       gdprAppliesGlobally: false,
       googleAdditionalConsentMode: true,
       inlineDelay: 100,
+      // iubenda defaults this to true, which asks for LGPD consent (and shows
+      // the banner) worldwide instead of in Brazil only
+      lgpdAppliesGlobally: false,
       perPurposeConsent: true,
       siteId: Number(siteId),
       tcfPurposes: {


### PR DESCRIPTION
## Problem

Users in non-GDPR countries (reported first from Israel, then confirmed everywhere) get the iubenda consent banner on webapp pages, even though the config is meant to show a banner only where a consent regime applies.

## Root cause

iubenda's `lgpdAppliesGlobally` parameter **defaults to `true`** ([advanced guide](https://www.iubenda.com/en/help/1205-how-to-configure-your-cookie-solution-advanced-guide)): "you'll apply LGPD protections to all users. Set this parameter to *false* and `countryDetection: true` to request LGPD consent to Brazilian users only."

Our `csConfiguration` sets `enableLgpd: true` but never sets `lgpdAppliesGlobally`, so LGPD consent applied to every visitor worldwide: EU visitors got the TCF/GDPR banner, everyone else got the LGPD banner (visually identical, since `applyStyles: false` styles all variants with our own CSS). GDPR itself was already scoped correctly because we do set `gdprAppliesGlobally: false`; USPR respects country detection by default.

Verified on the live site: the embed config has `lgpdAppliesGlobally: undefined` and iubenda's resolved runtime options show `lgpdAppliesGlobally: true, lgpdApplies: true` for a non-Brazilian visitor.

## Fix

Set `lgpdAppliesGlobally: false` so `countryDetection` scopes LGPD to Brazil, matching how GDPR is scoped.

## Notes

- The marketing sites' embeds (recruiter-landing, custom-scripts/head.html) mirror this config and need the same one-line fix in their repo — flagging separately.
- Visitors who already answered the banner in no-regime territories keep their recorded `_iub_cs-*` / `ilikecookies*` cookies; those who clicked Reject stay opted out of marketing until they change it in settings/privacy.

### Preview domain
https://fix-iubenda-lgpd-global-banner.preview.app.daily.dev