### PR TITLE
fix: link squad stack tools to tool pages

### DIFF
--- a/packages/shared/src/components/squads/stack/SourceStackItem.spec.tsx
+++ b/packages/shared/src/components/squads/stack/SourceStackItem.spec.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import type { SourceStack } from '../../../graphql/source/sourceStack';
+import { webappUrl } from '../../../lib/constants';
+import { SourceStackItem } from './SourceStackItem';
+
+jest.mock('../../utilities/Link', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const buildItem = (overrides?: Partial<SourceStack>): SourceStack => ({
+  id: 'source-stack-1',
+  tool: {
+    id: 'tool-1',
+    title: 'TypeScript',
+    slug: 'typescript',
+    faviconUrl: null,
+  },
+  position: 0,
+  icon: null,
+  title: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  createdBy: {
+    id: 'user-1',
+    name: 'Lee',
+    image: 'https://daily.dev/lee.png',
+  },
+  ...overrides,
+});
+
+describe('SourceStackItem', () => {
+  it('links stack tools to their tool page', () => {
+    render(<SourceStackItem item={buildItem()} canEdit={false} />);
+
+    expect(screen.getByRole('link', { name: 'TypeScript' })).toHaveAttribute(
+      'href',
+      `${webappUrl}tools/typescript`,
+    );
+  });
+
+  it('uses the tool slug when the stack item has a custom title', () => {
+    render(
+      <SourceStackItem
+        item={buildItem({ title: 'TypeScript strict mode' })}
+        canEdit={false}
+      />,
+    );
+
+    expect(
+      screen.getByRole('link', { name: 'TypeScript strict mode' }),
+    ).toHaveAttribute('href', `${webappUrl}tools/typescript`);
+  });
+
+  it('renders without a link when no tool slug is available', () => {
+    render(
+      <SourceStackItem
+        item={buildItem({
+          tool: {
+            id: 'tool-1',
+            title: 'TypeScript',
+            slug: '',
+            faviconUrl: null,
+          },
+        })}
+        canEdit={false}
+      />,
+    );
+
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/squads/stack/SourceStackItem.tsx
+++ b/packages/shared/src/components/squads/stack/SourceStackItem.tsx
@@ -9,6 +9,9 @@ import {
 } from '../../typography/Typography';
 import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
 import { EditIcon, PlusIcon, TrashIcon } from '../../icons';
+import Link from '../../utilities/Link';
+import ConditionalWrapper from '../../ConditionalWrapper';
+import { webappUrl } from '../../../lib/constants';
 
 interface SourceStackItemProps {
   item: SourceStack;
@@ -25,6 +28,8 @@ export function SourceStackItem({
 }: SourceStackItemProps): ReactElement {
   const { tool } = item;
   const title = item.title ?? tool.title;
+  const isLinkable = !!tool.slug;
+  const toolUrl = `${webappUrl}tools/${tool.slug}`;
 
   return (
     <div
@@ -33,29 +38,40 @@ export function SourceStackItem({
         'hover:border-border-subtlest-secondary',
       )}
     >
-      <div className="flex items-center gap-2">
-        {tool.faviconUrl ? (
-          <img
-            src={tool.faviconUrl}
-            alt=""
-            className="rounded size-6 flex-shrink-0"
-          />
-        ) : (
-          <PlusIcon className="size-6 flex-shrink-0 text-text-tertiary" />
+      <ConditionalWrapper
+        condition={isLinkable}
+        wrapper={(children) => (
+          <Link href={toolUrl}>
+            <a href={toolUrl} className="flex min-w-0 items-center gap-2">
+              {children}
+            </a>
+          </Link>
         )}
-        {!!title && (
-          <div className="flex min-w-0 flex-1 flex-col">
-            <Typography
-              type={TypographyType.Callout}
-              color={TypographyColor.Primary}
-              bold
-              truncate
-            >
-              {title}
-            </Typography>
-          </div>
-        )}
-      </div>
+      >
+        <div className="flex min-w-0 items-center gap-2">
+          {tool.faviconUrl ? (
+            <img
+              src={tool.faviconUrl}
+              alt=""
+              className="rounded size-6 flex-shrink-0"
+            />
+          ) : (
+            <PlusIcon className="size-6 flex-shrink-0 text-text-tertiary" />
+          )}
+          {!!title && (
+            <div className="flex min-w-0 flex-1 flex-col">
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Primary}
+                bold
+                truncate
+              >
+                {title}
+              </Typography>
+            </div>
+          )}
+        </div>
+      </ConditionalWrapper>
       {canEdit && (
         <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
           {onEdit && (


### PR DESCRIPTION
## Changes

- Link squad Stack & Tools items to their `${webappUrl}tools/{slug}` pages when a tool slug is available.
- Keep slugless items rendered without a link.
- Add SourceStackItem coverage for linked, custom-title, and no-slug states.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

- Not manually tested in browser; covered by automated component and package tests.

Verification:
- `NODE_ENV=test pnpm --filter @dailydotdev/shared exec jest src/components/squads/stack/SourceStackItem.spec.tsx --runInBand`
- `node ./scripts/typecheck-strict-changed.js`
- `NODE_ENV=test pnpm --filter webapp test`
- `pnpm --filter @dailydotdev/shared lint`