### PR TITLE
fix(ads): declare the targeted-advertising purpose for US visitors

### DIFF
--- a/packages/webapp/components/Iubenda.tsx
+++ b/packages/webapp/components/Iubenda.tsx
@@ -175,6 +175,7 @@ export const Iubenda = (): ReactElement | null => {
       // Scoped with its stub: a framework enabled without the __gpp stub
       // answers no one, and US privacy signals mean nothing elsewhere.
       enableUspr: withGpp,
+      usprPurposes: 's,sh,adv',
       gdprAppliesGlobally: false,
       googleAdditionalConsentMode: withTcf,
       inlineDelay: 100,


### PR DESCRIPTION
## Problem

AdSense stopped filling for US visitors after #6524 shipped.

## Root cause

AdSense reads consent from Google Consent Mode, which iubenda drives. Under US state laws (USPR) iubenda derives `ad_storage` / `ad_user_data` / `ad_personalization` from the three US purposes — `s` (sale), `sh` (sharing) and `adv` (targeted advertising). The site's iubenda configuration only declares `s` and `sh` (remote config: `_iub.csPurposes = [6,5,4,1,2,3,"sh","s"]`), so with one purpose missing iubenda resolves the ad signals as **denied**. With `gtag.js` on the page AdSense honors that and downgrades to limited ads, which mostly come back `unfilled`.

Before #6524 US visitors were (wrongly) under LGPD, saw a banner, clicked Accept, and purpose 5 consent produced `granted` — which masked the gap.

## Verification

Reproduced with a local page running our exact `csConfiguration` plus iubenda's `usprApplies: true` override (forces the US regime) and a real slot:

| Scenario | Consent Mode `ad_*` update |
|---|---|
| No regime | granted |
| US regime, current config | **denied** |
| US regime + `usprPurposes: 's,sh,adv'` | **granted** |

## Fix

Declare `usprPurposes: 's,sh,adv'` in the embed. The iubenda dashboard's US State Laws purposes should be aligned to include targeted advertising as well, so the remote and embed configs agree.

## Note for legal

Declaring the targeted-advertising purpose means US visitors should have notice and an opt-out for it; the webapp disables iubenda's floating badge and relies on settings/privacy for withdrawal — worth confirming that satisfies notice-at-collection.

### Preview domain
https://fix-iubenda-uspr-purposes.preview.app.daily.dev