### PR TITLE
fix(webapp): stop feed page tests flaking on a cold jest cache

### DIFF
--- a/packages/webapp/__tests__/MostDiscussedPage.tsx
+++ b/packages/webapp/__tests__/MostDiscussedPage.tsx
@@ -3,7 +3,7 @@ import { MOST_DISCUSSED_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed'
 import nock from 'nock';
 import React from 'react';
 import type { RenderResult } from '@testing-library/react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
 import type { NextRouter } from 'next/router';
@@ -18,6 +18,17 @@ import type { CommentFeedData } from '@dailydotdev/shared/src/graphql/comments';
 import { COMMENT_FEED_QUERY } from '@dailydotdev/shared/src/graphql/comments';
 import Discussed from '../pages/discussed';
 import { defaultCommentsPage } from './ProfileRepliesPage';
+
+// Compiling the feed module graph takes seconds on a cold jest transform cache,
+// so both the compile in beforeAll and the render need more than the defaults.
+jest.setTimeout(30000);
+const feedTimeout = 5000;
+
+beforeAll(async () => {
+  // MainFeedLayout only reaches the page through next/dynamic, so without this
+  // its compile lands inside the first findBy* wait and eats the whole budget.
+  await import('@dailydotdev/shared/src/components/MainFeedLayout');
+});
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -92,10 +103,10 @@ function renderComponent(
 
 it('should request most discussed feed when logged-in', async () => {
   renderComponent([createCommentFeedMock()]);
-  await waitFor(async () => {
-    const elements = await screen.findAllByTestId('comment');
-    expect(elements.length).toBeTruthy();
+  const elements = await screen.findAllByTestId('comment', undefined, {
+    timeout: feedTimeout,
   });
+  expect(elements.length).toBeTruthy();
 });
 
 it('should not request most discussed feed when not logged-in', async () => {

--- a/packages/webapp/__tests__/MostUpvotedPage.tsx
+++ b/packages/webapp/__tests__/MostUpvotedPage.tsx
@@ -16,6 +16,17 @@ import { mockGraphQL } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
 import Upvoted from '../pages/upvoted';
 
+// Compiling the feed module graph takes seconds on a cold jest transform cache,
+// so both the compile in beforeAll and the render need more than the defaults.
+jest.setTimeout(30000);
+const feedTimeout = 5000;
+
+beforeAll(async () => {
+  // MainFeedLayout only reaches the page through next/dynamic, so without this
+  // its compile lands inside the first findBy* wait and eats the whole budget.
+  await import('@dailydotdev/shared/src/components/MainFeedLayout');
+});
+
 afterEach(() => {
   nock.cleanAll();
 });
@@ -92,7 +103,7 @@ it('should request most upvoted feed when logged-in', async () => {
     () => {
       expect(screen.getAllByTestId('postItem').length).toBeTruthy();
     },
-    { timeout: 3000 },
+    { timeout: feedTimeout },
   );
 });
 
@@ -110,7 +121,10 @@ it('should request most upvoted feed when not', async () => {
     ],
     undefined,
   );
-  await waitFor(() => {
-    expect(screen.getAllByTestId('postItem').length).toBeTruthy();
-  });
+  await waitFor(
+    () => {
+      expect(screen.getAllByTestId('postItem').length).toBeTruthy();
+    },
+    { timeout: feedTimeout },
+  );
 });

--- a/packages/webapp/__tests__/MyFeedPage.tsx
+++ b/packages/webapp/__tests__/MyFeedPage.tsx
@@ -31,8 +31,16 @@ let defaultAlerts: Alerts = { filter: true };
 const updateAlerts = jest.fn();
 const originalScrollTo = window.scrollTo;
 
-beforeAll(() => {
+// Compiling the feed module graph takes seconds on a cold jest transform cache,
+// so both the compile in beforeAll and the render need more than the defaults.
+jest.setTimeout(30000);
+const feedTimeout = 5000;
+
+beforeAll(async () => {
   window.scrollTo = jest.fn();
+  // MainFeedLayout only reaches the page through next/dynamic, so without this
+  // its compile lands inside the first findBy* wait and eats the whole budget.
+  await import('@dailydotdev/shared/src/components/MainFeedLayout');
 });
 
 afterAll(() => {
@@ -144,7 +152,9 @@ it('should request user feed', async () => {
     });
 
   renderComponent([]);
-  const elements = await screen.findAllByTestId('postItem');
+  const elements = await screen.findAllByTestId('postItem', undefined, {
+    timeout: feedTimeout,
+  });
   expect(elements.length).toBeTruthy();
   await waitFor(() => {
     expect(graphQLRequests).toHaveLength(1);
@@ -174,7 +184,9 @@ it('should request anonymous my feed', async () => {
     ],
     undefined,
   );
-  await waitForNock();
-  const elements = await screen.findAllByTestId('postItem');
+  const elements = await screen.findAllByTestId('postItem', undefined, {
+    timeout: feedTimeout,
+  });
   expect(elements.length).toBeTruthy();
+  await waitForNock();
 });

--- a/packages/webapp/__tests__/PopularPage.tsx
+++ b/packages/webapp/__tests__/PopularPage.tsx
@@ -19,6 +19,17 @@ import { mockGraphQL } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
 import Popular from '../pages/popular';
 
+// Compiling the feed module graph takes seconds on a cold jest transform cache,
+// so both the compile in beforeAll and the render need more than the defaults.
+jest.setTimeout(30000);
+const feedTimeout = 5000;
+
+beforeAll(async () => {
+  // MainFeedLayout only reaches the page through next/dynamic, so without this
+  // its compile lands inside the first findBy* wait and eats the whole budget.
+  await import('@dailydotdev/shared/src/components/MainFeedLayout');
+});
+
 beforeEach(() => {
   jest.restoreAllMocks();
   jest.clearAllMocks();
@@ -86,6 +97,8 @@ it('should request anonymous popular feed', async () => {
     ],
     undefined,
   );
-  const elements = await screen.findAllByTestId('postItem');
+  const elements = await screen.findAllByTestId('postItem', undefined, {
+    timeout: feedTimeout,
+  });
   expect(elements.length).toBeTruthy();
 });


### PR DESCRIPTION
## Problem

`packages/webapp/__tests__/MyFeedPage.tsx` → `should request user feed` fails intermittently with `Unable to find an element by: [data-testid="postItem"]`. Seen on `main` (CircleCI build 161384) and on unrelated PRs (#6531, build 161573).

## Root cause

`MainFeedLayout` only reaches the feed pages through `next/dynamic`, so **its module graph is compiled by babel-jest inside the first `findBy*` wait**. An event-loop heartbeat during the test shows it plainly:

```
[60ms]  render returned
[494ms] event loop blocked for 493ms   <- dynamic import() compiling MainFeedLayout
[525ms] feed request
[681ms] found 8 postItems
```

With a warm transform cache that is ~470ms of a 1000ms budget. With a cold one the same block runs 3s+, and the test fails deterministically:

```bash
NODE_ENV=test pnpm exec jest __tests__/MyFeedPage.tsx --cacheDirectory=/tmp/cold-cache
# ✕ should request user feed (3037 ms)
```

CI reproduces this by accident: `test_webapp` runs `--runInBand` with `circleci tests run --split-by=timings` and restores only the pnpm deps cache, never a jest transform cache. File order changes between runs, so whichever feed page test lands first in the container pays the compile and fails; when another feed test runs first, the cache is warm and it passes.

## Fix

Preload the module in `beforeAll` so the compile no longer sits inside the wait window, raise the file timeout to cover that compile, and give the feed waits an explicit budget.

## Scope

A cold-cache sweep over 14 candidate test files found exactly four affected, all of them pages whose `getLayout` is `getMainFeedLayout` (the only path that reaches `MainFeedLayout` through `next/dynamic`):

| File | Cold, before | Cold, after |
|---|---|---|
| MyFeedPage | ✕ 3037 ms | ✓ 678 ms |
| PopularPage | ✕ 3662 ms | ✓ 494 ms |
| MostUpvotedPage | ✕ 4145 ms | ✓ 550 ms |
| MostDiscussedPage | ✕ 2992 ms | ✓ 566 ms |

TagPage, KeywordPage, SquadFeedPage, SearchPage, SearchResultsPage, BookmarksPage, HistoryPage and the Profile\* feed tests all pass cold — they reach the feed through static imports, so their compile happens at module load. That also clears `waitForNock`'s hardcoded 1000ms in practice, so no shared helper or global jest config change is included here.

Two incidental cleanups in the files being touched: `MostUpvotedPage`'s existing `{ timeout: 3000 }` was below the observed 4145ms, and `MostDiscussedPage` had a nested `waitFor(async () => findAllByTestId(...))` where a 1s inner wait sat inside a 1s outer one.

## Verification

- Cold cache (fresh `--cacheDirectory`), all four files: pass
- 22 loop iterations over the four files: 22/22
- 24 runs of MyFeedPage at 8x concurrency: 24/24
- Full webapp suite (`--ci --runInBand`): 74 suites, 587 tests, all pass
- `eslint` and `node ./scripts/typecheck-strict-changed.js`: clean

### Preview domain
https://claude-youthful-saha-7e3dd2.preview.app.daily.dev