### PR TITLE
chore(monetization): ship post_adsense at 100% and remove the experiment flag

### DIFF
--- a/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.spec.tsx
@@ -6,7 +6,6 @@ import {
   screen,
 } from '@testing-library/react';
 import { ArbitrageAdFormat, ArbitrageAdSlot } from './ArbitrageAdSlot';
-import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
 import type { AuthContextData } from '../../../contexts/AuthContext';
 import AuthContext from '../../../contexts/AuthContext';
 import { getLogContextStatic } from '../../../contexts/LogContext';
@@ -15,16 +14,9 @@ import { LogEvent } from '../../../lib/log';
 import { AdActions } from '../../../lib/ads';
 import type { AdsenseSlots } from '../../../features/monetization/adsense';
 import { ADSENSE_CLIENT_ID } from '../../../features/monetization/adsense';
-import {
-  featurePostAdsense,
-  featureReadAdsense,
-} from '../../../lib/featureManagement';
+import { featureReadAdsense } from '../../../lib/featureManagement';
 import { useFeature } from '../../GrowthBookProvider';
 import { ORGANIC_SLOT } from './slots';
-
-jest.mock('../../../hooks/useConditionalFeature', () => ({
-  useConditionalFeature: jest.fn(),
-}));
 
 jest.mock('../../GrowthBookProvider', () => ({
   ...(jest.requireActual('../../GrowthBookProvider') as Record<
@@ -55,10 +47,9 @@ const mockSlotMaps = jest.requireMock('./slots') as {
   ORGANIC_ADSENSE_SLOTS: AdsenseSlots;
 };
 
-const mockUseConditionalFeature = jest.mocked(useConditionalFeature);
 const mockUseFeature = jest.mocked(useFeature);
 
-const flags = { organic: false, read: true };
+const flags = { read: true };
 
 // Both surfaces are anonymous-only and wait for boot, so the default render
 // is an anonymous visitor with auth resolved.
@@ -90,26 +81,16 @@ const setSlots = (slots: AdsenseSlots): void => {
 };
 
 const setOrganicSlots = (slots: AdsenseSlots): void => {
-  flags.organic = Object.keys(slots).length > 0;
   mockSlotMaps.ORGANIC_ADSENSE_SLOTS = slots;
 };
 
 beforeEach(() => {
   mockConstants.isDevelopment = false;
-  flags.organic = false;
   flags.read = true;
   mockSlotMaps.READ_ADSENSE_SLOTS = {};
   mockSlotMaps.ORGANIC_ADSENSE_SLOTS = {};
   mockUseFeature.mockImplementation((feature) =>
     feature === featureReadAdsense ? flags.read : feature.defaultValue,
-  );
-  mockUseConditionalFeature.mockImplementation(
-    ({ feature, shouldEvaluate }) => {
-      if (feature === featurePostAdsense && shouldEvaluate) {
-        return { value: flags.organic, isLoading: false };
-      }
-      return { value: feature.defaultValue, isLoading: false };
-    },
   );
 });
 
@@ -327,7 +308,7 @@ describe('ArbitrageAdSlot on the organic surface', () => {
     [ORGANIC_SLOT.topLeaderboard]: { id: '5555555555', type: 'display' },
   };
 
-  it('renders when post_adsense is on for a non-Plus user', () => {
+  it('renders for an anonymous visitor when the unit is configured', () => {
     setOrganicSlots(organicFixture);
     render(
       <ArbitrageAdSlot
@@ -371,13 +352,10 @@ describe('ArbitrageAdSlot on the organic surface', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('never enrolls into post_adsense while no unit has an id', () => {
-    // Enrollment with nothing renderable fills the experiment with users for
-    // whom variant and control are byte-identical.
-    mockSlotMaps.ORGANIC_ADSENSE_SLOTS = {
+  it('collapses to nothing while no organic unit has an id', () => {
+    setOrganicSlots({
       [ORGANIC_SLOT.topLeaderboard]: { id: '', type: 'display' },
-    };
-    flags.organic = true;
+    });
     const { container } = render(
       <ArbitrageAdSlot
         surface="organic"
@@ -388,9 +366,6 @@ describe('ArbitrageAdSlot on the organic surface', () => {
     );
 
     expect(container).toBeEmptyDOMElement();
-    expect(mockUseConditionalFeature).toHaveBeenCalledWith(
-      expect.objectContaining({ shouldEvaluate: false }),
-    );
   });
 
   it('shows no development placeholder outside the read template', () => {

--- a/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitrageAdSlot.tsx
@@ -36,9 +36,9 @@ export interface ArbitrageAdSlotProps {
    */
   hideOnPhone?: boolean;
   /**
-   * Which slot map and flag gate the unit: the /read arbitrage template
-   * (default) or the organic post page. The dashed density-review placeholder
-   * is a /read-template tool and never renders for the organic surface.
+   * Which slot map gates the unit: the /read arbitrage template (default) or
+   * the organic post page. The dashed density-review placeholder is a
+   * /read-template tool and never renders for the organic surface.
    */
   surface?: ArbitrageAdSurface;
   /**
@@ -143,20 +143,17 @@ function OrganicArbitrageAdSlot(
 }
 
 /**
- * A programmatic ad slot. Live only while its surface's boolean flag is on
- * AND its hardcoded map (slots.ts) carries a unit id for this slot number;
- * everything else collapses to nothing — visitors get a clean page. The
- * dashed density-review placeholder only ever appears in local development
- * builds of the /read template.
+ * A programmatic ad slot. Live only while its surface's hook says so — the
+ * /read template sits behind the read_adsense kill switch, the organic post
+ * page is anonymous-only — AND its hardcoded map (slots.ts) carries a unit id
+ * for this slot number; everything else collapses to nothing — visitors get a
+ * clean page. The dashed density-review placeholder only ever appears in
+ * local development builds of the /read template.
  */
 export function ArbitrageAdSlot({
   surface = 'read',
   ...props
 }: ArbitrageAdSlotProps): ReactElement | null {
-  // Split by surface so each branch evaluates only its own slot source: the
-  // organic hook conditionally evaluates the post_adsense flag, and a /read
-  // page calling it would enroll every visitor in an experiment that does not
-  // govern that route.
   if (surface === 'organic') {
     return <OrganicArbitrageAdSlot {...props} />;
   }

--- a/packages/shared/src/components/post/arbitrage/slots.ts
+++ b/packages/shared/src/components/post/arbitrage/slots.ts
@@ -47,7 +47,7 @@ export const ARBITRAGE_SLOT = {
  * TODO(chris): enable "Anchor ads" under Auto ads in the AdSense account,
  * with BOTH preconditions met first:
  * 1. Scope it with an AdSense URL group to /articles only. The script also
- *    loads on /posts/[id] whenever post_adsense is on, so an unscoped
+ *    loads on /posts/[id] for every anonymous visitor, so an unscoped
  *    account-level anchor lands on the organic post page too, on top of the
  *    two reviewed units there.
  * 2. Verify the anchor against FooterNavBarLayout's fixed bottom bar on a
@@ -91,8 +91,7 @@ export const MAX_CONTENT_ADS_PER_SECTION = 4;
  * The AdSense units behind each slot, keyed by slot number. Deliberately in
  * code rather than remote config: unit ids are public (visible in the page
  * source of any live page) and stable after setup, and as a GrowthBook JSON
- * value they shipped in every boot payload of every surface. The remote side
- * is just the `post_adsense` boolean; the /read template needs none.
+ * value they shipped in every boot payload of every surface.
  *
  * A unit's `type` is set when it is created in AdSense and cannot be
  * overridden from here: an in-article unit is fluid whatever the <ins> asks
@@ -140,8 +139,8 @@ export const READ_ADSENSE_SLOTS: AdsenseSlots = {
 };
 
 /**
- * The organic post page (/posts/[id]) carries two units, gated by the
- * `post_adsense` boolean and hidden from Plus members like the internal ads.
+ * The organic post page (/posts/[id]) carries these units for anonymous
+ * visitors only — logged-in users never see them, like the internal ads.
  * Numbered after the /read range so reports never collide.
  */
 export const ORGANIC_SLOT = {

--- a/packages/shared/src/components/post/arbitrage/useReadAdsenseSlots.ts
+++ b/packages/shared/src/components/post/arbitrage/useReadAdsenseSlots.ts
@@ -1,14 +1,9 @@
 import { useContext } from 'react';
-import {
-  featurePostAdsense,
-  featureReadAdsense,
-} from '../../../lib/featureManagement';
+import { featureReadAdsense } from '../../../lib/featureManagement';
 import AuthContext from '../../../contexts/AuthContext';
 import { isDevelopment } from '../../../lib/constants';
-import { useConditionalFeature } from '../../../hooks/useConditionalFeature';
 import { useFeature } from '../../GrowthBookProvider';
 import type { AdsenseSlots } from '../../../features/monetization/adsense';
-import { hasLiveAdsenseUnits } from '../../../features/monetization/adsense';
 import { ORGANIC_ADSENSE_SLOTS, READ_ADSENSE_SLOTS } from './slots';
 
 const NO_SLOTS: AdsenseSlots = {};
@@ -44,9 +39,9 @@ export const useReadAdsenseSlots = (): AdsenseSlots => {
 };
 
 /**
- * The organic post page's units: only while the `post_adsense` flag is on,
- * and only for anonymous visitors — any logged-in user (member or Plus)
- * never sees programmatic ads on their post pages.
+ * The organic post page's units, permanent since the post_adsense experiment
+ * won: anonymous visitors only — any logged-in user (member or Plus) never
+ * sees programmatic ads on their post pages.
  *
  * `canRender` is the caller's own knowledge of whether its slots can appear
  * at all — the post page passes false in the focus-card redesign arm, whose
@@ -54,14 +49,6 @@ export const useReadAdsenseSlots = (): AdsenseSlots => {
  */
 export const useOrganicAdsenseSlots = (canRender = true): AdsenseSlots => {
   const isAnonymous = useIsAnonymous();
-  // Conditional evaluation, because evaluating enrolls: a visitor who is
-  // logged in — or who cannot be shown a unit — would fill the experiment
-  // with byte-identical variants.
-  const { value: enabled } = useConditionalFeature({
-    feature: featurePostAdsense,
-    shouldEvaluate:
-      canRender && isAnonymous && hasLiveAdsenseUnits(ORGANIC_ADSENSE_SLOTS),
-  });
 
-  return enabled && isAnonymous && canRender ? ORGANIC_ADSENSE_SLOTS : NO_SLOTS;
+  return isAnonymous && canRender ? ORGANIC_ADSENSE_SLOTS : NO_SLOTS;
 };

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -335,12 +335,6 @@ export const featurePlusSale = new Feature<PlusSaleConfig>(
   },
 );
 
-// AdSense on the organic post page: two units, anonymous visitors only. The
-// unit map lives in code (post/arbitrage/slots.ts) — ids are public in any
-// live page's source, and a remote JSON value cost every surface's boot
-// payload the whole map.
-export const featurePostAdsense = new Feature('post_adsense', false);
-
 // Emergency kill switch for the /read template's ads — NOT an experiment, so
 // the true default is deliberate: the surface ships always-on (it is only
 // reachable through paid placements), and the flag exists solely so a policy

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -239,11 +239,11 @@ export const PostPage = ({
   const requiresClassicLayout = !!router.query?.author || !!router.query?.squad;
   const showRedesign =
     isRedesignEligible && !requiresClassicLayout && isRedesignFlagOn;
-  // Empty for every logged-in visitor and while post_adsense is off; the slot
-  // components check the same hook, so with it empty neither markup nor script
-  // exists. Gated on a unit id being present, not key presence — the map keeps
-  // placeholder entries with empty ids, and the script must not load for
-  // inventory that cannot fill.
+  // Empty for every logged-in visitor; the slot components check the same
+  // hook, so with it empty neither markup nor script exists. Gated on a unit
+  // id being present, not key presence — the map keeps placeholder entries
+  // with empty ids, and the script must not load for inventory that cannot
+  // fill.
   const adsenseSlots = useOrganicAdsenseSlots(!showRedesign);
   const adsenseActive = hasLiveAdsenseUnits(adsenseSlots);
   // The same in-content treatment the /articles template ships, reused on


### PR DESCRIPTION
## Changes

The `post_adsense` experiment won, so the organic post page's AdSense units become permanent behavior instead of a flag-gated experiment:

- `useOrganicAdsenseSlots` no longer evaluates the flag — anonymous visitors on `/posts/[id]` (classic layout) always get the organic slot map. Logged-in users (member or Plus) still never see programmatic ads.
- `featurePostAdsense` deleted from `featureManagement.ts`.
- The `useConditionalFeature` enrollment plumbing and its spec mock are removed; the enrollment-guard test is reworked into a plain empty-unit collapse test.
- Comments referencing the experiment updated in `slots.ts`, `ArbitrageAdSlot.tsx`, and the post page.

## Post-merge

- Stop the `post_adsense` experiment in GrowthBook and archive the flag once this deploys (until then, forcing it to 100% in GrowthBook rolls it out immediately).

## Verification

- `shared` arbitrage suite: 49 tests pass
- `webapp` post tests: 27 tests pass
- Strict typecheck of changed files passes, ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://chore-post-adsense-rollout.preview.app.daily.dev