### PR TITLE
feat(agent): run view with load-latest, show-history setting, history connection

### DIFF
--- a/packages/shared/src/features/interests/AgentContext.spec.tsx
+++ b/packages/shared/src/features/interests/AgentContext.spec.tsx
@@ -313,16 +313,36 @@ describe('the live path', () => {
     turns = [] as InterestTurn[],
     findings = [] as AgentFeedItem[],
     posts = [] as { id: string; title: string; createdAt: string }[],
+    runId = undefined as string | undefined,
+    run = undefined as InterestTurn | undefined,
+    interest = {} as Record<string, unknown>,
+    onLeaveRunView = jest.fn(),
   } = {}) => {
     jest
       .spyOn(command, 'useSendInterestCommand')
       .mockReturnValue({ isSending: false, sendCommand: send } as never);
     jest.spyOn(queries, 'interestHistoryQueryOptions').mockReturnValue({
       queryKey: ['history', 'a1'],
-      queryFn: async () => turns,
+      queryFn: async () => ({
+        edges: turns.map((node) => ({ node, cursor: node.id })),
+        pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      }),
+    } as never);
+    jest.spyOn(queries, 'interestRunQueryOptions').mockReturnValue({
+      queryKey: ['run', 'a1', runId],
+      queryFn: async () => {
+        if (!run) {
+          throw new Error('run not found');
+        }
+        return run;
+      },
+      retry: false,
     } as never);
 
-    const seen: { current: Agent } = { current: undefined as never };
+    const seen: { current: Agent; onLeaveRunView: jest.Mock } = {
+      current: undefined as never,
+      onLeaveRunView,
+    };
 
     const Probe = () => {
       seen.current = useAgent();
@@ -334,8 +354,10 @@ describe('the live path', () => {
       <TestBootProvider client={new QueryClient()} auth={{ user: defaultUser }}>
         <AgentProvider
           id="a1"
-          interest={{ id: 'a1', query: 'zig' } as never}
+          interest={{ id: 'a1', query: 'zig', ...interest } as never}
           isDemo={false}
+          runId={runId}
+          onLeaveRunView={onLeaveRunView}
           findings={findings}
           posts={posts as never}
         >
@@ -623,6 +645,82 @@ describe('the live path', () => {
       'post',
       'run',
     ]);
+  });
+  const completedRun = (id: string, at: string): InterestTurn =>
+    ({
+      id,
+      role: 'agent',
+      createdAt: at,
+      status: 'completed',
+      trigger: 'scheduled',
+      findingsAdded: 1,
+      blocks: [{ type: 'text', html: `<p>${id}</p>` }],
+    } as InterestTurn);
+
+  it('shows only the deep-linked run and offers the latest one when it is older', async () => {
+    const agent = mountLive({
+      runId: 'run-1',
+      run: completedRun('run-1', '2026-01-01T00:00:00Z'),
+      turns: [
+        completedRun('run-1', '2026-01-01T00:00:00Z'),
+        completedRun('run-2', '2026-01-02T00:00:00Z'),
+      ],
+    });
+
+    await waitForHistory(agent, (current) => current.isOldRunView);
+    expect(agent.current.messages.map(({ id }) => id)).toEqual(['run-1']);
+
+    act(() => agent.current.leaveRunView());
+
+    expect(agent.onLeaveRunView).toHaveBeenCalled();
+  });
+
+  it('does not offer the latest run when the deep-linked run is the latest', async () => {
+    const agent = mountLive({
+      runId: 'run-2',
+      run: completedRun('run-2', '2026-01-02T00:00:00Z'),
+      turns: [
+        completedRun('run-1', '2026-01-01T00:00:00Z'),
+        completedRun('run-2', '2026-01-02T00:00:00Z'),
+      ],
+    });
+
+    await waitForHistory(agent, (current) => current.messages.length === 1);
+    expect(agent.current.isRunView).toBe(true);
+    expect(agent.current.isOldRunView).toBe(false);
+  });
+
+  it('falls back to the history when the deep-linked run cannot be loaded', async () => {
+    const agent = mountLive({
+      runId: 'run-gone',
+      turns: [completedRun('run-1', '2026-01-01T00:00:00Z')],
+    });
+
+    await waitForHistory(agent, (current) => current.messages.length === 1);
+    expect(agent.current.isRunView).toBe(false);
+  });
+
+  it('loads only the latest turn while history is switched off', async () => {
+    const agent = mountLive({ interest: { showHistory: false } });
+
+    await flushQueries();
+    expect(queries.interestHistoryQueryOptions).toHaveBeenLastCalledWith(
+      'a1',
+      expect.anything(),
+      1,
+    );
+    expect(agent.current.isHistoryLimited).toBe(true);
+
+    act(() => agent.current.showEarlier());
+
+    await waitFor(() =>
+      expect(queries.interestHistoryQueryOptions).toHaveBeenLastCalledWith(
+        'a1',
+        expect.anything(),
+        40,
+      ),
+    );
+    expect(agent.current.isHistoryLimited).toBe(false);
   });
 });
 

