### PR TITLE
feat: compact signup strip with a single-primary CTA hierarchy

### DIFF
--- a/packages/shared/src/components/auth/AuthenticationBanner.tsx
+++ b/packages/shared/src/components/auth/AuthenticationBanner.tsx
@@ -7,7 +7,6 @@ import AuthOptions from './AuthOptions';
 import { AuthTriggers } from '../../lib/auth';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { authGradientBg, BottomBannerContainer } from '../marketing/banners';
-import { ButtonVariant } from '../buttons/common';
 import { Image } from '../image/Image';
 import {
   cloudinaryAuthBannerBackground as bg,
@@ -66,7 +65,7 @@ export function AuthenticationBanner({
               <OnboardingHeadline
                 className={{
                   title: 'typo-mega3',
-                  description: 'mb-8 typo-title3',
+                  description: 'typo-title3',
                 }}
               />
             ))}
@@ -79,7 +78,16 @@ export function AuthenticationBanner({
             simplified
             defaultDisplay={AuthDisplay.OnboardingSignup}
             forceDefaultDisplay
+            // The horizon wall's CTA hierarchy: Google is the one solid
+            // primary, GitHub steps down to a fill, email is a text link and
+            // the divider goes — three identical buttons recommend nothing.
+            signupStyle="singlePrimary"
+            preferGithub={false}
             className={{
+              // The signup display's min-height is modal sizing; here it
+              // stretches both columns ~5rem past their content and the strip
+              // ends in dead space instead of its own padding.
+              container: '!min-h-0',
               onboardingSignup: compact ? '!gap-3' : '!gap-4',
             }}
             onAuthStateUpdate={(props) => {
@@ -91,9 +99,6 @@ export function AuthenticationBanner({
                   formValues: props.email ? { email: props.email } : undefined,
                 },
               });
-            }}
-            onboardingSignupButton={{
-              variant: ButtonVariant.Primary,
             }}
             hideLoginLink={compact}
             compact={compact}

--- a/packages/shared/src/components/marketing/banners/personalized/GeoPersonalizedBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/personalized/GeoPersonalizedBanner.tsx
@@ -1,6 +1,6 @@
 import type { ReactElement } from 'react';
 import React from 'react';
-import { geoToCountry, geoToEmoji } from '../../../../lib/geo';
+import { geoToCountry } from '../../../../lib/geo';
 import { AuthenticationBanner, OnboardingHeadline } from '../../../auth';
 
 const GeoPersonalizedBanner = ({
@@ -10,22 +10,14 @@ const GeoPersonalizedBanner = ({
   geo: string;
   compact?: boolean;
 }): ReactElement => {
-  const emoji = geoToEmoji(geo);
   const country = geoToCountry(geo);
 
   return (
     <AuthenticationBanner compact={compact}>
-      <span
-        className={
-          compact ? 'text-[2.5rem] leading-none' : 'text-[3.5rem] leading-none'
-        }
-      >
-        {emoji}
-      </span>
       <OnboardingHeadline
         className={{
           title: compact ? 'typo-large-title' : 'typo-mega3',
-          description: compact ? 'typo-body' : 'mb-8 typo-title3',
+          description: compact ? 'typo-body' : 'typo-title3',
         }}
         title={`daily.dev is the fastest growing developer platform in ${country}!`}
         description="We know how hard it is to be a developer. It doesn't have to be. Personalized news feed, dev community and search, much better than what's out there. Maybe ;)"

--- a/packages/shared/src/components/marketing/banners/personalized/SocialPersonalizedBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/personalized/SocialPersonalizedBanner.tsx
@@ -2,15 +2,9 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import classNames from 'classnames';
 import { AuthenticationBanner, OnboardingHeadline } from '../../../auth';
-import {
-  socialCTA,
-  socialGradient,
-  socialIcon,
-  SocialIconType,
-} from '../../../../lib/socialMedia';
+import { socialCTA, socialGradient } from '../../../../lib/socialMedia';
 import type { SupportedSocialReferrer } from '../../../../lib/socialMedia';
 import { capitalize } from '../../../../lib/strings';
-import { IconSize } from '../../../Icon';
 
 const SocialPersonalizedBanner = ({
   site,
@@ -19,22 +13,17 @@ const SocialPersonalizedBanner = ({
   site: SupportedSocialReferrer;
   compact?: boolean;
 }): ReactElement => {
-  const Icon = socialIcon[site];
   const gradient = socialGradient[site];
 
   return (
     <AuthenticationBanner compact={compact}>
-      <Icon
-        size={compact ? IconSize.Large : IconSize.Size48}
-        secondary={site === SocialIconType.Reddit}
-      />
       <OnboardingHeadline
         className={{
           title: classNames(
             compact ? 'typo-large-title' : 'typo-mega3',
             gradient,
           ),
-          description: compact ? 'typo-body' : 'mb-8 typo-title3',
+          description: compact ? 'typo-body' : 'typo-title3',
         }}
         pretitle={`Coming from ${capitalize(site)}?`}
         {...socialCTA[site]}

--- a/packages/shared/src/components/marketing/banners/personalized/UserPersonalizedBanner.tsx
+++ b/packages/shared/src/components/marketing/banners/personalized/UserPersonalizedBanner.tsx
@@ -3,7 +3,6 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { getBasicUserInfo } from '../../../../graphql/users';
 import { AuthenticationBanner, OnboardingHeadline } from '../../../auth';
-import { ProfilePicture } from '../../../ProfilePicture';
 import { generateQueryKey, RequestKey } from '../../../../lib/query';
 
 const UserPersonalizedBanner = ({
@@ -27,11 +26,10 @@ const UserPersonalizedBanner = ({
 
   return (
     <AuthenticationBanner compact={compact}>
-      {user?.image && <ProfilePicture user={user} />}
       <OnboardingHeadline
         className={{
           title: compact ? 'typo-large-title' : 'typo-mega3',
-          description: compact ? 'typo-body' : 'mb-8 typo-title3',
+          description: compact ? 'typo-body' : 'typo-title3',
         }}
         pretitle={user?.username}
         title="shared it, so it's probably a good one."

--- a/packages/shared/src/lib/geo.ts
+++ b/packages/shared/src/lib/geo.ts
@@ -1,11 +1,3 @@
-export const geoToEmoji = (geo: string): string => {
-  return geo
-    .toUpperCase()
-    .split('')
-    .map((char) => String.fromCodePoint(char.charCodeAt(0) + 0x1f1a5))
-    .join('');
-};
-
 const geoWithPrefix = [
   'US',
   'GB',


### PR DESCRIPTION
Extracted from #6536 (originally #6512, work by @tsahimatsliah) — and **slimmed substantially after #6491 merged**: the horizon signup wall already landed the `SignupStyle` union, the `singlePrimary` CTA hierarchy and the `AuthOptionsInner` threading this branch used to carry. Five files remain.

## What's left
- The signup strip drops the media above the headline (geo flag emoji, social network icon, referrer avatar) across all personalized banner variants, and its vertical padding evens out.
- `AuthenticationBanner` adopts the merged single-primary style for its CTA.
- `geoToEmoji` loses its last consumer and is removed.

## Review focus
Still touches the anonymous signup strip on post pages — smaller blast radius than before (no form/funnel changes anymore), but it ships **unflagged**; if conversion owners want a ramp, it needs a flag before merge.

## Verification
- Auth + marketing suites green (52), strict typecheck + full shared lint clean
- Rebuilt on current main; conflicts with #6491 resolved by subtraction, not merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://feat-compact-signup-banner.preview.app.daily.dev