### PR TITLE
feat(shared): user-level AdSense impression and click analytics

### DIFF
--- a/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
@@ -12,6 +12,7 @@ import AuthContext from '../../../contexts/AuthContext';
 import { getLogContextStatic } from '../../../contexts/LogContext';
 import type { LogContextData } from '../../../hooks/log/useLogContextData';
 import { LogEvent } from '../../../lib/log';
+import { AdActions } from '../../../lib/ads';
 import type { AdsenseSlots } from '../../../features/monetization/adsense';
 import { ADSENSE_CLIENT_ID } from '../../../features/monetization/adsense';
 import {
@@ -502,7 +503,7 @@ describe('ProgrammaticAd telemetry', () => {
 
     const clicks = logEvent.mock.calls.filter(
       ([event]) =>
-        event.event_name === LogEvent.Click && event.target_type === 'ad',
+        event.event_name === AdActions.Click && event.target_type === 'ad',
     );
     expect(clicks).toHaveLength(1);
     expect(clicks[0][0]).toMatchObject({
@@ -513,7 +514,79 @@ describe('ProgrammaticAd telemetry', () => {
       slot: 2,
       unit: '2222222222',
       surface: 'read',
+      signal: 'focus-blur',
     });
+  });
+
+  it('logs the loose impression at fill, in the internal ads shape', async () => {
+    setSlots({ '2': { id: '2222222222', type: 'display' } });
+    renderWithLog(
+      <ArbitrageAdSlot slot={2} format={ArbitrageAdFormat.Leaderboard} eager />,
+    );
+
+    screen
+      .getByTestId('adsense-slot-2')
+      .appendChild(document.createElement('iframe'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    const impressions = logEvent.mock.calls.filter(
+      ([event]) => event.event_name === AdActions.Impression,
+    );
+    expect(impressions).toHaveLength(1);
+    expect(impressions[0][0]).toMatchObject({
+      target_type: 'ad',
+      target_id: '2222222222',
+      ad_provider_id: 'adsense',
+    });
+    // The strict name is reserved for the MRC measurement from useViewability.
+    expect(loggedEvents()).not.toContain(AdActions.Viewable);
+  });
+
+  it('logs a same-tab click-through on pagehide', async () => {
+    setSlots({ '2': { id: '2222222222', type: 'display' } });
+    renderWithLog(
+      <ArbitrageAdSlot slot={2} format={ArbitrageAdFormat.Leaderboard} eager />,
+    );
+
+    const iframe = document.createElement('iframe');
+    screen.getByTestId('adsense-slot-2').appendChild(iframe);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    iframe.focus();
+    fireEvent(window, new Event('pagehide'));
+
+    const clicks = logEvent.mock.calls.filter(
+      ([event]) => event.event_name === AdActions.Click,
+    );
+    expect(clicks).toHaveLength(1);
+    expect(JSON.parse(clicks[0][0].extra)).toMatchObject({
+      signal: 'pagehide',
+    });
+  });
+
+  it('disarms a focused creative when the visitor returns without leaving', async () => {
+    setSlots({ '2': { id: '2222222222', type: 'display' } });
+    renderWithLog(
+      <ArbitrageAdSlot slot={2} format={ArbitrageAdFormat.Leaderboard} eager />,
+    );
+
+    const iframe = document.createElement('iframe');
+    screen.getByTestId('adsense-slot-2').appendChild(iframe);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Tap focuses the creative; the visitor stays, the window regains focus,
+    // and only minutes later blurs for an unrelated reason (alt-tab).
+    iframe.focus();
+    fireEvent.focus(window);
+    fireEvent.blur(window);
+
+    expect(loggedEvents()).not.toContain(AdActions.Click);
   });
 
   it('ignores window blur while focus is outside the creative', async () => {
@@ -531,7 +604,7 @@ describe('ProgrammaticAd telemetry', () => {
 
     fireEvent.blur(window);
 
-    expect(loggedEvents()).not.toContain(LogEvent.Click);
+    expect(loggedEvents()).not.toContain(AdActions.Click);
   });
 
   it('logs a push error when adsbygoogle rejects the request', () => {

--- a/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { act, render as rtlRender, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render as rtlRender,
+  screen,
+} from '@testing-library/react';
 import { ArbitrageAdFormat, ArbitrageAdSlot } from './ArbitrageAdSlot';
 import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
 import type { AuthContextData } from '../../../contexts/AuthContext';
@@ -475,6 +480,58 @@ describe('ProgrammaticAd telemetry', () => {
     });
 
     expect(loggedEvents()).toContain(LogEvent.FillAdsenseSlot);
+  });
+
+  it('logs a click once when focus moves into the filled creative', async () => {
+    setSlots({ '2': { id: '2222222222', type: 'display' } });
+    renderWithLog(
+      <ArbitrageAdSlot slot={2} format={ArbitrageAdFormat.Leaderboard} eager />,
+    );
+
+    const iframe = document.createElement('iframe');
+    screen.getByTestId('adsense-slot-2').appendChild(iframe);
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // A click on a cross-origin creative never bubbles here; the observable
+    // is focus landing on the iframe as the window blurs.
+    iframe.focus();
+    fireEvent.blur(window);
+    fireEvent.blur(window);
+
+    const clicks = logEvent.mock.calls.filter(
+      ([event]) =>
+        event.event_name === LogEvent.Click && event.target_type === 'ad',
+    );
+    expect(clicks).toHaveLength(1);
+    expect(clicks[0][0]).toMatchObject({
+      target_id: '2222222222',
+      ad_provider_id: 'adsense',
+    });
+    expect(JSON.parse(clicks[0][0].extra)).toMatchObject({
+      slot: 2,
+      unit: '2222222222',
+      surface: 'read',
+    });
+  });
+
+  it('ignores window blur while focus is outside the creative', async () => {
+    setSlots({ '2': { id: '2222222222', type: 'display' } });
+    renderWithLog(
+      <ArbitrageAdSlot slot={2} format={ArbitrageAdFormat.Leaderboard} eager />,
+    );
+
+    screen
+      .getByTestId('adsense-slot-2')
+      .appendChild(document.createElement('iframe'));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.blur(window);
+
+    expect(loggedEvents()).not.toContain(LogEvent.Click);
   });
 
   it('logs a push error when adsbygoogle rejects the request', () => {

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { webappUrl } from '../../lib/constants';
 import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent } from '../../lib/log';
+import { AdActions } from '../../lib/ads';
 import { useViewability } from './useViewability';
 import { viewabilityLogExtra } from './viewability';
 import type { AdsenseSlotConfig } from './adsense';
@@ -214,13 +215,31 @@ export function ProgrammaticAd({
   const hasPushed = useRef(false);
   const hasLoggedFill = useRef(false);
   const hasLoggedEmpty = useRef(false);
+  // Once-per-slot latches. A `refreshes` slot rotating creatives would need
+  // per-creative keys here and in the viewability trackingKey — deliberately
+  // out of scope: AdSense never refreshes a unit, so today the flag is only a
+  // forward-marker for the Ad Manager migration, where this must be revisited
+  // before declared refresh goes live.
   const hasLoggedClick = useRef(false);
   const { id: unitId, type: unitType, layoutKey: unitLayoutKey } = config;
 
   const logSlotEvent = useCallback(
-    (eventName: LogEvent, extra?: Record<string, unknown>): void => {
+    (
+      eventName: LogEvent | AdActions,
+      extra?: Record<string, unknown>,
+      asAdEvent = false,
+    ): void => {
       logEvent({
         event_name: eventName,
+        // Analytics interactions use the exact shape of the internal ads'
+        // events (adLogEvent): same names and target_type, the provider in
+        // ad_provider_id and the unit as the target — one query covers every
+        // ad on the platform, GROUP BY ad_provider_id splits the demand.
+        ...(asAdEvent && {
+          target_type: 'ad',
+          target_id: unitId,
+          ad_provider_id: 'adsense',
+        }),
         extra: JSON.stringify(
           getAdsenseSlotLogExtra({
             slot,
@@ -245,48 +264,22 @@ export function ProgrammaticAd({
     ],
   );
 
-  // Impressions and clicks use the exact shape of the internal ads' events
-  // (adLogEvent): same event names and target_type, the provider carried in
-  // ad_provider_id and the AdSense unit as the target — so one query covers
-  // every ad on the platform and GROUP BY ad_provider_id splits the demand.
   const logAdInteraction = useCallback(
-    (eventName: LogEvent, extra?: Record<string, unknown>): void => {
-      logEvent({
-        event_name: eventName,
-        target_type: 'ad',
-        target_id: unitId,
-        ad_provider_id: 'adsense',
-        extra: JSON.stringify(
-          getAdsenseSlotLogExtra({
-            slot,
-            config: { id: unitId, type: unitType, layoutKey: unitLayoutKey },
-            format,
-            surface,
-            refreshes,
-            extra,
-          }),
-        ),
-      });
-    },
-    [
-      format,
-      logEvent,
-      refreshes,
-      slot,
-      surface,
-      unitId,
-      unitLayoutKey,
-      unitType,
-    ],
+    (eventName: AdActions, extra?: Record<string, unknown>): void =>
+      logSlotEvent(eventName, extra, true),
+    [logSlotEvent],
   );
 
-  // The MRC viewable impression, measured only once a creative is actually in
-  // the slot — an empty reservation scrolling by is not an impression.
+  // The strict MRC measurement files under the strict name: internal ads log
+  // AdActions.Impression when a creative merely reaches the viewport and
+  // AdActions.Viewable for IAB-viewable, and mixing the two would make
+  // AdSense CTR read systematically higher than internal inventory in any
+  // cross-provider query. The loose impression is emitted at fill below.
   const { ref: setViewabilityRef } = useViewability<HTMLDivElement>({
     enabled: isFilled,
     trackingKey: `${surface}:${slot}:${unitId}:${format}`,
     onViewable: (data) => {
-      logAdInteraction(LogEvent.Impression, viewabilityLogExtra(data));
+      logAdInteraction(AdActions.Viewable, viewabilityLogExtra(data));
     },
   });
 
@@ -380,6 +373,10 @@ export function ProgrammaticAd({
         hasLoggedFill.current = true;
         setIsFilled(true);
         logSlotEvent(LogEvent.FillAdsenseSlot);
+        // The loose impression, in the internal ads' meaning: the creative
+        // rendered in/near the viewport (requests fire on intersection, so
+        // fill implies it). AdActions.Viewable above carries the strict one.
+        logAdInteraction(AdActions.Impression);
       }
       if (
         !hasLoggedEmpty.current &&
@@ -426,7 +423,7 @@ export function ProgrammaticAd({
     }
 
     return () => observer.disconnect();
-  }, [isRequested, logSlotEvent]);
+  }, [isRequested, logAdInteraction, logSlotEvent]);
 
   // First-party click signal. The creative is a cross-origin iframe, so no
   // click event ever reaches this document — but engaging it moves focus:
@@ -442,22 +439,40 @@ export function ProgrammaticAd({
       return undefined;
     }
 
-    const onWindowBlur = (): void => {
+    const activeCreative = (): HTMLElement | null => {
       const active = document.activeElement;
-      if (
-        hasLoggedClick.current ||
-        !active ||
-        active.tagName !== 'IFRAME' ||
-        !element.contains(active)
-      ) {
+      return active && active.tagName === 'IFRAME' && element.contains(active)
+        ? (active as HTMLElement)
+        : null;
+    };
+
+    const logClick = (signal: string): void => {
+      if (hasLoggedClick.current || !activeCreative()) {
         return;
       }
       hasLoggedClick.current = true;
-      logAdInteraction(LogEvent.Click);
+      logAdInteraction(AdActions.Click, { signal });
     };
 
+    // Click-throughs that open a new tab/window blur this one with focus on
+    // the creative's iframe.
+    const onWindowBlur = (): void => logClick('focus-blur');
+    // Same-tab click-throughs unload the document without a window blur —
+    // the most valuable click would otherwise be the one missed.
+    const onPageHide = (): void => logClick('pagehide');
+    // If the visitor comes back with the creative still holding focus, they
+    // tapped it without leaving. Dropping that focus means a later unrelated
+    // blur (alt-tab minutes on) can't be mistaken for an ad click.
+    const onWindowFocus = (): void => activeCreative()?.blur();
+
     window.addEventListener('blur', onWindowBlur);
-    return () => window.removeEventListener('blur', onWindowBlur);
+    window.addEventListener('focus', onWindowFocus);
+    window.addEventListener('pagehide', onPageHide);
+    return () => {
+      window.removeEventListener('blur', onWindowBlur);
+      window.removeEventListener('focus', onWindowFocus);
+      window.removeEventListener('pagehide', onPageHide);
+    };
   }, [isFilled, logAdInteraction]);
 
   return (

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -214,6 +214,7 @@ export function ProgrammaticAd({
   const hasPushed = useRef(false);
   const hasLoggedFill = useRef(false);
   const hasLoggedEmpty = useRef(false);
+  const hasLoggedClick = useRef(false);
   const { id: unitId, type: unitType, layoutKey: unitLayoutKey } = config;
 
   const logSlotEvent = useCallback(
@@ -244,13 +245,48 @@ export function ProgrammaticAd({
     ],
   );
 
+  // Impressions and clicks use the exact shape of the internal ads' events
+  // (adLogEvent): same event names and target_type, the provider carried in
+  // ad_provider_id and the AdSense unit as the target — so one query covers
+  // every ad on the platform and GROUP BY ad_provider_id splits the demand.
+  const logAdInteraction = useCallback(
+    (eventName: LogEvent, extra?: Record<string, unknown>): void => {
+      logEvent({
+        event_name: eventName,
+        target_type: 'ad',
+        target_id: unitId,
+        ad_provider_id: 'adsense',
+        extra: JSON.stringify(
+          getAdsenseSlotLogExtra({
+            slot,
+            config: { id: unitId, type: unitType, layoutKey: unitLayoutKey },
+            format,
+            surface,
+            refreshes,
+            extra,
+          }),
+        ),
+      });
+    },
+    [
+      format,
+      logEvent,
+      refreshes,
+      slot,
+      surface,
+      unitId,
+      unitLayoutKey,
+      unitType,
+    ],
+  );
+
   // The MRC viewable impression, measured only once a creative is actually in
   // the slot — an empty reservation scrolling by is not an impression.
   const { ref: setViewabilityRef } = useViewability<HTMLDivElement>({
     enabled: isFilled,
     trackingKey: `${surface}:${slot}:${unitId}:${format}`,
     onViewable: (data) => {
-      logSlotEvent(LogEvent.ViewAdsenseSlot, viewabilityLogExtra(data));
+      logAdInteraction(LogEvent.Impression, viewabilityLogExtra(data));
     },
   });
 
@@ -391,6 +427,38 @@ export function ProgrammaticAd({
 
     return () => observer.disconnect();
   }, [isRequested, logSlotEvent]);
+
+  // First-party click signal. The creative is a cross-origin iframe, so no
+  // click event ever reaches this document — but engaging it moves focus:
+  // the window blurs and document.activeElement becomes the iframe. That
+  // inference is the industry-standard AdSense click proxy; it can overcount
+  // the rare tap that focuses without completing the click-through, so
+  // AdSense's own reporting stays the exact source of truth while this event
+  // gives the per-user join our internal ads have. Logged once per slot: a
+  // second click on the same creative is the same user leaving again.
+  useEffect(() => {
+    const element = wrapperRef.current;
+    if (!isFilled || !element) {
+      return undefined;
+    }
+
+    const onWindowBlur = (): void => {
+      const active = document.activeElement;
+      if (
+        hasLoggedClick.current ||
+        !active ||
+        active.tagName !== 'IFRAME' ||
+        !element.contains(active)
+      ) {
+        return;
+      }
+      hasLoggedClick.current = true;
+      logAdInteraction(LogEvent.Click);
+    };
+
+    window.addEventListener('blur', onWindowBlur);
+    return () => window.removeEventListener('blur', onWindowBlur);
+  }, [isFilled, logAdInteraction]);
 
   return (
     // Square-cornered and unclipped: the box only centres the unit and

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -113,7 +113,6 @@ export enum LogEvent {
   RequestAdsenseSlot = 'request adsense slot',
   FillAdsenseSlot = 'fill adsense slot',
   EmptyAdsenseSlot = 'empty adsense slot',
-  ViewAdsenseSlot = 'view adsense slot',
   AdsenseSlotError = 'adsense slot error',
   AdsenseTestMode = 'adsense test mode',
   OpenSmartComposer = 'open smart composer',


### PR DESCRIPTION
Follow-up to #6500, answering "can we track AdSense at user level like our own ads".

## What ships

- **Impressions**: two events matching internal ads' two meanings — `AdActions.Impression` at fill (creative rendered near the viewport) and `AdActions.Viewable` for the MRC-viewable measurement (same `useViewability`, armed only once a creative actually fills) — both shaped as `target_type: 'ad'`, `target_id: <unit id>`, `ad_provider_id: 'adsense'` — the exact shape `adLogEvent` gives internal ads, so one ClickHouse query covers every ad on the platform and `GROUP BY ad_provider_id` splits internal vs AdSense demand. Slot, format, surface and viewability data ride in `extra`.
- **Clicks**: new. A cross-origin creative never bubbles a click, so the event is inferred the standard way — focus landing on the ad iframe as the window blurs. Logged once per slot as `AdActions.Click` in the same shape, with the inference `signal` (`focus-blur` for new-tab click-throughs, `pagehide` for same-tab) in `extra`; a visitor returning with the creative still focused disarms the proxy so unrelated later blurs can't count. **Not yet verified on a real phone** — until then, treat mobile CTR from this event as provisional and segment by `signal`. Slightly approximate by nature (an iframe focus that doesn't complete the click-through counts); AdSense's own reporting stays the exact source of truth, this gives the per-user join it can't.
- The bespoke `view/click adsense slot` names are removed before any dashboard depends on them; `request/fill/empty adsense slot`, `adsense slot error` and `adsense test mode` remain as delivery diagnostics (no internal-ads equivalent).

## Verification

- 30 arbitrage-slot tests including: click logged once with the uniform shape on iframe focus + window blur, no click on unrelated blur, label/lifecycle regressions
- Shared post + monetization suites green, strict typecheck + lint clean

User-level queries this unlocks: RPM per user cohort, clicked-an-ad user segments joined to retention/signup, per-slot CTR by geo — same joins the internal ad events already support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-adsense-click-tracking.preview.app.daily.dev
