### PR TITLE
feat: detect discord in profile links

### DIFF
--- a/packages/shared/src/lib/platforms.spec.ts
+++ b/packages/shared/src/lib/platforms.spec.ts
@@ -34,6 +34,24 @@ describe('detectPlatformFromUrl', () => {
     ).toBe('substack');
   });
 
+  it('should detect discord profile and invite URLs', () => {
+    expect(
+      detectPlatformFromUrl(
+        'https://discord.com/users/123456789012345678',
+        USER_PLATFORMS,
+      ),
+    ).toBe('discord');
+    expect(
+      detectPlatformFromUrl('https://discord.gg/inviteCode', USER_PLATFORMS),
+    ).toBe('discord');
+    expect(
+      detectPlatformFromUrl(
+        'https://discordapp.com/users/123456789012345678',
+        USER_PLATFORMS,
+      ),
+    ).toBe('discord');
+  });
+
   it('should return null for unknown URLs', () => {
     expect(
       detectPlatformFromUrl('https://example.com/profile', USER_PLATFORMS),

--- a/packages/shared/src/lib/platforms.tsx
+++ b/packages/shared/src/lib/platforms.tsx
@@ -7,6 +7,7 @@ import {
   CodebergIcon,
   CodePenIcon,
   CrunchbaseIcon,
+  DiscordIcon,
   FacebookIcon,
   GitHubIcon,
   GitLabIcon,
@@ -224,6 +225,13 @@ export const ORG_ONLY_PLATFORMS = {
  * User profile-specific platforms (extends core)
  */
 export const USER_ONLY_PLATFORMS = {
+  discord: {
+    id: 'discord',
+    label: 'Discord',
+    domains: ['discord.com', 'discord.gg', 'discordapp.com'],
+    icon: DiscordIcon,
+    // Discord profiles are keyed by user ID, not a username
+  },
   portfolio: {
     id: 'portfolio',
     label: 'Website',


### PR DESCRIPTION
## Changes

Pasting a Discord URL into the profile links field (`/settings/profile`) fell through to the generic "Link" platform instead of being recognised.

- Added `discord` to `USER_ONLY_PLATFORMS` in `packages/shared/src/lib/platforms.tsx`, matching `discord.com`, `discord.gg` and `discordapp.com`, with the existing `DiscordIcon`.
- No component changes needed — `detectUserPlatform`, the "Discord detected" hint in `SocialLinksInput`, and the icon/label rendering in `AboutMe` all read from `USER_PLATFORMS` generically.
- Added detection tests to `platforms.spec.ts`.

The matching server-side detection (so the platform is also resolved when the client doesn't send one) is a separate PR in `daily-api`.

### Key decisions

- **Scoped to user profiles, not organization links.** Discord went into `USER_ONLY_PLATFORMS` rather than `CORE_PLATFORMS`. In core, `detectPlatform` would return a match with `socialType: null`, and `LinksInput` would then build a `type: Social` link with a null `socialType` — contradicting the `OrganizationSocialLink` type. Adding Discord for orgs later just needs a `SocialMediaType.Discord` enum value first.
- **No urlBuilder.** Discord profiles are keyed by user ID, not a username, so there's nothing to build a URL from (and there's no legacy Discord profile column to migrate).
- **No backfill.** Detection runs at write time, so Discord links users already saved stay `platform: 'other'` until re-saved. Retroactively reclassifying them would need a data migration.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Verification run on the changed files:

- `packages/shared`: 32 suites / 239 tests across `lib`, `features/profile`, `features/organizations`, `components/profile`
- `webapp`: `ProfileIndexPage` 3/3
- `scripts/typecheck-strict-changed.js` and `eslint --max-warnings 0` clean

The change is data-only (one entry in a platform config map), so no layout or media-query surface is affected.

Closes ENG-2027

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-2027-feedback-feature-reques.preview.app.daily.dev