### PR TITLE
feat: auto cadence option for interest agent

### DIFF
--- a/packages/shared/src/features/interests/commands.ts
+++ b/packages/shared/src/features/interests/commands.ts
@@ -78,12 +78,14 @@ export const agentCommands: AgentCommand[] = [
   {
     name: 'schedule',
     label: 'Change cadence',
-    description: 'How often it runs on its own.',
+    description: 'How often it reports, or let it decide.',
     icon: TimerIcon,
     hint: '[how often]',
     ask: 'How often? Or send it as it is…',
     prompt: (args) =>
-      args ? `Run ${args} from now on` : 'How often are you running right now?',
+      args
+        ? `Report ${args} from now on`
+        : 'How often are you reporting right now?',
   },
   {
     name: 'why',

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
@@ -208,7 +208,7 @@ describe('AgentHomeScreen spawn settings', () => {
   it('peeks the current values until the controls are asked for', () => {
     renderHome();
 
-    expect(screen.getByText('Every hour')).toBeInTheDocument();
+    expect(screen.getByText('Whenever it matters')).toBeInTheDocument();
     expect(screen.getByText('Balanced')).toBeInTheDocument();
     expect(screen.getByText('feed, posts, notifications')).toBeInTheDocument();
     expect(screen.queryByLabelText('Every week')).not.toBeInTheDocument();

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
@@ -197,7 +197,7 @@ export const AgentHomeScreen = ({
 
   const cadenceSummary =
     cadenceOptions.find(({ value }) => value === settings.cadence)?.label ??
-    'Every hour';
+    'Whenever it matters';
   const deliverySummary = outputOptions
     .filter(({ key }) => settings.outputModes?.[key])
     .map(({ short }) => short)
@@ -211,7 +211,7 @@ export const AgentHomeScreen = ({
     fomoSummary = 'Show me everything';
   }
   const peekRows = [
-    ['When it runs', cadenceSummary],
+    ['When it reports', cadenceSummary],
     ['FOMO vs quality', fomoSummary],
     ['What it delivers', deliverySummary || 'Nothing yet'],
   ];
@@ -409,7 +409,7 @@ export const AgentHomeScreen = ({
             {isSettingsOpen && (
               <FlexCol className="agent-scroll max-h-[50vh] overflow-y-auto border-t border-border-subtlest-tertiary px-4">
                 <CadenceSection
-                  value={settings.cadence ?? UserInterestCadence.Hourly}
+                  value={settings.cadence ?? UserInterestCadence.Auto}
                   disabled={isCreating}
                   onChange={(cadence) =>
                     setSettings((current) => ({ ...current, cadence }))

--- a/packages/shared/src/features/interests/components/AgentSettingsFields.tsx
+++ b/packages/shared/src/features/interests/components/AgentSettingsFields.tsx
@@ -13,6 +13,7 @@ import type { InterestOutputModes } from '../../../graphql/interests';
 import { UserInterestCadence } from '../../../graphql/interests';
 
 export const cadenceOptions = [
+  { value: UserInterestCadence.Auto, label: 'Whenever it matters' },
   { value: UserInterestCadence.Hourly, label: 'Every hour' },
   { value: UserInterestCadence.Daily, label: 'Every day' },
   { value: UserInterestCadence.Weekly, label: 'Every week' },
@@ -82,8 +83,8 @@ export const CadenceSection = ({
   onChange: (cadence: UserInterestCadence) => void;
 }): ReactElement => (
   <SettingsSection
-    title="When it runs"
-    hint="How often the agent goes hunting for new content."
+    title="When it reports"
+    hint="Whenever it matters lets the agent keep looking on its own and only reach out when it has something worth your time."
   >
     <Radio
       name="agent-cadence"

--- a/packages/shared/src/features/interests/components/AgentSettingsPane.tsx
+++ b/packages/shared/src/features/interests/components/AgentSettingsPane.tsx
@@ -75,7 +75,7 @@ export const AgentSettingsPane = ({
       <div className="agent-scroll min-h-0 flex-1 overflow-y-auto px-5 tablet:px-8 laptop:px-10">
         <FlexCol className="mx-auto w-full max-w-[45rem] pb-8">
           <CadenceSection
-            value={interest?.cadence ?? UserInterestCadence.Daily}
+            value={interest?.cadence ?? UserInterestCadence.Auto}
             disabled={isUpdating || isStopped}
             onChange={(cadence) => update({ cadence })}
           />

--- a/packages/shared/src/features/interests/mock.ts
+++ b/packages/shared/src/features/interests/mock.ts
@@ -13,7 +13,7 @@ export const mockInterest: UserInterest = {
   query: 'Cool zig projects',
   title: 'Zig Project Radar',
   status: UserInterestStatus.Active,
-  cadence: UserInterestCadence.Daily,
+  cadence: UserInterestCadence.Auto,
   fomoThreshold: 0.62,
   sources: { dailyDev: true, web: false, github: false },
   outputModes: { feed: true, post: true, digest: false, notification: true },

--- a/packages/shared/src/graphql/interests.ts
+++ b/packages/shared/src/graphql/interests.ts
@@ -10,6 +10,7 @@ export enum UserInterestStatus {
 }
 
 export enum UserInterestCadence {
+  Auto = 'auto',
   Hourly = 'hourly',
   Daily = 'daily',
   Weekly = 'weekly',
@@ -76,7 +77,7 @@ export type UpdateInterestInput = {
 export type CreateInterestSettings = Omit<UpdateInterestInput, 'status'>;
 
 export const defaultCreateInterestSettings: CreateInterestSettings = {
-  cadence: UserInterestCadence.Hourly,
+  cadence: UserInterestCadence.Auto,
   fomoThreshold: 0.5,
   outputModes: { feed: true, post: true, digest: false, notification: true },
 };


### PR DESCRIPTION
Adds the 'auto' cadence ('Whenever it matters') as the default when spawning an agent and in the settings pane; the section is now titled 'When it reports' since auto lets the agent decide when to notify.

## Changes

<!--
### Describe what this PR does

- Short and concise, bullet points can help
- Screenshots if applicable can also help
-->

## Events

Did you introduce any new tracking events?

<!--
If yes please remove the comment HTML comment tags and fill the table below

Don't forget to update the [Analytics Taxonomy sheet](https://docs.google.com/spreadsheets/d/18Lv7zXges9QfVX5VYL1a-Hyl0e1sQ3sLr0OK8YZWKXI/edit#gid=0)

Log the new/changed events below:

| Type   | event_name  | value |
|--------|-------------|-------|
| Change/New | event name  | extra: { ... } |

-->

## Experiment

Did you introduce any new experiments?

<!--
If yes please remove the comment HTML comment tags and follow the instructions below

Don't forget to send a message to the [#experiments](https://dailydotdev.slack.com/archives/C02JAUF8HJL/p1715175315620999) channel, following the template in slack, and adding a link to the message here.

> [!IMPORTANT]
> Please do not merge the PR until the experiment enrolment is approved.

-->

## Manual Testing

> [!CAUTION]
> Please make sure existing components are not breaking/affected by this PR

<!--
If relevant, please remove the comment HTML comment tags and fill the checkboxes below

### On those affected packages:
- [ ] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

### Did you test the modified components media queries?
- [ ] MobileL (420px)
- [ ] Tablet (656px)
- [ ] Laptop (1020px)

#### Did you test on actual mobile devices?
- [ ] iOS (Chrome and Safari)
- [ ] Android

-->



### Preview domain
https://interest-agent-auto-cadence.preview.app.daily.dev