### PR TITLE
fix(post): keep the modal header reachable in the redesign layout

### DIFF
--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -41,6 +41,7 @@ export default function ArticlePostModal({
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
       navigationRedesign={showRedesign}
+      navigationPosition={position}
       onRequestClose={onRequestClose}
       postType={PostType.Article}
       source={post.source}

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -1,20 +1,21 @@
-import type { ReactElement, ReactNode } from 'react';
+import type { CSSProperties, ReactElement, ReactNode } from 'react';
 import React, { useState, useCallback } from 'react';
 import classNames from 'classnames';
 import type { ModalProps } from './common/Modal';
-import { Modal } from './common/Modal';
+import { Modal, modalSizeToClassName } from './common/Modal';
 import styles from './BasePostModal.module.css';
 import PostLoadingSkeleton from '../post/PostLoadingSkeleton';
 import type { Post, PostType } from '../../graphql/posts';
 import type { Source } from '../../graphql/sources';
 import PostNavigation from '../post/PostNavigation';
+import FixedPostNavigation from '../post/FixedPostNavigation';
 import type { PostPosition } from '../../hooks/usePostModalNavigation';
 import { usePostReferrerContext } from '../../contexts/PostReferrerContext';
 import { ActivePostContextProvider } from '../../contexts/ActivePostContext';
 import { LogExtraContextProvider } from '../../contexts/LogExtraContext';
 import { LogEvent, TargetType } from '../../lib/log';
 import { useLogContext } from '../../contexts/LogContext';
-import { useEventListener } from '../../hooks';
+import { useEventListener, useViewSize, ViewSize } from '../../hooks';
 import useDebounceFn from '../../hooks/useDebounceFn';
 import { useEngagementAdsContext } from '../../contexts/EngagementAdsContext';
 import { getEngagementLogExtra } from '../../lib/engagementAds';
@@ -37,6 +38,12 @@ interface BasePostModalProps extends ModalProps {
    * stats + "…" menu + close.
    */
   navigationRedesign?: boolean;
+  /**
+   * Scroll state from `usePostNavigationPosition`. The classic layout feeds
+   * this to `PostContent`; the redesign card has no equivalent, so the modal
+   * floats the fixed bar itself once it turns `fixed`.
+   */
+  navigationPosition?: CSSProperties['position'];
   loadingChildren?: ReactNode;
   post?: Post;
 }
@@ -56,6 +63,7 @@ function BasePostModal({
   navigationContainerClassName,
   navigationHideSubscribeAction,
   navigationRedesign,
+  navigationPosition,
   loadingChildren,
   post,
   onRequestClose,
@@ -90,6 +98,14 @@ function BasePostModal({
 
   const [debouncedOnScroll] = useDebounceFn(onScroll, 100);
   useEventListener(scrollNode, 'scroll', debouncedOnScroll);
+
+  // The redesign card renders no navigation of its own, so the strip above it
+  // scrolls away with the header and takes the close button with it. Float the
+  // same fixed bar the classic layout uses once scrolled past the offset.
+  // Matches `PostContentContainer`, which also skips it below MobileL.
+  const isMobile = useViewSize(ViewSize.MobileL);
+  const showFixedNavigation =
+    navigationRedesign && navigationPosition === 'fixed' && !isMobile;
 
   return (
     <ActivePostContextProvider post={post}>
@@ -129,6 +145,20 @@ function BasePostModal({
             </>
           ) : (
             <>
+              {showFixedNavigation && (
+                <FixedPostNavigation
+                  postPosition={postPosition}
+                  onPreviousPost={onPreviousPost}
+                  onNextPost={onNextPost}
+                  hideOptions
+                  onClose={onRequestClose}
+                  post={post}
+                  className={{
+                    container: modalSizeToClassName[size],
+                    actions: 'ml-auto',
+                  }}
+                />
+              )}
               <PostNavigation
                 className={{
                   container: classNames('px-4', navigationContainerClassName),

--- a/packages/shared/src/components/modals/CollectionPostModal.tsx
+++ b/packages/shared/src/components/modals/CollectionPostModal.tsx
@@ -43,6 +43,7 @@ export default function CollectionPostModal({
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
       navigationRedesign={showRedesign}
+      navigationPosition={position}
       onRequestClose={onRequestClose}
       postType={PostType.Collection}
       source={post.source}

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -43,6 +43,7 @@ export default function PostModal({
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
       navigationRedesign={showRedesign}
+      navigationPosition={position}
       onRequestClose={onRequestClose}
       postType={PostType.Share}
       source={post.source}


### PR DESCRIPTION
## Changes

Open a post in the modal with the redesign flag on, scroll past the header, and there is no way out but Esc or an overlay click — the close X has scrolled away with the top strip.

`BasePostModal`'s own `navigationRedesign` docstring already promised the fix:

> hide the top strip's "…" menu (it lives in the focus-card header) and, once scrolled, float a fixed bar with the post stats + "…" menu + close.

Nothing implemented the second half.

The classic layout has solved this for a long time: `PostContent` swaps in `FixedPostNavigation` once `usePostNavigationPosition` reports `position === 'fixed'`. All three post modals **already call that hook and already hold `position`** — they just drop it in the redesign branch, because the redesign card renders no navigation of its own.

So this passes `position` into `BasePostModal` and lets the modal float the same component the classic layout uses. No new positioning logic, no new component — 36 lines, mostly wiring.

- Gated on `navigationRedesign`, so the classic path is untouched and can't end up with two fixed bars.
- Skipped below MobileL, matching `PostContentContainer`.
- Restores **prev/next** while scrolled too, which the previous action-bar treatment never carried.

### Relationship to #6248

Independent — no file overlap, and this fixes `main` as it stands today. #6248 simplifies `FocusCardActionBar` and removes its pinned-top state, which is where the redesign's only close-while-scrolled used to live; this puts that affordance back where it belongs, in the modal chrome rather than in a content component's engagement bar. Either can merge first.

## Events

None.

## Experiment

No.

## Manual Testing

`packages/shared` modal + post suites (40 files, 231 tests), `packages/webapp/__tests__/PostPage.tsx` (53 tests), eslint on `src/components/modals`, and `typecheck:strict:changed` all pass locally.

**Needs a preview check** — this is positioning behaviour inside the modal's scroll overlay, which unit tests don't exercise:

- [ ] Tablet / laptop — open a post from the feed, scroll down, confirm the fixed bar appears with a working close X
- [ ] The bar's prev/next move between posts while scrolled
- [ ] Scroll back to the top — the fixed bar goes away, the in-flow strip returns, and there is never a moment with two bars
- [ ] MobileL and below — no fixed bar, matching the classic layout
- [ ] **Classic layout (flag off)** — completely unchanged, exactly one fixed bar on scroll

### Preview domain
https://post-modal-fixed-nav-dailydotdev.preview.app.daily.dev