### PR TITLE
feat: constant light island under every ad unit

### DIFF
--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -505,13 +505,17 @@ export function ProgrammaticAd({
     <div
       ref={setWrapperRef}
       className={classNames(
-        // Centered on a lighter block, so the unit reads as a deliberate
-        // frame rather than a creative floating on the page background.
+        // A constant light island, deliberately NOT a theme token: display
+        // creatives are designed against light backgrounds, and on a dark
+        // page a white-bodied ad floating on the theme surface reads as a
+        // hole punched in the UI. The white card makes the unit an
+        // intentional object in both themes — the standard dark-mode ad
+        // treatment — without touching the visitor's theme.
         // Vertical padding only: these boxes are border-box, so horizontal
         // padding would shrink the usable width below the IAB cap the
         // FORMAT_SPEC widths exist to guarantee (300x250 no longer fits a
         // padded max-w-[300px]).
-        'mx-auto w-full rounded-8 bg-surface-float py-2 text-center',
+        'mx-auto w-full rounded-8 bg-white py-2 text-center',
         // AdSense stamps data-ad-status="unfilled" when no creative was
         // returned. Without collapsing, the reserved min-height stays behind as
         // a block of empty page — most visible in the comment thread, where an
@@ -530,8 +534,10 @@ export function ProgrammaticAd({
           "Advertisements" is one of the two label strings AdSense permits
           (a bare "Advertisement" is not). Inside the wrapper, so an unfilled
           slot's collapse takes the label down with it. */}
+      {/* Constant gray, not a theme token: the label sits on the card's
+          constant white, where a dark-theme quaternary would vanish. */}
       {isRequested && (
-        <span className="block pb-1 pr-1 text-right text-text-quaternary typo-caption2">
+        <span className="block pb-1 pr-1 text-right text-raw-pepper-10 typo-caption2">
           Advertisements
         </span>
       )}


### PR DESCRIPTION
Supersedes #6540's approach: instead of flipping the enrolled visitor's theme to light (a visible dark→light flash ~half a second after paint, which product rejected), the page keeps the visitor's theme and **each ad unit renders on a constant white card** — the standard dark-mode ad treatment, since display creatives are designed against light backgrounds.

- Wrapper: `bg-white` in both themes (in light mode it reads as a subtle card; in dark, the intentional island). Present from first paint — no flash, no layout shift, nothing theme-dependent.
- Label: constant gray (`raw-pepper-10`) so it stays readable on the card in both themes (a theme-quaternary would vanish on white in dark mode).
- Applies to every surface using `ProgrammaticAd` (/articles and the organic page) automatically.

No AdSense-side work needed for this: all current units are image display units. If we later add styled native (in-feed) units, their palette is configured per-unit in the AdSense UI and could get a dark variant — noted for then, irrelevant now.

## Verification
- 139 shared post+monetization tests, full shared lint, strict typecheck green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-ad-light-island.preview.app.daily.dev