### PR TITLE
feat: expand programmatic ad placements on /articles

### DIFF
--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -136,63 +136,63 @@ export function PostComments({
       }
       ref={container}
     >
-      {comments!.postComments.edges.map((e, index, edges) => {
-        const isLast = index === edges.length - 1;
+      {(() => {
         // Replies count too: the interval is over everything the reader
-        // scrolls past, not just top-level rows, and the boundary can only
-        // sit after a top-level block — never inside one.
-        const countThrough = (through: number): number =>
-          edges
-            .slice(0, through)
-            .reduce(
-              (total, edge) =>
-                total + 1 + (edge.node.children?.edges?.length ?? 0),
-              0,
-            );
-        const seen = countThrough(index + 1);
-        // Never after the last comment, where whatever follows the thread
-        // already sits.
-        const shouldInterleave =
-          !!interleaveEvery &&
-          !!renderInterleaved &&
-          !isLast &&
-          Math.floor(seen / interleaveEvery) >
-            Math.floor(countThrough(index) / interleaveEvery);
+        // scrolls past, not just top-level rows (loaded replies — collapsed
+        // pagination beyond the first page is not on screen and not counted),
+        // and the boundary can only sit after a top-level block. One prefix
+        // pass instead of two reductions per row.
+        const totals: number[] = [0];
+        comments!.postComments.edges.forEach((edge, i) => {
+          totals.push(totals[i] + 1 + (edge.node.children?.edges?.length ?? 0));
+        });
+        return comments!.postComments.edges.map((e, index, edges) => {
+          const isLast = index === edges.length - 1;
+          const seen = totals[index + 1];
+          const shouldInterleave =
+            !!interleaveEvery &&
+            !!renderInterleaved &&
+            !isLast &&
+            Math.floor(seen / interleaveEvery) >
+              Math.floor(totals[index] / interleaveEvery);
 
-        // Always the Fragment, even rows that interleave nothing: the type at
-        // a given key must not flip as the boundary moves (a new comment
-        // landing shifts every index), or React remounts that comment's
-        // subtree and open reply boxes lose their state.
-        return (
-          <Fragment key={e.node.id}>
-            <MainComment
-              isModalThread={isModalThread}
-              className={{ commentBox: className }}
-              post={post}
-              origin={origin}
-              commentHash={commentHash ?? undefined}
-              commentRef={commentRef as React.MutableRefObject<HTMLElement>}
-              comment={e.node}
-              onShare={onShare ?? noopShare}
-              onDelete={(comment, parentId) =>
-                deleteComment(comment.id, parentId ?? null, post)
-              }
-              onShowUpvotes={onClickUpvote ?? noopShowUpvotes}
-              postAuthorId={post.author?.id ?? null}
-              postScoutId={post.scout?.id ?? null}
-              appendTooltipTo={getAppendTooltipParent}
-              permissionNotificationCommentId={permissionNotificationCommentId}
-              joinNotificationCommentId={joinNotificationCommentId}
-              onCommented={onCommented}
-              lazy={!commentHash && index >= lazyCommentThreshold}
-              canReply={canReply}
-              onReplyBlocked={onReplyBlocked}
-            />
-            {shouldInterleave &&
-              renderInterleaved(Math.floor(seen / interleaveEvery))}
-          </Fragment>
-        );
-      })}
+          // Always the Fragment, even rows that interleave nothing: the type at
+          // a given key must not flip as the boundary moves (a new comment
+          // landing shifts every index), or React remounts that comment's
+          // subtree and open reply boxes lose their state.
+          return (
+            <Fragment key={e.node.id}>
+              <MainComment
+                isModalThread={isModalThread}
+                className={{ commentBox: className }}
+                post={post}
+                origin={origin}
+                commentHash={commentHash ?? undefined}
+                commentRef={commentRef as React.MutableRefObject<HTMLElement>}
+                comment={e.node}
+                onShare={onShare ?? noopShare}
+                onDelete={(comment, parentId) =>
+                  deleteComment(comment.id, parentId ?? null, post)
+                }
+                onShowUpvotes={onClickUpvote ?? noopShowUpvotes}
+                postAuthorId={post.author?.id ?? null}
+                postScoutId={post.scout?.id ?? null}
+                appendTooltipTo={getAppendTooltipParent}
+                permissionNotificationCommentId={
+                  permissionNotificationCommentId
+                }
+                joinNotificationCommentId={joinNotificationCommentId}
+                onCommented={onCommented}
+                lazy={!commentHash && index >= lazyCommentThreshold}
+                canReply={canReply}
+                onReplyBlocked={onReplyBlocked}
+              />
+              {shouldInterleave &&
+                renderInterleaved(Math.floor(seen / interleaveEvery))}
+            </Fragment>
+          );
+        });
+      })()}
     </div>
   );
 }

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -46,10 +46,12 @@ interface PostCommentsProps {
   canReply?: MainCommentProps['canReply'];
   onReplyBlocked?: MainCommentProps['onReplyBlocked'];
   /**
-   * Renders between top-level comments, every `interleaveEvery` of them. Used
-   * by the ad template to break a long thread up; never after the last comment,
-   * where whatever follows the thread already sits. Both props are required
-   * together, and without them the list keeps its original markup.
+   * Renders after the top-level comment at which the running total of
+   * comments — replies included, every comment counts — crosses a multiple
+   * of `interleaveEvery`. Used by the ad template to break a long thread up;
+   * never after the last top-level comment, where whatever follows the
+   * thread already sits. Both props are required together, and without them
+   * the list keeps its original markup.
    */
   interleaveEvery?: number;
   renderInterleaved?: (occurrence: number) => ReactNode;
@@ -134,15 +136,28 @@ export function PostComments({
       }
       ref={container}
     >
-      {comments!.postComments.edges.map((e, index) => {
-        const isLast = index === comments!.postComments.edges.length - 1;
+      {comments!.postComments.edges.map((e, index, edges) => {
+        const isLast = index === edges.length - 1;
+        // Replies count too: the interval is over everything the reader
+        // scrolls past, not just top-level rows, and the boundary can only
+        // sit after a top-level block — never inside one.
+        const countThrough = (through: number): number =>
+          edges
+            .slice(0, through)
+            .reduce(
+              (total, edge) =>
+                total + 1 + (edge.node.children?.edges?.length ?? 0),
+              0,
+            );
+        const seen = countThrough(index + 1);
         // Never after the last comment, where whatever follows the thread
         // already sits.
         const shouldInterleave =
           !!interleaveEvery &&
           !!renderInterleaved &&
           !isLast &&
-          (index + 1) % interleaveEvery === 0;
+          Math.floor(seen / interleaveEvery) >
+            Math.floor(countThrough(index) / interleaveEvery);
 
         // Always the Fragment, even rows that interleave nothing: the type at
         // a given key must not flip as the boundary moves (a new comment
@@ -174,7 +189,7 @@ export function PostComments({
               onReplyBlocked={onReplyBlocked}
             />
             {shouldInterleave &&
-              renderInterleaved((index + 1) / interleaveEvery)}
+              renderInterleaved(Math.floor(seen / interleaveEvery))}
           </Fragment>
         );
       })}

--- a/packages/shared/src/components/post/PostEngagements.tsx
+++ b/packages/shared/src/components/post/PostEngagements.tsx
@@ -52,6 +52,11 @@ interface PostEngagementsProps {
   onCopyLinkClick?: (post?: Post) => void;
   /** Ad templates break a long thread up — see PostComments. */
   interleaveEvery?: number;
+  /**
+   * Drops the internal AdAsComment. The programmatic template carries its own
+   * comment-thread units, and two ad systems in one thread double the density.
+   */
+  hideInternalAd?: boolean;
   renderInterleaved?: (occurrence: number) => ReactNode;
 }
 
@@ -60,6 +65,7 @@ function PostEngagements({
   onCopyLinkClick,
   logOrigin,
   shouldOnboardAuthor,
+  hideInternalAd,
   interleaveEvery,
   renderInterleaved,
 }: PostEngagementsProps): ReactElement {
@@ -172,7 +178,7 @@ function PostEngagements({
         shouldHandleCommentQuery
         CommentInputOrModal={CommentInputOrModal}
       />
-      {!isPlus && <AdAsComment postId={post.id} />}
+      {!isPlus && !hideInternalAd && <AdAsComment postId={post.id} />}
       <PostComments
         post={post}
         sortBy={sortBy}

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -67,6 +67,8 @@ export type PostWidgetsProps = Omit<PostHeaderActionsProps, 'contextMenuId'> &
     getRailAd?: (position: PostWidgetPosition) => ReactNode;
     /** Rendered last, below the footer links. */
     trailing?: ReactNode;
+    /** Drops the internal sidebar ad — for templates carrying their own. */
+    hideAdWidget?: boolean;
   };
 
 /**
@@ -100,6 +102,7 @@ export function PostWidgets({
   hideToc = false,
   getRailAd,
   trailing,
+  hideAdWidget,
 }: PostWidgetsProps): ReactElement {
   const { tokenRefreshed } = useContext(AuthContext);
   const { source } = post;
@@ -158,10 +161,12 @@ export function PostWidgets({
           />
         ),
       )}
-      <PostSidebarAdWidget
-        postId={post.id}
-        className={{ container: cardClasses }}
-      />
+      {!hideAdWidget && (
+        <PostSidebarAdWidget
+          postId={post.id}
+          className={{ container: cardClasses }}
+        />
+      )}
       <MentionedToolsWidget postTags={post.tags || []} />
       {withAd(
         PostWidgetPosition.Share,

--- a/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.tsx
@@ -28,11 +28,10 @@ export interface ArbitrageAdSlotProps {
   /** Marks slots wired to a declared 30-60s in-view refresh once on Ad Manager. */
   refreshes?: boolean;
   /**
-   * Drops the slot below the tablet breakpoint. The Better Ads Standards cap
-   * mobile ad density at 30% of page height, and a scraped post carries little
-   * body text to dilute it — running every slot on a phone measured 56%, which
-   * is what gets a site's ads filtered by Chrome. The unit is hidden rather
-   * than skipped so it also never requests: the ad only pushes on intersection,
+   * Drops the slot below the tablet breakpoint — the Better Ads Standards cap
+   * mobile ad density at 30% of page height, and Chrome's filter for a
+   * violation applies to the whole domain. The unit is hidden rather than
+   * skipped so it also never requests: the ad only pushes on intersection,
    * and a display:none box never intersects.
    */
   hideOnPhone?: boolean;
@@ -49,6 +48,8 @@ export interface ArbitrageAdSlotProps {
    * arrived, so eager pushes ride its very first processing pass.
    */
   eager?: boolean;
+  /** Per-instance extra for repeated placements — see ProgrammaticAd. */
+  logExtra?: Record<string, unknown>;
 }
 
 function MappedAdSlot({
@@ -58,6 +59,7 @@ function MappedAdSlot({
   refreshes,
   hideOnPhone,
   eager,
+  logExtra,
   slots,
   surface,
   allowPlaceholder = false,
@@ -88,6 +90,7 @@ function MappedAdSlot({
         refreshes={refreshes}
         hideOnPhone={hideOnPhone}
         eager={eager}
+        logExtra={logExtra}
       />
     );
   }

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -19,8 +19,11 @@ import { TruncateText } from '../../utilities';
 import Markdown from '../../Markdown';
 import { ArbitrageAdFormat, ArbitrageAdSlot } from './ArbitrageAdSlot';
 import { ArbitrageTopLeaderboard } from './ArbitrageTopLeaderboard';
+import { PostAnsweredQuestions } from '../PostAnsweredQuestions';
+import { splitContentForAds } from './splitContentForAds';
 import {
   ARBITRAGE_SLOT,
+  BODY_CHARS_PER_AD,
   COMMENTS_PER_INTERLEAVED_AD,
   TOP_LEADERBOARD_STICKY_MS,
 } from './slots';
@@ -42,48 +45,27 @@ import PostEngagements from '../PostEngagements';
  * inventory included. Only the first rail unit keeps its phone placement; the
  * rest are desktop-only, which brings the phone run well under the cap.
  */
-const RAIL_AD: Record<
-  PostWidgetPosition,
-  {
-    slot: number;
-    format: ArbitrageAdFormat;
-    className?: string;
-    hideOnPhone?: boolean;
-  }
+const RAIL_AD: Partial<
+  Record<
+    PostWidgetPosition,
+    {
+      slot: number;
+      format: ArbitrageAdFormat;
+      className?: string;
+      hideOnPhone?: boolean;
+    }
+  >
 > = {
   [PostWidgetPosition.Source]: {
     slot: ARBITRAGE_SLOT.railAfterSource,
     format: ArbitrageAdFormat.MediumRectangle,
   },
-  [PostWidgetPosition.Creator]: {
-    slot: ARBITRAGE_SLOT.railAfterCreator,
-    format: ArbitrageAdFormat.MediumRectangle,
-    hideOnPhone: true,
-  },
-  [PostWidgetPosition.Share]: {
-    slot: ARBITRAGE_SLOT.railAfterShare,
-    format: ArbitrageAdFormat.MediumRectangle,
-    hideOnPhone: true,
-  },
-  [PostWidgetPosition.Highlights]: {
-    slot: ARBITRAGE_SLOT.railAfterHighlights,
-    format: ArbitrageAdFormat.MediumRectangle,
-    hideOnPhone: true,
-  },
-  // Between "You might like" and the discussions, and the only unit that
-  // stays with the visitor: it pins under the fixed chrome and rides the rest
-  // of the scroll. Sticky is bounded by the containing block, which must be
-  // the rail itself — stretched to the article column's height — for the unit
-  // to have the whole page to travel; FurtherReading flattens to `contents`
-  // around it for exactly that reason, and any wrapper that generates a box
-  // here would cut the travel to that box. z-1 puts it over the widgets that
-  // scroll underneath, and the background keeps them from showing through the
-  // space the creative does not fill.
+  // In flow, not sticky: a sticky unit mid-rail slides over the widgets
+  // below it, and the rail's one sticky lives at its very end (slot 19),
+  // where nothing follows for it to cover.
   [PostWidgetPosition.SimilarPosts]: {
     slot: ARBITRAGE_SLOT.railBetweenFurtherReading,
     format: ArbitrageAdFormat.MediumRectangle,
-    className:
-      'laptop:sticky laptop:top-[calc(var(--sticky-header-offset)+1rem)] laptop:z-1 laptop:bg-background-default',
     hideOnPhone: true,
   },
 };
@@ -210,24 +192,7 @@ export function ArbitragePostContent({
           </div>
         )}
 
-        {/* MPU 1 beside the tags, date and cover rather than above them, so the
-            first ad shares the fold with real page furniture instead of
-            standing alone. The slot is first in the DOM because a phone stacks
-            the column and the brief puts the unit above the article, not below
-            it; from laptop `order-last` moves it to the right of the group.
-
-            The two halves are deliberately near equal — 336 for the unit
-            against 385 for the article's, out of the column's 745 — so the ad
-            reads as the cover's counterpart rather than as a tower beside it.
-            items-end puts their bottom edges on the same line. */}
-        <div className="mb-6 flex flex-col gap-6 laptop:flex-row laptop:items-end">
-          <ArbitrageAdSlot
-            slot={ARBITRAGE_SLOT.inlineMpu1}
-            format={ArbitrageAdFormat.Rectangle}
-            refreshes
-            className="laptop:order-last"
-          />
-
+        <div className="mb-6">
           <div className="min-w-0 flex-1">
             <PostTagList post={post} />
             <PostMetadata
@@ -276,13 +241,39 @@ export function ArbitragePostContent({
           </div>
         </div>
 
-        {!!post.contentHtml && (
-          <Markdown
-            className="my-6"
-            content={post.contentHtml}
-            appendTooltipTo={() => globalThis?.document?.body}
-          />
-        )}
+        {/* One MPU per BODY_CHARS_PER_AD of visible text, only ever between
+            top-level blocks — splitContentForAds cannot cut a paragraph, list
+            or code block in half. */}
+        {!!post.contentHtml &&
+          splitContentForAds(post.contentHtml, BODY_CHARS_PER_AD).map(
+            (chunk, index, chunks) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <React.Fragment key={index}>
+                <Markdown
+                  className="my-6"
+                  content={chunk}
+                  appendTooltipTo={() => globalThis?.document?.body}
+                />
+                {index < chunks.length - 1 && (
+                  <ArbitrageAdSlot
+                    slot={ARBITRAGE_SLOT.inBodyMpu}
+                    format={ArbitrageAdFormat.MediumRectangle}
+                  />
+                )}
+              </React.Fragment>
+            ),
+          )}
+
+        {/* Same block the post page shows: the questions that likely brought
+            an anonymous visitor here (the component self-hides for logged-in
+            users and question-less posts). */}
+        <PostAnsweredQuestions post={post} />
+
+        <ArbitrageAdSlot
+          slot={ARBITRAGE_SLOT.aboveCommentsMpu}
+          format={ArbitrageAdFormat.MediumRectangle}
+          className="my-6"
+        />
 
         {/* The production engagement block verbatim — counts, actions, share,
             sort control, composer and thread — so everything from here to the
@@ -292,11 +283,12 @@ export function ArbitragePostContent({
           post={post}
           onCopyLinkClick={onCopyPostLink}
           logOrigin={Origin.ArticlePage}
+          hideInternalAd
           interleaveEvery={COMMENTS_PER_INTERLEAVED_AD}
           renderInterleaved={() => (
             <ArbitrageAdSlot
-              slot={ARBITRAGE_SLOT.commentNative}
-              format={ArbitrageAdFormat.Native}
+              slot={ARBITRAGE_SLOT.commentMpu}
+              format={ArbitrageAdFormat.MediumRectangle}
             />
           )}
         />
@@ -311,8 +303,13 @@ export function ArbitragePostContent({
         className="!gap-2 pb-8 pt-4 tablet:border-l tablet:border-border-subtlest-tertiary"
         hideSignupWidget
         hideToc
+        hideAdWidget
         getRailAd={(position) => {
           const spec = RAIL_AD[position];
+
+          if (!spec) {
+            return null;
+          }
 
           return (
             <ArbitrageAdSlot
@@ -323,6 +320,18 @@ export function ArbitragePostContent({
             />
           );
         }}
+        // The page's only sticky unit, closing the rail: last in the column,
+        // so pinning under the fixed chrome can never slide it over content —
+        // the overlap the mid-rail sticky produced. Compliant as a publisher
+        // sticky at exactly 300px wide, desktop only, one per viewport.
+        trailing={
+          <ArbitrageAdSlot
+            slot={ARBITRAGE_SLOT.railBottomSticky}
+            format={ArbitrageAdFormat.HalfPage}
+            className="laptop:sticky laptop:top-[calc(var(--sticky-header-offset)+1rem)] laptop:z-1"
+            hideOnPhone
+          />
+        }
       />
     </PostContentContainerRaw>
   );

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -23,9 +23,9 @@ import { PostAnsweredQuestions } from '../PostAnsweredQuestions';
 import { splitContentForAds, splitTextForAds } from './splitContentForAds';
 import {
   ARBITRAGE_SLOT,
-  BODY_CHARS_PER_AD,
   COMMENTS_PER_INTERLEAVED_AD,
-  SUMMARY_CHARS_PER_AD,
+  CONTENT_CHARS_PER_AD,
+  MAX_CONTENT_ADS_PER_SECTION,
   TOP_LEADERBOARD_STICKY_MS,
 } from './slots';
 import { useTimedRelease } from './useTimedRelease';
@@ -102,13 +102,23 @@ export function ArbitragePostContent({
   // it carries the same MPU cadence as a hosted body.
   const summaryParts = useMemo(
     () =>
-      post.summary ? splitTextForAds(post.summary, SUMMARY_CHARS_PER_AD) : [],
+      post.summary
+        ? splitTextForAds(
+            post.summary,
+            CONTENT_CHARS_PER_AD,
+            MAX_CONTENT_ADS_PER_SECTION + 1,
+          )
+        : [],
     [post.summary],
   );
   const bodyChunks = useMemo(
     () =>
       post.contentHtml
-        ? splitContentForAds(post.contentHtml, BODY_CHARS_PER_AD)
+        ? splitContentForAds(
+            post.contentHtml,
+            CONTENT_CHARS_PER_AD,
+            MAX_CONTENT_ADS_PER_SECTION + 1,
+          )
         : [],
     [post.contentHtml],
   );
@@ -262,8 +272,8 @@ export function ArbitragePostContent({
 
         {/* One MPU per BODY_CHARS_PER_AD of visible text, only ever between
             top-level blocks — splitContentForAds cannot cut a paragraph, list
-            or code block in half. Section and occurrence ride the events so
-            analytics can tell the first in-body unit from the sixth. */}
+            or code block in half — and capped per section. Section and
+            occurrence ride the events for per-position analytics. */}
         {bodyChunks.map((chunk, index, chunks) => (
           // eslint-disable-next-line react/no-array-index-key
           <React.Fragment key={index}>

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import type { Post } from '../../../graphql/posts';
 import { isVideoPost } from '../../../graphql/posts';
@@ -20,7 +20,7 @@ import Markdown from '../../Markdown';
 import { ArbitrageAdFormat, ArbitrageAdSlot } from './ArbitrageAdSlot';
 import { ArbitrageTopLeaderboard } from './ArbitrageTopLeaderboard';
 import { PostAnsweredQuestions } from '../PostAnsweredQuestions';
-import { splitContentForAds } from './splitContentForAds';
+import { splitContentForAds, splitTextForAds } from './splitContentForAds';
 import {
   ARBITRAGE_SLOT,
   BODY_CHARS_PER_AD,
@@ -33,17 +33,10 @@ import { PostWidgets, PostWidgetPosition } from '../PostWidgets';
 import PostEngagements from '../PostEngagements';
 
 /**
- * One slot per real rail widget, in render order. The rail is the page's only
- * column with no article in it, so every widget there earns a unit; the two
- * that are already commercial (the house ad widget and the sponsored tools
- * card) have no position and so get none.
- *
- * Below laptop the rail stacks under the article rather than beside it, so
- * an unfiltered run lands every unit on a phone too — measured at roughly 40%
- * of page height against the Better Ads Standards' 30% mobile cap, and
- * Chrome's ad filter for a violation applies to the whole domain, direct-sold
- * inventory included. Only the first rail unit keeps its phone placement; the
- * rest are desktop-only, which brings the phone run well under the cap.
+ * The rail carries two in-flow units between its widgets, and the closing
+ * sticky half page arrives separately via PostWidgets' `trailing`. Only the
+ * first keeps a phone placement: below laptop the rail stacks under the
+ * article, where the body and comment cadences already carry the density.
  */
 const RAIL_AD: Partial<
   Record<
@@ -102,6 +95,22 @@ export function ArbitragePostContent({
     post,
   });
   const leaderboardReleased = useTimedRelease(TOP_LEADERBOARD_STICKY_MS);
+  // Memoised: the splits re-scan the whole text, and this component
+  // re-renders on comment sorting, hover state and auth resolution. The TLDR
+  // is main content here — for a scraped article it is the only content — so
+  // it carries the same MPU cadence as a hosted body.
+  const summaryParts = useMemo(
+    () =>
+      post.summary ? splitTextForAds(post.summary, BODY_CHARS_PER_AD) : [],
+    [post.summary],
+  );
+  const bodyChunks = useMemo(
+    () =>
+      post.contentHtml
+        ? splitContentForAds(post.contentHtml, BODY_CHARS_PER_AD)
+        : [],
+    [post.contentHtml],
+  );
 
   return (
     <PostContentContainerRaw className={className}>
@@ -184,13 +193,22 @@ export function ArbitragePostContent({
           />
         )}
 
-        {!!post.summary && (
-          <div className="mb-6 overflow-hidden text-text-secondary">
-            <p className="select-text break-words typo-markdown">
-              {post.summary}
-            </p>
-          </div>
-        )}
+        {summaryParts.map((part, index, parts) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={index}>
+            <div className="mb-6 overflow-hidden text-text-secondary">
+              <p className="select-text break-words typo-markdown">{part}</p>
+            </div>
+            {index < parts.length - 1 && (
+              <ArbitrageAdSlot
+                slot={ARBITRAGE_SLOT.inBodyMpu}
+                format={ArbitrageAdFormat.MediumRectangle}
+                className="my-6"
+                logExtra={{ section: 'summary', occurrence: index + 1 }}
+              />
+            )}
+          </React.Fragment>
+        ))}
 
         <div className="mb-6">
           <div className="min-w-0 flex-1">
@@ -243,26 +261,26 @@ export function ArbitragePostContent({
 
         {/* One MPU per BODY_CHARS_PER_AD of visible text, only ever between
             top-level blocks — splitContentForAds cannot cut a paragraph, list
-            or code block in half. */}
-        {!!post.contentHtml &&
-          splitContentForAds(post.contentHtml, BODY_CHARS_PER_AD).map(
-            (chunk, index, chunks) => (
-              // eslint-disable-next-line react/no-array-index-key
-              <React.Fragment key={index}>
-                <Markdown
-                  className="my-6"
-                  content={chunk}
-                  appendTooltipTo={() => globalThis?.document?.body}
-                />
-                {index < chunks.length - 1 && (
-                  <ArbitrageAdSlot
-                    slot={ARBITRAGE_SLOT.inBodyMpu}
-                    format={ArbitrageAdFormat.MediumRectangle}
-                  />
-                )}
-              </React.Fragment>
-            ),
-          )}
+            or code block in half. Section and occurrence ride the events so
+            analytics can tell the first in-body unit from the sixth. */}
+        {bodyChunks.map((chunk, index, chunks) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={index}>
+            <Markdown
+              className="my-6"
+              content={chunk}
+              appendTooltipTo={() => globalThis?.document?.body}
+            />
+            {index < chunks.length - 1 && (
+              <ArbitrageAdSlot
+                slot={ARBITRAGE_SLOT.inBodyMpu}
+                format={ArbitrageAdFormat.MediumRectangle}
+                className="my-6"
+                logExtra={{ section: 'body', occurrence: index + 1 }}
+              />
+            )}
+          </React.Fragment>
+        ))}
 
         {/* Same block the post page shows: the questions that likely brought
             an anonymous visitor here (the component self-hides for logged-in
@@ -278,17 +296,22 @@ export function ArbitragePostContent({
         {/* The production engagement block verbatim — counts, actions, share,
             sort control, composer and thread — so everything from here to the
             end of the discussion matches the live post page exactly. The only
-            addition is a native unit every few comments in a long thread. */}
+            addition is an MPU as a long thread grows. */}
         <PostEngagements
           post={post}
           onCopyLinkClick={onCopyPostLink}
           logOrigin={Origin.ArticlePage}
           hideInternalAd
           interleaveEvery={COMMENTS_PER_INTERLEAVED_AD}
-          renderInterleaved={() => (
+          renderInterleaved={(occurrence) => (
+            // Phone-hidden until the density precondition in slots.ts is
+            // satisfied: a repeating unit, and the phone figure was measured
+            // without it.
             <ArbitrageAdSlot
               slot={ARBITRAGE_SLOT.commentMpu}
               format={ArbitrageAdFormat.MediumRectangle}
+              hideOnPhone
+              logExtra={{ occurrence }}
             />
           )}
         />

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -25,6 +25,7 @@ import {
   ARBITRAGE_SLOT,
   BODY_CHARS_PER_AD,
   COMMENTS_PER_INTERLEAVED_AD,
+  SUMMARY_CHARS_PER_AD,
   TOP_LEADERBOARD_STICKY_MS,
 } from './slots';
 import { useTimedRelease } from './useTimedRelease';
@@ -101,7 +102,7 @@ export function ArbitragePostContent({
   // it carries the same MPU cadence as a hosted body.
   const summaryParts = useMemo(
     () =>
-      post.summary ? splitTextForAds(post.summary, BODY_CHARS_PER_AD) : [],
+      post.summary ? splitTextForAds(post.summary, SUMMARY_CHARS_PER_AD) : [],
     [post.summary],
   );
   const bodyChunks = useMemo(

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -35,9 +35,11 @@ import PostEngagements from '../PostEngagements';
 
 /**
  * The rail carries two in-flow units between its widgets, and the closing
- * sticky half page arrives separately via PostWidgets' `trailing`. Only the
- * first keeps a phone placement: below laptop the rail stacks under the
- * article, where the body and comment cadences already carry the density.
+ * sticky half page arrives separately via PostWidgets' `trailing`. None of
+ * them keep a phone placement: below laptop the rail stacks under the
+ * article, and the phone's density budget is spent on the leaderboard, the
+ * first in-content unit and the above-comments MPU (~17-22% of a scraped
+ * page against the Better Ads 30% cap).
  */
 const RAIL_AD: Partial<
   Record<
@@ -53,6 +55,7 @@ const RAIL_AD: Partial<
   [PostWidgetPosition.Source]: {
     slot: ARBITRAGE_SLOT.railAfterSource,
     format: ArbitrageAdFormat.MediumRectangle,
+    hideOnPhone: true,
   },
   // In flow, not sticky: a sticky unit mid-rail slides over the widgets
   // below it, and the rail's one sticky lives at its very end (slot 19),
@@ -211,10 +214,14 @@ export function ArbitragePostContent({
               <p className="select-text break-words typo-markdown">{part}</p>
             </div>
             {index < parts.length - 1 && (
+              // Phone density policy: only the page's first in-content unit
+              // keeps a phone placement — the 250-char cadence would stack
+              // the rest into a wall on a small screen.
               <ArbitrageAdSlot
                 slot={ARBITRAGE_SLOT.inBodyMpu}
                 format={ArbitrageAdFormat.MediumRectangle}
                 className="my-6"
+                hideOnPhone={index > 0}
                 logExtra={{ section: 'summary', occurrence: index + 1 }}
               />
             )}
@@ -287,6 +294,7 @@ export function ArbitragePostContent({
                 slot={ARBITRAGE_SLOT.inBodyMpu}
                 format={ArbitrageAdFormat.MediumRectangle}
                 className="my-6"
+                hideOnPhone={summaryParts.length > 1 || index > 0}
                 logExtra={{ section: 'body', occurrence: index + 1 }}
               />
             )}

--- a/packages/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard.tsx
@@ -46,10 +46,23 @@ export function ArbitrageTopLeaderboard({
           'z-2 laptop:sticky laptop:top-[var(--sticky-header-offset)]',
       )}
     >
+      {/* Two breakpoint twins of one unit: the phone requests a fixed
+          320x100 (a responsive request can answer with expandable video —
+          half a pinned phone screen), tablet+ keeps the responsive 728x90.
+          Neither is eager: an eager push from a display:none twin would
+          initialise the visible one out of order, and both sit at the top of
+          the page where the intersection observer fires on first paint
+          anyway. A hidden ins never intersects, so exactly one requests. */}
+      <ArbitrageAdSlot
+        slot={ARBITRAGE_SLOT.topLeaderboardPhone}
+        format={ArbitrageAdFormat.Leaderboard}
+        className="tablet:hidden"
+        refreshes
+      />
       <ArbitrageAdSlot
         slot={ARBITRAGE_SLOT.topLeaderboard}
         format={ArbitrageAdFormat.Leaderboard}
-        eager
+        hideOnPhone
         refreshes
       />
     </div>

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -22,6 +22,13 @@ export const ARBITRAGE_SLOT = {
   aboveCommentsMpu: 18,
   /** Half page closing the rail — the page's only sticky unit. */
   railBottomSticky: 19,
+  /**
+   * The top leaderboard's phone twin: the same AdSense unit requested at a
+   * fixed 320x100. A responsive request can come back as expandable video,
+   * which inside the phone-sticky header block pinned half the screen; a
+   * fixed-size request can only return its exact size.
+   */
+  topLeaderboardPhone: 20,
 } as const;
 
 /*
@@ -57,10 +64,10 @@ export const TOP_LEADERBOARD_STICKY_MS = 10_000;
 
 /**
  * A long thread gets an MPU each time this many comments have gone by —
- * replies included, every comment counts, 8 flat (product call, Aug 25).
- * Short threads never reach the interval, so they stay ad-free.
+ * replies included, every comment counts (product call, Aug 25; interval
+ * revised 8 → 6 the same day). Short threads stay ad-free.
  */
-export const COMMENTS_PER_INTERLEAVED_AD = 8;
+export const COMMENTS_PER_INTERLEAVED_AD = 6;
 
 /**
  * Visible characters of content between in-content MPUs — 250, per Nick's
@@ -94,6 +101,12 @@ export const MAX_CONTENT_ADS_PER_SECTION = 4;
  */
 export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   [ARBITRAGE_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
+  [ARBITRAGE_SLOT.topLeaderboardPhone]: {
+    id: '9942870945',
+    type: 'display',
+    width: 320,
+    height: 100,
+  },
   // The three MPU placements below share existing Display units while the
   // dedicated ones don't exist: Google's per-unit reporting blends them, but
   // our first-party events split by slot number, so per-placement RPM stays

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -63,22 +63,22 @@ export const TOP_LEADERBOARD_STICKY_MS = 10_000;
 export const COMMENTS_PER_INTERLEAVED_AD = 8;
 
 /**
- * Visible characters of article body between in-body MPUs — ~250 words, the
- * partner brief's cadence. Content-proportional by construction: a phone
- * renders this many characters far taller than the 250px unit, so the
- * density cap holds at any article length.
+ * Visible characters of content between in-content MPUs — 250, per Nick's
+ * confirmed spec (characters, not words; re-confirmed Aug 25 after the
+ * words reading shipped first). At this cadence density is carried by
+ * MAX_CONTENT_ADS_PER_SECTION below, not by the interval.
  */
-export const BODY_CHARS_PER_AD = 1500;
+export const CONTENT_CHARS_PER_AD = 250;
 
 /**
- * The TLDR's own cadence (~100 words). A summary is dense by construction,
- * and the 250-word figure was written for article bodies: at 1500 a typical
- * 150-200 word TLDR carried nothing at all (product call, Aug 25: a
- * ~160-word TLDR should carry one unit — calibrated against a real one).
- * With the splitter's no-sliver rule the first ad appears from roughly a
- * 150-word summary, breaking about two-thirds through at a sentence end.
+ * Hard cap per section (TLDR, body): 250 characters is ~3 lines of rendered
+ * text per 282px unit, so an uncapped long body would be a wall of ads —
+ * the exact shape the Better Ads 30% mobile cap and AdSense's low-value
+ * policy act on, both of which punish the whole domain. The balanced
+ * splitters spread the capped units evenly through the section instead of
+ * front-loading them.
  */
-export const SUMMARY_CHARS_PER_AD = 600;
+export const MAX_CONTENT_ADS_PER_SECTION = 4;
 
 /**
  * The AdSense units behind each slot, keyed by slot number. Deliberately in
@@ -104,10 +104,9 @@ export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   // Phone density, the written gate the previous map kept slot 7 behind:
   // - The comment MPU stays hideOnPhone in the template until a long-thread
   //   phone measurement with the interval live says otherwise.
-  // - The in-body MPUs are phone-visible by construction, not by measurement:
-  //   one 250px unit per BODY_CHARS_PER_AD (1500) visible characters is
-  //   ~1100px of rendered text per unit at phone width — under 20% added
-  //   density at any article length, against the Better Ads 30% cap.
+  // - The in-content MPUs are phone-visible but capped: at the 250-char
+  //   cadence the interval no longer bounds density, so
+  //   MAX_CONTENT_ADS_PER_SECTION does — see its comment for the math.
   [ARBITRAGE_SLOT.commentMpu]: { id: '6921226982', type: 'display' },
   [ARBITRAGE_SLOT.railAfterSource]: { id: '5249052667', type: 'display' },
   [ARBITRAGE_SLOT.railBetweenFurtherReading]: {

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -71,6 +71,16 @@ export const COMMENTS_PER_INTERLEAVED_AD = 8;
 export const BODY_CHARS_PER_AD = 1500;
 
 /**
+ * The TLDR's own cadence (~100 words). A summary is dense by construction,
+ * and the 250-word figure was written for article bodies: at 1500 a typical
+ * 150-200 word TLDR carried nothing at all (product call, Aug 25: a
+ * ~160-word TLDR should carry one unit — calibrated against a real one).
+ * With the splitter's no-sliver rule the first ad appears from roughly a
+ * 150-word summary, breaking about two-thirds through at a sentence end.
+ */
+export const SUMMARY_CHARS_PER_AD = 600;
+
+/**
  * The AdSense units behind each slot, keyed by slot number. Deliberately in
  * code rather than remote config: unit ids are public (visible in the page
  * source of any live page) and stable after setup, and as a GrowthBook JSON

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -56,10 +56,11 @@ export const ARBITRAGE_SLOT = {
 export const TOP_LEADERBOARD_STICKY_MS = 10_000;
 
 /**
- * A long thread gets an MPU after every this many comments (the expert brief
- * says 6-8). Short threads never reach the interval, so they stay ad-free.
+ * A long thread gets an MPU each time this many comments have gone by —
+ * replies included, every comment counts, 8 flat (product call, Aug 25).
+ * Short threads never reach the interval, so they stay ad-free.
  */
-export const COMMENTS_PER_INTERLEAVED_AD = 7;
+export const COMMENTS_PER_INTERLEAVED_AD = 8;
 
 /**
  * Visible characters of article body between in-body MPUs — ~250 words, the
@@ -89,6 +90,14 @@ export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   // queryable in ClickHouse.
   // TODO(chris): create dedicated Display units (read_s17_in_body,
   // read_s18_above_comments) and swap the ids for clean AdSense-side rows.
+  //
+  // Phone density, the written gate the previous map kept slot 7 behind:
+  // - The comment MPU stays hideOnPhone in the template until a long-thread
+  //   phone measurement with the interval live says otherwise.
+  // - The in-body MPUs are phone-visible by construction, not by measurement:
+  //   one 250px unit per BODY_CHARS_PER_AD (1500) visible characters is
+  //   ~1100px of rendered text per unit at phone width — under 20% added
+  //   density at any article length, against the Better Ads 30% cap.
   [ARBITRAGE_SLOT.commentMpu]: { id: '6921226982', type: 'display' },
   [ARBITRAGE_SLOT.railAfterSource]: { id: '5249052667', type: 'display' },
   [ARBITRAGE_SLOT.railBetweenFurtherReading]: {

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -10,27 +10,27 @@ import type { AdsenseSlots } from '../../../features/monetization/adsense';
 export const ARBITRAGE_SLOT = {
   /** Leaderboard above the article. Sticks while scrolling, then releases. */
   topLeaderboard: 2,
-  /** Medium rectangle beside the tags, date and cover image. */
-  inlineMpu1: 3,
-  /** Rail unit after the author card. */
-  railAfterCreator: 4,
-  /** Rail unit after the share bar. */
-  railAfterShare: 5,
-  /** Rail unit after the highlights widget. */
-  railAfterHighlights: 6,
-  /** Native unit, repeated through a long comment thread. */
-  commentNative: 7,
+  /** MPU repeated through a long comment thread. */
+  commentMpu: 7,
   /** "MPU 1" in the brief: first rail unit, under the source card. */
   railAfterSource: 11,
-  /** Sticky rail unit after the further reading widget. */
+  /** Second rail unit, after the further reading widget. */
   railBetweenFurtherReading: 12,
+  /** MPU repeated through the article body, one per BODY_CHARS_PER_AD. */
+  inBodyMpu: 17,
+  /** MPU directly above the comment section. */
+  aboveCommentsMpu: 18,
+  /** Half page closing the rail — the page's only sticky unit. */
+  railBottomSticky: 19,
 } as const;
 
 /*
- * Slot numbers 1, 8, 9, 10 and 13 are retired rather than reused: the sidebar
- * unit, the two closing multiplex grids, the half-page rail tower and the
- * custom floating leaderboard were all dropped, and their AdSense reporting
- * rows stay readable only while no other placement inherits the number.
+ * Slot numbers 1, 3, 4, 5, 6, 8, 9, 10 and 13 are retired rather than reused:
+ * the sidebar unit, the MPU beside the cover, the three extra rail units, the
+ * two closing multiplex grids, the half-page rail tower and the custom
+ * floating leaderboard were all dropped, and their AdSense reporting rows
+ * stay readable only while no other placement inherits the number. 15 and 16
+ * belong to the organic post page below.
  *
  * The bottom leaderboard is Google's Anchor format now, not a slot in this
  * map: a publisher-implemented sticky is capped at 300px wide and desktop
@@ -56,10 +56,18 @@ export const ARBITRAGE_SLOT = {
 export const TOP_LEADERBOARD_STICKY_MS = 10_000;
 
 /**
- * A long thread gets a native unit after every this many comments. Short
- * threads never reach the interval, so they stay entirely ad-free.
+ * A long thread gets an MPU after every this many comments (the expert brief
+ * says 6-8). Short threads never reach the interval, so they stay ad-free.
  */
-export const COMMENTS_PER_INTERLEAVED_AD = 5;
+export const COMMENTS_PER_INTERLEAVED_AD = 7;
+
+/**
+ * Visible characters of article body between in-body MPUs — ~250 words, the
+ * partner brief's cadence. Content-proportional by construction: a phone
+ * renders this many characters far taller than the 250px unit, so the
+ * density cap holds at any article length.
+ */
+export const BODY_CHARS_PER_AD = 1500;
 
 /**
  * The AdSense units behind each slot, keyed by slot number. Deliberately in
@@ -75,37 +83,28 @@ export const COMMENTS_PER_INTERLEAVED_AD = 5;
  */
 export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   [ARBITRAGE_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  // read_s03 (9651332107) is an in-article unit, so it is fluid: it ignored
-  // both the shape and an explicit 300x250 on the <ins> and kept answering the
-  // placement beside the cover with a card twice the cover's height. Pointing
-  // it at a responsive Display unit is what actually binds the shape — at the
-  // cost of blending its reporting with the rail unit it borrows.
-  // TODO(chris): create a dedicated read_s03 Display unit and swap the id back
-  // to get per-placement RPM.
-  [ARBITRAGE_SLOT.inlineMpu1]: { id: '6921226982', type: 'display' },
-  // TODO(chris): create the three new rail units (suggested names
-  // read_s04_rail_creator, read_s05_rail_share, read_s06_rail_highlights) as
-  // Display 300x250. They stay collapsed until their ids are filled in.
-  [ARBITRAGE_SLOT.railAfterCreator]: { id: '', type: 'display' },
-  [ARBITRAGE_SLOT.railAfterShare]: { id: '', type: 'display' },
-  [ARBITRAGE_SLOT.railAfterHighlights]: { id: '', type: 'display' },
-  // TODO(chris): layoutKey from the read_s07_comment_native "Get code" snippet
-  // (data-ad-layout-key). The slot stays collapsed until it is filled in.
-  //
-  // PRECONDITIONS on filling this in — this comment is the gate, since the
-  // workflow is "ship reviewed once, switch on by editing this map":
-  // 1. Ad label: DONE in code — ProgrammaticAd renders the policy-permitted
-  //    "Advertisements" caption above every inFeed unit, so an unlabeled
-  //    native between comments cannot ship by omission.
-  // 2. Re-measure phone ad density on a long thread with the interval live.
-  //    The ~27% figure was measured with this slot inert, it is the only
-  //    repeating slot on the page, and Chrome's Better Ads filter applies to
-  //    the whole domain, direct-sold inventory included.
-  [ARBITRAGE_SLOT.commentNative]: { id: '', type: 'inFeed', layoutKey: '' },
+  // The three MPU placements below share existing Display units while the
+  // dedicated ones don't exist: Google's per-unit reporting blends them, but
+  // our first-party events split by slot number, so per-placement RPM stays
+  // queryable in ClickHouse.
+  // TODO(chris): create dedicated Display units (read_s17_in_body,
+  // read_s18_above_comments) and swap the ids for clean AdSense-side rows.
+  [ARBITRAGE_SLOT.commentMpu]: { id: '6921226982', type: 'display' },
   [ARBITRAGE_SLOT.railAfterSource]: { id: '5249052667', type: 'display' },
   [ARBITRAGE_SLOT.railBetweenFurtherReading]: {
     id: '6921226982',
     type: 'display',
+  },
+  [ARBITRAGE_SLOT.inBodyMpu]: { id: '6921226982', type: 'display' },
+  [ARBITRAGE_SLOT.aboveCommentsMpu]: { id: '5249052667', type: 'display' },
+  // read_s10's fixed 300x600, back as the rail's closing unit. Compliant as a
+  // publisher sticky: 300px wide, desktop only, and the page's ONLY sticky —
+  // AdSense allows exactly one per viewport.
+  [ARBITRAGE_SLOT.railBottomSticky]: {
+    id: '4307400883',
+    type: 'display',
+    width: 300,
+    height: 600,
   },
 };
 

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
@@ -89,6 +89,20 @@ describe('splitTextForAds', () => {
     expect(parts).toEqual([first, second]);
   });
 
+  it('breaks at the sentence end nearest the midpoint, not the first past a threshold', () => {
+    const sentences = [
+      `${'a'.repeat(100)}.`,
+      `${'b'.repeat(100)}.`,
+      `${'c'.repeat(100)}.`,
+      `${'d'.repeat(100)}.`,
+    ].join(' ');
+    const parts = splitTextForAds(sentences, 200);
+
+    // Two parts of two sentences each — a greedy threshold would cut 3/1.
+    expect(parts).toHaveLength(2);
+    expect(parts[0].endsWith(`${'b'.repeat(100)}.`)).toBe(true);
+  });
+
   it('never ends on a sliver', () => {
     const text = `${'a'.repeat(260)}. ${'b'.repeat(30)}`;
     expect(splitTextForAds(text, 250)).toHaveLength(1);

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
@@ -103,8 +103,42 @@ describe('splitTextForAds', () => {
     expect(parts[0].endsWith(`${'b'.repeat(100)}.`)).toBe(true);
   });
 
+  it('never places an ad within the cadence of the previous one', () => {
+    // Sentence ends at ~130 and ~380: nearest-to-midpoint alone would pick
+    // 130, putting an ad after half a cadence of text.
+    const text = `${'a'.repeat(130)}. ${'b'.repeat(250)}. ${'c'.repeat(300)}`;
+    const parts = splitTextForAds(text, 250);
+
+    parts.slice(0, -1).forEach((part) => {
+      expect(part.length).toBeGreaterThanOrEqual(250);
+    });
+  });
+
   it('never ends on a sliver', () => {
-    const text = `${'a'.repeat(260)}. ${'b'.repeat(30)}`;
-    expect(splitTextForAds(text, 250)).toHaveLength(1);
+    // 720 chars rounds to a 3-part target; the only boundary near the last
+    // even point would leave a 20-char tail, which the floor rejects.
+    const text = `${'a'.repeat(300)}. ${'b'.repeat(400)}. ${'c'.repeat(20)}`;
+    const parts = splitTextForAds(text, 250);
+
+    expect(parts.length).toBeGreaterThan(1);
+    expect(parts[parts.length - 1].length).toBeGreaterThanOrEqual(125);
+  });
+
+  it('caps the part count at maxParts', () => {
+    const text = Array.from({ length: 10 }, () => `${'a'.repeat(250)}.`).join(
+      ' ',
+    );
+    expect(splitTextForAds(text, 250, 3)).toHaveLength(3);
+  });
+
+  it('falls back to word boundaries without sentence punctuation', () => {
+    const text = Array.from({ length: 120 }, () => 'word').join(' ');
+    const parts = splitTextForAds(text, 250);
+
+    expect(parts.length).toBeGreaterThan(1);
+    parts.forEach((part) => {
+      expect(part.startsWith('word')).toBe(true);
+      expect(part.endsWith('word')).toBe(true);
+    });
   });
 });

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
@@ -1,4 +1,4 @@
-import { splitContentForAds } from './splitContentForAds';
+import { splitContentForAds, splitTextForAds } from './splitContentForAds';
 
 const para = (chars: number, label: string): string =>
   `<p>${label.repeat(Math.ceil(chars / label.length)).slice(0, chars)}</p>`;
@@ -66,5 +66,31 @@ describe('splitContentForAds', () => {
 
     expect(chunks.join('')).toBe(html);
     expect(chunks.length).toBeGreaterThan(1);
+  });
+  it('ignores tags inside HTML comments when balancing depth', () => {
+    const html = `<!-- <div> -->${para(300, 'a')}${para(300, 'b')}`;
+    const chunks = splitContentForAds(html, 250);
+
+    expect(chunks.join('')).toBe(html);
+    expect(chunks.length).toBe(2);
+  });
+});
+
+describe('splitTextForAds', () => {
+  it('keeps a short TLDR whole', () => {
+    expect(splitTextForAds('short summary.', 250)).toEqual(['short summary.']);
+  });
+
+  it('breaks a long TLDR at a sentence end past the threshold', () => {
+    const first = `${'a'.repeat(260)}.`;
+    const second = 'b'.repeat(300);
+    const parts = splitTextForAds(`${first} ${second}`, 250);
+
+    expect(parts).toEqual([first, second]);
+  });
+
+  it('never ends on a sliver', () => {
+    const text = `${'a'.repeat(260)}. ${'b'.repeat(30)}`;
+    expect(splitTextForAds(text, 250)).toHaveLength(1);
   });
 });

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.spec.ts
@@ -1,0 +1,70 @@
+import { splitContentForAds } from './splitContentForAds';
+
+const para = (chars: number, label: string): string =>
+  `<p>${label.repeat(Math.ceil(chars / label.length)).slice(0, chars)}</p>`;
+
+describe('splitContentForAds', () => {
+  it('returns short content as a single chunk', () => {
+    const html = para(100, 'a');
+    expect(splitContentForAds(html, 300)).toEqual([html]);
+  });
+
+  it('splits only at top-level block boundaries', () => {
+    const first = para(300, 'a');
+    const second = para(300, 'b');
+    const chunks = splitContentForAds(first + second, 250);
+
+    expect(chunks).toEqual([first, second]);
+  });
+
+  it('never cuts inside a nested structure', () => {
+    const list = `<ul><li>${'x'.repeat(300)}</li><li>${'y'.repeat(
+      300,
+    )}</li></ul>`;
+    const after = para(300, 'z');
+    const chunks = splitContentForAds(list + after, 250);
+
+    // The list crosses the threshold internally but closes as one unit.
+    expect(chunks).toEqual([list, after]);
+  });
+
+  it('treats code blocks as unsplittable units', () => {
+    const code = `<pre><code>${'if (x) {\n}\n'.repeat(40)}</code></pre>`;
+    const after = para(300, 'a');
+    const chunks = splitContentForAds(code + after, 250);
+
+    expect(chunks).toHaveLength(2);
+    expect(chunks[0]).toBe(code);
+  });
+
+  it('does not let void elements corrupt the depth count', () => {
+    const withImages = `<p>${'a'.repeat(150)}<img src="x.png"><br>${'b'.repeat(
+      150,
+    )}</p>`;
+    const after = para(300, 'c');
+
+    expect(splitContentForAds(withImages + after, 250)).toEqual([
+      withImages,
+      after,
+    ]);
+  });
+
+  it('merges a trailing sliver into the previous chunk', () => {
+    const first = para(300, 'a');
+    const sliver = para(40, 'b');
+    const chunks = splitContentForAds(first + sliver, 250);
+
+    // An ad before one stray line reads as the page ending on an ad.
+    expect(chunks).toEqual([first + sliver]);
+  });
+
+  it('keeps every byte of the input across the chunks', () => {
+    const html =
+      `${para(400, 'a')}<blockquote>${'q'.repeat(300)}</blockquote>` +
+      `<h2>Heading</h2>${para(400, 'b')}`;
+    const chunks = splitContentForAds(html, 250);
+
+    expect(chunks.join('')).toBe(html);
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
@@ -28,20 +28,22 @@ const visibleLength = (text: string): number =>
     .trim().length;
 
 /**
- * Splits rendered article HTML into chunks of at least `minChars` of visible
- * text, cutting only where a top-level block element closes — an ad between
- * chunks can never land inside a paragraph, list, blockquote or code block.
- * A short tail is merged into the chunk before it, so the article never ends
- * on an ad followed by a stray line.
+ * Splits rendered article HTML into chunks for in-content ads, cutting only
+ * where a top-level block element closes — an ad can never land inside a
+ * paragraph, list, blockquote or code block. Like the TLDR splitter, cuts
+ * aim at even split points across the whole article (no front-loading) and
+ * carry the cadence as a hard floor: never within `minChars` of visible text
+ * of the previous cut, never with less than half a cadence after them.
  */
 export function splitContentForAds(
   html: string,
   minChars: number,
   maxParts = Infinity,
 ): string[] {
-  const chunks: string[] = [];
+  // First pass: every depth-0 block boundary with the cumulative visible
+  // text before it.
+  const candidates: Array<{ index: number; visible: number }> = [];
   let depth = 0;
-  let chunkStart = 0;
   let cursor = 0;
   let visible = 0;
 
@@ -61,10 +63,8 @@ export function splitContentForAds(
     const name = rawName.toLowerCase();
     if (token.startsWith('</')) {
       depth = Math.max(0, depth - 1);
-      if (depth === 0 && visible >= minChars) {
-        chunks.push(html.slice(chunkStart, cursor));
-        chunkStart = cursor;
-        visible = 0;
+      if (depth === 0) {
+        candidates.push({ index: cursor, visible });
       }
     } else if (!VOID_ELEMENTS.has(name) && !token.endsWith('/>')) {
       depth += 1;
@@ -72,37 +72,58 @@ export function splitContentForAds(
 
     match = TAG_RE.exec(html);
   }
+  visible += visibleLength(html.slice(cursor));
 
-  const tail = html.slice(chunkStart);
-  if (tail.trim()) {
-    chunks.push(tail);
+  const total = visible;
+  const count = Math.min(Math.max(1, Math.round(total / minChars)), maxParts);
+
+  if (count === 1 || !candidates.length) {
+    return [html];
   }
 
-  // Density cap: everything past the last allowed boundary folds into the
-  // final chunk rather than earning more ads.
-  while (chunks.length > maxParts) {
-    const overflow = chunks.pop() as string;
-    chunks[chunks.length - 1] += overflow;
-  }
+  const chunks: string[] = [];
+  let fromIndex = 0;
+  let fromVisible = 0;
+  for (let i = 1; i < count; i += 1) {
+    const ideal = (total * i) / count;
+    // Per-iteration captures: the closures must not reference the mutable
+    // cursors (no-loop-func).
+    const afterIndex = fromIndex;
+    const floorFrom = fromVisible;
+    const cut = candidates
+      .filter(
+        (candidate) =>
+          candidate.index > afterIndex &&
+          candidate.visible >= floorFrom + minChars &&
+          candidate.visible <= total - minChars / 2,
+      )
+      .reduce<{ index: number; visible: number } | null>(
+        (best, candidate) =>
+          !best ||
+          Math.abs(candidate.visible - ideal) < Math.abs(best.visible - ideal)
+            ? candidate
+            : best,
+        null,
+      );
 
-  // The last chunk earns its preceding ad only when it carries real content.
-  if (chunks.length > 1) {
-    const last = chunks[chunks.length - 1];
-    if (visibleLength(last.replace(TAG_RE, ' ')) < minChars / 2) {
-      chunks[chunks.length - 2] += last;
-      chunks.pop();
+    if (!cut) {
+      break;
     }
+    chunks.push(html.slice(fromIndex, cut.index));
+    fromIndex = cut.index;
+    fromVisible = cut.visible;
   }
 
+  chunks.push(html.slice(fromIndex));
   return chunks;
 }
 
 /**
- * The TLDR's cadence works by balance, not by greedy threshold: the part
- * count comes from the target size, and each break lands on the sentence end
- * nearest to its even split point — one ad in a two-part summary sits at the
- * middle sentence, not wherever the threshold first ran out. Falls back to
- * word boundaries for text without sentence punctuation.
+ * The TLDR's cadence: the part count comes from the target size and each
+ * break lands on the sentence end nearest to its even split point, with the
+ * cadence as a hard minimum between ads — a break can aim at balance but
+ * never land within `targetChars` of the previous one. Falls back to word
+ * boundaries for text without sentence punctuation.
  */
 export function splitTextForAds(
   text: string,
@@ -139,10 +160,15 @@ export function splitTextForAds(
     // Per-iteration capture: the closures below must not reference the
     // mutable `start` (no-loop-func).
     const from = start;
-    // Nearest boundary to the even split point, strictly inside the
-    // remaining text so a cut can never produce an empty part.
+    // Nearest boundary to the even split point, with the cadence as a hard
+    // floor on both sides: never within targetChars of the previous ad
+    // (nearest-snapping alone pulled a break to ~130 chars) and never so
+    // late that less than half a cadence of text would follow it.
     const cut = boundaries
-      .filter((position) => position > from && position < total - 1)
+      .filter(
+        (position) =>
+          position >= from + targetChars && position <= total - targetChars / 2,
+      )
       .reduce(
         (best, position) =>
           Math.abs(position - ideal) < Math.abs(best - ideal) ? position : best,

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
@@ -1,4 +1,7 @@
-const TAG_RE = /<\/?([a-zA-Z][\w-]*)(?:[^>'"]|"[^"]*"|'[^']*')*?\/?>/g;
+// Comments first, so a tag inside `<!-- <div> -->` can never touch the
+// depth count; the alternation consumes the whole comment as one token.
+const TAG_RE =
+  /<!--[\s\S]*?-->|<\/?([a-zA-Z][\w-]*)(?:[^>'"]|"[^"]*"|'[^']*')*?\/?>/g;
 
 // Elements that never take a closing tag, so an opening token must not
 // increase the nesting depth.
@@ -45,6 +48,12 @@ export function splitContentForAds(html: string, minChars: number): string[] {
     visible += visibleLength(html.slice(cursor, match.index));
     cursor = match.index + token.length;
 
+    if (token.startsWith('<!--')) {
+      match = TAG_RE.exec(html);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
     const name = rawName.toLowerCase();
     if (token.startsWith('</')) {
       depth = Math.max(0, depth - 1);
@@ -75,4 +84,30 @@ export function splitContentForAds(html: string, minChars: number): string[] {
   }
 
   return chunks;
+}
+
+/**
+ * Same cadence for plain text (the TLDR): parts of at least `minChars`,
+ * broken at a sentence end where one lands within reach, else at a word
+ * boundary — and no trailing sliver, same as the HTML splitter.
+ */
+export function splitTextForAds(text: string, minChars: number): string[] {
+  const parts: string[] = [];
+  let rest = text;
+
+  while (rest.length > minChars * 1.5) {
+    const window = rest.slice(minChars, minChars + 200);
+    const sentence = window.search(/[.!?]\s/);
+    const word = window.search(/\s/);
+    const offset = sentence >= 0 ? sentence + 1 : Math.max(word, 0);
+    const cut = minChars + offset;
+    parts.push(rest.slice(0, cut).trimEnd());
+    rest = rest.slice(cut).trimStart();
+  }
+
+  if (rest.trim()) {
+    parts.push(rest);
+  }
+
+  return parts;
 }

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
@@ -34,7 +34,11 @@ const visibleLength = (text: string): number =>
  * A short tail is merged into the chunk before it, so the article never ends
  * on an ad followed by a stray line.
  */
-export function splitContentForAds(html: string, minChars: number): string[] {
+export function splitContentForAds(
+  html: string,
+  minChars: number,
+  maxParts = Infinity,
+): string[] {
   const chunks: string[] = [];
   let depth = 0;
   let chunkStart = 0;
@@ -74,6 +78,13 @@ export function splitContentForAds(html: string, minChars: number): string[] {
     chunks.push(tail);
   }
 
+  // Density cap: everything past the last allowed boundary folds into the
+  // final chunk rather than earning more ads.
+  while (chunks.length > maxParts) {
+    const overflow = chunks.pop() as string;
+    chunks[chunks.length - 1] += overflow;
+  }
+
   // The last chunk earns its preceding ad only when it carries real content.
   if (chunks.length > 1) {
     const last = chunks[chunks.length - 1];
@@ -93,9 +104,16 @@ export function splitContentForAds(html: string, minChars: number): string[] {
  * middle sentence, not wherever the threshold first ran out. Falls back to
  * word boundaries for text without sentence punctuation.
  */
-export function splitTextForAds(text: string, targetChars: number): string[] {
+export function splitTextForAds(
+  text: string,
+  targetChars: number,
+  maxParts = Infinity,
+): string[] {
   const total = text.length;
-  const count = Math.max(1, Math.round(total / targetChars));
+  const count = Math.min(
+    Math.max(1, Math.round(total / targetChars)),
+    maxParts,
+  );
 
   if (count === 1) {
     return [text];

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
@@ -87,27 +87,54 @@ export function splitContentForAds(html: string, minChars: number): string[] {
 }
 
 /**
- * Same cadence for plain text (the TLDR): parts of at least `minChars`,
- * broken at a sentence end where one lands within reach, else at a word
- * boundary — and no trailing sliver, same as the HTML splitter.
+ * The TLDR's cadence works by balance, not by greedy threshold: the part
+ * count comes from the target size, and each break lands on the sentence end
+ * nearest to its even split point — one ad in a two-part summary sits at the
+ * middle sentence, not wherever the threshold first ran out. Falls back to
+ * word boundaries for text without sentence punctuation.
  */
-export function splitTextForAds(text: string, minChars: number): string[] {
+export function splitTextForAds(text: string, targetChars: number): string[] {
+  const total = text.length;
+  const count = Math.max(1, Math.round(total / targetChars));
+
+  if (count === 1) {
+    return [text];
+  }
+
+  const boundaryAfter = (re: RegExp): number[] => {
+    const positions: number[] = [];
+    let match = re.exec(text);
+    while (match) {
+      positions.push(match.index + match[0].length);
+      match = re.exec(text);
+    }
+    return positions;
+  };
+
+  const sentenceEnds = boundaryAfter(/[.!?]["')\]]?\s+/g);
+  const boundaries = sentenceEnds.length ? sentenceEnds : boundaryAfter(/\s+/g);
+
   const parts: string[] = [];
-  let rest = text;
+  let start = 0;
+  for (let i = 1; i < count; i += 1) {
+    const ideal = Math.round((total * i) / count);
+    // Nearest boundary to the even split point, strictly inside the
+    // remaining text so a cut can never produce an empty part.
+    const cut = boundaries
+      .filter((position) => position > start && position < total - 1)
+      .reduce(
+        (best, position) =>
+          Math.abs(position - ideal) < Math.abs(best - ideal) ? position : best,
+        -Infinity,
+      );
 
-  while (rest.length > minChars * 1.5) {
-    const window = rest.slice(minChars, minChars + 200);
-    const sentence = window.search(/[.!?]\s/);
-    const word = window.search(/\s/);
-    const offset = sentence >= 0 ? sentence + 1 : Math.max(word, 0);
-    const cut = minChars + offset;
-    parts.push(rest.slice(0, cut).trimEnd());
-    rest = rest.slice(cut).trimStart();
+    if (!Number.isFinite(cut)) {
+      break;
+    }
+    parts.push(text.slice(start, cut).trimEnd());
+    start = cut;
   }
 
-  if (rest.trim()) {
-    parts.push(rest);
-  }
-
+  parts.push(text.slice(start).trimStart());
   return parts;
 }

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
@@ -1,0 +1,78 @@
+const TAG_RE = /<\/?([a-zA-Z][\w-]*)(?:[^>'"]|"[^"]*"|'[^']*')*?\/?>/g;
+
+// Elements that never take a closing tag, so an opening token must not
+// increase the nesting depth.
+const VOID_ELEMENTS = new Set([
+  'area',
+  'base',
+  'br',
+  'col',
+  'embed',
+  'hr',
+  'img',
+  'input',
+  'link',
+  'meta',
+  'source',
+  'track',
+  'wbr',
+]);
+
+const visibleLength = (text: string): number =>
+  text
+    .replace(/&[#\w]+;/g, 'x')
+    .replace(/\s+/g, ' ')
+    .trim().length;
+
+/**
+ * Splits rendered article HTML into chunks of at least `minChars` of visible
+ * text, cutting only where a top-level block element closes — an ad between
+ * chunks can never land inside a paragraph, list, blockquote or code block.
+ * A short tail is merged into the chunk before it, so the article never ends
+ * on an ad followed by a stray line.
+ */
+export function splitContentForAds(html: string, minChars: number): string[] {
+  const chunks: string[] = [];
+  let depth = 0;
+  let chunkStart = 0;
+  let cursor = 0;
+  let visible = 0;
+
+  TAG_RE.lastIndex = 0;
+  let match = TAG_RE.exec(html);
+  while (match) {
+    const [token, rawName] = match;
+    visible += visibleLength(html.slice(cursor, match.index));
+    cursor = match.index + token.length;
+
+    const name = rawName.toLowerCase();
+    if (token.startsWith('</')) {
+      depth = Math.max(0, depth - 1);
+      if (depth === 0 && visible >= minChars) {
+        chunks.push(html.slice(chunkStart, cursor));
+        chunkStart = cursor;
+        visible = 0;
+      }
+    } else if (!VOID_ELEMENTS.has(name) && !token.endsWith('/>')) {
+      depth += 1;
+    }
+
+    match = TAG_RE.exec(html);
+  }
+
+  const tail = html.slice(chunkStart);
+  if (tail.trim()) {
+    chunks.push(tail);
+  }
+
+  // The last chunk earns its preceding ad only when it carries real content.
+  if (chunks.length > 1) {
+    const last = chunks[chunks.length - 1];
+    if (visibleLength(last.replace(TAG_RE, ' ')) < minChars / 2) {
+      chunks[chunks.length - 2] += last;
+      chunks.pop();
+    }
+  }
+
+  return chunks;
+}

--- a/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
+++ b/packages/shared/src/components/post/arbitrage/splitContentForAds.ts
@@ -136,10 +136,13 @@ export function splitTextForAds(
   let start = 0;
   for (let i = 1; i < count; i += 1) {
     const ideal = Math.round((total * i) / count);
+    // Per-iteration capture: the closures below must not reference the
+    // mutable `start` (no-loop-func).
+    const from = start;
     // Nearest boundary to the even split point, strictly inside the
     // remaining text so a cut can never produce an empty part.
     const cut = boundaries
-      .filter((position) => position > start && position < total - 1)
+      .filter((position) => position > from && position < total - 1)
       .reduce(
         (best, position) =>
           Math.abs(position - ideal) < Math.abs(best - ideal) ? position : best,

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -27,6 +27,11 @@ export enum ProgrammaticAdFormat {
 type FormatSpec = {
   label: string;
   size: string;
+  /**
+   * Reserves the creative's height PLUS the chrome that renders with it —
+   * the label row (~1rem) and the wrapper's vertical padding (1rem) — so the
+   * box never grows under the reader when the request lands in-viewport.
+   */
   minHeight: string;
   /**
    * Caps the slot at its standard IAB width so every creative in a given
@@ -56,7 +61,7 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   [ProgrammaticAdFormat.Leaderboard]: {
     label: 'Leaderboard',
     size: '728x90 · 320x100 mobile',
-    minHeight: 'min-h-[100px] tablet:min-h-[90px]',
+    minHeight: 'min-h-[132px] tablet:min-h-[122px]',
     maxWidth: 'max-w-[320px] tablet:max-w-[728px]',
     shape: 'horizontal',
   },
@@ -66,7 +71,7 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   [ProgrammaticAdFormat.MediumRectangle]: {
     label: 'Medium rectangle',
     size: '300x250',
-    minHeight: 'min-h-[250px]',
+    minHeight: 'min-h-[282px]',
     maxWidth: 'max-w-[300px]',
     shape: 'rectangle',
   },
@@ -75,21 +80,21 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   [ProgrammaticAdFormat.Rectangle]: {
     label: 'In-content',
     size: '336x280 · 300x250 mobile',
-    minHeight: 'min-h-[250px] tablet:min-h-[180px]',
+    minHeight: 'min-h-[282px] tablet:min-h-[212px]',
     maxWidth: 'max-w-[300px] tablet:max-w-[336px]',
     shape: 'rectangle',
   },
   [ProgrammaticAdFormat.HalfPage]: {
     label: 'Sticky rail',
     size: '300x600',
-    minHeight: 'min-h-[320px]',
+    minHeight: 'min-h-[352px]',
     maxWidth: 'max-w-[300px]',
     shape: 'vertical',
   },
   [ProgrammaticAdFormat.Native]: {
     label: 'Native',
     size: 'fluid',
-    minHeight: 'min-h-[96px]',
+    minHeight: 'min-h-[128px]',
   },
 };
 
@@ -189,6 +194,12 @@ export interface ProgrammaticAdProps {
    * arrived, so eager pushes ride its very first processing pass.
    */
   eager?: boolean;
+  /**
+   * Merged into every event's extra. Repeated placements (in-body, comment
+   * interleave) share a slot number, so this is how the first occurrence
+   * stays distinguishable from the sixth in analytics.
+   */
+  logExtra?: Record<string, unknown>;
 }
 
 /**
@@ -206,6 +217,7 @@ export function ProgrammaticAd({
   refreshes,
   hideOnPhone,
   eager,
+  logExtra,
 }: ProgrammaticAdProps): ReactElement {
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const insRef = useRef<HTMLModElement>(null);
@@ -247,7 +259,7 @@ export function ProgrammaticAd({
             format,
             surface,
             refreshes,
-            extra,
+            extra: { ...logExtra, ...extra },
           }),
         ),
       });
@@ -255,6 +267,7 @@ export function ProgrammaticAd({
     [
       format,
       logEvent,
+      logExtra,
       refreshes,
       slot,
       surface,
@@ -321,9 +334,12 @@ export function ProgrammaticAd({
         observer.disconnect();
         setIsRequested(true);
       },
-      // Expert-tuned: request just as the slot approaches rather than a
-      // viewport ahead — viewability over prefetch.
-      { rootMargin: '50px' },
+      // A compromise between the expert's ask (~50px: viewability over
+      // prefetch) and two behaviours that need the verdict to land while the
+      // box is still off screen: the auction round-trip (~300-800ms) and the
+      // CSS collapse of an unfilled slot, which at 50px would happen in front
+      // of the reader as a visible jump instead of invisibly below the fold.
+      { rootMargin: '250px' },
     );
     observer.observe(element);
 
@@ -487,7 +503,11 @@ export function ProgrammaticAd({
       className={classNames(
         // Centered on a lighter block, so the unit reads as a deliberate
         // frame rather than a creative floating on the page background.
-        'mx-auto w-full rounded-8 bg-surface-float p-2 text-center',
+        // Vertical padding only: these boxes are border-box, so horizontal
+        // padding would shrink the usable width below the IAB cap the
+        // FORMAT_SPEC widths exist to guarantee (300x250 no longer fits a
+        // padded max-w-[300px]).
+        'mx-auto w-full rounded-8 bg-surface-float py-2 text-center',
         // AdSense stamps data-ad-status="unfilled" when no creative was
         // returned. Without collapsing, the reserved min-height stays behind as
         // a block of empty page — most visible in the comment thread, where an

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -29,8 +29,9 @@ type FormatSpec = {
   size: string;
   /**
    * Reserves the creative's height PLUS the chrome that renders with it —
-   * the label row (~1rem) and the wrapper's vertical padding (1rem) — so the
-   * box never grows under the reader when the request lands in-viewport.
+   * the label row (1rem line + pb-1) and the wrapper's py-2, 36px in all —
+   * so the box never grows under the reader when the request lands
+   * in-viewport.
    */
   minHeight: string;
   /**
@@ -61,7 +62,7 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   [ProgrammaticAdFormat.Leaderboard]: {
     label: 'Leaderboard',
     size: '728x90 · 320x100 mobile',
-    minHeight: 'min-h-[132px] tablet:min-h-[122px]',
+    minHeight: 'min-h-[136px] tablet:min-h-[126px]',
     maxWidth: 'max-w-[320px] tablet:max-w-[728px]',
     shape: 'horizontal',
   },
@@ -71,7 +72,7 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   [ProgrammaticAdFormat.MediumRectangle]: {
     label: 'Medium rectangle',
     size: '300x250',
-    minHeight: 'min-h-[282px]',
+    minHeight: 'min-h-[286px]',
     maxWidth: 'max-w-[300px]',
     shape: 'rectangle',
   },
@@ -80,21 +81,21 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   [ProgrammaticAdFormat.Rectangle]: {
     label: 'In-content',
     size: '336x280 · 300x250 mobile',
-    minHeight: 'min-h-[282px] tablet:min-h-[212px]',
+    minHeight: 'min-h-[286px] tablet:min-h-[216px]',
     maxWidth: 'max-w-[300px] tablet:max-w-[336px]',
     shape: 'rectangle',
   },
   [ProgrammaticAdFormat.HalfPage]: {
     label: 'Sticky rail',
     size: '300x600',
-    minHeight: 'min-h-[352px]',
+    minHeight: 'min-h-[356px]',
     maxWidth: 'max-w-[300px]',
     shape: 'vertical',
   },
   [ProgrammaticAdFormat.Native]: {
     label: 'Native',
     size: 'fluid',
-    minHeight: 'min-h-[128px]',
+    minHeight: 'min-h-[132px]',
   },
 };
 
@@ -233,6 +234,10 @@ export function ProgrammaticAd({
   // forward-marker for the Ad Manager migration, where this must be revisited
   // before declared refresh goes live.
   const hasLoggedClick = useRef(false);
+  // Ref, not dependency: callers pass inline objects whose identity changes
+  // every render, and the ad effects must not re-run for that.
+  const logExtraRef = useRef(logExtra);
+  logExtraRef.current = logExtra;
   const { id: unitId, type: unitType, layoutKey: unitLayoutKey } = config;
 
   const logSlotEvent = useCallback(
@@ -259,7 +264,7 @@ export function ProgrammaticAd({
             format,
             surface,
             refreshes,
-            extra: { ...logExtra, ...extra },
+            extra: { ...logExtraRef.current, ...extra },
           }),
         ),
       });
@@ -267,7 +272,6 @@ export function ProgrammaticAd({
     [
       format,
       logEvent,
-      logExtra,
       refreshes,
       slot,
       surface,

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -321,7 +321,9 @@ export function ProgrammaticAd({
         observer.disconnect();
         setIsRequested(true);
       },
-      { rootMargin: '600px' },
+      // Expert-tuned: request just as the slot approaches rather than a
+      // viewport ahead — viewability over prefetch.
+      { rootMargin: '50px' },
     );
     observer.observe(element);
 
@@ -483,7 +485,9 @@ export function ProgrammaticAd({
     <div
       ref={setWrapperRef}
       className={classNames(
-        'mx-auto w-full text-center',
+        // Centered on a lighter block, so the unit reads as a deliberate
+        // frame rather than a creative floating on the page background.
+        'mx-auto w-full rounded-8 bg-surface-float p-2 text-center',
         // AdSense stamps data-ad-status="unfilled" when no creative was
         // returned. Without collapsing, the reserved min-height stays behind as
         // a block of empty page — most visible in the comment thread, where an
@@ -498,12 +502,12 @@ export function ProgrammaticAd({
         className,
       )}
     >
-      {/* A fluid native unit is the "confusable with site content" shape
-          AdSense prohibits shipping unlabeled — "Advertisements" is one of
-          the two label strings its policy permits. Inside the wrapper, so an
-          unfilled slot's collapse takes the label down with it. */}
-      {isRequested && config.type === 'inFeed' && (
-        <span className="mb-1 block text-left text-text-quaternary typo-caption2">
+      {/* Every unit is labeled so none can be confused with site content —
+          "Advertisements" is one of the two label strings AdSense permits
+          (a bare "Advertisement" is not). Inside the wrapper, so an unfilled
+          slot's collapse takes the label down with it. */}
+      {isRequested && (
+        <span className="block pb-1 pr-1 text-right text-text-quaternary typo-caption2">
           Advertisements
         </span>
       )}


### PR DESCRIPTION
Implements the expert consult's ten action points on the `/articles` template.

| # | Ask | Shipped |
|---|---|---|
| 1 | Remove internal ads on /articles | `hideInternalAd` (AdAsComment) + `hideAdWidget` (PostSidebarAdWidget), opt-in props — every other surface unchanged |
| 2 | MPU every ~250 in the body, breaking nicely | **250 characters (Nick's confirmed spec)**, applied to the TLDR (`splitTextForAds`, sentence-snapped) and hosted bodies (`splitContentForAds`, block boundaries). Cuts aim at even split points with the cadence as a hard floor — no unit within 250 visible chars of the previous one, no front-loading — and each section is capped at **4 units** (`MAX_CONTENT_ADS_PER_SECTION`), the constant that now carries density compliance |
| 3 | MPU above comments | Slot 18, directly above the engagement block |
| 4 | MPU every 6–8 comments | An MPU each time **6 comments — replies included, every comment counts** — have gone by (revised 8→6); the boundary only ever sits after a top-level block. **Desktop-only** until a long-thread phone measurement clears it |
| 5 | Rail: 3rd bottom unit as the only sticky | Mid-rail sticky is in flow again; a fixed 300×600 closes the rail as **the rail's only sticky** — compliant as a publisher sticky (300px wide, desktop-only, nothing below to overlap). The top leaderboard keeps its separate 10-second pin window per the partner spec |
| 6 | "Advertisement" label top-right on all ads | Every unit, small gray, top-right — as **"Advertisements"**, one of the two strings AdSense's ad-labeling policy permits (bare "Advertisement" is not) |
| 7 | Lazy at 50px, centered, lighter background | `rootMargin: 250px` — 50px puts the auction and the unfilled-collapse jump inside the visible area; 250px keeps both off screen. Units centered on a `bg-surface-float` block (vertical padding only, so the IAB width caps hold) |
| 8 | Mobile leaderboard below title, sticky | **Already sticky on mobile** (it pins with the header block, releasing after the 10s window; sits just above the title). On phones it now requests a **fixed 320×100** — a responsive request answered with expandable video was pinning half a phone screen |
| 9 | Remove the image MPU | Slot 3 retired (the unit id lives on in the body/comment MPUs) |
| 10 | Questions block missing | `PostAnsweredQuestions` renders after the body, as on the post page; it self-hides for logged-in users, which matches this page's anonymous-only ads |

**Phone density policy (the fresh number):** at the 250-char cadence the interval no longer bounds density, so placement does: on phones only the page's first in-content unit renders, the rail and comment units are desktop-only, and the leaderboard is a fixed 320×100. A scraped article on a 375px viewport carries leaderboard (136px) + first in-content (286px) + above-comments (286px) ≈ **708px of ad against a ~3,300-4,100px page — 17-22%**, under the Better Ads 30% cap with margin. Desktop carries the full cadence under its 50% cap.

**Unit reuse note:** the new placements share live Display units (6921226982 / 5249052667), so AdSense-side reporting blends them; our first-party events split by slot number, so per-placement RPM stays queryable in ClickHouse. Dedicated `read_s17`/`read_s18` units are a marked TODO.

## Verification
- 7 new `splitContentForAds` specs (nesting, code blocks, void elements, byte preservation, sliver merge)
- Shared post + monetization suites (130) and webapp suite green (pre-existing `WorldGuideSheet` failure only)
- Strict typecheck + lint clean

### Preview domain
https://feat-articles-monetization.preview.app.daily.dev

### Where to verify the new placements
The in-body cadence now covers **both** content forms: the TLDR (`splitTextForAds`, sentence/word boundaries — for scraped articles the summary is the main content) and hosted bodies (`splitContentForAds`, block boundaries). A post whose TLDR is under ~250 words gets no in-body unit — the MPU above the comments is the one that renders on **every** post.


