### PR TITLE
fix(webapp): pin @next/bundle-analyzer type resolution to next 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,13 @@
   "pnpm": {
     "patchedDependencies": {
       "graphql-request@3.7.0": "patches/graphql-request@3.7.0.patch"
+    },
+    "packageExtensions": {
+      "@next/bundle-analyzer": {
+        "peerDependencies": {
+          "next": "*"
+        }
+      }
     }
   },
   "volta": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,8 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+packageExtensionsChecksum: sha256-eZMQ4MSwwkiqFDfLk4lvGgDqkfKxnnJAu5evrKDz7fU=
+
 patchedDependencies:
   graphql-request@3.7.0:
     hash: 0ab9ec08fff95d6fe401cbe554d4f92ca596df7c35c2636c4fd3fb2e914936aa
@@ -975,7 +977,7 @@ importers:
         version: link:../prettier-config
       '@next/bundle-analyzer':
         specifier: 16.2.6
-        version: 16.2.6
+        version: 16.2.6(next@16.2.6(@babel/core@7.26.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0))
       '@svgr/webpack':
         specifier: ^5.5.0
         version: 5.5.0
@@ -2934,6 +2936,8 @@ packages:
 
   '@next/bundle-analyzer@16.2.6':
     resolution: {integrity: sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==}
+    peerDependencies:
+      next: '*'
 
   '@next/env@15.5.18':
     resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
@@ -12331,8 +12335,9 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/bundle-analyzer@16.2.6':
+  '@next/bundle-analyzer@16.2.6(next@16.2.6(@babel/core@7.26.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0))':
     dependencies:
+      next: 16.2.6(@babel/core@7.26.0)(@playwright/test@1.58.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.82.0)
       webpack-bundle-analyzer: 4.10.1
     transitivePeerDependencies:
       - bufferutil


### PR DESCRIPTION
## Problem

The `Vercel - daily-webapp` check fails intermittently with a TypeScript error in `packages/webapp/next.config.ts`:

```
Type error: Type '{ loaders: {...}[]; as: string; } | TurbopackRuleConfigItemOrShortcut' is not assignable to type 'TurbopackRuleConfigCollection'.
  Type 'boolean' is not assignable to type 'TurbopackRuleConfigCollection'.
```

It is not caused by any particular PR. Identical `next.config.ts` source passed on one deploy, failed on the next, and passed again on a plain redeploy.

## Root cause

`@next/bundle-analyzer@16.2.6` declares no `next` dependency or peer dependency at all. Its `index.d.ts` does `import type { NextConfig } from 'next'`, which resolves by walking up out of its pnpm store directory and can land on either installed version depending on the install layout. The monorepo has two: the webapp and extension on `16.2.6`, and `packages/storybook` on `15.5.18`.

When it resolves to v15, `withBundleAnalyzer(...)` returns a v15-typed `NextConfig`. Spreading that into an object annotated as v16 `NextConfig` unions the literal `turbopack.rules['*.svg']` with v15's `TurbopackRuleConfigItemOrShortcut`, whose `TurbopackRuleConfigItem` includes `false`. That is the "Type 'boolean'" in the message, and v16's `TurbopackRuleConfigCollection` does not accept it.

CircleCI does not catch this: there is no webapp `next build` job, and `scripts/typecheck-strict-changed.js` only covers files changed in the PR.

## Fix

Declare a `next` peer dependency on the analyzer via `pnpm.packageExtensions`. pnpm then resolves it from the consumer, so the analyzer always sees the same `next` as the webapp. Using `*` rather than a hardcoded `16.2.6` means there is no second version to keep in sync on the next Next upgrade.

`next.config.ts` is untouched.

## Alternatives rejected

Two source-level workarounds were tested against a reproduction and both fail:

1. **Annotating or casting the analyzer result to the webapp's `NextConfig`** is rejected with TS2352, "neither type sufficiently overlaps". The v15 and v16 `NextConfig` types are not mutually comparable because `webpack`'s `WebpackConfigContext.config` differs. It would need `as unknown as NextConfig`, which discards typechecking of the entire analyzer config argument.
2. **Moving the `turbopack` key after the spread** collapses that one union but immediately exposes the next incompatibility, `headers()` returning v15 `Header[]` versus v16 `Header[]`. It moves the error rather than removing it, and leaves the same trap for whichever config key someone adds next.

## Verification

The failure was reproduced deterministically by symlinking `next@15.5.18` into the analyzer's package directory, giving the exact error at `next.config.ts:56`.

- With the fix applied and `next@15.5.18` planted in the hoisted fallback directory the analyzer previously walked into, the typecheck is clean, because the analyzer now finds its own local `next@16.2.6` first.
- `pnpm --filter webapp build` passes end to end, including the TypeScript phase that was failing.
- `pnpm install --frozen-lockfile` succeeds, which is what Vercel runs.

### Preview domain
https://claude-angry-chebyshev-b2ca74.preview.app.daily.dev