--- a/packages/shared/src/features/interests/AgentContext.tsx
+++ b/packages/shared/src/features/interests/AgentContext.tsx
@@ -113,6 +113,7 @@ type AgentContextValue = {
   isUpdating: boolean;
   activity: AgentActivityItem[];
   messages: AgentMessage[];
+  historyUpdatedAt: number;
   isRunView: boolean;
   isOldRunView: boolean;
   leaveRunView: () => void;
@@ -835,6 +836,7 @@ export const AgentProvider = ({
       isUpdating,
       activity,
       messages,
+      historyUpdatedAt: historyQuery.dataUpdatedAt,
       isRunView,
       isOldRunView,
       leaveRunView,
@@ -868,6 +870,7 @@ export const AgentProvider = ({
       reconcilePostTarget,
       activity,
       messages,
+      historyQuery.dataUpdatedAt,
       isRunView,
       isOldRunView,
       leaveRunView,

--- a/packages/shared/src/features/interests/AgentContext.tsx
+++ b/packages/shared/src/features/interests/AgentContext.tsx
@@ -23,7 +23,11 @@ import { useSendInterestCommand } from './hooks/useSendInterestCommand';
 import { useUpdateInterest } from './hooks/useUpdateInterest';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { useAuthContext } from '../../contexts/AuthContext';
-import { interestHistoryQueryOptions } from './queries';
+import {
+  historyPageSize,
+  interestHistoryQueryOptions,
+  interestRunQueryOptions,
+} from './queries';
 import { generateQueryKey, RequestKey } from '../../lib/query';
 import type { Post } from '../../graphql/posts';
 import type { AgentAttachment, AgentBlock, AgentMessage } from './chat';
@@ -109,6 +113,11 @@ type AgentContextValue = {
   isUpdating: boolean;
   activity: AgentActivityItem[];
   messages: AgentMessage[];
+  isRunView: boolean;
+  isOldRunView: boolean;
+  leaveRunView: () => void;
+  isHistoryLimited: boolean;
+  showEarlier: () => void;
   findingsPosts: Post[];
   summaryPosts: AgentSummaryPost[];
   isSettingsOpen: boolean;
@@ -274,6 +283,8 @@ export const AgentProvider = ({
   id,
   interest,
   isDemo,
+  runId,
+  onLeaveRunView,
   initialMessages = [],
   findings = [],
   posts = [],
@@ -282,6 +293,8 @@ export const AgentProvider = ({
   id: string;
   interest?: UserInterest;
   isDemo: boolean;
+  runId?: string;
+  onLeaveRunView?: () => void;
   initialMessages?: AgentMessage[];
   findings?: AgentFeedItem[];
   posts?: AgentSummaryPost[];
@@ -335,17 +348,49 @@ export const AgentProvider = ({
   // A sent echo also keeps the poll alive: its queued run may not be visible on
   // the replica yet, and without polling it would stay pending forever.
   const hasSentEcho = echoes.some((echo) => echo.state === 'sent');
+  const [historyLastOverride, setHistoryLastOverride] = useState<number>();
+  const historyLast =
+    historyLastOverride ??
+    (interest?.showHistory === false ? 1 : historyPageSize);
+  const isHistoryEnabled = !isDemo && !!user?.id && !!id && !!interest;
   const historyQuery = useQuery({
-    ...interestHistoryQueryOptions(id, user),
-    enabled: !isDemo && !!user?.id && !!id,
+    ...interestHistoryQueryOptions(id, user, historyLast),
+    enabled: isHistoryEnabled,
     refetchInterval: (query) =>
-      query.state.data?.some(isRunPending) || hasSentEcho
+      query.state.data?.edges.some(({ node }) => isRunPending(node)) ||
+      hasSentEcho
         ? pendingPollMs
         : false,
   });
-  const turns = useMemo(
-    () => (isDemo ? [] : historyQuery.data ?? []),
+  const runQuery = useQuery({
+    ...interestRunQueryOptions(id, runId ?? '', user),
+    enabled: isHistoryEnabled && !!runId,
+  });
+  const historyTurns = useMemo(
+    () =>
+      isDemo ? [] : (historyQuery.data?.edges ?? []).map(({ node }) => node),
     [historyQuery.data, isDemo],
+  );
+  const isRunView = !!runId && !runQuery.isError;
+  const turns = useMemo(() => {
+    if (!isRunView) {
+      return historyTurns;
+    }
+
+    return runQuery.data ? [runQuery.data] : [];
+  }, [historyTurns, isRunView, runQuery.data]);
+  const latestRunId = historyTurns
+    .filter(({ role }) => role === 'agent')
+    .map(({ id: turnId }) => turnId)
+    .pop();
+  const isOldRunView = isRunView && !!latestRunId && latestRunId !== runId;
+  const isHistoryLimited = !isRunView && historyLast === 1;
+  const leaveRunView = useCallback(() => {
+    onLeaveRunView?.();
+  }, [onLeaveRunView]);
+  const showEarlier = useCallback(
+    () => setHistoryLastOverride(historyPageSize),
+    [],
   );
 
   const { postsById, allPosts } = useMemo(() => {
@@ -355,8 +400,8 @@ export const AgentProvider = ({
   }, [findings]);
 
   const unresolvedEchoes = useMemo(
-    () => echoes.filter((echo) => !echoResolved(echo, turns)),
-    [echoes, turns],
+    () => echoes.filter((echo) => !echoResolved(echo, historyTurns)),
+    [echoes, historyTurns],
   );
 
   // Resolved echoes exist in the server history now; holding them longer would
@@ -467,7 +512,7 @@ export const AgentProvider = ({
     );
   }, [findings, isDemo, turns]);
 
-  const serverPending = turns.some(isRunPending);
+  const serverPending = historyTurns.some(isRunPending);
   const echoPending = unresolvedEchoes.some((echo) => echo.state !== 'error');
   const isWorking = isDemo
     ? !!workingMeta && workingRef.current
@@ -790,6 +835,11 @@ export const AgentProvider = ({
       isUpdating,
       activity,
       messages,
+      isRunView,
+      isOldRunView,
+      leaveRunView,
+      isHistoryLimited,
+      showEarlier,
       findingsPosts: allPosts,
       summaryPosts: posts,
       isSettingsOpen,
@@ -818,6 +868,11 @@ export const AgentProvider = ({
       reconcilePostTarget,
       activity,
       messages,
+      isRunView,
+      isOldRunView,
+      leaveRunView,
+      isHistoryLimited,
+      showEarlier,
       allPosts,
       posts,
       id,

--- a/packages/shared/src/features/interests/AgentContext.tsx
+++ b/packages/shared/src/features/interests/AgentContext.tsx
@@ -113,7 +113,7 @@ type AgentContextValue = {
   isUpdating: boolean;
   activity: AgentActivityItem[];
   messages: AgentMessage[];
-  historyUpdatedAt: number;
+  isHistoryPending: boolean;
   isRunView: boolean;
   isOldRunView: boolean;
   leaveRunView: () => void;
@@ -836,7 +836,7 @@ export const AgentProvider = ({
       isUpdating,
       activity,
       messages,
-      historyUpdatedAt: historyQuery.dataUpdatedAt,
+      isHistoryPending: historyQuery.isPending,
       isRunView,
       isOldRunView,
       leaveRunView,
@@ -870,7 +870,7 @@ export const AgentProvider = ({
       reconcilePostTarget,
       activity,
       messages,
-      historyQuery.dataUpdatedAt,
+      historyQuery.isPending,
       isRunView,
       isOldRunView,
       leaveRunView,

--- a/packages/shared/src/features/interests/components/AgentEmptyState.tsx
+++ b/packages/shared/src/features/interests/components/AgentEmptyState.tsx
@@ -1,0 +1,28 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { CharmEmptyState } from '../../../components/charm/CharmEmptyState';
+import { cloudinaryCharmReadLater } from '../../../lib/image';
+import { useAgent } from '../AgentContext';
+
+export const AgentEmptyState = (): ReactElement => {
+  const { interest, update } = useAgent();
+  const needsNotifications = interest?.outputModes.notification === false;
+
+  return (
+    <CharmEmptyState
+      className="my-8"
+      image={cloudinaryCharmReadLater}
+      imageAlt="daily.dev charm waiting for the agent's next update"
+      title="Your agent is working"
+      description="It keeps looking on its own and will let you know when there's something new."
+      action={
+        needsNotifications
+          ? {
+              label: 'Turn on notifications',
+              onClick: () => update({ outputModes: { notification: true } }),
+            }
+          : undefined
+      }
+    />
+  );
+};

--- a/packages/shared/src/features/interests/components/AgentHistoryEdge.tsx
+++ b/packages/shared/src/features/interests/components/AgentHistoryEdge.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { FlexRow } from '../../../components/utilities';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '../../../components/buttons/Button';
+import { useAgent } from '../AgentContext';
+
+export const AgentHistoryEdge = (): ReactElement | null => {
+  const { isHistoryLimited, isOldRunView, showEarlier, leaveRunView } =
+    useAgent();
+
+  if (isOldRunView) {
+    return (
+      <FlexRow className="justify-center">
+        <Button
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Subtle}
+          onClick={leaveRunView}
+        >
+          Load latest run
+        </Button>
+      </FlexRow>
+    );
+  }
+
+  if (!isHistoryLimited) {
+    return null;
+  }
+
+  return (
+    <FlexRow className="justify-center">
+      <Button
+        size={ButtonSize.XSmall}
+        variant={ButtonVariant.Subtle}
+        onClick={showEarlier}
+      >
+        Show earlier activity
+      </Button>
+    </FlexRow>
+  );
+};

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.spec.tsx
@@ -201,6 +201,7 @@ describe('AgentHomeScreen spawn settings', () => {
           digest: true,
           notification: true,
         },
+        showHistory: true,
       },
     });
   });
@@ -211,6 +212,7 @@ describe('AgentHomeScreen spawn settings', () => {
     expect(screen.getByText('Whenever it matters')).toBeInTheDocument();
     expect(screen.getByText('Balanced')).toBeInTheDocument();
     expect(screen.getByText('feed, posts, notifications')).toBeInTheDocument();
+    expect(screen.getByText('Full history')).toBeInTheDocument();
     expect(screen.queryByLabelText('Every week')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Agent settings' }));

--- a/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
+++ b/packages/shared/src/features/interests/components/AgentHomeScreen.tsx
@@ -34,6 +34,7 @@ import { AgentSendButton } from './AgentSendButton';
 import {
   CadenceSection,
   FomoSection,
+  HistorySection,
   OutputModesSection,
   cadenceOptions,
   outputOptions,
@@ -214,6 +215,10 @@ export const AgentHomeScreen = ({
     ['When it reports', cadenceSummary],
     ['FOMO vs quality', fomoSummary],
     ['What it delivers', deliverySummary || 'Nothing yet'],
+    [
+      'History',
+      settings.showHistory === false ? 'Latest only' : 'Full history',
+    ],
   ];
 
   return (
@@ -429,6 +434,13 @@ export const AgentHomeScreen = ({
                       ...current,
                       outputModes: { ...current.outputModes, ...outputModes },
                     }))
+                  }
+                />
+                <HistorySection
+                  value={settings.showHistory ?? true}
+                  disabled={isCreating}
+                  onChange={(showHistory) =>
+                    setSettings((current) => ({ ...current, showHistory }))
                   }
                 />
               </FlexCol>

--- a/packages/shared/src/features/interests/components/AgentSettingsFields.tsx
+++ b/packages/shared/src/features/interests/components/AgentSettingsFields.tsx
@@ -173,3 +173,28 @@ export const OutputModesSection = ({
     ))}
   </SettingsSection>
 );
+
+export const HistorySection = ({
+  value,
+  disabled,
+  onChange,
+}: {
+  value: boolean;
+  disabled?: boolean;
+  onChange: (showHistory: boolean) => void;
+}): ReactElement => (
+  <SettingsSection
+    title="History"
+    hint="Off shows only the latest update when you open this agent."
+  >
+    <Switch
+      inputId="agent-show-history"
+      name="agent-show-history"
+      checked={value}
+      disabled={disabled}
+      onToggle={() => onChange(!value)}
+    >
+      Show history
+    </Switch>
+  </SettingsSection>
+);

--- a/packages/shared/src/features/interests/components/AgentSettingsPane.tsx
+++ b/packages/shared/src/features/interests/components/AgentSettingsPane.tsx
@@ -25,6 +25,7 @@ import { useAgent } from '../AgentContext';
 import {
   CadenceSection,
   FomoSection,
+  HistorySection,
   OutputModesSection,
   SettingsSection,
 } from './AgentSettingsFields';
@@ -89,6 +90,12 @@ export const AgentSettingsPane = ({
             value={interest?.outputModes}
             disabled={isUpdating}
             onChange={(outputModes) => update({ outputModes })}
+          />
+
+          <HistorySection
+            value={interest?.showHistory ?? true}
+            disabled={isUpdating}
+            onChange={(showHistory) => update({ showHistory })}
           />
 
           <SettingsSection

--- a/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
@@ -492,12 +492,13 @@ describe('AgentWorkspace history window', () => {
       queryFn: async () => run,
     } as never);
 
-    render(
-      <TestBootProvider client={new QueryClient()} auth={{ user: defaultUser }}>
+    const client = new QueryClient();
+    const tree = (currentRunId?: string) => (
+      <TestBootProvider client={client} auth={{ user: defaultUser }}>
         <AgentProvider
           id="a1"
           isDemo={false}
-          runId={runId}
+          runId={currentRunId}
           onLeaveRunView={onLeaveRunView}
           interest={
             {
@@ -514,13 +515,17 @@ describe('AgentWorkspace history window', () => {
             items={[]}
             onDelete={jest.fn()}
             isDeleting={false}
-            runId={runId}
+            runId={currentRunId}
           />
         </AgentProvider>
-      </TestBootProvider>,
+      </TestBootProvider>
     );
+    const view = render(tree(runId));
 
-    return { onLeaveRunView };
+    return {
+      onLeaveRunView,
+      leaveRunView: () => view.rerender(tree(undefined)),
+    };
   };
 
   it('shows only the deep-linked run with a way to the latest one', async () => {
@@ -541,6 +546,30 @@ describe('AgentWorkspace history window', () => {
     );
 
     expect(onLeaveRunView).toHaveBeenCalled();
+  });
+
+  it('hides the scroll-to-latest arrow on the run view and pins the tail after leaving it', async () => {
+    const { leaveRunView } = renderLive({
+      runId: 'run-1',
+      run: turnAt('run-1', '2026-01-01T00:00:00Z'),
+      turns: [
+        turnAt('run-1', '2026-01-01T00:00:00Z'),
+        turnAt('run-2', '2026-01-02T00:00:00Z'),
+      ],
+    });
+
+    await screen.findByText('Findings from run-1.');
+    expect(screen.queryByLabelText('Scroll to latest')).not.toBeInTheDocument();
+
+    const transcript = document.querySelector('.agent-scroll') as HTMLElement;
+    Object.defineProperty(transcript, 'scrollHeight', {
+      configurable: true,
+      value: 2000,
+    });
+    leaveRunView();
+
+    await screen.findByText('Findings from run-2.');
+    await waitFor(() => expect(transcript.scrollTop).toBe(2000));
   });
 
   it('shows the latest turn with a way back into history when history is off', async () => {

--- a/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
@@ -450,7 +450,15 @@ describe('AgentWorkspace panel on a phone', () => {
 });
 
 describe('AgentWorkspace history window', () => {
-  beforeEach(() => jest.useRealTimers());
+  beforeEach(() => {
+    jest.useRealTimers();
+    HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { scrollIntoView?: unknown })
+      .scrollIntoView;
+  });
 
   const turnAt = (id: string, at: string): InterestTurn =>
     ({

--- a/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
@@ -13,7 +13,11 @@ import {
   mockMatchMedia,
 } from '../../../../__tests__/helpers/media';
 import usePersistentContext from '../../../hooks/usePersistentContext';
+import defaultUser from '../../../../__tests__/fixture/loggedUser';
 import type { AgentMessage } from '../chat';
+import type { InterestTurn } from '../../../graphql/interests';
+import * as queries from '../queries';
+import * as updateHook from '../hooks/useUpdateInterest';
 import { AgentProvider, useAgent } from '../AgentContext';
 import { AgentWorkspace } from './AgentWorkspace';
 
@@ -442,5 +446,127 @@ describe('AgentWorkspace panel on a phone', () => {
       'style',
       expect.stringContaining('width'),
     );
+  });
+});
+
+describe('AgentWorkspace history window', () => {
+  beforeEach(() => jest.useRealTimers());
+
+  const turnAt = (id: string, at: string): InterestTurn =>
+    ({
+      id,
+      role: 'agent',
+      createdAt: at,
+      finishedAt: at,
+      status: 'completed',
+      trigger: 'scheduled',
+      findingsAdded: 1,
+      blocks: [{ type: 'text', html: `<p>Findings from ${id}.</p>` }],
+    } as InterestTurn);
+
+  const renderLive = ({
+    turns = [] as InterestTurn[],
+    runId = undefined as string | undefined,
+    run = undefined as InterestTurn | undefined,
+    interest = {} as Record<string, unknown>,
+    onLeaveRunView = jest.fn(),
+  } = {}) => {
+    stubStore(600);
+    jest.spyOn(queries, 'interestHistoryQueryOptions').mockReturnValue({
+      queryKey: ['history', 'a1'],
+      queryFn: async () => ({
+        edges: turns.map((node) => ({ node, cursor: node.id })),
+        pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      }),
+    } as never);
+    jest.spyOn(queries, 'interestRunQueryOptions').mockReturnValue({
+      queryKey: ['run', 'a1', runId],
+      queryFn: async () => run,
+    } as never);
+
+    render(
+      <TestBootProvider client={new QueryClient()} auth={{ user: defaultUser }}>
+        <AgentProvider
+          id="a1"
+          isDemo={false}
+          runId={runId}
+          onLeaveRunView={onLeaveRunView}
+          interest={
+            {
+              id: 'a1',
+              query: 'zig',
+              status: 'active',
+              cadence: 'auto',
+              outputModes: { notification: true },
+              ...interest,
+            } as never
+          }
+        >
+          <AgentWorkspace
+            items={[]}
+            onDelete={jest.fn()}
+            isDeleting={false}
+            runId={runId}
+          />
+        </AgentProvider>
+      </TestBootProvider>,
+    );
+
+    return { onLeaveRunView };
+  };
+
+  it('shows only the deep-linked run with a way to the latest one', async () => {
+    const { onLeaveRunView } = renderLive({
+      runId: 'run-1',
+      run: turnAt('run-1', '2026-01-01T00:00:00Z'),
+      turns: [
+        turnAt('run-1', '2026-01-01T00:00:00Z'),
+        turnAt('run-2', '2026-01-02T00:00:00Z'),
+      ],
+    });
+
+    expect(await screen.findByText('Findings from run-1.')).toBeInTheDocument();
+    expect(screen.queryByText('Findings from run-2.')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Load latest run' }),
+    );
+
+    expect(onLeaveRunView).toHaveBeenCalled();
+  });
+
+  it('shows the latest turn with a way back into history when history is off', async () => {
+    renderLive({
+      turns: [turnAt('run-1', new Date().toISOString())],
+      interest: { showHistory: false },
+    });
+
+    expect(await screen.findByText('Findings from run-1.')).toBeInTheDocument();
+    expect(screen.getByText('Show earlier activity')).toBeInTheDocument();
+    expect(screen.queryByText('Your agent is working')).not.toBeInTheDocument();
+  });
+
+  it('shows the working state instead of a stale turn when history is off', async () => {
+    const update = jest.fn().mockResolvedValue(undefined);
+    jest
+      .spyOn(updateHook, 'useUpdateInterest')
+      .mockReturnValue({ isUpdating: false, updateInterest: update } as never);
+    renderLive({
+      turns: [turnAt('run-1', '2026-01-01T00:00:00Z')],
+      interest: { showHistory: false, outputModes: { notification: false } },
+    });
+
+    expect(
+      await screen.findByText('Your agent is working'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Findings from run-1.')).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Turn on notifications' }),
+    );
+
+    expect(update).toHaveBeenCalledWith({
+      outputModes: { notification: true },
+    });
   });
 });

--- a/packages/shared/src/features/interests/components/AgentWorkspace.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.tsx
@@ -49,7 +49,7 @@ export const AgentWorkspace = ({
     openContent,
     messages,
     summaryPosts,
-    historyUpdatedAt,
+    isHistoryPending,
     isRunView,
     isHistoryLimited,
   } = useAgent();
@@ -155,30 +155,18 @@ export const AgentWorkspace = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages.length]);
 
-  const wasRunViewRef = useRef(isRunView);
-
   useEffect(() => {
-    const wasRunView = wasRunViewRef.current;
-    wasRunViewRef.current = isRunView;
-
-    if (isRunView) {
-      return;
-    }
-
-    if (wasRunView) {
-      isPinnedRef.current = true;
-    }
-
     const transcript = transcriptRef.current;
 
-    if (!isPinnedRef.current || !transcript) {
+    if (isRunView || isHistoryPending || !transcript) {
       return;
     }
 
     transcript.scrollTop = transcript.scrollHeight;
+    isPinnedRef.current = true;
     setIsAwayFromBottom(false);
     setHasUnseenReply(false);
-  }, [historyUpdatedAt, isRunView]);
+  }, [isHistoryPending, isRunView]);
 
   const latestMessage = messages[messages.length - 1];
   const isLatestStale =

--- a/packages/shared/src/features/interests/components/AgentWorkspace.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.tsx
@@ -49,6 +49,7 @@ export const AgentWorkspace = ({
     openContent,
     messages,
     summaryPosts,
+    historyUpdatedAt,
     isRunView,
     isHistoryLimited,
   } = useAgent();
@@ -160,25 +161,24 @@ export const AgentWorkspace = ({
     const wasRunView = wasRunViewRef.current;
     wasRunViewRef.current = isRunView;
 
-    if (!wasRunView || isRunView) {
-      return undefined;
+    if (isRunView) {
+      return;
     }
 
-    isPinnedRef.current = true;
+    if (wasRunView) {
+      isPinnedRef.current = true;
+    }
+
+    const transcript = transcriptRef.current;
+
+    if (!isPinnedRef.current || !transcript) {
+      return;
+    }
+
+    transcript.scrollTop = transcript.scrollHeight;
     setIsAwayFromBottom(false);
-
-    return followTail();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isRunView]);
-
-  useEffect(() => {
-    if (!isFeedReady || !isPinnedRef.current) {
-      return undefined;
-    }
-
-    return followTail();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isFeedReady]);
+    setHasUnseenReply(false);
+  }, [historyUpdatedAt, isRunView]);
 
   const latestMessage = messages[messages.length - 1];
   const isLatestStale =

--- a/packages/shared/src/features/interests/components/AgentWorkspace.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.tsx
@@ -10,12 +10,15 @@ import {
 import { ArrowIcon } from '../../../components/icons';
 import { IconSize } from '../../../components/Icon';
 import usePersistentContext from '../../../hooks/usePersistentContext';
+import { oneDay } from '../../../lib/dateFormat';
 import { useAgentShellHeight } from '../shell';
 import type { AgentFeedItem } from '../hooks/useAgentFeed';
 import { useAgent } from '../AgentContext';
 import { AgentWorkspaceHeader } from './AgentWorkspaceHeader';
 import { AgentIntro } from './AgentIntro';
 import { AgentChatSection } from './AgentChatSection';
+import { AgentHistoryEdge } from './AgentHistoryEdge';
+import { AgentEmptyState } from './AgentEmptyState';
 import { AgentComposer } from './AgentComposer';
 import { AgentQuoteAction } from './AgentQuoteAction';
 import { AgentContentPane } from './AgentContentPane';
@@ -41,7 +44,14 @@ export const AgentWorkspace = ({
   runId?: string;
   isFeedReady?: boolean;
 }): ReactElement => {
-  const { isSettingsOpen, openContent, messages, summaryPosts } = useAgent();
+  const {
+    isSettingsOpen,
+    openContent,
+    messages,
+    summaryPosts,
+    isRunView,
+    isHistoryLimited,
+  } = useAgent();
   const shellHeight = useAgentShellHeight(isStandalone);
   const [storedWidth, setStoredWidth, isWidthLoaded] =
     usePersistentContext<number>('agentPaneWidth', defaultPaneWidth);
@@ -144,6 +154,13 @@ export const AgentWorkspace = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages.length]);
 
+  const latestMessage = messages[messages.length - 1];
+  const isLatestStale =
+    isHistoryLimited &&
+    !!latestMessage &&
+    !latestMessage.isPending &&
+    Date.now() - new Date(latestMessage.at).getTime() > oneDay * 1000;
+
   const isTailPending = !!messages.at(-1)?.isPending;
 
   useEffect(() => {
@@ -236,10 +253,16 @@ export const AgentWorkspace = ({
                     findingsCount={items.length}
                     postsCount={summaryPosts.length}
                   />
-                  <AgentChatSection
-                    focusedRunId={isFeedReady ? runId : undefined}
-                    onFocusRun={onFocusRun}
-                  />
+                  {!isRunView && <AgentHistoryEdge />}
+                  {isLatestStale ? (
+                    <AgentEmptyState />
+                  ) : (
+                    <AgentChatSection
+                      focusedRunId={isFeedReady ? runId : undefined}
+                      onFocusRun={onFocusRun}
+                    />
+                  )}
+                  {isRunView && <AgentHistoryEdge />}
                 </FlexCol>
               </div>
             </div>

--- a/packages/shared/src/features/interests/components/AgentWorkspace.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.tsx
@@ -154,6 +154,32 @@ export const AgentWorkspace = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [messages.length]);
 
+  const wasRunViewRef = useRef(isRunView);
+
+  useEffect(() => {
+    const wasRunView = wasRunViewRef.current;
+    wasRunViewRef.current = isRunView;
+
+    if (!wasRunView || isRunView) {
+      return undefined;
+    }
+
+    isPinnedRef.current = true;
+    setIsAwayFromBottom(false);
+
+    return followTail();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isRunView]);
+
+  useEffect(() => {
+    if (!isFeedReady || !isPinnedRef.current) {
+      return undefined;
+    }
+
+    return followTail();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isFeedReady]);
+
   const latestMessage = messages[messages.length - 1];
   const isLatestStale =
     isHistoryLimited &&
@@ -268,7 +294,7 @@ export const AgentWorkspace = ({
             </div>
             <AgentQuoteAction containerRef={transcriptRef} />
             <div className="relative">
-              {isAwayFromBottom && (
+              {isAwayFromBottom && !isRunView && (
                 <Button
                   icon={
                     <ArrowIcon size={IconSize.Size16} className="rotate-180" />

--- a/packages/shared/src/features/interests/mock.ts
+++ b/packages/shared/src/features/interests/mock.ts
@@ -17,6 +17,7 @@ export const mockInterest: UserInterest = {
   fomoThreshold: 0.62,
   sources: { dailyDev: true, web: false, github: false },
   outputModes: { feed: true, post: true, digest: false, notification: true },
+  showHistory: true,
   lastRunAt: minutesAgo(42),
   lastRunSummary: 'Scanned 128 posts, kept 6',
   lastRunStatus: InterestRunStatus.Completed,

--- a/packages/shared/src/features/interests/queries.ts
+++ b/packages/shared/src/features/interests/queries.ts
@@ -4,6 +4,7 @@ import {
   getInterestFindings,
   getInterestHistory,
   getInterestPosts,
+  getInterestRun,
   getInterests,
 } from '../../graphql/interests';
 import { generateQueryKey, RequestKey } from '../../lib/query';
@@ -37,14 +38,28 @@ export const interestFindingsQueryOptions = (
     enabled: !!user?.id && !!id,
   });
 
+export const historyPageSize = 40;
+
 export const interestHistoryQueryOptions = (
   id: string,
+  user: Pick<LoggedUser, 'id'> | undefined,
+  last: number,
+) =>
+  queryOptions({
+    queryKey: generateQueryKey(RequestKey.Interests, user, id, 'history', last),
+    queryFn: () => getInterestHistory({ id, last }),
+    enabled: !!user?.id && !!id,
+  });
+
+export const interestRunQueryOptions = (
+  id: string,
+  runId: string,
   user?: Pick<LoggedUser, 'id'>,
 ) =>
   queryOptions({
-    queryKey: generateQueryKey(RequestKey.Interests, user, id, 'history'),
-    queryFn: () => getInterestHistory(id),
-    enabled: !!user?.id && !!id,
+    queryKey: generateQueryKey(RequestKey.Interests, user, id, 'run', runId),
+    queryFn: () => getInterestRun({ id, runId }),
+    enabled: !!user?.id && !!id && !!runId,
   });
 
 export const interestPostsQueryOptions = (

--- a/packages/shared/src/graphql/interests.ts
+++ b/packages/shared/src/graphql/interests.ts
@@ -1,4 +1,5 @@
 import { gqlClient } from './common';
+import type { Connection } from './common';
 import type { Post } from './posts';
 import { FEED_POST_FRAGMENT } from './fragments';
 import { USER_POST_FRAGMENT } from './feed';
@@ -51,6 +52,7 @@ export type UserInterest = {
   fomoThreshold: number;
   sources: InterestSources;
   outputModes: InterestOutputModes;
+  showHistory: boolean;
   feedId?: string | null;
   sourceId?: string | null;
   lastRunAt?: string | null;
@@ -72,6 +74,7 @@ export type UpdateInterestInput = {
   fomoThreshold?: number;
   sources?: Partial<InterestSources>;
   outputModes?: Partial<InterestOutputModes>;
+  showHistory?: boolean;
 };
 
 export type CreateInterestSettings = Omit<UpdateInterestInput, 'status'>;
@@ -80,6 +83,7 @@ export const defaultCreateInterestSettings: CreateInterestSettings = {
   cadence: UserInterestCadence.Auto,
   fomoThreshold: 0.5,
   outputModes: { feed: true, post: true, digest: false, notification: true },
+  showHistory: true,
 };
 
 export type InterestFinding = {
@@ -130,6 +134,7 @@ const USER_INTEREST_FRAGMENT = `
     fomoThreshold
     sources
     outputModes
+    showHistory
     feedId
     sourceId
     lastRunAt
@@ -194,21 +199,44 @@ export const SEND_INTEREST_COMMAND_MUTATION = `
 `;
 
 export const INTEREST_HISTORY_QUERY = `
-  query InterestHistory($id: ID!) {
-    interestHistory(id: $id) {
-      id
-      role
-      createdAt
-      text
-      relationships
-      status
-      trigger
-      feedbackId
-      blocks
-      findingsAdded
-      summaryPostId
-      startedAt
-      finishedAt
+  query InterestHistory(
+    $id: ID!
+    $first: Int
+    $after: String
+    $last: Int
+    $before: String
+  ) {
+    interestHistory(
+      id: $id
+      first: $first
+      after: $after
+      last: $last
+      before: $before
+    ) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      edges {
+        cursor
+        node {
+          id
+          role
+          createdAt
+          text
+          relationships
+          status
+          trigger
+          feedbackId
+          blocks
+          findingsAdded
+          summaryPostId
+          startedAt
+          finishedAt
+        }
+      }
     }
   }
 `;
@@ -309,14 +337,55 @@ export const sendInterestCommand = async ({
   return res.sendInterestCommand;
 };
 
+export type InterestHistoryArgs = {
+  id: string;
+  first?: number;
+  after?: string;
+  last?: number;
+  before?: string;
+};
+
 export const getInterestHistory = async (
-  id: string,
-): Promise<InterestTurn[]> => {
-  const res = await gqlClient.request<{ interestHistory: InterestTurn[] }>(
-    INTEREST_HISTORY_QUERY,
-    { id },
-  );
+  args: InterestHistoryArgs,
+): Promise<Connection<InterestTurn>> => {
+  const res = await gqlClient.request<{
+    interestHistory: Connection<InterestTurn>;
+  }>(INTEREST_HISTORY_QUERY, args);
   return res.interestHistory;
+};
+
+export const INTEREST_RUN_QUERY = `
+  query InterestRun($id: ID!, $runId: ID!) {
+    interestRun(id: $id, runId: $runId) {
+      id
+      role
+      createdAt
+      text
+      relationships
+      status
+      trigger
+      feedbackId
+      blocks
+      findingsAdded
+      summaryPostId
+      startedAt
+      finishedAt
+    }
+  }
+`;
+
+export const getInterestRun = async ({
+  id,
+  runId,
+}: {
+  id: string;
+  runId: string;
+}): Promise<InterestTurn> => {
+  const res = await gqlClient.request<{ interestRun: InterestTurn }>(
+    INTEREST_RUN_QUERY,
+    { id, runId },
+  );
+  return res.interestRun;
 };
 
 export const updateInterest = async ({

--- a/packages/webapp/pages/agent/[id].tsx
+++ b/packages/webapp/pages/agent/[id].tsx
@@ -83,7 +83,7 @@ const LiveAgentPage = ({
         isDemo={false}
         runId={runId}
         onLeaveRunView={() =>
-          router.replace(
+          router.push(
             { pathname: router.pathname, query: { id } },
             undefined,
             { shallow: true },

--- a/packages/webapp/pages/agent/[id].tsx
+++ b/packages/webapp/pages/agent/[id].tsx
@@ -81,6 +81,14 @@ const LiveAgentPage = ({
         id={id}
         interest={interest}
         isDemo={false}
+        runId={runId}
+        onLeaveRunView={() =>
+          router.replace(
+            { pathname: router.pathname, query: { id } },
+            undefined,
+            { shallow: true },
+          )
+        }
         findings={feed.items}
         posts={posts}
         key={id}

--- a/packages/webapp/pages/agent/[id].tsx
+++ b/packages/webapp/pages/agent/[id].tsx
@@ -83,11 +83,9 @@ const LiveAgentPage = ({
         isDemo={false}
         runId={runId}
         onLeaveRunView={() =>
-          router.push(
-            { pathname: router.pathname, query: { id } },
-            undefined,
-            { shallow: true },
-          )
+          router.push({ pathname: router.pathname, query: { id } }, undefined, {
+            shallow: true,
+          })
         }
         findings={feed.items}
         posts={posts}


### PR DESCRIPTION
Counterpart to dailydotdev/daily-api (branch `interest-history-window`); needs the API deployed first (`interestHistory` return shape + `interestRun` + `showHistory`).

- **Run view**: `?run=<id>` renders only that run via `interestRun`. The latest history page (`last: 40`) is always fetched in the background — it preloads the normal view and tells us whether the run is the newest; when it isn't, **Load latest run** navigates to `/agent/[id]` (drops the param). Echoes and pending state resolve against the history turns so polling keeps working from the run view; an unloadable run falls back to the transcript.
- **Show history** setting (default on) in the settings pane and the spawn-screen peek/expanded settings. Off → `last: 1`: the latest turn of any role plus **Show earlier activity**; if that turn is older than 24h and nothing is pending, an empty state ("Your agent is working…") with a **Turn on notifications** CTA when that output mode is off.
- `interestHistory` consumed as a connection (`edges.map(node)`); no client-side paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://interest-history-window.preview.app.daily.dev