### PR TITLE
feat(profile): count comment and hot take upvotes in the profile stat

### DIFF
--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -135,7 +135,7 @@ sources: publicSourceMemberships(userId: $id, first: 30) {
 export const PROFILE_V2_EXTRA_QUERY = gql`
   query ProfileV2($id: ID!) {
     userStats(id: $id) {
-      upvotes: numPostUpvotes
+      upvotes: numTotalUpvotes
       views: numPostViews
       numFollowers
       numFollowing


### PR DESCRIPTION
Follow-up to dailydotdev/daily-api#4170, which added `numTotalUpvotes` to `userStats`.

The profile stat asked for `numPostUpvotes`, so members who drive discussion in comments and hot takes but rarely post saw a 0 there. `PROFILE_V2_EXTRA_QUERY` now aliases `upvotes` to `numTotalUpvotes` — post + comment + hot take upvotes.

One line; the API change is already on main, so nothing else moves. The `ProfileV2` type and `UserStats` component are unchanged since the alias keeps the same shape.

## Not included

The label still reads "Upvotes" in `UserStats.tsx`. Renaming it to "Likes" is a copy decision, so I left it — happy to add it here if that's the wording we want.

### Preview domain
https://profile-total-upvotes-stat.preview.app.daily.dev