### PR TITLE
feat: programmatic ads on the organic post page + compact signup banner

### DIFF
--- a/packages/shared/src/components/post/BasePostContent.tsx
+++ b/packages/shared/src/components/post/BasePostContent.tsx
@@ -32,6 +32,8 @@ export function BasePostContent({
   navigationProps,
   engagementProps,
   shouldOnboardAuthor,
+  aboveComments,
+  commentAds,
   isPostPage,
 }: BasePostContentProps): ReactElement {
   const { id } = post ?? {};
@@ -64,12 +66,16 @@ export function BasePostContent({
       )}
       {children}
       {isPostPage && <PostAnsweredQuestions post={post} className="mt-6" />}
+      {aboveComments}
       {!!engagementProps && (
         <PostEngagements
           post={post}
           onCopyLinkClick={onCopyPostLink}
           logOrigin={origin}
           shouldOnboardAuthor={shouldOnboardAuthor}
+          hideInternalAd={!!commentAds}
+          interleaveEvery={commentAds?.interleaveEvery}
+          renderInterleaved={commentAds?.renderInterleaved}
         />
       )}
     </>

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -90,7 +90,11 @@ export function PostContentRaw({
   backToSquad,
   isBannerVisible,
   isPostPage,
-  widgetsTrailing,
+  getWidgetRailAd,
+  contentLeading,
+  renderSummarySegments,
+  aboveComments,
+  commentAds,
 }: PostContentRawProps): ReactElement {
   const { subject } = useToastNotification();
   const engagementActions = usePostContent({
@@ -160,10 +164,17 @@ export function PostContentRaw({
 
   const postMainColumn = (
     <PostContainer
-      className={classNames('relative', className?.content)}
+      className={classNames(
+        'relative',
+        !!contentLeading && '!overflow-x-clip !overflow-y-visible',
+        className?.content,
+      )}
       data-testid="postContainer"
     >
+      {contentLeading}
       <BasePostContent
+        aboveComments={aboveComments}
+        commentAds={commentAds}
         className={{
           ...className,
           onboarding: classNames(className?.onboarding, backToSquad && 'mb-6'),
@@ -208,21 +219,24 @@ export function PostContentRaw({
             className="mb-7"
           />
         )}
-        {post.summary && (
-          <div
-            className={classNames(
-              'mb-6 overflow-hidden text-text-secondary',
-              isCompactModalSpacing && 'mb-4',
-            )}
-          >
-            <p
-              className="select-text break-words typo-markdown"
-              data-testid="tldr-container"
+        {post.summary &&
+          (renderSummarySegments ? (
+            renderSummarySegments(post.summary)
+          ) : (
+            <div
+              className={classNames(
+                'mb-6 overflow-hidden text-text-secondary',
+                isCompactModalSpacing && 'mb-4',
+              )}
             >
-              {post.summary}
-            </p>
-          </div>
-        )}
+              <p
+                className="select-text break-words typo-markdown"
+                data-testid="tldr-container"
+              >
+                {post.summary}
+              </p>
+            </div>
+          ))}
         <PostTagList post={post} />
         <PostMetadata
           createdAt={post.createdAt}
@@ -298,7 +312,7 @@ export function PostContentRaw({
       onClose={onClose}
       origin={origin}
       onCopyPostLink={onCopyPostLink}
-      trailing={widgetsTrailing}
+      getRailAd={getWidgetRailAd}
     />
   );
 

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -44,14 +44,16 @@ const SquadEntityCard = dynamic(
 );
 
 /**
- * The points in the rail an ad template may follow with a slot: one per real
- * widget, in render order. PostSidebarAdWidget and MentionedToolsWidget are
- * absent on purpose — both are already commercial units, so following them
- * would stack two ads.
+ * The points in the rail an ad template may follow with a slot, in render
+ * order. MentionedToolsWidget has no position on purpose — it is itself a
+ * commercial unit and /read skips DirectAd for the same reason; the organic
+ * template deliberately groups its programmatic unit with the direct-sold
+ * one instead.
  */
 export enum PostWidgetPosition {
   Source = 'source',
   Creator = 'creator',
+  DirectAd = 'directAd',
   Share = 'share',
   Highlights = 'highlights',
   SimilarPosts = 'similarPosts',
@@ -143,6 +145,19 @@ export function PostWidgets({
       return widget;
     }
 
+    // After the direct-sold widget the programmatic unit IS the backfill:
+    // it must render exactly when the widget has nothing (Plus, no fill),
+    // so the first-child-hidden rule that protects every other position
+    // would remove it at the moment it matters most.
+    if (position === PostWidgetPosition.DirectAd) {
+      return (
+        <>
+          {widget}
+          {ad}
+        </>
+      );
+    }
+
     return <WidgetWithAd widget={widget} ad={ad} />;
   };
 
@@ -161,12 +176,14 @@ export function PostWidgets({
           />
         ),
       )}
-      {!hideAdWidget && (
-        <PostSidebarAdWidget
-          postId={post.id}
-          className={{ container: cardClasses }}
-        />
-      )}
+      {!hideAdWidget &&
+        withAd(
+          PostWidgetPosition.DirectAd,
+          <PostSidebarAdWidget
+            postId={post.id}
+            className={{ container: cardClasses }}
+          />,
+        )}
       <MentionedToolsWidget postTags={post.tags || []} />
       {withAd(
         PostWidgetPosition.Share,

--- a/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
@@ -251,24 +251,26 @@ describe('ArbitrageAdSlot', () => {
 
   it('renders fixed-size units at exactly the configured size', () => {
     setOrganicSlots({
-      [ORGANIC_SLOT.railHalfPage]: {
+      [ORGANIC_SLOT.railAfterDirectAd]: {
         id: '3333333333',
         type: 'display',
         width: 300,
-        height: 600,
+        height: 250,
       },
     });
     render(
       <ArbitrageAdSlot
         surface="organic"
-        slot={ORGANIC_SLOT.railHalfPage}
-        format={ArbitrageAdFormat.HalfPage}
+        slot={ORGANIC_SLOT.railAfterDirectAd}
+        format={ArbitrageAdFormat.MediumRectangle}
         eager
       />,
     );
 
-    const ins = screen.getByTestId(`adsense-slot-${ORGANIC_SLOT.railHalfPage}`);
-    expect(ins).toHaveStyle({ width: '300px', height: '600px' });
+    const ins = screen.getByTestId(
+      `adsense-slot-${ORGANIC_SLOT.railAfterDirectAd}`,
+    );
+    expect(ins).toHaveStyle({ width: '300px', height: '250px' });
     expect(ins).not.toHaveAttribute('data-ad-format');
   });
 

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -41,6 +41,8 @@ import PostEngagements from '../PostEngagements';
  * first in-content unit and the above-comments MPU (~17-22% of a scraped
  * page against the Better Ads 30% cap).
  */
+// No DirectAd entry: following the direct-sold widget here would stack two
+// ads back to back in a rail that already carries a unit per real widget.
 const RAIL_AD: Partial<
   Record<
     PostWidgetPosition,

--- a/packages/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard.spec.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard.spec.tsx
@@ -53,6 +53,16 @@ describe('ArbitrageTopLeaderboard', () => {
 
     expect(isPinned(container)).toBe(false);
   });
+
+  it('owns its release window when no released prop is passed', () => {
+    const { container } = render(<ArbitrageTopLeaderboard />);
+    expect(isPinned(container)).toBe(true);
+
+    scroll();
+    advancePastStickyWindow();
+
+    expect(isPinned(container)).toBe(false);
+  });
 });
 
 describe('useTimedRelease', () => {

--- a/packages/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard.tsx
@@ -2,11 +2,25 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import { ArbitrageAdFormat, ArbitrageAdSlot } from './ArbitrageAdSlot';
-import { ARBITRAGE_SLOT } from './slots';
+import { ARBITRAGE_SLOT, TOP_LEADERBOARD_STICKY_MS } from './slots';
+import { useTimedRelease } from './useTimedRelease';
 
 export interface ArbitrageTopLeaderboardProps {
-  /** False while the unit is still inside its sticky window. */
-  released: boolean;
+  /**
+   * False while the unit is still inside its sticky window. Owned internally
+   * when omitted — /read passes it because the mobile header block shares the
+   * same window, while the organic page has no other consumer.
+   */
+  released?: boolean;
+  slot?: number;
+  /**
+   * The fixed 320x100 twin the phone requests instead of the responsive
+   * unit. Must come from the same surface's map as `slot`, or the twin
+   * would ride the other surface's flag gating.
+   */
+  phoneSlot?: number;
+  surface?: 'read' | 'organic';
+  className?: string;
 }
 
 /**
@@ -21,11 +35,19 @@ export interface ArbitrageTopLeaderboardProps {
  */
 export function ArbitrageTopLeaderboard({
   released,
+  slot = ARBITRAGE_SLOT.topLeaderboard,
+  phoneSlot = ARBITRAGE_SLOT.topLeaderboardPhone,
+  surface = 'read',
+  className,
 }: ArbitrageTopLeaderboardProps): ReactElement {
+  const ownReleased = useTimedRelease(TOP_LEADERBOARD_STICKY_MS);
+  const isReleased = released ?? ownReleased;
+
   return (
     <div
       className={classNames(
         'bg-background-default pb-2 pt-4',
+        className,
         // --sticky-header-offset is published by MainLayout and matches the
         // fixed chrome this layout actually has: 4rem for the v1 header, 0 on
         // mobile and under the v2 sidebar which owns its own header, more again
@@ -42,7 +64,7 @@ export function ArbitrageTopLeaderboard({
         // above, which keeps the two from sliding over each other; sticky here
         // as well would give the block a second sticky element inside a pinned
         // one, and it would climb to the top of it and cover the leaderboard.
-        !released &&
+        !isReleased &&
           'z-2 laptop:sticky laptop:top-[var(--sticky-header-offset)]',
       )}
     >
@@ -54,13 +76,15 @@ export function ArbitrageTopLeaderboard({
           the page where the intersection observer fires on first paint
           anyway. A hidden ins never intersects, so exactly one requests. */}
       <ArbitrageAdSlot
-        slot={ARBITRAGE_SLOT.topLeaderboardPhone}
+        slot={phoneSlot}
+        surface={surface}
         format={ArbitrageAdFormat.Leaderboard}
         className="tablet:hidden"
         refreshes
       />
       <ArbitrageAdSlot
-        slot={ARBITRAGE_SLOT.topLeaderboard}
+        slot={slot}
+        surface={surface}
         format={ArbitrageAdFormat.Leaderboard}
         hideOnPhone
         refreshes

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -147,19 +147,34 @@ export const READ_ADSENSE_SLOTS: AdsenseSlots = {
 export const ORGANIC_SLOT = {
   /** Leaderboard above the post content, spanning the page column. */
   topLeaderboard: 15,
-  /** Half page closing the widget column, sticky for the rest of the read. */
-  railHalfPage: 16,
+  /** Rail unit below the direct-sold ad widget. */
+  railAfterDirectAd: 16,
+  /** The organic leaderboard's fixed 320x100 phone twin — see slot 20. */
+  topLeaderboardPhone: 21,
+  /** MPU repeated through the TLDR, same cadence as the articles page. */
+  inContentMpu: 22,
+  /** MPU directly above the comment section. */
+  aboveCommentsMpu: 23,
+  /** MPU through a long thread, every COMMENTS_PER_INTERLEAVED_AD. */
+  commentMpu: 24,
 } as const;
 
-// TODO(chris): create the two organic units in AdSense (suggested names
-// post_s15_top_leaderboard, post_s16_rail_half_page) and fill in the ids.
-// Both slots stay collapsed until then.
+// Borrowed /read units so the placements serve before their own exist;
+// their reporting blends with the /read rows meanwhile.
+// TODO(chris): create post_s15_top_leaderboard and post_s16_rail_mpu
+// (Display 300x250) in AdSense and swap the ids for per-placement RPM.
 export const ORGANIC_ADSENSE_SLOTS: AdsenseSlots = {
-  [ORGANIC_SLOT.topLeaderboard]: { id: '', type: 'display' },
-  [ORGANIC_SLOT.railHalfPage]: {
-    id: '',
+  [ORGANIC_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
+  [ORGANIC_SLOT.topLeaderboardPhone]: {
+    id: '9942870945',
     type: 'display',
-    width: 300,
-    height: 600,
+    width: 320,
+    height: 100,
   },
+  [ORGANIC_SLOT.railAfterDirectAd]: { id: '6921226982', type: 'display' },
+  // Shared units, same trade as the articles map: Google's per-unit rows
+  // blend, first-party events split by slot number.
+  [ORGANIC_SLOT.inContentMpu]: { id: '6921226982', type: 'display' },
+  [ORGANIC_SLOT.aboveCommentsMpu]: { id: '5249052667', type: 'display' },
+  [ORGANIC_SLOT.commentMpu]: { id: '6921226982', type: 'display' },
 };

--- a/packages/shared/src/components/post/arbitrage/useReadAdsenseSlots.ts
+++ b/packages/shared/src/components/post/arbitrage/useReadAdsenseSlots.ts
@@ -47,16 +47,21 @@ export const useReadAdsenseSlots = (): AdsenseSlots => {
  * The organic post page's units: only while the `post_adsense` flag is on,
  * and only for anonymous visitors — any logged-in user (member or Plus)
  * never sees programmatic ads on their post pages.
+ *
+ * `canRender` is the caller's own knowledge of whether its slots can appear
+ * at all — the post page passes false in the focus-card redesign arm, whose
+ * layout carries no slot markup.
  */
-export const useOrganicAdsenseSlots = (): AdsenseSlots => {
+export const useOrganicAdsenseSlots = (canRender = true): AdsenseSlots => {
   const isAnonymous = useIsAnonymous();
   // Conditional evaluation, because evaluating enrolls: a visitor who is
-  // logged in — or whose units have no AdSense id yet and so cannot render
-  // anything — would fill the experiment with byte-identical variants.
+  // logged in — or who cannot be shown a unit — would fill the experiment
+  // with byte-identical variants.
   const { value: enabled } = useConditionalFeature({
     feature: featurePostAdsense,
-    shouldEvaluate: isAnonymous && hasLiveAdsenseUnits(ORGANIC_ADSENSE_SLOTS),
+    shouldEvaluate:
+      canRender && isAnonymous && hasLiveAdsenseUnits(ORGANIC_ADSENSE_SLOTS),
   });
 
-  return enabled && isAnonymous ? ORGANIC_ADSENSE_SLOTS : NO_SLOTS;
+  return enabled && isAnonymous && canRender ? ORGANIC_ADSENSE_SLOTS : NO_SLOTS;
 };

--- a/packages/shared/src/components/post/common.tsx
+++ b/packages/shared/src/components/post/common.tsx
@@ -13,6 +13,7 @@ import type {
   UsePostContentProps,
 } from '../../hooks/usePostContent';
 import type { ButtonSize } from '../buttons/common';
+import type { PostWidgetPosition } from './PostWidgets';
 
 export interface PostContentClassName {
   container?: string;
@@ -90,11 +91,33 @@ export interface PostContentProps
   backToSquad?: boolean;
   isPostPage?: boolean;
   /**
-   * Rendered as the widget column's last child. Only the webapp post page
-   * passes it (an AdSense unit) — post modals and the extension must never,
-   * as the ad script only exists on the page and AdSense bans extensions.
+   * Forwarded to the widget column's per-position ad hook. Only the webapp
+   * post page passes it (AdSense units) — post modals and the extension must
+   * never, as the ad script only exists on the page and AdSense bans
+   * extensions.
    */
-  widgetsTrailing?: ReactNode;
+  getWidgetRailAd?: (position: PostWidgetPosition) => ReactNode;
+  /**
+   * Replaces the default TLDR paragraph so an ad template can interleave
+   * units between summary segments. Like every ad prop here: only the
+   * webapp post page passes it — post modals and the extension render the
+   * same component and must never carry ad markup.
+   */
+  renderSummarySegments?: (summary: string) => ReactNode;
+  /** Rendered between the article content and the engagement block. */
+  aboveComments?: ReactNode;
+  /** Interleaves the comment thread — see PostEngagements. */
+  commentAds?: {
+    interleaveEvery: number;
+    renderInterleaved: (occurrence: number) => ReactNode;
+  };
+  /**
+   * Rendered first in the article column, same page-only rule as
+   * getWidgetRailAd. The column's overflow-hidden is relaxed while this is
+   * set, because the ad template's leaderboard pins with position: sticky and
+   * an overflow-hidden ancestor silently stops it.
+   */
+  contentLeading?: ReactNode;
 }
 
 export const PostContainer = classed(
@@ -110,6 +133,11 @@ export interface BasePostContentProps extends UsePostContentProps {
   navigationProps?: PostNavigationProps;
   engagementProps?: UsePostContent;
   shouldOnboardAuthor?: boolean;
+  aboveComments?: ReactNode;
+  commentAds?: {
+    interleaveEvery: number;
+    renderInterleaved: (occurrence: number) => ReactNode;
+  };
   loadingPlaceholder?: ReactNode;
   customNavigation?: ReactNode;
   isPostPage?: boolean;

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -54,7 +54,7 @@ import * as hooks from '@dailydotdev/shared/src/hooks/useViewSize';
 import { UserVoteEntity } from '@dailydotdev/shared/src/hooks';
 import { getLogContextStatic } from '@dailydotdev/shared/src/contexts/LogContext';
 import type { Props } from '../pages/posts/[id]';
-import { PostPage } from '../pages/posts/[id]';
+import { isPostDetailPath, PostPage } from '../pages/posts/[id]';
 import { getSeoDescription } from '../components/PostSEOSchema';
 import { getLayout as getMainLayout } from '../components/layouts/MainLayout';
 
@@ -105,10 +105,11 @@ jest.mock('@dailydotdev/shared/src/hooks/useConditionalFeature', () => ({
   },
 }));
 
-beforeEach(() => {
-  nock.cleanAll();
-  jest.clearAllMocks();
-  mockRedesignOn = false;
+// The ad-teardown effect subscribes to router events on anonymous renders,
+// so the mock has to carry the emitter surface.
+const routerEvents = { on: jest.fn(), off: jest.fn(), emit: jest.fn() };
+
+const mockRouter = (overrides: Partial<NextRouter> = {}): void => {
   jest.mocked(useRouter).mockImplementation(
     () =>
       ({
@@ -116,8 +117,18 @@ beforeEach(() => {
         pathname: '/posts',
         isReady: true,
         query: {},
+        events: routerEvents,
+        beforePopState: jest.fn(),
+        ...overrides,
       } as unknown as NextRouter),
   );
+};
+
+beforeEach(() => {
+  nock.cleanAll();
+  jest.clearAllMocks();
+  mockRedesignOn = false;
+  mockRouter();
 });
 
 const defaultPost = {
@@ -643,13 +654,7 @@ it('should not show author onboarding by default', () => {
 });
 
 it('should show author onboarding when the query param is set', async () => {
-  jest.mocked(useRouter).mockImplementation(
-    () =>
-      ({
-        isFallback: false,
-        query: { author: 'true' },
-      } as unknown as NextRouter),
-  );
+  mockRouter({ query: { author: 'true' } });
   renderPost();
   const el = await screen.findByTestId('authorOnboarding');
   expect(el).toBeInTheDocument();
@@ -1125,15 +1130,7 @@ describe('article', () => {
 
 describe('post redesign', () => {
   const mockRouterQuery = (query: Record<string, string>) => {
-    jest.mocked(useRouter).mockImplementation(
-      () =>
-        ({
-          isFallback: false,
-          pathname: '/posts',
-          isReady: true,
-          query,
-        } as unknown as NextRouter),
-    );
+    mockRouter({ query });
   };
 
   it('should render the focus card redesign when the flag is on', async () => {
@@ -1192,5 +1189,22 @@ describe('post redesign', () => {
     renderPost();
     expect(await screen.findByTestId('postContainer')).toBeInTheDocument();
     expect(screen.queryByTestId('post-focus-card')).not.toBeInTheDocument();
+  });
+});
+
+describe('isPostDetailPath (ad navigation boundary)', () => {
+  it('keeps client-side navigation only for other post detail pages', () => {
+    expect(isPostDetailPath('/posts/abc123')).toBe(true);
+    expect(isPostDetailPath('/posts/abc123?comment=1')).toBe(true);
+    expect(isPostDetailPath('/posts/abc123/share')).toBe(true);
+  });
+
+  it('treats the post list pages as departures that tear ads down', () => {
+    expect(isPostDetailPath('/posts/best-of/2026/08')).toBe(false);
+    expect(isPostDetailPath('/posts/latest')).toBe(false);
+    expect(isPostDetailPath('/posts/discussed')).toBe(false);
+    expect(isPostDetailPath('/posts/upvoted')).toBe(false);
+    expect(isPostDetailPath('/posts')).toBe(false);
+    expect(isPostDetailPath('/my-feed')).toBe(false);
   });
 });

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -1,5 +1,5 @@
 import type { ComponentType, CSSProperties, ReactElement } from 'react';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/router';
 import dynamic from 'next/dynamic';
 import Script from 'next/script';
@@ -7,11 +7,19 @@ import {
   ArbitrageAdFormat,
   ArbitrageAdSlot,
 } from '@dailydotdev/shared/src/components/post/arbitrage/ArbitrageAdSlot';
+import { ArbitrageTopLeaderboard } from '@dailydotdev/shared/src/components/post/arbitrage/ArbitrageTopLeaderboard';
+import { PostWidgetPosition } from '@dailydotdev/shared/src/components/post/PostWidgets';
 import {
   ADSENSE_SCRIPT_SRC,
   hasLiveAdsenseUnits,
 } from '@dailydotdev/shared/src/features/monetization/adsense';
-import { ORGANIC_SLOT } from '@dailydotdev/shared/src/components/post/arbitrage/slots';
+import {
+  COMMENTS_PER_INTERLEAVED_AD,
+  CONTENT_CHARS_PER_AD,
+  MAX_CONTENT_ADS_PER_SECTION,
+  ORGANIC_SLOT,
+} from '@dailydotdev/shared/src/components/post/arbitrage/slots';
+import { splitTextForAds } from '@dailydotdev/shared/src/components/post/arbitrage/splitContentForAds';
 import { useOrganicAdsenseSlots } from '@dailydotdev/shared/src/components/post/arbitrage/useReadAdsenseSlots';
 import type {
   GetStaticPathsResult,
@@ -138,6 +146,25 @@ const DigestPostContent = dynamic(() =>
   ).then((module) => module.DigestPostContent),
 );
 
+/**
+ * Whether a URL is another post detail page — the only destinations that keep
+ * client-side navigation while ads are live, because they re-enter this same
+ * ad-carrying route. A bare `/posts/` prefix is NOT that: /posts/best-of/*,
+ * /posts/latest, /posts/discussed and /posts/upvoted are list pages with no
+ * slots, linked from this page's own rail, and navigating to them must tear
+ * the ad globals down like any other departure.
+ */
+const POST_LIST_SEGMENTS = new Set([
+  'best-of',
+  'latest',
+  'discussed',
+  'upvoted',
+]);
+export const isPostDetailPath = (url: string): boolean => {
+  const match = /^\/posts\/([^/?#]+)(?:[/?#]|$)/.exec(url);
+  return !!match && !POST_LIST_SEGMENTS.has(match[1]);
+};
+
 export interface Props extends DynamicSeoProps {
   id: string;
   initialData?: PostData;
@@ -217,8 +244,98 @@ export const PostPage = ({
   // exists. Gated on a unit id being present, not key presence — the map keeps
   // placeholder entries with empty ids, and the script must not load for
   // inventory that cannot fill.
-  const adsenseSlots = useOrganicAdsenseSlots();
+  const adsenseSlots = useOrganicAdsenseSlots(!showRedesign);
   const adsenseActive = hasLiveAdsenseUnits(adsenseSlots);
+  // The same in-content treatment the /articles template ships, reused on
+  // the organic page: the TLDR splits at the shared cadence with an MPU
+  // between segments (phones keep only the first), an MPU sits above the
+  // comments, and a long thread carries one per interval — all only while
+  // ads are live, so members and modal/extension surfaces keep the
+  // untouched production markup.
+  const summarySegments = useMemo(
+    () =>
+      adsenseActive && post?.summary
+        ? splitTextForAds(
+            post.summary,
+            CONTENT_CHARS_PER_AD,
+            MAX_CONTENT_ADS_PER_SECTION + 1,
+          )
+        : null,
+    [adsenseActive, post?.summary],
+  );
+  const renderSummarySegments = useMemo(() => {
+    if (!summarySegments) {
+      return undefined;
+    }
+    // A render prop, not a component: PostContent calls it as a function.
+    // eslint-disable-next-line react/display-name
+    return () => (
+      <>
+        {summarySegments.map((segment, index, segments) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={index}>
+            <div className="mb-6 overflow-hidden text-text-secondary">
+              <p
+                className="select-text break-words typo-markdown"
+                data-testid={index === 0 ? 'tldr-container' : undefined}
+              >
+                {segment}
+              </p>
+            </div>
+            {index < segments.length - 1 && (
+              <ArbitrageAdSlot
+                surface="organic"
+                slot={ORGANIC_SLOT.inContentMpu}
+                format={ArbitrageAdFormat.MediumRectangle}
+                className="my-6"
+                hideOnPhone={index > 0}
+                logExtra={{ section: 'summary', occurrence: index + 1 }}
+              />
+            )}
+          </React.Fragment>
+        ))}
+      </>
+    );
+  }, [summarySegments]);
+
+  // Same boundary the /read template draws: adsbygoogle must never follow a
+  // client-side navigation off the post pages, because its Auto ads overlays
+  // persist across soft navigations. Post-to-post stays client-side — the
+  // destination carries its own slots — while any departure forces a full
+  // page load that tears every Google global down.
+  useEffect(() => {
+    if (!adsenseActive) {
+      return undefined;
+    }
+    const forceHardNavigation = (
+      url: string,
+      { shallow }: { shallow: boolean },
+    ): void => {
+      if (shallow || isPostDetailPath(url)) {
+        return;
+      }
+      router.events.emit('routeChangeError');
+      window.location.assign(url);
+      // Next.js has no cancel API; throwing inside the handler is the
+      // established way to abort the client-side transition.
+      throw new Error(`Aborted client navigation to ${url} to unload ads`);
+    };
+    router.events.on('routeChangeStart', forceHardNavigation);
+    // On popstate the history pointer has already moved, so assign() would
+    // navigate forward again; loading the target URL in place respects the
+    // position the user just moved to.
+    router.beforePopState(({ as }) => {
+      if (isPostDetailPath(as)) {
+        return true;
+      }
+      window.location.href = as;
+      return false;
+    });
+    return () => {
+      router.events.off('routeChangeStart', forceHardNavigation);
+      router.beforePopState(() => true);
+    };
+  }, [adsenseActive, router]);
   const featureTheme = useFeatureTheme();
   const containerClass = classNames(
     'mb-16 min-h-page max-w-[69.25rem] tablet:mb-8 laptop:mb-0 laptop:pb-6 laptopL:pb-0',
@@ -306,19 +423,6 @@ export const PostPage = ({
             </>
           )}
           <PostSEOSchema post={post} topComments={topComments} />
-          {/* Above the whole two-column container rather than inside the
-              article column: the classic and focus layouts differ inside, and
-              the unit must never render in post modals, which share those
-              components but not this page. */}
-          {!showRedesign && (
-            <ArbitrageAdSlot
-              surface="organic"
-              slot={ORGANIC_SLOT.topLeaderboard}
-              format={ArbitrageAdFormat.Leaderboard}
-              className="mx-auto mt-4 max-w-[69.25rem]"
-              eager
-            />
-          )}
           {showRedesign ? (
             <div className="mx-auto w-full max-w-[63.75rem]">
               <PostFocusCard post={post} origin={Origin.ArticlePage} />
@@ -333,16 +437,56 @@ export const PostPage = ({
               shouldOnboardAuthor={!!router.query?.author}
               origin={Origin.ArticlePage}
               isBannerVisible={shouldShowAuthBanner && !isLaptop}
-              widgetsTrailing={
-                <ArbitrageAdSlot
-                  surface="organic"
-                  slot={ORGANIC_SLOT.railHalfPage}
-                  format={ArbitrageAdFormat.HalfPage}
-                  // The offset MainLayout publishes for this page's actual
-                  // chrome, plus a gap — a hardcoded 5rem is wrong whenever a
-                  // top banner adds 2rem above the header.
-                  className="laptop:sticky laptop:top-[calc(var(--sticky-header-offset)+1rem)]"
-                />
+              contentLeading={
+                adsenseActive ? (
+                  <ArbitrageTopLeaderboard
+                    surface="organic"
+                    slot={ORGANIC_SLOT.topLeaderboard}
+                    phoneSlot={ORGANIC_SLOT.topLeaderboardPhone}
+                  />
+                ) : undefined
+              }
+              // Only while ads are actually live: a truthy hook flattens the
+              // further-reading widget around the slot, and without an ad that
+              // changes rail spacing for members who never see one.
+              renderSummarySegments={renderSummarySegments}
+              aboveComments={
+                adsenseActive ? (
+                  <ArbitrageAdSlot
+                    surface="organic"
+                    slot={ORGANIC_SLOT.aboveCommentsMpu}
+                    format={ArbitrageAdFormat.MediumRectangle}
+                    className="my-6"
+                  />
+                ) : undefined
+              }
+              commentAds={
+                adsenseActive
+                  ? {
+                      interleaveEvery: COMMENTS_PER_INTERLEAVED_AD,
+                      renderInterleaved: (occurrence) => (
+                        <ArbitrageAdSlot
+                          surface="organic"
+                          slot={ORGANIC_SLOT.commentMpu}
+                          format={ArbitrageAdFormat.MediumRectangle}
+                          hideOnPhone
+                          logExtra={{ occurrence }}
+                        />
+                      ),
+                    }
+                  : undefined
+              }
+              getWidgetRailAd={
+                adsenseActive
+                  ? (widgetPosition) =>
+                      widgetPosition === PostWidgetPosition.DirectAd ? (
+                        <ArbitrageAdSlot
+                          surface="organic"
+                          slot={ORGANIC_SLOT.railAfterDirectAd}
+                          format={ArbitrageAdFormat.MediumRectangle}
+                        />
+                      ) : null
+                  : undefined
               }
               className={{
                 container: containerClass,


### PR DESCRIPTION
Continuation of #6512 (closed — renamed branch, reconciled with #6529). Original work by @tsahimatsliah; this transplants it onto `feat/articles-monetization` and resolves the collisions.

## What (unchanged from #6512)

For **anonymous visitors only** (`post_adsense` flag, default off), the organic post page gets:
- **Top leaderboard** above the content, pinning for the first 10 seconds of scrolling then releasing — the same component the articles template ships, now generalized to any slot/surface.
- **Rail unit below the direct-sold widget**, via the existing `getRailAd` mechanism threaded as `getWidgetRailAd`; only passed while ads are live, so members' rail keeps its original DOM.
- **Compact signup strip**: media above the headline removed across variants, vertical breathing room evened out.

## Reconciliation with #6529 (the delta from the original)

- **Kept alive what had grown consumers**: `PostWidgets.trailing` (carries the articles rail's closing sticky), the `HalfPage` format (that unit's shape), and `geoToEmoji`'s removal stands (genuinely dead).
- **Phone twin made surface-safe**: the fixed 320×100 phone leaderboard now takes `phoneSlot` from the same map/flag as its desktop sibling — without this, the organic page's phone leaderboard would have served through the read surface's default-on flag even with `post_adsense` off. The organic map carries its own fixed phone entry (slot 21).
- The internal sidebar ad keeps both the `hideAdWidget` gate (articles template) and the new `DirectAd` rail position (organic).
- The `TEMP-REVIEW` commit defaulting `post_adsense` **on** was dropped in the transplant.

**Stacked on #6529** — this PR targets `feat/articles-monetization` and should merge after it (GitHub retargets to main automatically when the base branch merges).

## Verification
- 139 shared post+monetization tests, full `lint_shared` clean, strict typecheck green, webapp green minus the pre-existing `WorldGuideSheet` failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-post-page-ads.preview.app.daily.dev