### PR TITLE
feat(adsense): report UTM traffic sources via custom channels

### DIFF
--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -8,6 +8,7 @@ import { useViewability } from './useViewability';
 import { viewabilityLogExtra } from './viewability';
 import type { AdsenseSlotConfig } from './adsense';
 import { ADSENSE_CLIENT_ID, isAdsenseProductionHost } from './adsense';
+import { useAdsenseUtmChannel } from './useAdsenseUtmChannel';
 
 // Module-level, not per-slot: one warning per page load says everything.
 let hasLoggedTestMode = false;
@@ -238,6 +239,7 @@ export function ProgrammaticAd({
   const logExtraRef = useRef(logExtra);
   logExtraRef.current = logExtra;
   const { id: unitId, type: unitType, layoutKey: unitLayoutKey } = config;
+  const { channel: adChannel, utm } = useAdsenseUtmChannel();
 
   const logSlotEvent = useCallback(
     (
@@ -263,12 +265,21 @@ export function ProgrammaticAd({
             format,
             surface,
             refreshes,
-            extra: { ...logExtraRef.current, ...extra },
+            extra: {
+              utm_source: utm?.source,
+              utm_medium: utm?.medium,
+              utm_campaign: utm?.campaign,
+              utm_content: utm?.content,
+              ad_channel: adChannel,
+              ...logExtraRef.current,
+              ...extra,
+            },
           }),
         ),
       });
     },
     [
+      adChannel,
       format,
       logEvent,
       refreshes,
@@ -277,6 +288,7 @@ export function ProgrammaticAd({
       unitId,
       unitLayoutKey,
       unitType,
+      utm,
     ],
   );
 
@@ -541,6 +553,7 @@ export function ProgrammaticAd({
           data-testid={`adsense-slot-${slot}`}
           data-ad-client={ADSENSE_CLIENT_ID}
           data-ad-slot={config.id}
+          data-ad-channel={adChannel}
           {...getInsAttributes(config, FORMAT_SPEC[format].shape)}
         />
       )}

--- a/packages/shared/src/features/monetization/adsense.ts
+++ b/packages/shared/src/features/monetization/adsense.ts
@@ -57,3 +57,50 @@ declare global {
     adsbygoogle?: Record<string, unknown>[];
   }
 }
+
+/**
+ * AdSense custom channel ids keyed by UTM value. `data-ad-channel` only
+ * accepts ids of channels that exist in the account and drops anything else,
+ * so a raw utm value can never be sent — every value to report on needs an
+ * entry here and a matching channel in the AdSense UI. At most 5 channels ride
+ * one request, so one per utm dimension leaves headroom for a combined one.
+ */
+export const ADSENSE_UTM_KEYS = [
+  'source',
+  'medium',
+  'campaign',
+  'content',
+] as const;
+
+export type AdsenseUtmKey = (typeof ADSENSE_UTM_KEYS)[number];
+
+export type AdsenseUtm = Partial<Record<AdsenseUtmKey, string>>;
+
+export const ADSENSE_UTM_CHANNELS: Record<
+  AdsenseUtmKey,
+  Record<string, string>
+> = {
+  source: {
+    quora: '1363957592',
+  },
+  medium: {
+    cpc: '4451381864',
+  },
+  campaign: {
+    traffic_general_202608: '7344304362',
+  },
+  content: {
+    text_v1: '2065831022',
+    text_v2: '8747623594',
+    text_v3: '6121460250',
+    image_v1: '1520754748',
+  },
+};
+
+export const getAdsenseUtmChannel = (utm: AdsenseUtm): string | undefined => {
+  const ids = ADSENSE_UTM_KEYS.map((key) => {
+    const value = utm[key];
+    return value && ADSENSE_UTM_CHANNELS[key][value.toLowerCase()];
+  }).filter(Boolean);
+  return ids.length ? ids.join(',') : undefined;
+};

