### PR TITLE
feat(seo): advertise markdown twins to agents and add llms-full.txt

### DIFF
--- a/packages/webapp/lib/seo.ts
+++ b/packages/webapp/lib/seo.ts
@@ -32,6 +32,12 @@ export const getLlmsTxtUrl = (): string => `${getAppOrigin()}/llms.txt`;
 export const getPostCanonicalUrl = (slug: string): string =>
   `${getAppOrigin()}/posts/${slug}`;
 
+export const getPostMarkdownUrl = ({
+  post,
+}: {
+  post: Pick<Post, 'id' | 'slug'>;
+}): string => `${getPostCanonicalUrl(post.slug ?? post.id)}.md`;
+
 const THIN_NOINDEX_POST_TYPES = [PostType.Brief, PostType.SocialTwitter];
 
 /** Structural subset of {@link Post} so non-page callers can reuse the gate. */

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -339,6 +339,7 @@ function InternalApp({ Component, pageProps, router }: AppProps): ReactElement {
             title="Sitemap"
             href="/sitemap.xml"
           />
+          <link rel="llms-txt" href="/llms.txt" />
           <link
             rel="alternate"
             type="text/plain"

--- a/packages/webapp/pages/api/md/posts/[id].ts
+++ b/packages/webapp/pages/api/md/posts/[id].ts
@@ -88,8 +88,6 @@ const handler = async (
       'Cache-Control',
       'public, s-maxage=86400, stale-while-revalidate=604800',
     );
-    res.setHeader('Link', '</llms.txt>; rel="llms-txt"');
-    res.setHeader('X-Llms-Txt', '/llms.txt');
     res.setHeader('X-Robots-Tag', 'noindex, nofollow');
     res.status(200).send(markdown);
   } catch (error: unknown) {

--- a/packages/webapp/pages/api/md/sources.ts
+++ b/packages/webapp/pages/api/md/sources.ts
@@ -79,8 +79,6 @@ ${data.topVideoSources.map(formatSource).join('\n')}
       'Cache-Control',
       'public, s-maxage=86400, stale-while-revalidate=604800',
     );
-    res.setHeader('Link', '</llms.txt>; rel="llms-txt"');
-    res.setHeader('X-Llms-Txt', '/llms.txt');
     res.setHeader('X-Robots-Tag', 'noindex, nofollow');
     res.status(200).send(markdown);
   } catch (error: unknown) {

--- a/packages/webapp/pages/api/md/squads.ts
+++ b/packages/webapp/pages/api/md/squads.ts
@@ -119,8 +119,6 @@ ${categorySections}
       'Cache-Control',
       'public, s-maxage=86400, stale-while-revalidate=604800',
     );
-    res.setHeader('Link', '</llms.txt>; rel="llms-txt"');
-    res.setHeader('X-Llms-Txt', '/llms.txt');
     res.setHeader('X-Robots-Tag', 'noindex, nofollow');
     res.status(200).send(markdown);
   } catch (error: unknown) {

--- a/packages/webapp/pages/api/md/tags.ts
+++ b/packages/webapp/pages/api/md/tags.ts
@@ -104,8 +104,6 @@ ${allTagsMarkdown}
       'Cache-Control',
       'public, s-maxage=86400, stale-while-revalidate=604800',
     );
