### PR TITLE
feat: light mode on the organic post page for ad-enrolled visitors

### DIFF
--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -61,6 +61,10 @@ import CustomAuthBanner from '@dailydotdev/shared/src/components/auth/CustomAuth
 import { isSourceUserSource } from '@dailydotdev/shared/src/graphql/sources';
 import { usePostReferrerContext } from '@dailydotdev/shared/src/contexts/PostReferrerContext';
 import { ActivePostContextProvider } from '@dailydotdev/shared/src/contexts/ActivePostContext';
+import {
+  ThemeMode,
+  useSettingsContext,
+} from '@dailydotdev/shared/src/contexts/SettingsContext';
 import { LogExtraContextProvider } from '@dailydotdev/shared/src/contexts/LogExtraContext';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import useDebounceFn from '@dailydotdev/shared/src/hooks/useDebounceFn';
@@ -246,6 +250,23 @@ export const PostPage = ({
   // inventory that cannot fill.
   const adsenseSlots = useOrganicAdsenseSlots(!showRedesign);
   const adsenseActive = hasLiveAdsenseUnits(adsenseSlots);
+  const { applyThemeMode } = useSettingsContext();
+
+  // Same light forcing the /articles template ships, but only for visitors
+  // actually enrolled in the ad treatment — the partner's creatives are
+  // designed against light pages. Display-only: the stored preference is
+  // untouched and restored on leave. The flip lands ~half a second after
+  // first paint (the flag resolves with boot), a color-only flash with no
+  // layout shift — the same trade /articles already makes.
+  useEffect(() => {
+    if (!adsenseActive) {
+      return undefined;
+    }
+    applyThemeMode(ThemeMode.Light);
+    return () => {
+      applyThemeMode();
+    };
+  }, [adsenseActive, applyThemeMode]);
   // The same in-content treatment the /articles template ships, reused on
   // the organic page: the TLDR splits at the shared cadence with an MPU
   // between segments (phones keep only the first), an MPU sits above the


### PR DESCRIPTION
Follow-up to #6536 (this commit missed the merge by a minute). The `/articles` light-mode treatment, scoped to enrollment on the organic post page: only while `post_adsense` is live for an anonymous visitor does the page flip to light — the ad partner's creatives are designed against light pages. Members and unenrolled visitors keep their theme untouched.

Display-only (`applyThemeMode` override; the stored preference is never written), restored on leave. Known trade, same as `/articles`: the flip lands with boot (~half a second after first paint), a color-only flash with no layout shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-organic-enrolled-light-mode.preview.app.daily.dev