--- a/packages/shared/src/features/monetization/useAdsenseUtmChannel.spec.ts
+++ b/packages/shared/src/features/monetization/useAdsenseUtmChannel.spec.ts
@@ -1,0 +1,47 @@
+import { ADSENSE_UTM_CHANNELS, getAdsenseUtmChannel } from './adsense';
+import { resolveAdsenseUtm } from './useAdsenseUtmChannel';
+
+const QUORA_UTM = {
+  source: 'quora',
+  medium: 'cpc',
+  campaign: 'traffic_general_202608',
+  content: 'text_v1',
+};
+
+describe('getAdsenseUtmChannel', () => {
+  it('joins one channel id per mapped utm dimension', () => {
+    expect(getAdsenseUtmChannel({ ...QUORA_UTM, source: 'Quora' })).toBe(
+      [
+        ADSENSE_UTM_CHANNELS.source.quora,
+        ADSENSE_UTM_CHANNELS.medium.cpc,
+        ADSENSE_UTM_CHANNELS.campaign.traffic_general_202608,
+        ADSENSE_UTM_CHANNELS.content.text_v1,
+      ].join(','),
+    );
+  });
+
+  it('drops values without a mapped channel', () => {
+    expect(getAdsenseUtmChannel({ source: 'quora', campaign: 'x' })).toBe(
+      ADSENSE_UTM_CHANNELS.source.quora,
+    );
+    expect(getAdsenseUtmChannel({ source: 'unknown' })).toBeUndefined();
+    expect(getAdsenseUtmChannel({})).toBeUndefined();
+  });
+});
+
+describe('resolveAdsenseUtm', () => {
+  beforeEach(() => window.sessionStorage.clear());
+
+  it('reads utm params from the url and persists them for the session', () => {
+    expect(
+      resolveAdsenseUtm(
+        '?utm_source=quora&utm_medium=cpc&utm_campaign=traffic_general_202608&utm_content=text_v1',
+      ),
+    ).toEqual(QUORA_UTM);
+    expect(resolveAdsenseUtm('')).toEqual(QUORA_UTM);
+  });
+
+  it('returns nothing without utm params or a stored session', () => {
+    expect(resolveAdsenseUtm('?foo=bar')).toBeUndefined();
+  });
+});

--- a/packages/shared/src/features/monetization/useAdsenseUtmChannel.ts
+++ b/packages/shared/src/features/monetization/useAdsenseUtmChannel.ts
@@ -1,0 +1,53 @@
+import { useMemo } from 'react';
+import type { AdsenseUtm } from './adsense';
+import { ADSENSE_UTM_KEYS, getAdsenseUtmChannel } from './adsense';
+
+const STORAGE_KEY = 'adsense_utm';
+
+// UTMs only ride the landing URL; the session copy keeps the second post the
+// visitor opens attributed to the same source.
+function readSessionUtm(): AdsenseUtm | undefined {
+  try {
+    const stored = window.sessionStorage.getItem(STORAGE_KEY);
+    return stored ? (JSON.parse(stored) as AdsenseUtm) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function writeSessionUtm(utm: AdsenseUtm): void {
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(utm));
+  } catch {
+    // Storage blocked (private mode, quota) — attribution just stays per page.
+  }
+}
+
+export function resolveAdsenseUtm(search: string): AdsenseUtm | undefined {
+  const params = new URLSearchParams(search);
+  const fromUrl: AdsenseUtm = {};
+  ADSENSE_UTM_KEYS.forEach((key) => {
+    const value = params.get(`utm_${key}`);
+    if (value) {
+      fromUrl[key] = value;
+    }
+  });
+  if (Object.keys(fromUrl).length) {
+    writeSessionUtm(fromUrl);
+    return fromUrl;
+  }
+  return readSessionUtm();
+}
+
+export function useAdsenseUtmChannel(): {
+  channel?: string;
+  utm?: AdsenseUtm;
+} {
+  return useMemo(() => {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+    const utm = resolveAdsenseUtm(window.location.search);
+    return { utm, channel: utm && getAdsenseUtmChannel(utm) };
+  }, []);
+}


### PR DESCRIPTION
## Summary
- Add `ADSENSE_UTM_CHANNELS`, a `utm value → custom channel id` map for `source`/`medium`/`campaign`/`content`, seeded with the Quora paid campaign channels
- New `useAdsenseUtmChannel` hook reads `utm_*` from the URL, persists them in `sessionStorage` for the visit, and resolves the comma-joined channel ids
- `ProgrammaticAd` sets `data-ad-channel` on the `<ins>` (omitted when nothing maps) and adds `utm_*` + `ad_channel` to slot event extras

Channels are managed in AdSense under Reports → ⚙ → Manage custom channels. Values without a map entry are dropped by AdSense, so new sources/campaigns need both a channel and a map entry.

## Test plan
- [x] `useAdsenseUtmChannel.spec.ts` — mapping, unmapped values, URL parsing, session persistence
- [x] shared monetization + arbitrage suites, webapp related tests
- [x] eslint, prettier, strict typecheck guard
- [ ] Verify on production with `?utm_source=quora&utm_medium=cpc&utm_campaign=traffic_general_202608&utm_content=text_v1` that the `<ins>` carries `data-ad-channel="1363957592,4451381864,7344304362,2065831022"`

### Preview domain
https://feat-adsense-utm-custom-channels.preview.app.daily.dev