### PR TITLE
fix: /users prerender survives a partial leaderboard failure

### DIFF
--- a/packages/webapp/__tests__/UsersLeaderboardStaticProps.spec.ts
+++ b/packages/webapp/__tests__/UsersLeaderboardStaticProps.spec.ts
@@ -46,6 +46,53 @@ describe('leaderboard static props', () => {
     mockRequest.mockReset();
   });
 
+  it('renders the boards that resolved when one resolver errors', async () => {
+    // graphql-request throws on any errors entry even when the response
+    // carries data for every other board — the exact shape that took the
+    // /users prerender (and with it every deploy) down.
+    mockRequest.mockImplementation((query: string) => {
+      if (query === LEADERBOARD_QUERY) {
+        return Promise.reject({
+          response: {
+            data: { ...baseLeaderboardResponse, mostAchievementPoints: null },
+            errors: [{ message: 'Unexpected error' }],
+            status: 200,
+          },
+        });
+      }
+
+      if (query === POPULAR_HOT_TAKES_QUERY) {
+        return Promise.resolve({ popularHotTakes: [] });
+      }
+
+      if (query === HIGHEST_LEVEL_QUERY) {
+        return Promise.resolve({ highestLevel: [] });
+      }
+
+      return Promise.reject(new Error('Unexpected query'));
+    });
+
+    const result = await getUsersStaticProps();
+
+    expect(result).toMatchObject({
+      props: {
+        highestReputation: [],
+        mostAchievementPoints: [],
+      },
+      revalidate: 3600,
+    });
+  });
+
+  it('still throws when the failure carries no board data at all', async () => {
+    mockRequest.mockImplementation(() =>
+      Promise.reject({
+        response: { errors: [{ message: 'Unexpected error' }] },
+      }),
+    );
+
+    await expect(getUsersStaticProps()).rejects.toBeTruthy();
+  });
+
   it('should hide highest-level data when API schema does not support it', async () => {
     mockRequest.mockImplementation((query: string) => {
       if (query === LEADERBOARD_QUERY) {

--- a/packages/webapp/pages/users.tsx
+++ b/packages/webapp/pages/users.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import React from 'react';
 import type { GetStaticPropsResult } from 'next';
+import type { ClientError } from 'graphql-request';
 import type { NextSeoProps } from 'next-seo/lib/types';
 import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
 import {
@@ -210,9 +211,24 @@ export async function getStaticProps(): Promise<
   GetStaticPropsResult<PageProps>
 > {
   try {
-    const res = await gqlClient.request<
-      Omit<PageProps, 'highestLevel' | 'popularHotTakes'>
-    >(LEADERBOARD_QUERY);
+    type LeaderboardData = Omit<PageProps, 'highestLevel' | 'popularHotTakes'>;
+    let res: LeaderboardData;
+    try {
+      res = await gqlClient.request<LeaderboardData>(LEADERBOARD_QUERY);
+    } catch (leaderboardError: unknown) {
+      const partial = (leaderboardError as ClientError)?.response?.data as
+        | LeaderboardData
+        | undefined;
+
+      // One failing resolver must not take the whole page's prerender (and
+      // with it every deploy) down: graphql-request throws on any `errors`
+      // entry even when the response carries data for every other board.
+      // Render what came back; the boards below null-coalesce per field.
+      if (!partial?.highestReputation) {
+        throw leaderboardError;
+      }
+      res = partial;
+    }
 
     let highestLevel: UserLeaderboard[] = [];
     let isHighestLevelSupported = false;
@@ -247,16 +263,16 @@ export async function getStaticProps(): Promise<
 
     return {
       props: {
-        highestReputation: res.highestReputation,
-        longestStreak: res.longestStreak,
-        highestPostViews: res.highestPostViews,
-        mostUpvoted: res.mostUpvoted,
-        mostReferrals: res.mostReferrals,
-        mostReadingDays: res.mostReadingDays,
-        mostAchievementPoints: res.mostAchievementPoints,
+        highestReputation: res.highestReputation ?? [],
+        longestStreak: res.longestStreak ?? [],
+        highestPostViews: res.highestPostViews ?? [],
+        mostUpvoted: res.mostUpvoted ?? [],
+        mostReferrals: res.mostReferrals ?? [],
+        mostReadingDays: res.mostReadingDays ?? [],
+        mostAchievementPoints: res.mostAchievementPoints ?? [],
         highestLevel,
         isHighestLevelSupported,
-        mostVerifiedUsers: res.mostVerifiedUsers,
+        mostVerifiedUsers: res.mostVerifiedUsers ?? [],
         popularHotTakes,
       },
       revalidate: 3600,


### PR DESCRIPTION
Every deploy is currently failing on `Error occurred prerendering page "/users"`: the leaderboard API returns data for every board plus an `errors` entry for `mostAchievementPoints`, and `graphql-request` throws on any error even with the rest of the payload intact — so one broken resolver kills the whole build.

**Fix:** when the thrown error carries the core board data, use it and null-coalesce the missing boards (the page renders what resolved); a failure with no data at all still throws, and the existing NotFound/Forbidden fallback is untouched. Two regression tests pin both paths.

**Follow-up (API side):** the `mostAchievementPoints` resolver itself is erroring in production and needs its own investigation in daily-api — this PR only stops it from holding every webapp deploy hostage.

## Verification
- 7 leaderboard static-props tests green (2 new: partial-error render, no-data rethrow)
- Strict typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://fix-users-leaderboard-prerender.preview.app.daily.dev