-    res.setHeader('Link', '</llms.txt>; rel="llms-txt"');
-    res.setHeader('X-Llms-Txt', '/llms.txt');
     res.setHeader('X-Robots-Tag', 'noindex, nofollow');
     res.status(200).send(markdown);
   } catch (error: unknown) {

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -74,7 +74,11 @@ import {
 import type { DynamicSeoProps } from '../../../components/common';
 import { noindexSeoProps } from '../../../next-seo';
 import useSharedByToast from '../../../hooks/useSharedByToast';
-import { getPostCanonicalUrl, shouldNoindexPost } from '../../../lib/seo';
+import {
+  getPostCanonicalUrl,
+  getPostMarkdownUrl,
+  shouldNoindexPost,
+} from '../../../lib/seo';
 
 const Unauthorized = dynamic(
   () =>
@@ -395,11 +399,22 @@ export async function getStaticProps({
     const post = initialData.post as Post;
     const topComments = commentsData.topComments || [];
     const pageSeoTitles = getPageSeoTitles(seoTitle(post) ?? '');
+    const noindex = shouldNoindexPost(post);
     const seo: NextSeoProps = {
       canonical: post?.slug ? getPostCanonicalUrl(post.slug) : undefined,
       title: pageSeoTitles.title,
       description: getSeoDescription(post),
-      noindex: shouldNoindexPost(post),
+      noindex,
+      additionalLinkTags:
+        post && !noindex
+          ? [
+              {
+                rel: 'alternate',
+                type: 'text/markdown',
+                href: getPostMarkdownUrl({ post }),
+              },
+            ]
+          : undefined,
       openGraph: {
         ...pageSeoTitles.openGraph,
         images: [

--- a/packages/webapp/public/llms-full.txt
+++ b/packages/webapp/public/llms-full.txt
@@ -1,0 +1,2197 @@
+# daily.dev - Full Documentation
+
+> This is the expanded llms.txt for daily.dev, containing the full markdown content of every page indexed in https://daily.dev/llms.txt (blog posts are listed as links only), for AI/LLM consumption with larger context windows. Individual posts are not inlined; fetch them via `.md` URLs or the Public API.
+
+---
+
+## Core Pages
+
+---
+title: "daily.dev Blog | Developer news, deep-dives, and editorial"
+url: https://daily.dev/blog/
+description: "Developer news, deep-dives, and opinion from the daily.dev community. Browse all posts at /blog/ or fetch each post as markdown via /blog/[slug].md/."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## daily.dev Blog
+
+The daily.dev blog publishes original deep-dives on developer tools and frameworks, breaking news on the engineering ecosystem, and editorial from the daily.dev community.
+
+### Browse
+
+- [Blog index](https://daily.dev/blog/): every post, newest-first, with category filters and search
+- [RSS feed](https://daily.dev/rss.xml): subscribe to new posts
+- Category archives at `https://daily.dev/categories/[slug]/`
+
+### Read individual posts as markdown
+
+Every blog post is also available as plain markdown for LLM ingestion. Append `.md/` to any post URL:
+
+- `https://daily.dev/blog/[slug]/` returns the rendered HTML page
+- `https://daily.dev/blog/[slug].md/` returns the same content as plain markdown
+
+Use the [RSS feed](https://daily.dev/rss.xml) or [sitemap](https://daily.dev/sitemap-blog.xml) to enumerate available posts.
+
+---
+
+---
+title: "AI Handbook"
+url: "https://daily.dev/agentic-ai-hub"
+---
+
+# The Agentic AI Hub
+
+> A software engineer's complete reference to AI, from foundations to agents.
+
+Version 1.1 · Last updated 2026-07-22 · License CC BY 4.0 · Published by daily.dev
+
+Every page below is available as LLM-friendly markdown via its `.md/` URL. For rendered HTML, omit `.md`.
+
+## Part I. Foundations
+
+- [How LLMs Actually Work](https://daily.dev/agentic-ai-hub/how-llms-actually-work.md/): A large language model predicts the next token given the tokens so far, and that is essentially all it does.
+- [Core Concepts](https://daily.dev/agentic-ai-hub/core-concepts.md/): Quick definitions for the vocabulary you'll run into everywhere. Each one is short, and several get a fuller treatment later in the handbook.
+- [Prompting & Context Engineering](https://daily.dev/agentic-ai-hub/prompting-context-engineering.md/): Prompting is the highest-leverage, lowest-cost skill in this whole handbook. Small changes in how you frame a request move quality more than most people expect.
+- [Safety, Alignment & Governance](https://daily.dev/agentic-ai-hub/safety-alignment-governance.md/): Building with AI means owning its failure modes. This section is deliberately neutral and tight, enough to reason about risk without ideology.
+
+## Part II. Models, Labs & Benchmarks
+
+- [The Labs: Who's Who](https://daily.dev/agentic-ai-hub/the-labs-whos-who.md/): Snapshot as of July 19, 2026. Valuations and funding are dated and sourced.
+- [Frontier Model Comparison](https://daily.dev/agentic-ai-hub/frontier-model-comparison.md/): A dated snapshot of the current top-tier, closed ("frontier") models, meaning the API-only models from the major labs that set the capability bar.
+- [Open-Weight Models](https://daily.dev/agentic-ai-hub/open-weight-models.md/): The models you can download, self-host, and fine-tune. As of July 2026. Two things to know: (1) "open weight" ≠ open source.
+- [Specialized Models](https://daily.dev/agentic-ai-hub/specialized-models.md/): Beyond the general-purpose flagships, each modality and job has its own leaders, and the "best" one shifts constantly, so treat these as categories to shop in with current examples.
+- [Benchmarks & Leaderboards](https://daily.dev/agentic-ai-hub/benchmarks-leaderboards.md/): The single most useful mental model here is that benchmarks tell you what a model can do on someone else's task.
+- [Pricing & Cost Reference](https://daily.dev/agentic-ai-hub/pricing-cost-reference.md/): Pricing is a Frontier Model Comparison snapshot. This section is the durable part: how to reason about cost so you're not surprised by a bill.
+- [How to Choose a Model](https://daily.dev/agentic-ai-hub/how-to-choose-a-model.md/): The honest answer is to shortlist from benchmarks and reputation, then run a small eval on your actual task.
+
+## Part III. Tools, Products & Agents
+
+- [Chat Assistants & Apps](https://daily.dev/agentic-ai-hub/chat-assistants-apps.md/): The consumer/prosumer chat apps are the front door to each lab's frontier model.
+- [Coding Tools & CLI Agents](https://daily.dev/agentic-ai-hub/coding-tools-cli-agents.md/): Two families here: IDE assistants (autocomplete + chat + in-editor agents living in your editor) and CLI/terminal agents (you talk to an agent in the shell.
+- [Agent Harnesses & Frameworks](https://daily.dev/agentic-ai-hub/agent-harnesses-frameworks.md/): Two very different things get called "agent tooling."
+- [No-Code & App Builders](https://daily.dev/agentic-ai-hub/no-code-app-builders.md/): Prompt-to-app tools turn a description into a running web app with UI, backend, and deploy.
+- [Voice & Real-Time Agents](https://daily.dev/agentic-ai-hub/voice-real-time-agents.md/): Real-time voice agents = STT (speech-to-text) → LLM → TTS (text-to-speech) stitched into a low-latency loop (or, increasingly, a single speech-to-speech model).
+- [Browser & Computer-Use Agents](https://daily.dev/agentic-ai-hub/browser-computer-use-agents.md/): These agents perceive a screen or DOM and act (click, type, scroll, navigate) to complete tasks a human would do in a browser or OS.
+- [Multimodal Creative Tools](https://daily.dev/agentic-ai-hub/multimodal-creative-tools.md/): Image, video, and audio generation. Quality is now high across the board. Choose by control, licensing, and API availability more than raw "wow."
+- [MCP & the Tool/Context Ecosystem](https://daily.dev/agentic-ai-hub/mcp-tool-context-ecosystem.md/): Models are only half the story. The other half is the plumbing that gives models hands: how an assistant reaches your files, databases, SaaS tools, and the web.
+
+## Part IV. Building with AI: The Engineering Stack
+
+- [RAG & Retrieval](https://daily.dev/agentic-ai-hub/rag-retrieval.md/): Retrieval-Augmented Generation (RAG) is the practice of fetching relevant text (or other data) at query time and injecting it into the model's context so the model can answer from information it wasn't trained on.
+- [Vector Databases & Memory](https://daily.dev/agentic-ai-hub/vector-databases-memory.md/): A vector database stores embeddings and serves approximate nearest-neighbor (ANN) search, which finds the closest vectors to a query vector quickly using index structures like HNSW (graph-based, the most common) or IVF/IVF-PQ (cluster + quantize, memory-efficient at scale).
+- [Fine-Tuning & Post-Training](https://daily.dev/agentic-ai-hub/fine-tuning-post-training.md/): Reach for the cheapest tool that works, in this order:
+- [Dataset Engineering](https://daily.dev/agentic-ai-hub/dataset-engineering.md/): Data quality, not model choice, is usually the ceiling on a fine-tune.
+- [Inference, Serving & Optimization](https://daily.dev/agentic-ai-hub/inference-serving-optimization.md/): TTFT (Time To First Token). Latency until the first token appears. Dominated by the prefill (prompt-processing) phase and prompt length.
+- [AI Hardware & Accelerators](https://daily.dev/agentic-ai-hub/ai-hardware-accelerators.md/): The 2026 picture is that NVIDIA still dominates training and general inference.
+- [APIs, Inference Platforms & Gateways](https://daily.dev/agentic-ai-hub/apis-inference-platforms-gateways.md/): Four rough tiers, each with different trade-offs on model access, speed, price, and control.
+- [Local & Self-Hosting Stack](https://daily.dev/agentic-ai-hub/local-self-hosting-stack.md/): Running models on your own machine or servers.
+- [LLMOps: Evals, Observability & Guardrails](https://daily.dev/agentic-ai-hub/llmops-evals-observability-guardrails.md/): Shipping LLM features without evals and observability is flying blind: outputs are non-deterministic, quality is subjective, and regressions are silent.
+
+## Part V. Working with AI: Techniques, Workflows & Adoption
+
+- [Levels of AI Adoption](https://daily.dev/agentic-ai-hub/levels-of-ai-adoption.md/): Before you can improve how your team works with agents, you need a shared way to say where you are.
+- [Agentic Engineering: Core Ideas](https://daily.dev/agentic-ai-hub/agentic-engineering-core-ideas.md/): "Agentic coding" is an overloaded term.
+- [Orchestration Patterns](https://daily.dev/agentic-ai-hub/orchestration-patterns.md/): Once one agent works, the obvious move is to run several. This is where the biggest gains and the biggest self-inflicted wounds both live.
+- [Context, Skills & Memory](https://daily.dev/agentic-ai-hub/context-skills-memory.md/): Agents are only as good as what they know when they start, and by default they start knowing nothing about your repo, your conventions, or last week's decisions.
+- [Verification & Testing for Agents](https://daily.dev/agentic-ai-hub/verification-testing-for-agents.md/): If generation is cheap and verification is the bottleneck, then verification infrastructure is your leverage.
+- [Human Factors & the Agent-Era Career](https://daily.dev/agentic-ai-hub/human-factors-agent-era-career.md/): The techniques above make you faster. This chapter is about what they can quietly cost you, and how not to pay it.
+
+## Part VI. Ecosystem & Staying Current
+
+- [People to Follow (X/Twitter)](https://daily.dev/agentic-ai-hub/people-to-follow.md/): X/Twitter is where much of AI moves in real time. Papers get discussed hours before the press notices, and model launches often break here first.
+- [Newsletters](https://daily.dev/agentic-ai-hub/newsletters.md/): Email survives because it's async and curated. Tagged by focus and cadence.
+- [Blogs & Publications](https://daily.dev/agentic-ai-hub/blogs-publications.md/): OpenAI Blog: openai.com/news. Launches and research. The announcement of record.
+- [Podcasts & YouTube](https://daily.dev/agentic-ai-hub/podcasts-youtube.md/): Latent Space (swyx & Alessio): latent.space/podcast. Best for: the AI-engineering discipline.
+- [Communities](https://daily.dev/agentic-ai-hub/communities.md/): Where real-time, tacit knowledge lives, the kind that never makes it into a blog post.
+- [Key Papers & Reading List](https://daily.dev/agentic-ai-hub/key-papers-reading-list.md/): A chronological spine of the field. The ones tagged Start here or Landmark are the priority reads; the rest fill in context.
+- [Platforms](https://daily.dev/agentic-ai-hub/platforms.md/): The infrastructure you'll actually live in.
+- [Events & Conferences](https://daily.dev/agentic-ai-hub/events-conferences.md/): 🔄 Dates and formats change yearly. Always confirm on the official site.
+- [Learning Paths, Courses & Books](https://daily.dev/agentic-ai-hub/learning-paths-courses-books.md/): Organized beginner → advanced. Pick a lane and go deep. Breadth comes with time.
+
+## Part VII. Appendices
+
+- [AI Adoption Stats & Trends](https://daily.dev/agentic-ai-hub/ai-adoption-stats-trends.md/): 🔄 Fast-moving section. All figures are dated and sourced; surveys are annual and market forecasts get revised, so check the live sources for the latest.
+- [Glossary of Key Terms](https://daily.dev/agentic-ai-hub/glossary.md/): A jargon-buster for the terms used throughout this handbook. Where a full section exists, terms link to it.
+
+---
+
+---
+title: "daily.dev apps | Browser extension, iOS, Android, web app"
+url: https://daily.dev/apps/
+description: "Get daily.dev as a browser extension (Chrome / Edge), an iOS app, an Android app, or a web app. Free forever, no signup required."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Get daily.dev wherever you work
+
+daily.dev ships across every surface engineers use day-to-day. Pick your platform. Your feed, squads, and history sync between all of them.
+
+### Available platforms
+
+- [Browser extension](https://api.daily.dev/get): turns every new tab into a personalized dev feed (Chrome, Edge)
+- [iOS app](https://apps.apple.com/app/daily-dev/id6740634400): read on the go, save for later, native push for must-read posts
+- [Android app](https://play.google.com/store/apps/details?id=dev.daily): same feed, same squads, native experience
+- [Web app](https://daily.dev): works in any modern browser, no install required
+
+### Why developers use the apps daily
+
+- Every surface is free, forever. No paywall, no signup required to read
+- Personalization gets sharper the more you use it. A relevant feed within 7 days
+- Squads sync across mobile and desktop so you can keep the conversation going
+- All apps are fully open source; the codebase is on [GitHub](https://github.com/dailydotdev/daily)
+
+[See the rendered apps page](https://daily.dev/apps/) for download badges, screenshots, and the full feature breakdown.
+
+---
+
+---
+title: "Features | daily.dev"
+url: https://daily.dev/features/
+description: "Every daily.dev feature in one place: the personalized feed, squads, AI search, bookmarks, streaks, the browser extension, and the agent surfaces. Free forever, with an optional Plus upgrade."
+lastUpdated: "2026-08-23"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## What daily.dev does
+
+daily.dev pulls thousands of sources into one ranked feed that opens with every new tab. Millions of developers use it to keep up without keeping tabs open. Almost all of it is free; the handful of Plus features are marked below.
+
+### The feed
+
+- **Personalized feed**: ranked from what you read, upvote, and follow, and it sharpens over time
+- **New tab takeover**: the browser extension replaces the blank new-tab page with your feed
+- **Presidential briefing**: an AI brief compressing everything that mattered into a two-minute read (unlimited on Plus)
+- **Breaking news**: the stories blowing up right now, ranked by how the community is reacting
+- **Follow tags and sources**: languages, frameworks, tools, and publications you choose
+- **Advanced custom feeds** (Plus): extra feeds scoped to one topic each
+- **Keyword filters** (Plus): mute the buzzwords you are sick of hearing
+- **AI-powered clean titles** (Plus): clickbait headlines rewritten into what the post actually says
+- **Auto-translate** (Plus): titles and summaries in your language
+- **Ad-free reading** (Plus): the free feed carries developer-relevant ads; Plus turns them off
+
+### Reading
+
+- **Built-in reader**: articles open inside daily.dev with the discussion beside them
+- **Bookmarks and reading reminders**: save anything, set a time to come back to it
+- **Spotlight search**: Cmd+K for posts, squads, people, tags, and actions
+- **AI search**: plain-language questions answered from community-vetted posts, with sources linked
+- **Reading history**: everything you have opened, in order
+- **Bookmark folders** (Plus): organize a long reading list into folders
+
+### Community
+
+- **Squads**: communities built around the tools you use
+- **Discussions, upvotes, and downvotes**: every post arrives with its conversation attached
+- **Create and share posts**: publish a link, a question, or a write-up into a squad
+- **Follow developers**: see what the people whose taste you trust are surfacing
+- **Members-only Squad** (Plus): a space for Plus members, feedback, and priority support
+
+### Your profile
+
+- **Reading streaks**, **reputation**, a **public profile**, a shareable **DevCard**, and **notifications** you control
+
+### Everywhere
+
+- **Browser extension** (Chrome, Edge), **iOS and Android apps**, and the **web app**
+- **Cross-device sync** for bookmarks, history, squads, follows, and your streak
+- **Dark and light themes** on every surface
+
+### For agents and automation
+
+- **Markdown twins**: every marketing, blog, and post page answers on a `.md` URL and honours `Accept: text/markdown`
+- **llms.txt**: a single index of every structured surface on the domain
+- **Agent Skills**: discoverable at [/.well-known/agent-skills/index.json](https://daily.dev/.well-known/agent-skills/index.json)
+- **Claude Code plugin**: the same skills, packaged
+- **Public API** (Plus): REST access to feeds, posts, comments, search, bookmarks, and custom feeds
+
+### Getting the most out of it
+
+1. Make it your new tab and then forget about it
+2. Follow eight to twelve tags on day one
+3. Downvote early; the ranking learns fastest from what you reject
+4. Bookmark with a reminder, not with hope
+5. Join two squads, not ten
+6. Read the replies before the article
+
+[See the rendered features page](https://daily.dev/features/) for the full breakdown, and [pricing](https://daily.dev/pricing/) for what free covers.
+
+---
+
+---
+title: "Pricing | daily.dev"
+url: https://daily.dev/pricing/
+description: "daily.dev is free forever. The feed, the extension, the mobile apps, squads, AI search, and bookmarks cost nothing, with no trial and no credit card. Plus is an optional upgrade for power users."
+lastUpdated: "2026-08-23"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## daily.dev is free forever
+
+Not free for a trial, and not free until we change our minds. Millions of developers use daily.dev every day without paying anything.
+
+### What free includes
+
+- Personalized feed, and the new-tab takeover via the browser extension
+- iOS and Android apps, and the web app, all synced to one account
+- Squads, discussions, and upvotes
+- AI search
+- Bookmarks and reading reminders
+- Streaks, reputation, and your public profile
+- Reading history, and following tags, sources, and people
+- Over a hundred other features
+
+### What free does not mean here
+
+- **No trial that ends**: there is no day 14 and no downgrade email
+- **No credit card**: nothing on the free plan asks for payment details, and you do not need an account to start reading
+- **No seat limits**: no team plan to outgrow and no per-seat maths
+- **No paywalled content**: free readers see the same feed, squads, and discussions as everyone else
+
+We pay for this with developer-relevant ads in the free feed, and with the people who choose to subscribe to Plus.
+
+### daily.dev Plus (optional)
+
+Plus is for developers who live in daily.dev all day and want sharper control over what reaches them. It is also how a lot of people choose to support the team. It adds:
+
+- Advanced custom feeds
+- Unlimited presidential briefings
+- AI-powered clean titles
+- Keyword filters
+- Auto-translate your feed
+- Bookmark folders
+- Ad-free experience
+- Members-only Squad
+- Public API access
+
+Monthly or annual, cancel any time. Prices are localized, so they are shown in your own currency on [the Plus page](https://daily.dev/plus) rather than quoted here.
+
+### If you cancel
+
+You keep Plus until the end of the period you paid for, then continue on the free plan with your feed, bookmarks, squads, and streak intact.
+
+[See the rendered pricing page](https://daily.dev/pricing/) for the full comparison, and [features](https://daily.dev/features/) for everything the product does.
+
+---
+
+---
+title: "About daily.dev | The developer community"
+url: https://daily.dev/about-us/
+description: "daily.dev is the developer-first community where engineers come to discover what is next. Read about the mission, the team, and the open-source values."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## What daily.dev is
+
+daily.dev is an editorial home for engineers. We started in 2017 with a simple browser extension that replaced your new-tab page with a feed of posts every developer should know about. Today, millions of engineers across iOS, Android, web, and four browser extensions use daily.dev to keep their finger on the pulse.
+
+### The mission
+
+To build the developer network you wish existed: open, relevant, and aligned with the people who actually write the code.
+
+### What we believe
+
+- The best learning happens between peers, not from gurus
+- Quality should always beat quantity; algorithms should serve the reader, not the advertiser
+- Open source is a value, not a marketing line. Most of our codebase is on [GitHub](https://github.com/dailydotdev/daily) and we credit every contributor who ships work into production
+- Distributed-by-default is a feature: the team works async across 8 countries and we hire for output, not hours
+
+### Where to read more
+
+- [Careers](https://daily.dev/careers/): open roles
+- [Recruitment process](https://daily.dev/recruitment-process/): how we hire
+- [Brand assets](https://brand.daily.dev/): logos, screenshots, press materials
+- [Blog](https://daily.dev/blog/): what we publish
+
+[See the rendered About us page](https://daily.dev/about-us/) for the full story.
+
+---
+
+---
+title: "Wall of Love | daily.dev"
+url: https://daily.dev/wall-of-love/
+description: "Real, consented testimonials from developers in the daily.dev community — engineers, founders, CTOs, and students in their own words. Every quote links to a verifiable daily.dev profile."
+lastUpdated: "2026-05-28"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## What developers say about daily.dev
+
+Every quote on the [Wall of Love](https://daily.dev/wall-of-love/) was written by a real developer in the daily.dev community and published with their explicit permission. No edits, no paid endorsements. Each card links to that developer's daily.dev profile so anyone can verify the human behind the quote.
+
+### The three things developers tell us most
+
+- **Stay current** — the largest share of testimonials describe daily.dev as how they stay up to date with tech without browsing all over the internet. *"It allows me to be up to date with tech without having to browse all over the internet."* — Ross, Tech Lead.
+- **Learn faster** — developers credit the curated feed with surfacing tools, articles, and ideas they would never have searched for. *"I often discover useful articles and resources that help me grow and stay motivated."* — Kristijan Kelić, Full-stack engineer.
+- **Find your people** — the community (squads, comments, discussions) turns a news feed into a place developers feel part of. *"I've met other devs through squads and comments — feels like a real community."* — Claudette, Software Developer.
+
+The voices span every career stage — Senior engineers, Tech Leads, Principal Architects, CTOs, Founders, and Students — across the daily.dev community of millions of developers.
+
+[Read the full wall](https://daily.dev/wall-of-love/), or [share your own story](https://it057218.typeform.com/to/uQihIeNC).
+
+---
+
+---
+title: "Careers at daily.dev | Remote-first engineering, design, content"
+url: https://daily.dev/careers/
+description: "Build daily.dev with us. Remote-first, async-by-default, equity-aligned. No open roles right now, but you can hear about the next one the day it opens."
+lastUpdated: "2026-08-09"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Build daily.dev with us
+
+We are a small, remote-first team building the place engineers actually trust to learn, connect, and grow careers.
+
+### How we work
+
+- Async-by-default. Output over hours
+- Equity-aligned for every full-time hire: generous grants, real outcomes
+- Remote-first, forever. No mandatory office. Two retreats a year somewhere lovely
+- Flexible schedule. Work the hours that match your time zone and your focus
+
+### Where we are
+
+Eight countries across European, African, Middle East, and North American time zones: Israel, United Kingdom, Croatia, Australia, United Arab Emirates, Portugal, South Africa, United States.
+
+### Open roles
+
+We have no open roles right now. We are a small team and we open roles a few times a year, so rather than leave a posting up to collect applications we cannot act on, we say so plainly.
+
+Two things you can do in the meantime:
+
+- Turn on [job preferences](https://daily.dev/settings/job-preferences) on daily.dev. We post our roles inside the product before anywhere else, so you will hear about ours the day it opens alongside every other role that fits you.
+- Write to `hi@daily.dev` anyway. We have hired people who wrote to us before a role existed. A human reads every one of these.
+
+[See the rendered careers page](https://daily.dev/careers/) for the full culture pitch and perks list.
+
+---
+
+---
+title: "Contact daily.dev | Press, partnerships, and product"
+url: https://daily.dev/contact/
+description: "Reach the daily.dev team for press, partnerships, business, advertising, content, or product feedback. Email and form-based options for every audience."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## How to reach us
+
+Pick the channel that matches what you need. We route through dedicated inboxes so the right person gets back to you fast.
+
+### Channels
+
+- **Press & PR**: `hello@daily.dev` (or grab assets from [brand.daily.dev](https://brand.daily.dev/))
+- **Partnerships**: `partnerships@daily.dev`
+- **Recruiter sourcing**: see the [recruiter site](https://recruiter.daily.dev/)
+- **Native ads & sponsorships**: see the [business site](https://business.daily.dev/)
+- **Product feedback**: [feedback page](https://daily.dev/feedback/) or upvote what is already on the roadmap
+- **Bug reports**: open an issue on [GitHub](https://github.com/dailydotdev/daily)
+- **Privacy & data requests**: `privacy@daily.dev` (see the [privacy center](https://daily.dev/privacy/))
+
+[See the rendered contact page](https://daily.dev/contact/) for the form-based options.
+
+---
+
+---
+title: "Recruitment process | How daily.dev hires"
+url: https://daily.dev/recruitment-process/
+description: "How daily.dev hires: the steps, the timing, what we evaluate, and how we keep the process humane and predictable for every candidate."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## How we hire
+
+We optimize the recruitment process for two things: respect for the candidate's time, and quality we can actually trust.
+
+### The steps
+
+1. **Application**: short form, no cover letter required. Apply via the role on the [careers page](https://daily.dev/careers/), or email `hi@daily.dev` if nothing open fits you
+2. **Intro chat** (30 min): with the hiring manager. Two-way: we tell you about the work, you tell us what you are looking for
+3. **Take-home or live exercise**: scoped to about 2 hours, paid where local rules allow, designed around real work the role does
+4. **Team interviews** (90 to 120 min total): usually two conversations: technical depth and craft / collaboration
+5. **Founder chat** (30 min): with one of the founders, focused on values, ambition, and questions you have
+6. **Offer**: within 48 hours of the founder chat. We share the full comp range up front
+
+### What we evaluate
+
+- **Craft**: taste, rigor, attention to the work
+- **Output bias**: ship-vs-discuss ratio
+- **Async fluency**: written communication, decision documentation
+- **Open-source instincts**: how you handle being wrong in public
+
+### What we do not evaluate
+
+- Pedigree. We do not care where you went to school or which name brand you worked at
+- Brain teasers, whiteboard puzzles, leetcode trivia
+- Hours worked. We hire grown-ups; you decide when your brain is on
+
+[See the rendered recruitment process page](https://daily.dev/recruitment-process/) for the full story.
+
+---
+
+---
+title: "Product feedback | daily.dev"
+url: https://daily.dev/feedback/
+description: "Tell daily.dev what to build next. Upvote ideas, file bugs, or write a long-form proposal. Every input goes into the public roadmap."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Help us build the right thing
+
+Every product decision at daily.dev passes the "would I want this in my new tab?" test. Your feedback is the strongest input we have.
+
+### How to leave feedback
+
+- **Upvote / suggest**: the in-app feedback panel surfaces requests across the community
+- **File a bug**: open an issue at [github.com/dailydotdev/daily](https://github.com/dailydotdev/daily)
+- **Long-form proposal**: email `product@daily.dev` with the rough scope and the user pain you are solving for
+- **Public Discord**: drop into the daily.dev community Discord for real-time conversations
+
+### What happens after you submit
+
+- Every request is read by a human within 48 hours on weekdays
+- Bug reports get triaged into the next sprint or the public backlog
+- Larger proposals get a written response from the relevant product owner
+
+[See the rendered feedback page](https://daily.dev/feedback/) for the upvote panel and the Discord invite.
+
+---
+
+---
+title: "Uninstall confirmation | daily.dev"
+url: https://daily.dev/uninstall/
+description: "Confirmation page after uninstalling the daily.dev browser extension. Tell us why so we can do better next time, or reinstall in one click."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Sorry to see you go
+
+This page is the post-uninstall confirmation for the daily.dev browser extension.
+
+### What we ask
+
+A two-question feedback form: why you uninstalled, and what would have made you stay. Both optional.
+
+### What we offer
+
+- A one-click [reinstall link](https://api.daily.dev/get) if you changed your mind
+- A pointer at our [iOS](https://apps.apple.com/app/daily-dev/id6740634400) and [Android](https://play.google.com/store/apps/details?id=dev.daily) apps if a different surface fits better
+- A direct line to `product@daily.dev` if there is something specific you want fixed
+
+[See the rendered uninstall page](https://daily.dev/uninstall/) for the form.
+
+---
+
+## The app
+
+---
+title: Sources Directory
+url: https://daily.dev/sources
+description: 1,300+ curated content sources on daily.dev
+---
+
+> ## Documentation Index
+> Fetch the complete documentation index at: https://daily.dev/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Sources Directory
+
+> 1,300+ curated content sources on daily.dev
+
+Explore the top sources for developer content. Find trending blogs, publications, YouTube channels and more from our trusted developer network.
+
+## Trending Sources
+
+- [SeyoungCho](/sources/o3uczsadxc0iladsoh3rx)
+- [Joud Awad](/sources/iac4jsbu0lv8wbsc85fsh)
+- [Traversy Media](/sources/traversymedia): Traversy Media offers the best tutrorials and courses on web development on Youtube as well as Traversymedia.com and Udemy.
+- [Addy Osmani](/sources/addy): Addy's platform is a resource for web developers and performance enthusiasts, offering insights into web performance optimization, browser rendering, and front-end development techniques. Through articles, tools, and case studies, Addy offers insights into measuring and improving web page speed and user experience. Developers can learn about performance budgets, lazy loading, and optimizing web assets to create fast and responsive websites.
+- [Better Stack](/sources/betterstack): Development tricks and tips. Radically better observability stack. Ship higher-quality software faster. Be the hero of your engineering teams.
+- [Flavio Copes](/sources/flaviocopes)
+- [JigJoy](/sources/jigjoy): We’re building infra for concurrent AI agents.
+- [XDA Developers](/sources/xda-developers)
+- [PHP Dev](/sources/phpdev): Welcome to PHP Dev, a dedicated space for sharing knowledge about PHP and its ecosystem \(only PHP directly related\).
+Help us find good articles and blogposts and provide links. Upvote or downvote, after reading, it's essential
+- [The Next Web](/sources/tnw): TNW is a technology media company that covers the latest trends, news, and insights in the tech industry. With a focus on innovation, entrepreneurship, and digital culture, TNW offers resources for developers, startups, and tech enthusiasts. Developers can learn about emerging technologies, industry trends, and best practices through TNW's articles, podcasts, and events.
+
+## Popular Sources
+
+- [daily.dev Changelog](/sources/daily_updates): Get the latest product updates and announcements about daily.dev
+- [Joud Awad](/sources/iac4jsbu0lv8wbsc85fsh)
+- [Alexey Zerkalenkov](/sources/tzhsbevyajhcmr0fmoxfj)
+- [daily.dev World](/sources/dailydevworld): Where we talk all things daily.dev. Check out the threads below and share what you love, or tell us what you hate. Can't wait to meet you 🤗
+- [Nestjs Developers](/sources/nestjsdevs): Welcome to the NestJS Developers Hub, a collaborative community for developers passionate about NestJS\! Whether you're a seasoned expert or just getting started, this group is dedicated to sharing knowledge, solving problems, and advancing our skills
+- [Dev World](/sources/dev_world): This squad was established to be able to share anything about development. Post, Comment, and Upvote\!
+- [Awesome](/sources/awesome-coding): Awesome Coding's resource offer curated lists of resources, tools, and libraries for software developers. Readers can learn about programming languages, frameworks, and development tools across various domains. With carefully selected recommendations and community contributions, Awesome Coding helps developers discover new tools and resources to enhance their productivity and skills.
+- [80 LEVEL](/sources/80lv): 80lv's platform is a resource for game developers and 3D artists, offering insights into game development techniques, industry trends, and visual effects \(VFX\). Through articles, interviews, and case studies, 80lv offers insights into 3D modeling, texturing, animation, and rendering. Developers and artists can learn about game engines, shader programming, and advanced rendering techniques to create immersive and visually stunning games and animations.
+- [Better Stack](/sources/betterstack): Development tricks and tips. Radically better observability stack. Ship higher-quality software faster. Be the hero of your engineering teams.
+- [Hacker News](/sources/hn): Hacker News is a community-driven platform for sharing and discussing technology news, startups, and programming-related topics. Through user submissions and comments, Hacker News offers insights into emerging technology trends, industry developments, and entrepreneurial ventures. Readers can participate in discussions, share their insights, and stay informed about the latest advancements in technology and innovation.
+
+## Recently Added Sources
+
+- [OpenSearch](/sources/opensearch)
+- [Bevy Engine](/sources/bevy)
+- [TanStack](/sources/tanstack-blog)
+- [Ollama](/sources/ollama)
+- [MariaDB.org](/sources/mariadb-foundation)
+- [Valibot: The modular and type safe schema library](/sources/valibot)
+- [
+      Tuist
+    ](/sources/tuist-blog)
+- [Nitro Modules](/sources/margelo)
+- [Linkerd](/sources/linkerd)
+- [YARA-X](/sources/yara-x)
+
+## Top Video Sources
+
+- [Awesome](/sources/awesome-coding): Awesome Coding's resource offer curated lists of resources, tools, and libraries for software developers. Readers can learn about programming languages, frameworks, and development tools across various domains. With carefully selected recommendations and community contributions, Awesome Coding helps developers discover new tools and resources to enhance their productivity and skills.
+- [Kevin Powell](/sources/kevinpowell)
+- [CodeHead](/sources/codehead)
+- [Continuous Delivery](/sources/continuousdelivery)
+- [Let's Get Rusty](/sources/letsgetrusty)
+- [Chris Titus Tech](/sources/christitustech)
+- [Fireship](/sources/fireship): Fireship is a YouTube channel created by Jeff Delaney that offers quick tutorials and explanations on web development, programming, and tech trends. Known for the “100 Seconds of Code” and “The Code Report” series, the channel breaks down complex topics in a short, engaging format, covering everything from JavaScript frameworks to emerging technologies.
+- [Low Level Learning](/sources/lowlevellearning)
+- [ThePrimeTime](/sources/primeagen): Primeagen's resource offers insights, tutorials, and resources for software developers and technology enthusiasts. Readers can learn about productivity hacks, career development strategies, and personal growth. With articles, videos, and practical advice, Primeagen provides  guidance and expertise for achieving professional success and fulfillment.
+- [DevOps Toolbox](/sources/devopstoolbox)
+
+---
+
+[View all sources on daily.dev](/sources)
+
+---
+
+---
+title: Tags Directory
+url: https://daily.dev/tags
+description: Discover topics that matter to developers on daily.dev
+---
+
+> ## Documentation Index
+> Fetch the complete documentation index at: https://daily.dev/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Tags Directory
+
+> Discover topics that matter to developers on daily.dev
+
+Browse trending, popular, and all available tags to find content that matches your interests.
+
+## Trending Tags
+
+- [frontend](/tags/frontend)
+- [aws](/tags/aws)
+- [prompt-engineering](/tags/prompt-engineering)
+- [aws-dynamodb](/tags/aws-dynamodb)
+- [react-native](/tags/react-native)
+- [nodejs](/tags/nodejs)
+- [claude-code](/tags/claude-code)
+- [javascript](/tags/javascript)
+- [css](/tags/css)
+- [vibe-coding](/tags/vibe-coding)
+
+## Popular Tags
+
+- [distributed-systems](/tags/distributed-systems)
+- [dailydev](/tags/dailydev)
+- [nestjs](/tags/nestjs)
+- [tech-news](/tags/tech-news)
+- [frontend](/tags/frontend)
+- [career](/tags/career)
+- [backend](/tags/backend)
+- [code-review](/tags/code-review)
+- [architecture](/tags/architecture)
+- [git](/tags/git)
+
+## All Tags
+
+### A
+
+- [ab-testing](/tags/ab-testing)
+- [accessibility](/tags/accessibility)
+- [acquisition](/tags/acquisition)
+- [active-directory](/tags/active-directory)
+- [activitypub](/tags/activitypub)
+- [adobe](/tags/adobe)
+- [adonisjs](/tags/adonisjs)
+- [advertising](/tags/advertising)
+- [agentic-ai](/tags/agentic-ai)
+- [agile](/tags/agile)
+- [ai](/tags/ai)
+- [ai-agents](/tags/ai-agents)
+- [ai-coding](/tags/ai-coding)
+- [ai-engineering](/tags/ai-engineering)
+- [ai-gateway](/tags/ai-gateway)
+- [ai-governance](/tags/ai-governance)
+- [ai-image-generation](/tags/ai-image-generation)
+- [ai-inference](/tags/ai-inference)
+- [ai-infrastructure](/tags/ai-infrastructure)
+- [ai-regulation](/tags/ai-regulation)
+- [ai-safety](/tags/ai-safety)
+- [ai-sdk](/tags/ai-sdk)
+- [ai-search](/tags/ai-search)
+- [ai-security](/tags/ai-security)
+- [ai-video-generation](/tags/ai-video-generation)
+- [aiops](/tags/aiops)
+- [akka](/tags/akka)
+- [alexa](/tags/alexa)
+- [algolia](/tags/algolia)
+- [algorithms](/tags/algorithms)
+- [alibaba](/tags/alibaba)
+- [alibaba-cloud](/tags/alibaba-cloud)
+- [alloydb](/tags/alloydb)
+- [alpinejs](/tags/alpinejs)
+- [amazon](/tags/amazon)
+- [amazon-bedrock](/tags/amazon-bedrock)
+- [amazon-ivs](/tags/amazon-ivs)
+- [amazon-q](/tags/amazon-q)
+- [amd](/tags/amd)
+- [amplication](/tags/amplication)
+- [analytics-intelligence](/tags/analytics-intelligence)
+- [analytics-platforms](/tags/analytics-platforms)
+- [android](/tags/android)
+- [android-development](/tags/android-development)
+- [android-studio](/tags/android-studio)
+- [angel-investors](/tags/angel-investors)
+- [angular](/tags/angular)
+- [ansible](/tags/ansible)
+- [anthropic](/tags/anthropic)
+- [apache](/tags/apache)
+- [apache-activemq](/tags/apache-activemq)
+- [apache-airflow](/tags/apache-airflow)
+- [apache-apisix](/tags/apache-apisix)
+- [apache-arrow](/tags/apache-arrow)
+- [apache-camel](/tags/apache-camel)
+- [apache-cassandra](/tags/apache-cassandra)
+- [apache-flink](/tags/apache-flink)
+- [apache-hadoop](/tags/apache-hadoop)
+- [apache-iceberg](/tags/apache-iceberg)
+- [apache-kafka](/tags/apache-kafka)
+- [apache-spark](/tags/apache-spark)
+- [api-gateway](/tags/api-gateway)
+- [apm](/tags/apm)
+- [apollo](/tags/apollo)
+- [app-store](/tags/app-store)
+- [apple](/tags/apple)
+- [apple-intelligence](/tags/apple-intelligence)
+- [appsec](/tags/appsec)
+- [appwrite](/tags/appwrite)
+- [ar](/tags/ar)
+- [arangodb](/tags/arangodb)
+- [architecture](/tags/architecture)
+- [argocd](/tags/argocd)
+- [arm](/tags/arm)
+- [armo](/tags/armo)
+- [artifactory](/tags/artifactory)
+- [aspnet](/tags/aspnet)
+- [aspnetcore](/tags/aspnetcore)
+- [assembly](/tags/assembly)
+- [astro](/tags/astro)
+- [astrophysics](/tags/astrophysics)
+- [atlassian](/tags/atlassian)
+- [audio-processing](/tags/audio-processing)
+- [audit](/tags/audit)
+- [aurora](/tags/aurora)
+- [auth0](/tags/auth0)
+- [authentication](/tags/authentication)
+- [authorization](/tags/authorization)
+- [automation](/tags/automation)
+- [automl](/tags/automl)
+- [automotive](/tags/automotive)
+- [autonomous-cars](/tags/autonomous-cars)
+- [autonomous-systems](/tags/autonomous-systems)
+- [avalonia](/tags/avalonia)
+- [aws](/tags/aws)
+- [aws-cloudformation](/tags/aws-cloudformation)
+- [aws-cloudwatch](/tags/aws-cloudwatch)
+- [aws-dynamodb](/tags/aws-dynamodb)
+- [aws-ec2](/tags/aws-ec2)
+- [aws-iam](/tags/aws-iam)
+- [aws-lambda](/tags/aws-lambda)
+- [aws-rds](/tags/aws-rds)
+- [aws-s3](/tags/aws-s3)
+- [aws-sagemaker](/tags/aws-sagemaker)
+- [axios](/tags/axios)
+- [azure](/tags/azure)
+- [azure-ai](/tags/azure-ai)
+- [azure-cosmos-db](/tags/azure-cosmos-db)
+- [azure-devops](/tags/azure-devops)
+- [azure-functions](/tags/azure-functions)
+- [azure-openai](/tags/azure-openai)
+
+### B
+
+- [babel](/tags/babel)
+- [backend](/tags/backend)
+- [ballerina](/tags/ballerina)
+- [banking](/tags/banking)
+- [bard](/tags/bard)
+- [bash](/tags/bash)
+- [bazel](/tags/bazel)
+- [bcachefs](/tags/bcachefs)
+- [bereal](/tags/bereal)
+- [bert](/tags/bert)
+- [bgp](/tags/bgp)
+- [bi](/tags/bi)
+- [big-data](/tags/big-data)
+- [big-tech](/tags/big-tech)
+- [binary-search](/tags/binary-search)
+- [binary-tree](/tags/binary-tree)
+- [bing-chat](/tags/bing-chat)
+- [biotech](/tags/biotech)
+- [bitbucket](/tags/bitbucket)
+- [bitcoin](/tags/bitcoin)
+- [blazor](/tags/blazor)
+- [blender](/tags/blender)
+- [blockchain](/tags/blockchain)
+- [bluetooth](/tags/bluetooth)
+- [bootcamp](/tags/bootcamp)
+- [bootloader](/tags/bootloader)
+- [bootstrap-css](/tags/bootstrap-css)
+- [boto3](/tags/boto3)
+- [bots](/tags/bots)
+- [brain-computer-interface](/tags/brain-computer-interface)
+- [brave-browser](/tags/brave-browser)
+- [browsers](/tags/browsers)
+- [build-systems](/tags/build-systems)
+- [bun](/tags/bun)
+- [burp-suite](/tags/burp-suite)
+- [business](/tags/business)
+- [business-development](/tags/business-development)
+
+### C
+
+- [c](/tags/c)
+- [c\#](/tags/c#)
+- [c\+\+](/tags/c++)
+- [career](/tags/career)
+- [cd-projekt-red](/tags/cd-projekt-red)
+- [celery](/tags/celery)
+- [cerbos](/tags/cerbos)
+- [cerebras](/tags/cerebras)
+- [ces](/tags/ces)
+- [change-data-capture](/tags/change-data-capture)
+- [chatgpt](/tags/chatgpt)
+- [chef](/tags/chef)
+- [chemical-engineering](/tags/chemical-engineering)
+- [chromeos](/tags/chromeos)
+- [chromium](/tags/chromium)
+- [cicd](/tags/cicd)
+- [cilium](/tags/cilium)
+- [circleci](/tags/circleci)
+- [cisco](/tags/cisco)
+- [classification](/tags/classification)
+- [claude](/tags/claude)
+- [claude-code](/tags/claude-code)
+- [clean-energy](/tags/clean-energy)
+- [cli](/tags/cli)
+- [clickhouse](/tags/clickhouse)
+- [climate-tech](/tags/climate-tech)
+- [clojure](/tags/clojure)
+- [cloud](/tags/cloud)
+- [cloud-native](/tags/cloud-native)
+- [cloudflare](/tags/cloudflare)
+- [cms](/tags/cms)
+- [cnapp](/tags/cnapp)
+- [cncf](/tags/cncf)
+- [cockroachdb](/tags/cockroachdb)
+- [cocoapods](/tags/cocoapods)
+- [code-review](/tags/code-review)
+- [code-scanning](/tags/code-scanning)
+- [code-security](/tags/code-security)
+- [codeql](/tags/codeql)
+- [codewhisperer](/tags/codewhisperer)
+- [cognitive-science](/tags/cognitive-science)
+- [cohere](/tags/cohere)
+- [coinbase](/tags/coinbase)
+- [community](/tags/community)
+- [company-culture](/tags/company-culture)
+- [compiler](/tags/compiler)
+- [compiler-optimization](/tags/compiler-optimization)
+- [compliance](/tags/compliance)
+- [compose-multiplatform](/tags/compose-multiplatform)
+- [compression](/tags/compression)
+- [computer-science](/tags/computer-science)
+- [computer-vision](/tags/computer-vision)
+- [computing](/tags/computing)
+- [computing-history](/tags/computing-history)
+- [conference](/tags/conference)
+- [confluent-cloud](/tags/confluent-cloud)
+- [containers](/tags/containers)
+- [content-creation](/tags/content-creation)
+- [context-engineering](/tags/context-engineering)
+- [continuous-improvement](/tags/continuous-improvement)
+- [conversational-ai](/tags/conversational-ai)
+- [coralogix](/tags/coralogix)
+- [cosmos-db](/tags/cosmos-db)
+- [couchbase](/tags/couchbase)
+- [couchbase-capella](/tags/couchbase-capella)
+- [course](/tags/course)
+- [cpra](/tags/cpra)
+- [cpython](/tags/cpython)
+- [cratedb](/tags/cratedb)
+- [crawling](/tags/crawling)
+- [creative-coding](/tags/creative-coding)
+- [creator-economy](/tags/creator-economy)
+- [crm](/tags/crm)
+- [crossplane](/tags/crossplane)
+- [crypto](/tags/crypto)
+- [cryptography](/tags/cryptography)
+- [css](/tags/css)
+- [cuda](/tags/cuda)
+- [curl](/tags/curl)
+- [customer-service](/tags/customer-service)
+- [cyber](/tags/cyber)
+- [cypress](/tags/cypress)
+
+### D
+
+- [dagster](/tags/dagster)
+- [dailydev](/tags/dailydev)
+- [dalle](/tags/dalle)
+- [dao](/tags/dao)
+- [dart](/tags/dart)
+- [data-analysis](/tags/data-analysis)
+- [data-architecture](/tags/data-architecture)
+- [data-breach](/tags/data-breach)
+- [data-engineering](/tags/data-engineering)
+- [data-exfiltration](/tags/data-exfiltration)
+- [data-labelling](/tags/data-labelling)
+- [data-lake](/tags/data-lake)
+- [data-leak](/tags/data-leak)
+- [data-management](/tags/data-management)
+- [data-observability](/tags/data-observability)
+- [data-privacy](/tags/data-privacy)
+- [data-processing](/tags/data-processing)
+- [data-protection](/tags/data-protection)
+- [data-quality](/tags/data-quality)
+- [data-retrieval](/tags/data-retrieval)
+- [data-science](/tags/data-science)
+- [data-streaming](/tags/data-streaming)
+- [data-structures](/tags/data-structures)
+- [data-visualization](/tags/data-visualization)
+- [data-warehouse](/tags/data-warehouse)
+- [database](/tags/database)
+- [databricks](/tags/databricks)
+- [datacenters](/tags/datacenters)
+- [datasette](/tags/datasette)
+- [dataverse](/tags/dataverse)
+- [debezium](/tags/debezium)
+- [decentralization](/tags/decentralization)
+- [decentralized](/tags/decentralized)
+- [decentralized-finance](/tags/decentralized-finance)
+- [decision-tree](/tags/decision-tree)
+- [deep-learning](/tags/deep-learning)
+- [deep-tech](/tags/deep-tech)
+- [deepgram](/tags/deepgram)
+- [deepseek](/tags/deepseek)
+- [defcon](/tags/defcon)
+- [defense-tech](/tags/defense-tech)
+- [defi](/tags/defi)
+- [deno](/tags/deno)
+- [dependabot](/tags/dependabot)
+- [dependency-injection](/tags/dependency-injection)
+- [design-patterns](/tags/design-patterns)
+- [design-systems](/tags/design-systems)
+- [design-tools](/tags/design-tools)
+- [desktop-development](/tags/desktop-development)
+- [devin](/tags/devin)
+- [devops](/tags/devops)
+- [devrel](/tags/devrel)
+- [devsecops](/tags/devsecops)
+- [devtools](/tags/devtools)
+- [devtron](/tags/devtron)
+- [diffusion-models](/tags/diffusion-models)
+- [digital-payments](/tags/digital-payments)
+- [digital-transformation](/tags/digital-transformation)
+- [digital-twin](/tags/digital-twin)
+- [digital-wallet](/tags/digital-wallet)
+- [digitalocean](/tags/digitalocean)
+- [directus](/tags/directus)
+- [discord](/tags/discord)
+- [disney](/tags/disney)
+- [distributed-systems](/tags/distributed-systems)
+- [diversity-and-inclusion](/tags/diversity-and-inclusion)
+- [django](/tags/django)
+- [dma](/tags/dma)
+- [dns](/tags/dns)
+- [docker](/tags/docker)
+- [docker-compose](/tags/docker-compose)
+- [docker-swarm](/tags/docker-swarm)
+- [docusaurus](/tags/docusaurus)
+- [dom](/tags/dom)
+- [domain-driven-design](/tags/domain-driven-design)
+- [dora](/tags/dora)
+- [dora-metrics](/tags/dora-metrics)
+- [drizzle](/tags/drizzle)
+- [droidcon](/tags/droidcon)
+- [duckdb](/tags/duckdb)
+- [duet-ai](/tags/duet-ai)
+- [dynamic-programming](/tags/dynamic-programming)
+
+### E
+
+- [ecommerce](/tags/ecommerce)
+- [ecto](/tags/ecto)
+- [edge-computing](/tags/edge-computing)
+- [edtech](/tags/edtech)
+- [education-technology](/tags/education-technology)
+- [electron](/tags/electron)
+- [elevenlabs](/tags/elevenlabs)
+- [elixir](/tags/elixir)
+- [elk](/tags/elk)
+- [elm](/tags/elm)
+- [embedded](/tags/embedded)
+- [embeddings](/tags/embeddings)
+- [emberjs](/tags/emberjs)
+- [encryption](/tags/encryption)
+- [enterprise](/tags/enterprise)
+- [entrepreneurship](/tags/entrepreneurship)
+- [envoy](/tags/envoy)
+- [erlang](/tags/erlang)
+- [erp](/tags/erp)
+- [ethereum](/tags/ethereum)
+- [ethical-ai](/tags/ethical-ai)
+- [ethics](/tags/ethics)
+- [etl](/tags/etl)
+- [evm](/tags/evm)
+- [evpn](/tags/evpn)
+- [explainable-ai](/tags/explainable-ai)
+- [exploratory-data-analysis](/tags/exploratory-data-analysis)
+- [express](/tags/express)
+- [ey](/tags/ey)
+
+### F
+
+- [facebook](/tags/facebook)
+- [facial-recognition](/tags/facial-recognition)
+- [fastapi](/tags/fastapi)
+- [fastify](/tags/fastify)
+- [faunadb](/tags/faunadb)
+- [feature-engineering](/tags/feature-engineering)
+- [fediverse](/tags/fediverse)
+- [fedora](/tags/fedora)
+- [fermyon](/tags/fermyon)
+- [figma](/tags/figma)
+- [filesystems](/tags/filesystems)
+- [finance](/tags/finance)
+- [finops](/tags/finops)
+- [fintech](/tags/fintech)
+- [firebase](/tags/firebase)
+- [firefox](/tags/firefox)
+- [firestore](/tags/firestore)
+- [firewall](/tags/firewall)
+- [firmware](/tags/firmware)
+- [flask](/tags/flask)
+- [flutter](/tags/flutter)
+- [flux](/tags/flux)
+- [forgejo](/tags/forgejo)
+- [fortinet](/tags/fortinet)
+- [fortran](/tags/fortran)
+- [fpga](/tags/fpga)
+- [framer](/tags/framer)
+- [framer-motion](/tags/framer-motion)
+- [fraud-detection](/tags/fraud-detection)
+- [freedos](/tags/freedos)
+- [frontend](/tags/frontend)
+- [fsharp](/tags/fsharp)
+- [ftx](/tags/ftx)
+- [full-text-search](/tags/full-text-search)
+- [functional-programming](/tags/functional-programming)
+- [future](/tags/future)
+- [future-of-work](/tags/future-of-work)
+
+### G
+
+- [game-design](/tags/game-design)
+- [game-development](/tags/game-development)
+- [gaming](/tags/gaming)
+- [gateway-api](/tags/gateway-api)
+- [gatsby](/tags/gatsby)
+- [gcp](/tags/gcp)
+- [gcp-cloud-functions](/tags/gcp-cloud-functions)
+- [gdpr](/tags/gdpr)
+- [gem](/tags/gem)
+- [gemma](/tags/gemma)
+- [genai](/tags/genai)
+- [general-programming](/tags/general-programming)
+- [generative-art](/tags/generative-art)
+- [gis](/tags/gis)
+- [git](/tags/git)
+- [gitguardian](/tags/gitguardian)
+- [github](/tags/github)
+- [github-actions](/tags/github-actions)
+- [github-pages](/tags/github-pages)
+- [gitlab](/tags/gitlab)
+- [gitlab-ci](/tags/gitlab-ci)
+- [gitops](/tags/gitops)
+- [gitpod](/tags/gitpod)
+- [gke](/tags/gke)
+- [gleam](/tags/gleam)
+- [godot](/tags/godot)
+- [goerli](/tags/goerli)
+- [golang](/tags/golang)
+- [google](/tags/google)
+- [google-ai](/tags/google-ai)
+- [google-ai-studio](/tags/google-ai-studio)
+- [google-analytics](/tags/google-analytics)
+- [google-assistant](/tags/google-assistant)
+- [google-bard](/tags/google-bard)
+- [google-bigquery](/tags/google-bigquery)
+- [google-chrome](/tags/google-chrome)
+- [google-deepmind](/tags/google-deepmind)
+- [google-drive](/tags/google-drive)
+- [google-gemini](/tags/google-gemini)
+- [google-io](/tags/google-io)
+- [google-play](/tags/google-play)
+- [gpt](/tags/gpt)
+- [gpt-store](/tags/gpt-store)
+- [gpu](/tags/gpu)
+- [gradient-descent](/tags/gradient-descent)
+- [gradio](/tags/gradio)
+- [gradle](/tags/gradle)
+- [grafana](/tags/grafana)
+- [graph-theory](/tags/graph-theory)
+- [graphics-programming](/tags/graphics-programming)
+- [graphql](/tags/graphql)
+- [graviton](/tags/graviton)
+- [green-energy](/tags/green-energy)
+- [grok](/tags/grok)
+- [grpc](/tags/grpc)
+- [gstreamer](/tags/gstreamer)
+
+### H
+
+- [hackathon](/tags/hackathon)
+- [hacktoberfest](/tags/hacktoberfest)
+- [hanami](/tags/hanami)
+- [hardhat](/tags/hardhat)
+- [hardware](/tags/hardware)
+- [harperdb](/tags/harperdb)
+- [hashicorp](/tags/hashicorp)
+- [haskell](/tags/haskell)
+- [health-tech](/tags/health-tech)
+- [healthcare](/tags/healthcare)
+- [helios](/tags/helios)
+- [helm](/tags/helm)
+- [heroku](/tags/heroku)
+- [hive](/tags/hive)
+- [homelab](/tags/homelab)
+- [hotwire](/tags/hotwire)
+- [hr](/tags/hr)
+- [hr-tech](/tags/hr-tech)
+- [html](/tags/html)
+- [htmx](/tags/htmx)
+- [huawei](/tags/huawei)
+- [hubspot](/tags/hubspot)
+- [huggingface](/tags/huggingface)
+- [human-computer-interaction](/tags/human-computer-interaction)
+- [hybrid-cloud](/tags/hybrid-cloud)
+- [hybrid-work](/tags/hybrid-work)
+
+### I
+
+- [iac](/tags/iac)
+- [iam](/tags/iam)
+- [ibm](/tags/ibm)
+- [ibm-cloud](/tags/ibm-cloud)
+- [identity-theft](/tags/identity-theft)
+- [identity-verification](/tags/identity-verification)
+- [image-editing](/tags/image-editing)
+- [image-processing](/tags/image-processing)
+- [indie-dev](/tags/indie-dev)
+- [indie-hacking](/tags/indie-hacking)
+- [influencer-marketing](/tags/influencer-marketing)
+- [influxdb](/tags/influxdb)
+- [infrastructure](/tags/infrastructure)
+- [instagram](/tags/instagram)
+- [intel](/tags/intel)
+- [internal-developer-platform](/tags/internal-developer-platform)
+- [internship](/tags/internship)
+- [interview](/tags/interview)
+- [interview-questions](/tags/interview-questions)
+- [investing](/tags/investing)
+- [ionic](/tags/ionic)
+- [ios](/tags/ios)
+- [iot](/tags/iot)
+- [iphone](/tags/iphone)
+- [ipo](/tags/ipo)
+- [istio](/tags/istio)
+- [it](/tags/it)
+
+### J
+
+- [jakarta-ee](/tags/jakarta-ee)
+- [jamstack](/tags/jamstack)
+- [java](/tags/java)
+- [javascript](/tags/javascript)
+- [jdk](/tags/jdk)
+- [jellyfin](/tags/jellyfin)
+- [jenkins](/tags/jenkins)
+- [jest](/tags/jest)
+- [jetbrains](/tags/jetbrains)
+- [jetpack-compose](/tags/jetpack-compose)
+- [jfrog](/tags/jfrog)
+- [jhipster](/tags/jhipster)
+- [jira](/tags/jira)
+- [jquery](/tags/jquery)
+- [jsx](/tags/jsx)
+- [julia](/tags/julia)
+- [jupyter](/tags/jupyter)
+- [jvm](/tags/jvm)
+- [jwt](/tags/jwt)
+
+### K
+
+- [kafka](/tags/kafka)
+- [kamal](/tags/kamal)
+- [kaspersky](/tags/kaspersky)
+- [kendo-ui](/tags/kendo-ui)
+- [keras](/tags/keras)
+- [kerberos](/tags/kerberos)
+- [kernel-development](/tags/kernel-development)
+- [kimi](/tags/kimi)
+- [konami](/tags/konami)
+- [kotlin](/tags/kotlin)
+- [ktor](/tags/ktor)
+- [kubernetes](/tags/kubernetes)
+- [kubescape](/tags/kubescape)
+- [kyverno](/tags/kyverno)
+
+### L
+
+- [langchain](/tags/langchain)
+- [langchain4j](/tags/langchain4j)
+- [langgraph](/tags/langgraph)
+- [langsmith](/tags/langsmith)
+- [language-design](/tags/language-design)
+- [laravel](/tags/laravel)
+- [law](/tags/law)
+- [leadership](/tags/leadership)
+- [legal](/tags/legal)
+- [licensing](/tags/licensing)
+- [lightbend](/tags/lightbend)
+- [lighthouse](/tags/lighthouse)
+- [linear-regression](/tags/linear-regression)
+- [linkedin](/tags/linkedin)
+- [linux](/tags/linux)
+- [lisp](/tags/lisp)
+- [litellm](/tags/litellm)
+- [livebook](/tags/livebook)
+- [liveview](/tags/liveview)
+- [llama](/tags/llama)
+- [llama-cpp](/tags/llama-cpp)
+- [llm](/tags/llm)
+- [llm-observability](/tags/llm-observability)
+- [llmops](/tags/llmops)
+- [lm-studio](/tags/lm-studio)
+- [load-testing](/tags/load-testing)
+- [local-ai](/tags/local-ai)
+- [local-first](/tags/local-first)
+- [localization](/tags/localization)
+- [lockbit](/tags/lockbit)
+- [log4shell](/tags/log4shell)
+- [logging](/tags/logging)
+- [logistic-regression](/tags/logistic-regression)
+- [lora](/tags/lora)
+- [lovable](/tags/lovable)
+- [lsp](/tags/lsp)
+- [lstm](/tags/lstm)
+- [lua](/tags/lua)
+- [lyft](/tags/lyft)
+
+### M
+
+- [mac](/tags/mac)
+- [machine-learning](/tags/machine-learning)
+- [magento](/tags/magento)
+- [mainnet](/tags/mainnet)
+- [malware](/tags/malware)
+- [manticore-search](/tags/manticore-search)
+- [manufacturing](/tags/manufacturing)
+- [markdown](/tags/markdown)
+- [market-analysis](/tags/market-analysis)
+- [market-research](/tags/market-research)
+- [marketing](/tags/marketing)
+- [mastodon](/tags/mastodon)
+- [materialize](/tags/materialize)
+- [math](/tags/math)
+- [matplotlib](/tags/matplotlib)
+- [maven](/tags/maven)
+- [mcp](/tags/mcp)
+- [mechanical-engineering](/tags/mechanical-engineering)
+- [medical-research](/tags/medical-research)
+- [meilisearch](/tags/meilisearch)
+- [mental-health](/tags/mental-health)
+- [mesa](/tags/mesa)
+- [metahuman](/tags/metahuman)
+- [metamask](/tags/metamask)
+- [metaverse](/tags/metaverse)
+- [micropython](/tags/micropython)
+- [microservices](/tags/microservices)
+- [microsoft](/tags/microsoft)
+- [microsoft-copilot](/tags/microsoft-copilot)
+- [microsoft-edge](/tags/microsoft-edge)
+- [microsoft-fabric](/tags/microsoft-fabric)
+- [microsoft-sql-server](/tags/microsoft-sql-server)
+- [midjourney](/tags/midjourney)
+- [mistral-ai](/tags/mistral-ai)
+- [mit](/tags/mit)
+- [mixture-of-experts](/tags/mixture-of-experts)
+- [mlops](/tags/mlops)
+- [mmorpg](/tags/mmorpg)
+- [mnist](/tags/mnist)
+- [mobile](/tags/mobile)
+- [mobile-design](/tags/mobile-design)
+- [mobile-gaming](/tags/mobile-gaming)
+- [mobility](/tags/mobility)
+- [modding](/tags/modding)
+- [mongodb](/tags/mongodb)
+- [mongoose](/tags/mongoose)
+- [monitoring](/tags/monitoring)
+- [monolith](/tags/monolith)
+- [moonshot-ai](/tags/moonshot-ai)
+- [moralis](/tags/moralis)
+- [mozilla](/tags/mozilla)
+- [mulesoft](/tags/mulesoft)
+- [multi-cloud](/tags/multi-cloud)
+- [multi-tenancy](/tags/multi-tenancy)
+- [multimodal](/tags/multimodal)
+- [mutation-testing](/tags/mutation-testing)
+- [mysql](/tags/mysql)
+
+### N
+
+- [n8n](/tags/n8n)
+- [nanotechnology](/tags/nanotechnology)
+- [nasa](/tags/nasa)
+- [nativescript](/tags/nativescript)
+- [neo4j](/tags/neo4j)
+- [nestjs](/tags/nestjs)
+- [netflix](/tags/netflix)
+- [netlify](/tags/netlify)
+- [networking](/tags/networking)
+- [neural-networks](/tags/neural-networks)
+- [nextjs](/tags/nextjs)
+- [nft](/tags/nft)
+- [nginx](/tags/nginx)
+- [nintendo](/tags/nintendo)
+- [nixos](/tags/nixos)
+- [nlp](/tags/nlp)
+- [nocode](/tags/nocode)
+- [nodejs](/tags/nodejs)
+- [nosql](/tags/nosql)
+- [notebooklm](/tags/notebooklm)
+- [notion](/tags/notion)
+- [novu](/tags/novu)
+- [npm](/tags/npm)
+- [nuget](/tags/nuget)
+- [numpy](/tags/numpy)
+- [nuxt](/tags/nuxt)
+- [nvidia](/tags/nvidia)
+- [nvidia-nemo](/tags/nvidia-nemo)
+
+### O
+
+- [oauth](/tags/oauth)
+- [object-detection](/tags/object-detection)
+- [objective-c](/tags/objective-c)
+- [observability](/tags/observability)
+- [ocaml](/tags/ocaml)
+- [octopus-deploy](/tags/octopus-deploy)
+- [offensive-security](/tags/offensive-security)
+- [offline-first](/tags/offline-first)
+- [okta](/tags/okta)
+- [olap](/tags/olap)
+- [ollama](/tags/ollama)
+- [open-source](/tags/open-source)
+- [openai](/tags/openai)
+- [openai-codex](/tags/openai-codex)
+- [openapi](/tags/openapi)
+- [openbsd](/tags/openbsd)
+- [opencl](/tags/opencl)
+- [openclaw](/tags/openclaw)
+- [opencode](/tags/opencode)
+- [opencv](/tags/opencv)
+- [openrouter](/tags/openrouter)
+- [opensearch](/tags/opensearch)
+- [openshift](/tags/openshift)
+- [opensuse](/tags/opensuse)
+- [opentelemetry](/tags/opentelemetry)
+- [opentofu](/tags/opentofu)
+- [openusd](/tags/openusd)
+- [openxr](/tags/openxr)
+- [oracle](/tags/oracle)
+- [orchestration](/tags/orchestration)
+- [osint](/tags/osint)
+- [overfitting](/tags/overfitting)
+
+### P
+
+- [palm](/tags/palm)
+- [pandas](/tags/pandas)
+- [passive-income](/tags/passive-income)
+- [passkeys](/tags/passkeys)
+- [payment-processing](/tags/payment-processing)
+- [paypal](/tags/paypal)
+- [peer-to-peer](/tags/peer-to-peer)
+- [pentest](/tags/pentest)
+- [pentesting](/tags/pentesting)
+- [performance](/tags/performance)
+- [perl](/tags/perl)
+- [perplexity](/tags/perplexity)
+- [personal-branding](/tags/personal-branding)
+- [pgvector](/tags/pgvector)
+- [phishing](/tags/phishing)
+- [photo-editing](/tags/photo-editing)
+- [photoshop](/tags/photoshop)
+- [php](/tags/php)
+- [phpstan](/tags/phpstan)
+- [phpunit](/tags/phpunit)
+- [physics](/tags/physics)
+- [pinecone](/tags/pinecone)
+- [pinterest](/tags/pinterest)
+- [pip](/tags/pip)
+- [pki](/tags/pki)
+- [planetscale](/tags/planetscale)
+- [platform-engineering](/tags/platform-engineering)
+- [plotly](/tags/plotly)
+- [pnpm](/tags/pnpm)
+- [polars](/tags/polars)
+- [policy-as-code](/tags/policy-as-code)
+- [polypane](/tags/polypane)
+- [postgresql](/tags/postgresql)
+- [postman](/tags/postman)
+- [power-bi](/tags/power-bi)
+- [power-pages](/tags/power-pages)
+- [powershell](/tags/powershell)
+- [preact](/tags/preact)
+- [predictive-analytics](/tags/predictive-analytics)
+- [prisma](/tags/prisma)
+- [privacy](/tags/privacy)
+- [product-management](/tags/product-management)
+- [productivity](/tags/productivity)
+- [project-management](/tags/project-management)
+- [prometheus](/tags/prometheus)
+- [prompt-engineering](/tags/prompt-engineering)
+- [prompt-injection](/tags/prompt-injection)
+- [proof-of-stake](/tags/proof-of-stake)
+- [proof-of-work](/tags/proof-of-work)
+- [proxmox](/tags/proxmox)
+- [public-cloud](/tags/public-cloud)
+- [public-speaking](/tags/public-speaking)
+- [pulumi](/tags/pulumi)
+- [puppet](/tags/puppet)
+- [pwa](/tags/pwa)
+- [pydantic](/tags/pydantic)
+- [pyimagesearch](/tags/pyimagesearch)
+- [pyspark](/tags/pyspark)
+- [python](/tags/python)
+- [pytorch](/tags/pytorch)
+
+### Q
+
+- [qa](/tags/qa)
+- [qakbot](/tags/qakbot)
+- [qcon](/tags/qcon)
+- [qiskit](/tags/qiskit)
+- [qml](/tags/qml)
+- [qt](/tags/qt)
+- [quantum-computing](/tags/quantum-computing)
+- [quarkus](/tags/quarkus)
+- [quarto](/tags/quarto)
+- [qwen](/tags/qwen)
+- [qwik](/tags/qwik)
+
+### R
+
+- [r](/tags/r)
+- [rabbitmq](/tags/rabbitmq)
+- [rag](/tags/rag)
+- [rails](/tags/rails)
+- [random-forest](/tags/random-forest)
+- [ransomware](/tags/ransomware)
+- [raspberry-pi](/tags/raspberry-pi)
+- [ravendb](/tags/ravendb)
+- [react](/tags/react)
+- [react-hooks](/tags/react-hooks)
+- [react-native](/tags/react-native)
+- [react-query](/tags/react-query)
+- [react-router](/tags/react-router)
+- [react-three-fiber](/tags/react-three-fiber)
+- [reactive-programming](/tags/reactive-programming)
+- [real-time-analytics](/tags/real-time-analytics)
+- [real-time-systems](/tags/real-time-systems)
+- [recommendation-systems](/tags/recommendation-systems)
+- [recursion](/tags/recursion)
+- [red-hat](/tags/red-hat)
+- [red-teaming](/tags/red-teaming)
+- [redis](/tags/redis)
+- [redpanda](/tags/redpanda)
+- [redshift](/tags/redshift)
+- [redux](/tags/redux)
+- [regression-analysis](/tags/regression-analysis)
+- [regulation](/tags/regulation)
+- [regulatory-compliance](/tags/regulatory-compliance)
+- [reinforcement-learning](/tags/reinforcement-learning)
+- [remote-work](/tags/remote-work)
+- [responsible-ai](/tags/responsible-ai)
+- [rest-api](/tags/rest-api)
+- [retool](/tags/retool)
+- [retrocomputing](/tags/retrocomputing)
+- [revenue](/tags/revenue)
+- [reverse-engineering](/tags/reverse-engineering)
+- [riverpod](/tags/riverpod)
+- [robotics](/tags/robotics)
+- [rocm](/tags/rocm)
+- [rstudio](/tags/rstudio)
+- [rtos](/tags/rtos)
+- [ruby](/tags/ruby)
+- [rust](/tags/rust)
+- [rxjs](/tags/rxjs)
+
+### S
+
+- [safari](/tags/safari)
+- [sales](/tags/sales)
+- [salesforce](/tags/salesforce)
+- [samsung](/tags/samsung)
+- [sap](/tags/sap)
+- [sbom](/tags/sbom)
+- [scala](/tags/scala)
+- [science](/tags/science)
+- [scientific-research](/tags/scientific-research)
+- [scikit](/tags/scikit)
+- [scrum](/tags/scrum)
+- [scylladb](/tags/scylladb)
+- [secrets-management](/tags/secrets-management)
+- [security](/tags/security)
+- [security-token](/tags/security-token)
+- [segmentation](/tags/segmentation)
+- [selenium](/tags/selenium)
+- [self-hosting](/tags/self-hosting)
+- [semantic-kernel](/tags/semantic-kernel)
+- [sensors](/tags/sensors)
+- [sentiment-analysis](/tags/sentiment-analysis)
+- [sentinelone](/tags/sentinelone)
+- [seo](/tags/seo)
+- [series-a](/tags/series-a)
+- [server-sent-events](/tags/server-sent-events)
+- [serverless](/tags/serverless)
+- [service-mesh](/tags/service-mesh)
+- [shadcn](/tags/shadcn)
+- [sharepoint](/tags/sharepoint)
+- [shell](/tags/shell)
+- [shopify](/tags/shopify)
+- [signal-processing](/tags/signal-processing)
+- [sinatra](/tags/sinatra)
+- [singlestore](/tags/singlestore)
+- [slack](/tags/slack)
+- [smart-contracts](/tags/smart-contracts)
+- [snap](/tags/snap)
+- [snowflake](/tags/snowflake)
+- [social-media](/tags/social-media)
+- [softbank](/tags/softbank)
+- [solana](/tags/solana)
+- [solidity](/tags/solidity)
+- [solidjs](/tags/solidjs)
+- [sony](/tags/sony)
+- [sora](/tags/sora)
+- [space-technology](/tags/space-technology)
+- [spacelift](/tags/spacelift)
+- [spacex](/tags/spacex)
+- [spanner](/tags/spanner)
+- [spark](/tags/spark)
+- [spatial-computing](/tags/spatial-computing)
+- [spec-driven-development](/tags/spec-driven-development)
+- [speech-recognition](/tags/speech-recognition)
+- [spotify](/tags/spotify)
+- [spring](/tags/spring)
+- [spring-ai](/tags/spring-ai)
+- [spring-boot](/tags/spring-boot)
+- [spring-security](/tags/spring-security)
+- [sql](/tags/sql)
+- [sqlite](/tags/sqlite)
+- [sre](/tags/sre)
+- [ssh](/tags/ssh)
+- [stability-ai](/tags/stability-ai)
+- [stable-diffusion](/tags/stable-diffusion)
+- [stablecoin](/tags/stablecoin)
+- [startup](/tags/startup)
+- [statistical-analysis](/tags/statistical-analysis)
+- [statistics](/tags/statistics)
+- [steam](/tags/steam)
+- [steam-deck](/tags/steam-deck)
+- [steamos](/tags/steamos)
+- [stm32](/tags/stm32)
+- [storage](/tags/storage)
+- [storybook](/tags/storybook)
+- [stripe](/tags/stripe)
+- [strongdm](/tags/strongdm)
+- [styled-components](/tags/styled-components)
+- [substance-3d](/tags/substance-3d)
+- [substance-3d-designer](/tags/substance-3d-designer)
+- [substance-3d-painter](/tags/substance-3d-painter)
+- [supabase](/tags/supabase)
+- [supply-chain](/tags/supply-chain)
+- [sustainability](/tags/sustainability)
+- [svb](/tags/svb)
+- [svelte](/tags/svelte)
+- [sveltekit](/tags/sveltekit)
+- [svg](/tags/svg)
+- [swift](/tags/swift)
+- [swiftui](/tags/swiftui)
+- [symfony](/tags/symfony)
+- [sysadmin](/tags/sysadmin)
+- [sysdig](/tags/sysdig)
+- [system-design-interview](/tags/system-design-interview)
+
+### T
+
+- [tableau](/tags/tableau)
+- [tailscale](/tags/tailscale)
+- [tailwind-css](/tags/tailwind-css)
+- [tanstack](/tags/tanstack)
+- [tauri](/tags/tauri)
+- [tdd](/tags/tdd)
+- [tech-news](/tags/tech-news)
+- [technical-debt](/tags/technical-debt)
+- [telegram](/tags/telegram)
+- [telerik-ui](/tags/telerik-ui)
+- [tensorflow](/tags/tensorflow)
+- [terraform](/tags/terraform)
+- [tesla](/tags/tesla)
+- [testing](/tags/testing)
+- [text-generation](/tags/text-generation)
+- [text-to-image](/tags/text-to-image)
+- [text-to-speech](/tags/text-to-speech)
+- [text-to-video](/tags/text-to-video)
+- [threejs](/tags/threejs)
+- [tiktok](/tags/tiktok)
+- [time-complexity](/tags/time-complexity)
+- [time-series-forecasting](/tags/time-series-forecasting)
+- [timescale](/tags/timescale)
+- [timescaledb](/tags/timescaledb)
+- [tinybird](/tags/tinybird)
+- [tools](/tags/tools)
+- [transfer-learning](/tags/transfer-learning)
+- [transformers](/tags/transformers)
+- [triplebyte](/tags/triplebyte)
+- [trpc](/tags/trpc)
+- [truenas](/tags/truenas)
+- [twilio](/tags/twilio)
+- [twitch](/tags/twitch)
+- [twitter](/tags/twitter)
+- [type-systems](/tags/type-systems)
+- [typescript](/tags/typescript)
+- [typography](/tags/typography)
+
+### U
+
+- [uber](/tags/uber)
+- [ubuntu](/tags/ubuntu)
+- [ui-design](/tags/ui-design)
+- [ui-ux](/tags/ui-ux)
+- [unity](/tags/unity)
+- [unity-catalog](/tags/unity-catalog)
+- [unix](/tags/unix)
+- [unreal-engine](/tags/unreal-engine)
+- [unsupervised-learning](/tags/unsupervised-learning)
+- [user-testing](/tags/user-testing)
+- [ux](/tags/ux)
+
+### V
+
+- [v8](/tags/v8)
+- [vaadin](/tags/vaadin)
+- [valkey](/tags/valkey)
+- [vb](/tags/vb)
+- [vector-search](/tags/vector-search)
+- [venture-capital](/tags/venture-capital)
+- [vercel](/tags/vercel)
+- [version-control](/tags/version-control)
+- [vertex-ai](/tags/vertex-ai)
+- [vibe-coding](/tags/vibe-coding)
+- [video-generation](/tags/video-generation)
+- [video-production](/tags/video-production)
+- [view-transitions](/tags/view-transitions)
+- [vim](/tags/vim)
+- [virtual-assistant](/tags/virtual-assistant)
+- [virtual-machine](/tags/virtual-machine)
+- [vision-pro](/tags/vision-pro)
+- [visionos](/tags/visionos)
+- [visual-studio](/tags/visual-studio)
+- [vite](/tags/vite)
+- [vitest](/tags/vitest)
+- [vllm](/tags/vllm)
+- [vlm](/tags/vlm)
+- [vmware](/tags/vmware)
+- [voice-ai](/tags/voice-ai)
+- [voice-cloning](/tags/voice-cloning)
+- [vpn](/tags/vpn)
+- [vr](/tags/vr)
+- [vscode](/tags/vscode)
+- [vuejs](/tags/vuejs)
+- [vuex](/tags/vuex)
+- [vulkan](/tags/vulkan)
+- [vulnerability](/tags/vulnerability)
+
+### W
+
+- [wear-os](/tags/wear-os)
+- [wearable](/tags/wearable)
+- [weaviate](/tags/weaviate)
+- [web-animation](/tags/web-animation)
+- [web-components](/tags/web-components)
+- [web-security](/tags/web-security)
+- [web3](/tags/web3)
+- [webassembly](/tags/webassembly)
+- [webdev](/tags/webdev)
+- [webgpu](/tags/webgpu)
+- [webpack](/tags/webpack)
+- [webrtc](/tags/webrtc)
+- [websocket](/tags/websocket)
+- [whisper](/tags/whisper)
+- [window-manager](/tags/window-manager)
+- [windows](/tags/windows)
+- [windsurf](/tags/windsurf)
+- [winui](/tags/winui)
+- [wireshark](/tags/wireshark)
+- [women-in-tech](/tags/women-in-tech)
+- [woocommerce](/tags/woocommerce)
+- [wordpress](/tags/wordpress)
+- [work-life-balance](/tags/work-life-balance)
+- [workflow-orchestration](/tags/workflow-orchestration)
+- [world-models](/tags/world-models)
+- [wpf](/tags/wpf)
+- [wundergraph](/tags/wundergraph)
+- [wwdc](/tags/wwdc)
+
+### X
+
+- [xamarin](/tags/xamarin)
+- [xbox](/tags/xbox)
+- [xcode](/tags/xcode)
+
+### #
+
+- [.net](/tags/.net)
+- [.net-core](/tags/.net-core)
+- [.net-maui](/tags/.net-maui)
+- [3d](/tags/3d)
+
+---
+
+[View all tags on daily.dev](/tags)
+
+---
+
+---
+title: Squads Directory
+url: https://daily.dev/squads/discover
+description: Developer communities on daily.dev
+---
+
+> ## Documentation Index
+> Fetch the complete documentation index at: https://daily.dev/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Squads Directory
+
+> Developer communities on daily.dev
+
+Squads are specialized developer communities focused on specific technologies and topics. Join Squads to connect with like-minded developers, share knowledge, and engage in focused discussions.
+
+## Featured Squads
+
+- [AI](/squads/ai) (29,268 members): The official daily.dev AI community. Led by thought leaders and AI experts. Stay tuned for insights, news and discussions. 
+- [Learn Python](/squads/lpython) (27,295 members): Welcome to Learn Python Community, created by Sophia Iroegbu, a Python developer who loves making videos about cool ways to build in Python. Join us to learn Python, share your knowledge and connect with fellow Pythonistas 🐍
+- [PHP Dev](/squads/phpdev) (21,531 members): Welcome to PHP Dev, a dedicated space for sharing knowledge about PHP and its ecosystem \(only PHP directly related\).
+Help us find good articles and blogposts and provide links. Upvote or downvote, after reading, it's essential
+- [Engineering Leadership](/squads/engineeringleadership) (16,218 members): All about Engineering Management, Leadership and Career Growth.
+- [Open Source](/squads/opensourcesquad) (15,109 members): The official Open Source daily.dev Squad. 
+- [Game Developers](/squads/game_developers) (14,813 members): A place where all game developers are welcomed to discuss, connect to unleash their creativity by helping each other.
+
+- [DevOps](/squads/joindevops) (13,485 members): The official daily.dev DevOps community. Led by thought leaders and DevOps experts. Join the Squad\!
+- [Build With GenAI](/squads/buildwithgenai) (12,386 members): Squad for devs building apps with GenAI and LLMs\! Connect, share, exchange ideas, and get feedback. 
+- [Watercooler](/squads/watercooler) (11,814 members): Feed for all things unimportant and nonsense at daily.dev. It’s designed to waste your time and distract you, buckle up.
+- [Just Java](/squads/justjava) (9,646 members): All Java, All the time.
+
+Newcomers to veterans, all are welcome to post and comment about anything Java related. Love it, hate it - all topics are safe here. 
+- [DevOps Daily](/squads/devopsdaily) (9,546 members): All things DevOps
+- [.NET](/squads/dotnetsquad) (8,077 members): All about .NET, C\#, and ASP.NET Core. News, tutorials, articles, projects, and more. 
+- [Syntax](/squads/syntax) (8,033 members): The tastiest treats web development treats out there. We share fun and interesting projects, blogs, tools and more. Find the best stuff curated by the Syntax team and community.
+- [Go Developers](/squads/golangnuts) (7,831 members): A supportive squad for Go developers who want to dive deeper into what makes Go special. We focus on the language's clean simplicity, powerful concurrency, and reliable performance.
+- [Dart Developers](/squads/dartdevs) (7,162 members): Welcome to the Dart & Flutter Community\! Here, we share valuable resources, promote learning, and showcase innovative packages and products built with Dart & Flutter. Join us to stay updated and enhance your development skills\!
+- [The Dev Craft](/squads/thedevcraft) (6,054 members): Dedicated to developers who want to learn and share how they git gud at their craft 🦾. Is there a mindset you think is currently hurting developers growth? What tools do you love? 
+- [Agentic Engineering](/squads/agentic) (5,004 members): Everything about agentic engineering and vibe coding 🤖
+Tools, tips, tricks, workflows, best practices, you name it.
+Let the vibes guide you
+- [Daily Open Source Tools](/squads/dailyopensourcetools) (4,803 members): 🚀 Daily Open Source Tools Squad delivers daily articles, open-source projects, and technical resources for Developers & DevOps pros. Stay updated with the latest trends & insights\!
+
+📬 Join our mailing list\! → theinfinity.dev
+- [Laravel Dev](/squads/laraveldev) (4,487 members): Welcome to Laravel Dev\! It's a cozy corner for all things Laravel. Share, learn, and explore the Laravel universe. Upvote or downvote, after reading, it's essential
+- [Developer Relations](/squads/devrel) (4,024 members): In this Squad we bring some of the best developer advocates together to share insights about building developer communities.
+
+## Squads by Category
+
+### Languages
+
+- [Node.js developers](/squads/nodejsdevelopers) (41,946 members): News, updates, and discussions about everything happening in and around the Node.js runtime.
+- [Learn Python](/squads/lpython) (27,295 members): Welcome to Learn Python Community, created by Sophia Iroegbu, a Python developer who loves making videos about cool ways to build in Python. Join us to learn Python, share your knowledge and connect with fellow Pythonistas 🐍
+- [PHP Dev](/squads/phpdev) (21,531 members): Welcome to PHP Dev, a dedicated space for sharing knowledge about PHP and its ecosystem \(only PHP directly related\).
+Help us find good articles and blogposts and provide links. Upvote or downvote, after reading, it's essential
+- [Angular](/squads/angulardev) (11,632 members): A place to  find, read, and discuss about angular
+- [Learn JavaScript](/squads/learn_javascript) (10,464 members): Squad for those interested in learning JavaScript, and looking for interesting resources and materials.
+- [Just Java](/squads/justjava) (9,646 members): All Java, All the time.
+
+Newcomers to veterans, all are welcome to post and comment about anything Java related. Love it, hate it - all topics are safe here. 
+- [.NET](/squads/dotnetsquad) (8,077 members): All about .NET, C\#, and ASP.NET Core. News, tutorials, articles, projects, and more. 
+- [Go Developers](/squads/golangnuts) (7,831 members): A supportive squad for Go developers who want to dive deeper into what makes Go special. We focus on the language's clean simplicity, powerful concurrency, and reliable performance.
+- [TypeScript](/squads/typescriptdevelopers) (5,576 members): SOLID Principles
+- Clean Code
+- Engineering Excellence
+- Best Practices
+- Tips
+- Design Patterns
+- Code Quality
+- Test Driven Development
+- Refactoring
+
+- [JavaScript Developer](/squads/jsdeveloper) (5,544 members): 
+Code Together: Dive into JavaScript Mastery — Join the squad where curiosity meets expertise\!
+
+### Web
+
+- [NextJS](/squads/nextjs) (34,399 members): An independent Squad for discussions, questions and answers about Next.JS. 
+
+- [WebDev](/squads/webdev) (27,384 members): The official daily.dev web development community. Led by thought leaders and webdev experts. Join the Squad\!
+- [Exceptional Frontend](/squads/exceptionalfrontend) (14,563 members): Heyoo & welcome\!
+
+Exceptional Frontend teaches devs how to translate their technical talent into business impact \(i.e, get the right things built → business makes money → YOU get $$$\)
+
+Learn more about it here: https://exceptionalfrontend.com
+- [The React Community](/squads/the_react_community) (11,289 members): A safe place for React developers. Here you can find all kinds of topics related to React. Feel free to share your own :\)
+- [Syntax](/squads/syntax) (8,033 members): The tastiest treats web development treats out there. We share fun and interesting projects, blogs, tools and more. Find the best stuff curated by the Syntax team and community.
+- [Backend Developer ](/squads/amandeep58) (6,476 members): You can share you thought with this squad 
+- [ReactTsx](/squads/reactjsx) (4,292 members): This squad goal to help the developer community\!
+- [UX/UI](/squads/uxui) (3,951 members): Welcome to the UX/UI Squad\! This is a space where developers, designers, and project managers come together to share UX/UI insights and create better web and app services.
+- [Vuejs&Nuxtjs](/squads/nuxtandvue) (3,835 members): Hey there\! Welcome to The Looop Tech - Vue.js. I’m your host IGC , your friendly neighborhood Vue.js enthusiast\! Join me each week as I chat about the latest Vue.js news, share fun tips, and dive into all things Nuxt.js. It’s just me here, so if you’
+- [Svelte Developers](/squads/svelte_developers) (3,819 members): Join a vibrant community of Svelte developers, where collaboration sparks creativity, and skill-building happens through shared knowledge and support. Connect, learn, and grow together with fellow enthusiasts.
+
+### Mobile
+
+- [Mobile developers](/squads/mobile) (11,275 members): For iOS, Android and all the developers in between, this is the Squad for mobile developers.
+- [React Native](/squads/rndevs) (7,429 members): A space for sharing cutting-edge mobile dev insights, troubleshooting tips, and industry best practices. Join us to elevate your cross-platform app development skills\!
+- [Dart Developers](/squads/dartdevs) (7,162 members): Welcome to the Dart & Flutter Community\! Here, we share valuable resources, promote learning, and showcase innovative packages and products built with Dart & Flutter. Join us to stay updated and enhance your development skills\!
+- [Flutter Developers](/squads/fluttersquad) (4,880 members): 🚀 Calling all Flutter lovers\! 
+Share code, swap ideas, stay on top of Flutter trends\! Whether you're a newbie or a pro, you've found your tribe. Let's build something awesome together\! 💙 
+- [Deep Flutter](/squads/deepflutter) (2,508 members): Welcome to the Flutter Enthusiasts Group\! This community is dedicated to developers, designers, and technology lovers who are passionate about Flutter, Google's UI toolkit for crafting beautiful, natively compiled applications for mobile, web, and de
+- [React Native Devs](/squads/rn_squad) (1,433 members): Its a public squad for all React Native Developers to post about their project, discuss about any problem or solutions. Let's build a React Native Developers Community
+- [Android Developers](/squads/developwithandroid) (1,327 members): A squad dedicated to devs who primarily develop within the Android ecosystem.
+
+Any articles posted here should be somehow related to Android development. This includes things like Jetpack Compose, Android Views, Kotlin, supporting libraries, etc.
+- [Flutter Daily](/squads/flutter_daily) (789 members): Welcome to the Flutter Daily Community\! This is a space where we share useful resources, encourage learning, and highlight creative packages and projects built with Dart and Flutter. Join us to stay informed and improve your development expertise\!
+- [SwiftUI Developers](/squads/swiftuidevelopers) (569 members): A squad is dedicated to developers who primarily work within the iOS ecosystem. Any articles posted here should be related to SwiftUI and supporting libraries.
+- [iOS Developers](/squads/ios_dev) (552 members): A community for iOS developers to learn, build, and grow together. Share Swift, SwiftUI, UIKit, Xcode tips, architecture, AI, app development insights, career advice, and the latest Apple ecosystem updates.
+
+### DevOps & Cloud
+
+- [DevOps](/squads/joindevops) (13,485 members): The official daily.dev DevOps community. Led by thought leaders and DevOps experts. Join the Squad\!
+- [Cloud](/squads/cloud) (9,593 members): This is the official daily.dev Squad for all things Cloud. ☁️
+
+
+- [DevOps Daily](/squads/devopsdaily) (9,546 members): All things DevOps
+- [Amigoscode](/squads/amigoscode) (8,737 members): Dive into the freshest insights, best practices, and bleeding-edge trends in Backend and DevOps Engineering.
+- [Hacking the Cloud](/squads/hackingthecloud) (5,204 members): Keeping updated with news around Cloud Security
+- [KubeSquad](/squads/kubesquad) (3,596 members): The squad for Kubernetes afficionados. 
+All things Kubernetes: best practices, tools, tricks, new features, operator building. 
+For experienced Kubernetes administrators and Kube-newbies alike.
+
+- [Database Daily](/squads/databasedaily) (2,454 members): Your go-to source for the latest in database technology, trends, and tips. Covering Postgres, MySQL, Kafka, Data Warehouses, and more. 
+- [Postgres Daily](/squads/postgresdaily) (1,206 members): Welcome to the Postgres Daily squad\! This is your go-to space for sharing and discovering valuable content focused exclusively on PostgreSQL. Join us to explore insightful articles, tutorials, and discussions that dive deep into the world of Postgres
+- [Deployments](/squads/deploy) (1,010 members): Posts around deployment tools and methods
+- [Platform & AI](/squads/platformai) (900 members): Exploring advanced technology in platforms, DevOps, Kubernetes, IaC, open-source AI tools, and more. Innovation and collaboration.
+
+### AI
+
+- [AI](/squads/ai) (29,268 members): The official daily.dev AI community. Led by thought leaders and AI experts. Stay tuned for insights, news and discussions. 
+- [Build With GenAI](/squads/buildwithgenai) (12,386 members): Squad for devs building apps with GenAI and LLMs\! Connect, share, exchange ideas, and get feedback. 
+- [Data science](/squads/datascience) (9,065 members): The place for all things data science on daily.dev: Machine learning, data visualization, Big data and more. Whether you're just getting started or a seasoned data scientist, join us. 
+- [Machine Learning News](/squads/mlnews) (8,778 members): We are a community of AI/ ML/Generative AI enthusiasts/researchers/journalists/writers who share interesting news and articles about the applications of AI. 
+- [Agentic Engineering](/squads/agentic) (5,004 members): Everything about agentic engineering and vibe coding 🤖
+Tools, tips, tricks, workflows, best practices, you name it.
+Let the vibes guide you
+- [AI ❤️ JS ](/squads/javascriptai) (4,426 members): This group is for people building the future of AI with JavaScript. Share insights, explore new tools, and connect with others pushing the boundaries of what's possible.
+- [Data Engineering](/squads/dataengineering) (2,791 members): Data Engineer's Hub to share and learn. 
+- [ML & AI](/squads/ml_ai) (2,420 members): Whether you're a beginner or an expert, join us to learn and grow together\! 🌱💡
+\#AI \#MachineLearning \#Innovation \#TechCommunity \#LearnTogether
+- [Prompt Engineering](/squads/promptengineering) (2,233 members): Prompt engineering is a cutting-edge discipline that focuses on harnessing the full potential of language models by strategically designing input instructions \("prompts"\)
+- [Next AI Tool](/squads/nextaitool) (2,087 members): Discover new AI tools
+
+### Games
+
+- [Game Developers](/squads/game_developers) (14,813 members): A place where all game developers are welcomed to discuss, connect to unleash their creativity by helping each other.
+
+- [Unity Developers ](/squads/unity_developers) (2,669 members): Where all unity developers and designers meet
+- [Godot Developers](/squads/godotdevelopers) (2,193 members): A community of passionate Godot engine developers, sharing knowledge, tips, and resources to create amazing 2D and 3D games. Whether you're a beginner or expert, join us to collaborate, learn, and push the boundaries of game development with Godot\!
+- [Unreal Developers](/squads/unrealdevelopers) (1,377 members): Where all unreal developers meet\!
+- [Godot Developers](/squads/godot_developers) (718 members): An official squad under @game\_developers squad
+- [Indie Game Showcase](/squads/indiegameshowcase) (396 members): This squad is the perfect stage for indie developers to showcase their games, gather feedback, and involve the community in their development journey. Whether it’s early prototypes, exciting progress, or fully released games 
+- [Gamedev Assets](/squads/gamedevassets) (142 members): Post the assets you're working on for your games. Whether it's 2D or 3D, from simple UI art to complex concept art.
+
+This also includes music.
+- [Raylib](/squads/raylib) (132 members): A squad for everyone developing with raylib in any language or just interested in more low level game dev without big game engines
+- [The Alliance](/squads/thealliance) (127 members): Welcome to your new tech adventure with the Alliance. This will be a space for developers and hackers.
+- [Gamification](/squads/gamification) (118 members): Discuss gamification of mundane UI and UX.
+
+### DevTools
+
+- [Dev Tools](/squads/devtools) (14,033 members): A dedicated squad for devtools: discussions, recommendations and questions. 
+- [builder.io](/squads/builderio) (4,434 members): Practical content for shipping production-ready code with AI, covering AI coding workflows, design-to-code, frontend performance, design systems, and framework patterns to help you build faster without rewriting AI output
+- [Appwrite](/squads/appwrite) (2,218 members): All things Appwrite. The developers' cloud. 
+- [Neovim Squad](/squads/nvim) (1,566 members): Here we share knowledge, tips and tricks about Vim and Neovim
+- [Devs with ADHD](/squads/clariti) (1,202 members): A community for devs with ADHD / deep focus goals. Share hacks, tools, and sounds to boost productivity. Built with Clariti’s founder, but powered by all of us. 🎧 Join if you want fewer distractions and more flow. 🚀 $ brew install clariti
+- [Trunk.io](/squads/trunkio) (595 members): Hi, Trunk makes developer tools to solve problems developers hate.
+
+But we also love sharing about what we learn along the way as we speak to engineering leaders\!
+- [Apollo GraphQL](/squads/apollographql) (523 members): API Orchestration for the cloud native world
+- [Low-Code Devs](/squads/lowcodedevs) (475 members): Low-code tips and tutorials, featuring Google Apps Script, APIs, SQL, FileMaker Pro, Appsmith, n8n, Baserow, Supabase, and more. 
+- [evolvedev](/squads/evolvedev) (435 members): Sharing blogs, tutorials, tools, open source projects.
+- [Primary Tech](/squads/primarytech) (403 members): Primary Tech squad
+
+### Career
+
+- [roadmap.sh](/squads/roadmap) (18,237 members): Community driven learning paths, articles, projects and guides for developers to grow in their career.
+- [Engineering Leadership](/squads/engineeringleadership) (16,218 members): All about Engineering Management, Leadership and Career Growth.
+- [Dev Leader](/squads/devleader) (6,815 members): Simplifying software engineering and leveling up your C\# development\!
+- [The Dev Craft](/squads/thedevcraft) (6,054 members): Dedicated to developers who want to learn and share how they git gud at their craft 🦾. Is there a mindset you think is currently hurting developers growth? What tools do you love? 
+- [Managing Dev](/squads/managingdev) (4,587 members): Our squad is open to R&D managers to learn and share day-to-day managerial challenges. Join us to:
+
+🤝 Network with R&D managers 
+
+🧠 Seek guidance, advice, and support 
+
+💡 Gain valuable perspectives and practical tools
+
+  
+- [Chief Suffering Officer](/squads/cso) (2,764 members): Dive into the world of leadership, engineering, and entrepreneurship. And if you don't care about these topics, you'll enjoy reading about my suffering throughout the journey of building daily.dev
+- [Just Another CTO](/squads/justanothercto) (1,944 members): Hi\! My name is Vadim and I'm Just Another CTO and I write about everything related to building digital software products.
+- [Advance Concepts](/squads/advanceconcepts) (1,202 members): Welcome to our squad🎉. This is the place for us to share ideas, learn together, and learn some advanced concepts—all in a friendly and fun way\!
+- [Devs Together Strong](/squads/devstogetherstrong) (1,134 members): Learn. Share. Grow. By devs for devs - a place for sharing information useful to any developer no matter what path they are on. 
+- [FREE COURSES\!](/squads/freecourses) (1,056 members): Welcome to Free Courses, your gateway to high-quality education at no cost\! Whether you're looking to enhance your skills, pursue a new passion, or advance your career, our diverse collection of free online courses offers something for everyone. 
+
+### Open Source
+
+- [Open Source](/squads/opensourcesquad) (15,109 members): The official Open Source daily.dev Squad. 
+- [selfhosted](/squads/selfhosted) (5,549 members): Self-hosted refers to the practice of running your own applications and services on your own servers or devices, giving you full control over your data and how it is managed.
+- [Daily Open Source Tools](/squads/dailyopensourcetools) (4,803 members): 🚀 Daily Open Source Tools Squad delivers daily articles, open-source projects, and technical resources for Developers & DevOps pros. Stay updated with the latest trends & insights\!
+
+📬 Join our mailing list\! → theinfinity.dev
+- [Open Source Front End](/squads/opensourcefrontend) (2,701 members): A squad for posts, articles and videos about open source development.
+- [Linux Community](/squads/linuxcom) (2,550 members): A space for Linux fans to keep up with the latest news, tips, and everything happening in the world of GNU/Linux. Whether you're just starting or have been using Linux for years, share what you know, and discover new tools, distros and other.
+- [OpenSouls](/squads/opensouls) (2,185 members): A safe space for developers interested in open source projects, articles, tips and useful coding tools.
+- [GitHub Community](/squads/github_community) (1,630 members): Best Projects from GitHub
+- [Open Source](/squads/opensource) (1,434 members): Let's talk about Open Source, FOSS, and everything in between.
+- [Cyber Security](/squads/cyber_sec) (1,011 members): This is a space to share content covering cybersecurity news, tools, source code, training courses, home lab setups, and basically anything that could be of interest to those who want to learn about cybersecurity. 
+- [n8n](/squads/n8n) (947 members): All things n8n, the place for the fans of the world's most popular workflow automation platform\!
+
+### DevRel
+
+- [daily.dev Changelog](/squads/daily_updates) (11,457 members): Get the latest product updates and announcements about daily.dev
+- [daily.dev World](/squads/dailydevworld) (10,175 members): Where we talk all things daily.dev. Check out the threads below and share what you love, or tell us what you hate. Can't wait to meet you 🤗
+- [Dev Squad](/squads/devsquad) (9,402 members): Get 1% better daily. Development resource sharing made easy. Post, comment, or upvote to show your contribution and support other developers\! 🙌
+
+⚠️ Please do not post any promotional resources.
+- [Fullstack Developer](/squads/fullstackdeveloper) (4,271 members): This squad was created to support resource sharing within the Fullstack Developer community. Developers can post anything related to software development.
+- [Developer Relations](/squads/devrel) (4,024 members): In this Squad we bring some of the best developer advocates together to share insights about building developer communities.
+- [Dev World](/squads/dev_world) (2,383 members): This squad was established to be able to share anything about development. Post, Comment, and Upvote\!
+- [Leetcode DSA](/squads/leetcode) (722 members): A public squad for all enthusiasts of Data Structures and Algorithms \(DSA\) and competitive programming. Open to coders of all levels, from beginners to experts. Share your LeetCode solutions, discuss optimal approaches.
+- [The DevRel](/squads/thedevrel) (673 members): A place for experienced DevRel's and Open Source Maintainers to share their expertise
+- [Misfits Developers](/squads/misfitsdevelopers) (649 members): The Misfits Developer squad aims to build a community for every developer to share their insights and experience or seek guidance from other members.
+- [Cyber Security](/squads/cybersecurityinfo) (173 members): Join our Cyber Security Awareness group\! We educate and empower members about online scams, phishing, and fraud prevention. Together, we share resources, experiences, and best practices to create a safer digital environment for everyone.
+
+### Fun
+
+- [Watercooler](/squads/watercooler) (11,814 members): Feed for all things unimportant and nonsense at daily.dev. It’s designed to waste your time and distract you, buckle up.
+- [controversy.dev](/squads/controversy) (10,002 members): The hottest most controversial dev discussions. Found something you'd like to share? Add it in the thread 👇
+
+- [Software Philosophy](/squads/softwarephilosophy) (7,708 members): About modern software development, effectiveness in work, continuous learning mindset, DevOps culture, and building resilient software.
+- [Project board](/squads/projectboard) (3,626 members): The daily.dev project board. Share your projects, ask for feedback, contributions or any kind of input you need. 
+- [Meme Monday ](/squads/mememonday) (1,985 members): A collection of code, caffeine, and questionable humor from a developer who’s convinced his bugs are funnier than yours.
+
+- [SK NEXUS](/squads/sknexus) (665 members): Knowledge by Execution - Breaking Down Tech for the Mango Man \(Aam Aadmi/Regular Person\) - https://www.sknexus.org/
+- [Beginners ](/squads/beginners3919) (594 members): This squad is for learners and beginner. who are not only new to tech world, but learning a lot about tech world. And want to share their thoughts and their favourites about tech in whole world. 
+- [Daily.Memes](/squads/dailymemes) (318 members): Daily dose of programming and coding memes to keep the fun alive\! because a little fun makes work way better\!
+- [Developer Timeline](/squads/developertimeline) (286 members): POV: Being a Developer \| If all movies were about programming...
+- [TheCoverLikers](/squads/thecoverlikers) (227 members): Get your aesthetic enjoyment.
+
+---
+
+[Discover all Squads on daily.dev](/squads/discover)
+
+---
+
+## Legal
+
+---
+title: "Terms of Service | daily.dev"
+url: https://daily.dev/tos/
+description: "The terms governing your use of daily.dev. Accounts, content, intellectual property, liability, governing law, and how disputes are resolved."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Terms of Service
+
+These are the rules that govern your use of daily.dev. Reading them in full at the [canonical Terms of Service page](https://daily.dev/tos/) is the only safe summary; this is a navigation aid, not legal advice.
+
+### What the full document covers
+
+- **Account creation and termination**: eligibility, login, and what gets you off the platform
+- **Acceptable use**: what you can and cannot do with the product
+- **Content & licensing**: what you grant us when you submit content, and what we grant you when you read others' content
+- **Intellectual property**: daily.dev marks, third-party marks, and DMCA / takedown procedures
+- **Disclaimers and limitation of liability**: service is provided "as is"; cap on damages
+- **Governing law and dispute resolution**: jurisdiction, arbitration, class-action waiver
+- **Changes**: how we communicate updates and what counts as accepting new terms
+
+### Related documents
+
+- [Privacy center](https://daily.dev/privacy/): how we handle your data
+- [Creators terms](https://daily.dev/creators-terms/): additional terms for content creators publishing on daily.dev
+- [Cookies policy](https://www.iubenda.com/privacy-policy/14695236/cookie-policy): what we set and why
+
+[See the rendered Terms of Service page](https://daily.dev/tos/) for the binding legal text.
+
+---
+
+---
+title: "Refund Policy | daily.dev"
+url: https://daily.dev/refunds/
+description: "The 30-day refund policy for daily.dev Plus. Eligibility, how to request, cancellations, and what is and is not covered."
+lastUpdated: "2025-02-18"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Refund Policy for daily.dev Plus
+
+Every daily.dev Plus plan is covered by a 30-day hassle-free refund policy. If daily.dev Plus isn't the right fit, you can request a full refund within 30 days of your initial purchase. No questions asked.
+
+### Eligibility
+
+- 30-day window from initial purchase, full refund to the original payment method
+- First-purchase only: renewal payments (monthly or annual) are non-refundable
+- After the 30-day window: cancel anytime to stop future charges, but no partial refunds for unused time
+
+### How to request
+
+- Email `support@daily.dev`, or contact Paddle (our payment processor) at `help@paddle.com`
+- Include your account details so we can process the request quickly
+- Approved refunds are credited back within 5 to 10 business days
+
+### Cancellation vs refund
+
+- Cancelling stops future renewals and keeps access until the end of the current billing period
+- A cancellation by itself does NOT trigger a refund unless the request is made inside the 30-day window
+- Manage subscription from `daily.dev` account settings
+
+### Refunds are not issued for
+
+- Requests after the 30-day window
+- Subscription renewals
+- Partial refunds for unused time after cancellation
+- Requests tied to a policy violation (Terms of Service breach, platform misuse)
+
+### Related documents
+
+- [Terms of Service](https://daily.dev/tos/): base terms governing daily.dev usage
+- [Privacy center](https://daily.dev/privacy/): how we handle your data
+
+[See the rendered Refund Policy page](https://daily.dev/refunds/) for the binding policy text.
+
+---
+
+---
+title: "Creators Terms | daily.dev"
+url: https://daily.dev/creators-terms/
+description: "Additional terms for creators publishing content on daily.dev. Licensing, attribution, content guidelines, monetization, and takedowns."
+lastUpdated: "2026-04-30"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## Creators Terms
+
+The Creators Terms supplement the [main Terms of Service](https://daily.dev/tos/) for anyone publishing content on daily.dev: sources, squads, contributors, and partner publications.
+
+### What the full document covers
+
+- **Licensing**: the rights you grant daily.dev when you submit content, and what readers can do with it
+- **Attribution**: how authors and original sources are credited
+- **Content guidelines**: quality bar, prohibited content, AI-generated disclosure rules
+- **Monetization**: revenue share for partners and contributors where applicable
+- **Takedowns**: how we handle requests to remove content, both yours and third parties
+
+### Related documents
+
+- [Terms of Service](https://daily.dev/tos/): base terms (these creators terms add to those)
+- [Privacy center](https://daily.dev/privacy/): how we handle data, including from contributors
+
+[See the rendered Creators Terms page](https://daily.dev/creators-terms/) for the binding legal text.
+
+---
+
+---
+title: "Privacy Center | daily.dev"
+url: https://daily.dev/privacy/
+description: "Privacy hub for daily.dev: the privacy policy and cookie policy covering the website, web app, browser extensions and mobile apps, plus data requests. Authoritative copies hosted on iubenda."
+lastUpdated: "2026-08-18"
+llmsTxt: https://daily.dev/llms.txt
+---
+
+## daily.dev Privacy Center
+
+A single hub for every privacy and data document we publish. The authoritative copies live on iubenda; we link out so you always read the latest counsel-reviewed version.
+
+### Policies
+
+One privacy policy and one cookie policy cover every daily.dev surface: the website, the web app, the browser extensions, and the mobile apps.
+
+- [Privacy Policy](https://www.iubenda.com/privacy-policy/14695236): what we collect, why, who we share it with, and your rights
+- [Cookie Policy](https://www.iubenda.com/privacy-policy/14695236/cookie-policy): analytics, marketing and feature-flag cookies, and cookies set inside the apps
+- [Permissions Explained](https://daily.dev/blog/permissions-explained-daily-dev-browser-extension/): plain-English breakdown of every browser-extension permission we request
+
+### Data subject requests
+
+Email `privacy@daily.dev` for any GDPR / CCPA request: access, deletion, portability, or correction.
+
+### Related documents
+
+- [Terms of Service](https://daily.dev/tos/)
+- [Creators Terms](https://daily.dev/creators-terms/)
+
+[See the rendered privacy hub](https://daily.dev/privacy/) for the full overview.
+
+---
+
+## AI Handbook — The Agentic AI Hub
+
+---
+title: "Handbook index"
+url: "https://daily.dev/agentic-ai-hub"
+---
+
+# The Agentic AI Hub
+
+> A software engineer's complete reference to AI, from foundations to agents.
+
+Version 1.1 · Last updated 2026-07-22 · License CC BY 4.0 · Published by daily.dev
+
+Every page below is available as LLM-friendly markdown via its `.md/` URL. For rendered HTML, omit `.md`.
+
+## Part I. Foundations
+
+- [How LLMs Actually Work](https://daily.dev/agentic-ai-hub/how-llms-actually-work.md/): A large language model predicts the next token given the tokens so far, and that is essentially all it does.
+- [Core Concepts](https://daily.dev/agentic-ai-hub/core-concepts.md/): Quick definitions for the vocabulary you'll run into everywhere. Each one is short, and several get a fuller treatment later in the handbook.
+- [Prompting & Context Engineering](https://daily.dev/agentic-ai-hub/prompting-context-engineering.md/): Prompting is the highest-leverage, lowest-cost skill in this whole handbook. Small changes in how you frame a request move quality more than most people expect.
+- [Safety, Alignment & Governance](https://daily.dev/agentic-ai-hub/safety-alignment-governance.md/): Building with AI means owning its failure modes. This section is deliberately neutral and tight, enough to reason about risk without ideology.
+
+## Part II. Models, Labs & Benchmarks
+
+- [The Labs: Who's Who](https://daily.dev/agentic-ai-hub/the-labs-whos-who.md/): Snapshot as of July 19, 2026. Valuations and funding are dated and sourced.
+- [Frontier Model Comparison](https://daily.dev/agentic-ai-hub/frontier-model-comparison.md/): A dated snapshot of the current top-tier, closed ("frontier") models, meaning the API-only models from the major labs that set the capability bar.
+- [Open-Weight Models](https://daily.dev/agentic-ai-hub/open-weight-models.md/): The models you can download, self-host, and fine-tune. As of July 2026. Two things to know: (1) "open weight" ≠ open source.
+- [Specialized Models](https://daily.dev/agentic-ai-hub/specialized-models.md/): Beyond the general-purpose flagships, each modality and job has its own leaders, and the "best" one shifts constantly, so treat these as categories to shop in with current examples.
+- [Benchmarks & Leaderboards](https://daily.dev/agentic-ai-hub/benchmarks-leaderboards.md/): The single most useful mental model here is that benchmarks tell you what a model can do on someone else's task.
+- [Pricing & Cost Reference](https://daily.dev/agentic-ai-hub/pricing-cost-reference.md/): Pricing is a Frontier Model Comparison snapshot. This section is the durable part: how to reason about cost so you're not surprised by a bill.
+- [How to Choose a Model](https://daily.dev/agentic-ai-hub/how-to-choose-a-model.md/): The honest answer is to shortlist from benchmarks and reputation, then run a small eval on your actual task.
+
+## Part III. Tools, Products & Agents
+
+- [Chat Assistants & Apps](https://daily.dev/agentic-ai-hub/chat-assistants-apps.md/): The consumer/prosumer chat apps are the front door to each lab's frontier model.
+- [Coding Tools & CLI Agents](https://daily.dev/agentic-ai-hub/coding-tools-cli-agents.md/): Two families here: IDE assistants (autocomplete + chat + in-editor agents living in your editor) and CLI/terminal agents (you talk to an agent in the shell.
+- [Agent Harnesses & Frameworks](https://daily.dev/agentic-ai-hub/agent-harnesses-frameworks.md/): Two very different things get called "agent tooling."
+- [No-Code & App Builders](https://daily.dev/agentic-ai-hub/no-code-app-builders.md/): Prompt-to-app tools turn a description into a running web app with UI, backend, and deploy.
+- [Voice & Real-Time Agents](https://daily.dev/agentic-ai-hub/voice-real-time-agents.md/): Real-time voice agents = STT (speech-to-text) → LLM → TTS (text-to-speech) stitched into a low-latency loop (or, increasingly, a single speech-to-speech model).
+- [Browser & Computer-Use Agents](https://daily.dev/agentic-ai-hub/browser-computer-use-agents.md/): These agents perceive a screen or DOM and act (click, type, scroll, navigate) to complete tasks a human would do in a browser or OS.
+- [Multimodal Creative Tools](https://daily.dev/agentic-ai-hub/multimodal-creative-tools.md/): Image, video, and audio generation. Quality is now high across the board. Choose by control, licensing, and API availability more than raw "wow."
+- [MCP & the Tool/Context Ecosystem](https://daily.dev/agentic-ai-hub/mcp-tool-context-ecosystem.md/): Models are only half the story. The other half is the plumbing that gives models hands: how an assistant reaches your files, databases, SaaS tools, and the web.
+
+## Part IV. Building with AI: The Engineering Stack
+
+- [RAG & Retrieval](https://daily.dev/agentic-ai-hub/rag-retrieval.md/): Retrieval-Augmented Generation (RAG) is the practice of fetching relevant text (or other data) at query time and injecting it into the model's context so the model can answer from information it wasn't trained on.
+- [Vector Databases & Memory](https://daily.dev/agentic-ai-hub/vector-databases-memory.md/): A vector database stores embeddings and serves approximate nearest-neighbor (ANN) search, which finds the closest vectors to a query vector quickly using index structures like HNSW (graph-based, the most common) or IVF/IVF-PQ (cluster + quantize, memory-efficient at scale).
+- [Fine-Tuning & Post-Training](https://daily.dev/agentic-ai-hub/fine-tuning-post-training.md/): Reach for the cheapest tool that works, in this order:
+- [Dataset Engineering](https://daily.dev/agentic-ai-hub/dataset-engineering.md/): Data quality, not model choice, is usually the ceiling on a fine-tune.
+- [Inference, Serving & Optimization](https://daily.dev/agentic-ai-hub/inference-serving-optimization.md/): TTFT (Time To First Token). Latency until the first token appears. Dominated by the prefill (prompt-processing) phase and prompt length.
+- [AI Hardware & Accelerators](https://daily.dev/agentic-ai-hub/ai-hardware-accelerators.md/): The 2026 picture is that NVIDIA still dominates training and general inference.
+- [APIs, Inference Platforms & Gateways](https://daily.dev/agentic-ai-hub/apis-inference-platforms-gateways.md/): Four rough tiers, each with different trade-offs on model access, speed, price, and control.
+- [Local & Self-Hosting Stack](https://daily.dev/agentic-ai-hub/local-self-hosting-stack.md/): Running models on your own machine or servers.
+- [LLMOps: Evals, Observability & Guardrails](https://daily.dev/agentic-ai-hub/llmops-evals-observability-guardrails.md/): Shipping LLM features without evals and observability is flying blind: outputs are non-deterministic, quality is subjective, and regressions are silent.
+
+## Part V. Working with AI: Techniques, Workflows & Adoption
+
+- [Levels of AI Adoption](https://daily.dev/agentic-ai-hub/levels-of-ai-adoption.md/): Before you can improve how your team works with agents, you need a shared way to say where you are.
+- [Agentic Engineering: Core Ideas](https://daily.dev/agentic-ai-hub/agentic-engineering-core-ideas.md/): "Agentic coding" is an overloaded term.
+- [Orchestration Patterns](https://daily.dev/agentic-ai-hub/orchestration-patterns.md/): Once one agent works, the obvious move is to run several. This is where the biggest gains and the biggest self-inflicted wounds both live.
+- [Context, Skills & Memory](https://daily.dev/agentic-ai-hub/context-skills-memory.md/): Agents are only as good as what they know when they start, and by default they start knowing nothing about your repo, your conventions, or last week's decisions.
+- [Verification & Testing for Agents](https://daily.dev/agentic-ai-hub/verification-testing-for-agents.md/): If generation is cheap and verification is the bottleneck, then verification infrastructure is your leverage.
+- [Human Factors & the Agent-Era Career](https://daily.dev/agentic-ai-hub/human-factors-agent-era-career.md/): The techniques above make you faster. This chapter is about what they can quietly cost you, and how not to pay it.
+
+## Part VI. Ecosystem & Staying Current
+
+- [People to Follow (X/Twitter)](https://daily.dev/agentic-ai-hub/people-to-follow.md/): X/Twitter is where much of AI moves in real time. Papers get discussed hours before the press notices, and model launches often break here first.
+- [Newsletters](https://daily.dev/agentic-ai-hub/newsletters.md/): Email survives because it's async and curated. Tagged by focus and cadence.
+- [Blogs & Publications](https://daily.dev/agentic-ai-hub/blogs-publications.md/): OpenAI Blog: openai.com/news. Launches and research. The announcement of record.
+- [Podcasts & YouTube](https://daily.dev/agentic-ai-hub/podcasts-youtube.md/): Latent Space (swyx & Alessio): latent.space/podcast. Best for: the AI-engineering discipline.
+- [Communities](https://daily.dev/agentic-ai-hub/communities.md/): Where real-time, tacit knowledge lives, the kind that never makes it into a blog post.
+- [Key Papers & Reading List](https://daily.dev/agentic-ai-hub/key-papers-reading-list.md/): A chronological spine of the field. The ones tagged Start here or Landmark are the priority reads; the rest fill in context.
+- [Platforms](https://daily.dev/agentic-ai-hub/platforms.md/): The infrastructure you'll actually live in.
+- [Events & Conferences](https://daily.dev/agentic-ai-hub/events-conferences.md/): 🔄 Dates and formats change yearly. Always confirm on the official site.
+- [Learning Paths, Courses & Books](https://daily.dev/agentic-ai-hub/learning-paths-courses-books.md/): Organized beginner → advanced. Pick a lane and go deep. Breadth comes with time.
+
+## Part VII. Appendices
+
+- [AI Adoption Stats & Trends](https://daily.dev/agentic-ai-hub/ai-adoption-stats-trends.md/): 🔄 Fast-moving section. All figures are dated and sourced; surveys are annual and market forecasts get revised, so check the live sources for the latest.
+- [Glossary of Key Terms](https://daily.dev/agentic-ai-hub/glossary.md/): A jargon-buster for the terms used throughout this handbook. Where a full section exists, terms link to it.
+
+---
+
+## Blog
+
+Blog posts are indexed here as links only; append `.md` to any post URL for its markdown source.
+
+- [Blog index](https://daily.dev/blog.md): Latest articles and guides
+- [The Best Tech News Apps for Developers in 2026](https://daily.dev/blog/best-tech-news-apps-for-developers.md): How to pick developer news apps: use one personalized feed, ...
+- [Best Reddit Alternatives for Developers: Where to Find Quality Tech Discussion](https://daily.dev/blog/reddit-alternatives-where-to-find-for-developers.md): Compare 8 developer-focused Reddit alternatives—Q&A, blogs, ...
+- [Where to Discover New AI Developer Tools in 2026](https://daily.dev/blog/discover-ai-developer-tools.md): Structured methods to find, evaluate, and adopt AI developer...
+- [The Best Alternatives to Hacker News in 2026](https://daily.dev/blog/best-hacker-news-alternatives.md): Compare top alternatives to Hacker News for personalized fee...
+- [How to Keep Up with AI as a Developer in 2026](https://daily.dev/blog/ai-keep-up-guide-for-developers.md): Practical routines, tools, and skills—agents, RAG, MCP, cont...
+- [The Best Developer Communities to Join in 2026](https://daily.dev/blog/best-developer-communities-to-join.md): Pick 2–3 developer communities—each for news, help, or publi...
+- [Best Websites to Learn Programming in 2026: A Developer's Guide](https://daily.dev/blog/best-websites-learn-programming-developer-guide.md): Compare top free, paid, and AI-assisted platforms to learn p...
+- [daily.dev vs TLDR: Which Developer News Source Fits You?](https://daily.dev/blog/daily-dev-vs-tldr-developer-news-which-fits-you.md): Use a personalized browser feed for steady discovery or a co...
+- [Where Developers Find New Tools: The Best Discovery Platforms in 2026](https://daily.dev/blog/best-developer-discovery-platforms-2026.md): A concise 2026 guide to top platforms and a simple weekly wo...
+- [Best Developer Browser Extensions for Productivity in 2026](https://daily.dev/blog/best-developer-browser-extensions-for-productivity.md): Curated list of top browser extensions for debugging, API te...
+- [15 Essential Developer Tools Every Programmer Needs in 2026](https://daily.dev/blog/essential-developer-tools-for-programmers.md): Modern tooling — from AI coding assistants to containers, CI...
+- [The Daily Learning Routine That Makes Great Developers](https://daily.dev/blog/daily-learning-routine-makes-great-developers.md): Build developer skills with 30-minute daily blocks: morning ...
+- [Dev Resources: Top Community Picks](https://daily.dev/blog/dev-resources-top-community-picks.md): Discover top dev resources for continuous learning, communit...
+- [Developer Tools for Work-Life Balance and Avoiding Burnout in 2026](https://daily.dev/blog/developer-tools-for-work-life-balance-avoid-burnout.md): Protect mornings, mute nonessential alerts, batch communicat...
+- [How to Keep Up With AI Coding Tools Without Losing Your Week](https://daily.dev/blog/how-to-keep-up-with-ai-coding-tools-without-losing-your-week.md): Use a three-source system and one 30–45 minute weekly sessio...
+- [The Best Newsletters for AI Engineers in 2026](https://daily.dev/blog/best-newsletters-ai-engineers.md): Pick one daily brief and one weekly digest to keep up with A...
+- [News for Programmers: Community-Driven Insights](https://daily.dev/blog/news-for-programmers-community-driven-insights.md): Explore how community-driven discussions enhance the value o...
+- [Best Programming Communities to Join in 2026](https://daily.dev/blog/general-programming-communities-to-join.md): The top programming communities for developers in 2026 — Git...
+- [The Best AI Engineers to Follow on X in 2026](https://daily.dev/blog/best-ai-engineers-to-follow-on-x.md): Curate a tight X feed of frontier, tooling, and research AI ...
+- [Will AI Replace Software Engineers in 2026? An Honest Take](https://daily.dev/blog/will-ai-replace-software-engineers-2026-honest-take.md): AI automates routine coding by 2026, shrinking junior roles ...
+- [Daily.dev: A Global Dev Community Hub](https://daily.dev/blog/dailydev-a-global-dev-community-hub.md): Daily.dev is a global hub for developers offering personaliz...
+- [Top 10 Best Tech Websites & Blogs 2026](https://daily.dev/blog/top-10-best-tech-websites-and-blogs-2024.md): Stay updated with the top 10 best tech websites & blogs in 2...
+- [What Is MCP (Model Context Protocol) and Why Every Developer Should Care](https://daily.dev/blog/mcp-model-context-protocol-why-developers-should-care.md): Explains MCP—an open standard that enables stateful, secure ...
+- [11 Best Programming Forums in 2026 (Still Active)](https://daily.dev/blog/11-best-programming-forums-2024.md): The most active programming forums in 2026 — Stack Overflow,...
+- [15 Fun Coding Problems From Easy to Hard (2026)](https://daily.dev/blog/fun-coding-problems-from-easy-to-hard.md): 15 fun coding problems from easy to hard, each with the core...
+
+---


### PR DESCRIPTION
## Changes

**Post pages advertise their `.md` twin**
`<link rel="alternate" type="text/markdown" href="https://daily.dev/posts/<slug>.md">` is emitted via `additionalLinkTags` on `/posts/[id]`, gated on `!shouldNoindexPost(post)` so we never advertise a URL the markdown route would 404. `getPostMarkdownUrl({ post })` in `lib/seo.ts` owns the slug-or-id choice. Agent traffic has moved to direct `.md` URL requests over `Accept` negotiation; this is the discoverability signal for that path.

**Header dedupe on `/api/md/*`**
The four markdown routes set `Link: </llms.txt>; rel="llms-txt"` and `X-Llms-Txt` themselves, and `next.config.ts` sets the same two globally on `/:path*`. `Link` is list-valued, so live responses carried it twice. Removed the per-route copies; the global rule still covers every response.

**`public/llms-full.txt`** (116 KB)
`daily.dev/llms-full.txt` was a Next 404 shell — the router sends only `/llms.txt` and friends to the marketing origin, so this path lands here. Static snapshot in cloudflare.com's marketing-site format: header stating scope, then every `.md` page indexed in `daily.dev/llms.txt` inlined with frontmatter and `---` separators (Core Pages, Legal, AI Handbook, app directories). Blog posts are listed as links only to keep the file in one context window. Generated once; regenerate when `llms.txt` changes materially.

## Verification
- `node ./scripts/typecheck-strict-changed.js` passes; lint clean on changed files.
- Live check after deploy: `curl -sI https://daily.dev/llms-full.txt` → 200 text/plain; `curl -s https://daily.dev/posts/<slug> | grep 'text/markdown'`; `curl -sD - -o /dev/null https://daily.dev/posts/<slug>.md | grep -i '^link'` shows a single `Link`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://agent-markdown-fixes.preview.app.daily.dev