### PR TITLE
fix(drawer): keep the full-screen composer inside the iOS safe area and freeze the page behind it

### DIFF
--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -59,6 +59,7 @@ export function CompanionDiscussion({
         <PostComments
           post={post}
           origin={Origin.Companion}
+          forceInlineComposer
           onShare={(comment) => openShareComment(comment, post)}
           onClickUpvote={onShowUpvoted}
           modalParentSelector={getCompanionWrapper}

--- a/packages/shared/src/components/comments/MainComment.spec.tsx
+++ b/packages/shared/src/components/comments/MainComment.spec.tsx
@@ -209,6 +209,26 @@ it('should render the comment box', async () => {
   expect(commentBox).toBeInTheDocument();
 });
 
+it('opens the mobile reply composer as a full-screen drawer by default', async () => {
+  mockUseViewSize.mockImplementation(() => false);
+  renderLayout({}, loggedUser);
+  const el = await screen.findByLabelText('Reply');
+  el.click();
+
+  await screen.findAllByRole('textbox');
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+});
+
+it('keeps the mobile reply composer inline with forceInlineComposer', async () => {
+  mockUseViewSize.mockImplementation(() => false);
+  renderLayout({ forceInlineComposer: true }, loggedUser);
+  const el = await screen.findByLabelText('Reply');
+  el.click();
+
+  await screen.findAllByRole('textbox');
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
 it('should block the reply composer and call onReplyBlocked when canReply is false', async () => {
   const onReplyBlocked = jest.fn();
   renderLayout({ canReply: false, onReplyBlocked }, loggedUser);

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -53,8 +53,8 @@ export interface MainCommentProps
    */
   canReply?: boolean;
   onReplyBlocked?: () => void;
-  /** Inline reply/edit composers on small viewports too — the companion must
-   * not cover the host page. */
+  /** Inline reply/edit composers on small viewports too, so the companion
+   * never covers the host page. */
   forceInlineComposer?: boolean;
 }
 

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -53,6 +53,9 @@ export interface MainCommentProps
    */
   canReply?: boolean;
   onReplyBlocked?: () => void;
+  /** Inline reply/edit composers on small viewports too — the companion must
+   * not cover the host page. */
+  forceInlineComposer?: boolean;
 }
 
 const shouldShowBannerOnComment = (
@@ -77,6 +80,7 @@ export default function MainComment({
   isModalThread = false,
   canReply = true,
   onReplyBlocked,
+  forceInlineComposer = false,
   ...props
 }: MainCommentProps): ReactElement {
   const { user } = useContext(AuthContext);
@@ -210,6 +214,7 @@ export default function MainComment({
         <CommentInput
           {...editProps}
           post={props.post}
+          forceInline={forceInlineComposer}
           onCommented={(...params) => {
             onEdit(null);
             onCommented?.(...params);
@@ -223,6 +228,7 @@ export default function MainComment({
           <CommentInput
             {...replyProps}
             post={props.post}
+            forceInline={forceInlineComposer}
             onCommented={(...params) => {
               onReplyTo(null);
               onCommented?.(...params);
@@ -291,6 +297,7 @@ export default function MainComment({
               extendTopConnector={isModalThread && commentId === comment.id}
               canReply={canReply}
               onReplyBlocked={onReplyBlocked}
+              forceInlineComposer={forceInlineComposer}
             />
           ))}
         </div>

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -23,6 +23,7 @@ export interface SubCommentProps
   extendTopConnector?: boolean;
   canReply?: boolean;
   onReplyBlocked?: () => void;
+  forceInlineComposer?: boolean;
 }
 
 function SubComment({
@@ -36,6 +37,7 @@ function SubComment({
   extendTopConnector = false,
   canReply = true,
   onReplyBlocked,
+  forceInlineComposer = false,
   ...props
 }: SubCommentProps): ReactElement {
   const { inputProps, commentId, onReplyTo } = useComments(props.post);
@@ -116,6 +118,7 @@ function SubComment({
         <CommentInput
           {...editProps}
           post={props.post}
+          forceInline={forceInlineComposer}
           onCommented={(data, isNew) => {
             onEdit(null);
             onCommented?.(data, isNew);
@@ -130,6 +133,7 @@ function SubComment({
             {...inputProps}
             className={className}
             post={props.post}
+            forceInline={forceInlineComposer}
             onCommented={(...params) => {
               onReplyTo(null);
               onCommented?.(...params);

--- a/packages/shared/src/components/drawers/Drawer.spec.tsx
+++ b/packages/shared/src/components/drawers/Drawer.spec.tsx
@@ -32,9 +32,9 @@ describe('Drawer', () => {
     expect(overlay.style.getPropertyValue('--safe-area-top-offset')).toBe(
       '40px',
     );
-    // The overlay keeps its CSS height so the page cannot show through the
-    // translucent keyboard; only the wrapper tracks the visual viewport.
-    expect(overlay).toHaveStyle({ height: '' });
+    // The overlay stays at full layout height so the page cannot show
+    // through the keyboard; only the wrapper tracks the visual viewport.
+    expect(overlay).toHaveStyle({ height: '100vh' });
     const wrapper = screen
       .getByText('content')
       .closest('.overflow-y-auto') as HTMLElement;
@@ -72,6 +72,38 @@ describe('Drawer', () => {
     expect(document.body).not.toHaveClass('hidden-scrollbar');
     expect(document.documentElement).not.toHaveStyle({ overflow: 'hidden' });
     expect(document.body).not.toHaveStyle({ position: 'fixed' });
+  });
+
+  it('undoes the iOS keyboard reveal scroll while full-screen', () => {
+    const scrollTo = jest.fn();
+    Object.defineProperty(window, 'scrollTo', {
+      configurable: true,
+      value: scrollTo,
+    });
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 120,
+      writable: true,
+    });
+
+    const { unmount } = render(
+      <Drawer isOpen isFullScreen onClose={jest.fn()}>
+        content
+      </Drawer>,
+    );
+
+    fireEvent.scroll(window);
+    expect(scrollTo).toHaveBeenCalledWith(0, 0);
+
+    scrollTo.mockClear();
+    unmount();
+    Object.defineProperty(window, 'scrollY', {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+    fireEvent.scroll(window);
+    expect(scrollTo).not.toHaveBeenCalledWith(0, 0);
   });
 
   it('keeps the page locked until the last stacked drawer closes', () => {

--- a/packages/shared/src/components/drawers/Drawer.spec.tsx
+++ b/packages/shared/src/components/drawers/Drawer.spec.tsx
@@ -15,7 +15,7 @@ describe('Drawer', () => {
       .mockReturnValue({ width: 375, height: 812, offsetTop: 0 });
   });
 
-  it('sizes a full-screen drawer to the visual viewport', () => {
+  it('starts below the iOS status bar and ends above the keyboard', () => {
     jest
       .mocked(useVisualViewport)
       .mockReturnValue({ width: 375, height: 500, offsetTop: 40 });
@@ -26,8 +26,21 @@ describe('Drawer', () => {
       </Drawer>,
     );
 
-    const overlay = screen.getByText('content').closest('.fixed');
-    expect(overlay).toHaveStyle({ height: '500px', top: '40px' });
+    const overlay = screen
+      .getByText('content')
+      .closest('.fixed') as HTMLElement;
+    expect(overlay.style.getPropertyValue('--safe-area-top-offset')).toBe(
+      '40px',
+    );
+    // The overlay keeps its CSS height so the page cannot show through the
+    // translucent keyboard; only the wrapper tracks the visual viewport.
+    expect(overlay).toHaveStyle({ height: '' });
+    const wrapper = screen
+      .getByText('content')
+      .closest('.overflow-y-auto') as HTMLElement;
+    expect(wrapper.style.getPropertyValue('--drawer-viewport-height')).toBe(
+      '500px',
+    );
   });
 
   it('leaves non-full-screen drawers sized by CSS', () => {
@@ -37,8 +50,10 @@ describe('Drawer', () => {
       </Drawer>,
     );
 
-    const overlay = screen.getByText('content').closest('.fixed');
-    expect(overlay).not.toHaveStyle({ height: '812px' });
+    const overlay = screen
+      .getByText('content')
+      .closest('.fixed') as HTMLElement;
+    expect(overlay).not.toHaveAttribute('style');
   });
 
   it('locks the page scroll behind it while open', () => {
@@ -50,10 +65,13 @@ describe('Drawer', () => {
 
     expect(document.body).toHaveClass('hidden-scrollbar');
     expect(document.documentElement).toHaveStyle({ overflow: 'hidden' });
+    // iOS's keyboard reveal scroll ignores overflow, so the body is pinned.
+    expect(document.body).toHaveStyle({ position: 'fixed' });
 
     unmount();
     expect(document.body).not.toHaveClass('hidden-scrollbar');
     expect(document.documentElement).not.toHaveStyle({ overflow: 'hidden' });
+    expect(document.body).not.toHaveStyle({ position: 'fixed' });
   });
 
   it('keeps the page locked until the last stacked drawer closes', () => {

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -61,6 +61,7 @@ export interface DrawerOnMobileProps {
 // Drawers can stack; the page unlocks only when the last one leaves.
 let scrollLockCount = 0;
 let previousHtmlOverflow = '';
+let lockedScrollY = 0;
 
 // Escape must close only the top-most drawer of a stack.
 const drawerStack: symbol[] = [];
@@ -102,9 +103,25 @@ function BaseDrawer({
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const { height: viewportHeight, offsetTop } = useVisualViewport(isFullScreen);
-  const keyboardSafeStyle =
+  // The native iOS shell draws the webview under the status bar and covers
+  // that strip with an opaque `body::before` (safeArea.css), so the overlay
+  // must start below `--safe-area-top` — a plain `top: offsetTop` hides the
+  // drawer header behind the cover, where it cannot be tapped. Feeding the
+  // visual-viewport offset through `--safe-area-top-offset` lets the
+  // safeArea.css rules keep both constraints.
+  const overlayKeyboardStyle =
     isFullScreen && viewportHeight
-      ? { height: viewportHeight, top: offsetTop }
+      ? ({
+          '--safe-area-top-offset': `${offsetTop ?? 0}px`,
+        } as React.CSSProperties)
+      : undefined;
+  // Only the wrapper tracks the visual viewport; the overlay keeps its full
+  // layout height so the page never shows through the translucent keyboard.
+  const wrapperKeyboardStyle =
+    isFullScreen && viewportHeight
+      ? ({
+          '--drawer-viewport-height': `${viewportHeight}px`,
+        } as React.CSSProperties)
       : undefined;
   const [hasAnimated, setHasAnimated] = useState(instantOpen);
   const [animate] = useDebounceFn(() => setHasAnimated(true), 1);
@@ -154,6 +171,13 @@ function BaseDrawer({
     // alone never reaches the viewport.
     if (scrollLockCount === 0) {
       previousHtmlOverflow = document.documentElement.style.overflow;
+      // WebKit's keyboard reveal scroll ignores `overflow: hidden`; pinning
+      // the body removes the scrollable range so the page cannot move at all.
+      lockedScrollY = window.scrollY;
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${lockedScrollY}px`;
+      document.body.style.left = '0';
+      document.body.style.right = '0';
     }
     scrollLockCount += 1;
     document.body.classList.add('hidden-scrollbar');
@@ -165,10 +189,17 @@ function BaseDrawer({
         return;
       }
       document.body.classList.remove('hidden-scrollbar');
+      document.body.style.removeProperty('position');
+      document.body.style.removeProperty('top');
+      document.body.style.removeProperty('left');
+      document.body.style.removeProperty('right');
       if (previousHtmlOverflow) {
         document.documentElement.style.overflow = previousHtmlOverflow;
       } else {
         document.documentElement.style.removeProperty('overflow');
+      }
+      if (lockedScrollY) {
+        window.scrollTo(0, lockedScrollY);
       }
     };
   }, [isFullScreen]);
@@ -211,15 +242,13 @@ function BaseDrawer({
     <div
       className={classNames(
         'fixed z-modal transition-opacity duration-300 ease-in-out',
-        // Sized to the *visual* viewport: iOS never shrinks the layout
-        // viewport for the keyboard, so `inset-0` alone leaves the bottom
-        // actions underneath it.
-        isFullScreen ? 'inset-x-0 top-0 h-full' : 'inset-0',
-        !isFullScreen && 'bg-overlay-quaternary-onion',
+        isFullScreen
+          ? 'inset-x-0 top-0 h-full bg-background-default'
+          : 'inset-0 bg-overlay-quaternary-onion',
         className?.overlay,
         isAnimating && 'opacity-0',
       )}
-      style={keyboardSafeStyle}
+      style={overlayKeyboardStyle}
       onClick={handleOverlayClick}
     >
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
@@ -232,9 +261,16 @@ function BaseDrawer({
         }
         tabIndex={-1}
         onKeyDown={trapFocus}
+        // iOS never shrinks the layout viewport for the keyboard, so the
+        // wrapper is sized to the visual viewport to keep the bottom actions
+        // above it. The height wins over `inset-0`'s bottom edge; without the
+        // inline variable the calc is invalid and `inset-0` takes over.
+        style={wrapperKeyboardStyle}
         className={classNames(
           'drawer-padding absolute flex w-full flex-col overflow-y-auto overscroll-contain bg-background-default transition-transform duration-300 ease-in-out',
-          isFullScreen ? 'inset-0' : 'max-h-[calc(100%-5rem)]',
+          isFullScreen
+            ? 'inset-0 h-[calc(var(--drawer-viewport-height)_-_var(--safe-area-top,0px))]'
+            : 'max-h-[calc(100%-5rem)]',
           !isFullScreen && drawerPositionToClassName[position],
           isAnimating && animatePositionClassName[position],
           !title && 'px-4 pt-3',

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -58,6 +58,16 @@ export interface DrawerOnMobileProps {
   drawerProps?: Omit<DrawerProps, 'children' | 'onClose'>;
 }
 
+// TEMP-DEBUG: persist the readout flag at chunk load, before any client-side
+// navigation drops the query string. Revert before merge.
+try {
+  if (globalThis.window?.location.search.includes('drawerDebug')) {
+    globalThis.window.localStorage.setItem('drawerDebug', '1');
+  }
+} catch {
+  // storage unavailable
+}
+
 // Drawers can stack; the page unlocks only when the last one leaves.
 let scrollLockCount = 0;
 let previousHtmlOverflow = '';
@@ -138,9 +148,6 @@ function BaseDrawer({
       return undefined;
     }
     try {
-      if (window.location.search.includes('drawerDebug')) {
-        window.localStorage.setItem('drawerDebug', '1');
-      }
       if (!window.localStorage.getItem('drawerDebug')) {
         return undefined;
       }
@@ -172,6 +179,8 @@ function BaseDrawer({
           ],
           sy: Math.round(window.scrollY),
           ih: window.innerHeight,
+          underBody: overlay.parentElement === document.body,
+          par: overlay.parentElement?.tagName,
           // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
           bid: (window as any).__NEXT_DATA__?.buildId,
         }),

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -103,14 +103,10 @@ function BaseDrawer({
   const onCloseRef = useRef(onClose);
   onCloseRef.current = onClose;
   const { height: viewportHeight, offsetTop } = useVisualViewport(isFullScreen);
-  // The native iOS shell draws the webview under the status bar and covers
-  // that strip with an opaque `body::before` (safeArea.css), so the overlay
-  // must start below `--safe-area-top` — a plain `top: offsetTop` hides the
-  // drawer header behind the cover, where it cannot be tapped. Feeding the
-  // visual-viewport offset through `--safe-area-top-offset` lets the
-  // safeArea.css rules keep both constraints.
-  // Height is pinned to 100vh (not the safeArea.css calc, which shrinks by
-  // the offset): even mid-pan the opaque cover must reach the keyboard.
+  // safeArea.css owns the top offset (an opaque `body::before` covers the
+  // status bar), so the viewport offset goes through its variable rather
+  // than an inline `top`. Height stays 100vh so the cover reaches the
+  // keyboard even mid-pan.
   const overlayKeyboardStyle =
     isFullScreen && viewportHeight
       ? ({
@@ -118,10 +114,9 @@ function BaseDrawer({
           height: '100vh',
         } as React.CSSProperties)
       : undefined;
-  // Only the wrapper tracks the visual viewport; the overlay keeps its full
-  // layout height so the page never shows through the translucent keyboard.
-  // --keyboard-inset lets content cancel the stale safe-area-inset-bottom
-  // that WKWebView keeps reporting while the keyboard covers it.
+  // Only the wrapper tracks the visual viewport. --keyboard-inset lets
+  // content cancel the safe-area-inset-bottom WKWebView keeps reporting
+  // while the keyboard covers the home indicator.
   const wrapperKeyboardStyle =
     isFullScreen && viewportHeight
       ? ({
@@ -213,10 +208,10 @@ function BaseDrawer({
     };
   }, [isFullScreen]);
 
-  // iOS pans the webview to reveal the focused input when the keyboard
-  // opens — a native scroll the body pin cannot stop (WKWebView extends the
-  // scroll range by the keyboard inset). Undoing it keeps the drawer's
-  // geometry static; the wrapper already keeps the caret above the keyboard.
+  // WKWebView extends the scroll range by the keyboard inset and pans to
+  // reveal the focused input, a native scroll the body pin cannot stop.
+  // Undoing it is safe: the wrapper already keeps the caret above the
+  // keyboard.
   useEffect(() => {
     if (!isFullScreen) {
       return undefined;

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -109,10 +109,13 @@ function BaseDrawer({
   // drawer header behind the cover, where it cannot be tapped. Feeding the
   // visual-viewport offset through `--safe-area-top-offset` lets the
   // safeArea.css rules keep both constraints.
+  // Height is pinned to 100vh (not the safeArea.css calc, which shrinks by
+  // the offset): even mid-pan the opaque cover must reach the keyboard.
   const overlayKeyboardStyle =
     isFullScreen && viewportHeight
       ? ({
           '--safe-area-top-offset': `${offsetTop ?? 0}px`,
+          height: '100vh',
         } as React.CSSProperties)
       : undefined;
   // Only the wrapper tracks the visual viewport; the overlay keeps its full
@@ -201,6 +204,50 @@ function BaseDrawer({
       if (lockedScrollY) {
         window.scrollTo(0, lockedScrollY);
       }
+    };
+  }, [isFullScreen]);
+
+  // iOS pans the webview to reveal the focused input when the keyboard
+  // opens — a native scroll the body pin cannot stop (WKWebView extends the
+  // scroll range by the keyboard inset). Undoing it keeps the drawer's
+  // geometry static; the wrapper already keeps the caret above the keyboard.
+  useEffect(() => {
+    if (!isFullScreen) {
+      return undefined;
+    }
+
+    const undoPan = () => {
+      if (window.scrollY !== 0) {
+        window.scrollTo(0, 0);
+      }
+    };
+    // Touch pans reach the native scroller even from unscrollable content;
+    // block them unless an inner scroller (textarea, drawer body) owns them.
+    const onTouchMove = (e: TouchEvent) => {
+      let el = e.target as HTMLElement | null;
+      while (el && el !== e.currentTarget) {
+        if (el.scrollHeight > el.clientHeight) {
+          const { overflowY } = getComputedStyle(el);
+          if (overflowY === 'auto' || overflowY === 'scroll') {
+            return;
+          }
+        }
+        el = el.parentElement;
+      }
+      e.preventDefault();
+    };
+
+    const overlay = container.current?.parentElement;
+    window.addEventListener('scroll', undoPan);
+    window.visualViewport?.addEventListener('scroll', undoPan);
+    window.visualViewport?.addEventListener('resize', undoPan);
+    overlay?.addEventListener('touchmove', onTouchMove, { passive: false });
+
+    return () => {
+      window.removeEventListener('scroll', undoPan);
+      window.visualViewport?.removeEventListener('scroll', undoPan);
+      window.visualViewport?.removeEventListener('resize', undoPan);
+      overlay?.removeEventListener('touchmove', onTouchMove);
     };
   }, [isFullScreen]);
 

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -353,7 +353,11 @@ function BaseDrawer({
         className?.overlay,
         isAnimating && 'opacity-0',
       )}
-      style={overlayKeyboardStyle}
+      style={
+        debugInfo
+          ? { ...overlayKeyboardStyle, outline: '3px solid lime' }
+          : overlayKeyboardStyle
+      }
       onClick={handleOverlayClick}
     >
       {debugInfo && (

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -58,16 +58,6 @@ export interface DrawerOnMobileProps {
   drawerProps?: Omit<DrawerProps, 'children' | 'onClose'>;
 }
 
-// TEMP-DEBUG: persist the readout flag at chunk load, before any client-side
-// navigation drops the query string. Revert before merge.
-try {
-  if (globalThis.window?.location.search.includes('drawerDebug')) {
-    globalThis.window.localStorage.setItem('drawerDebug', '1');
-  }
-} catch {
-  // storage unavailable
-}
-
 // Drawers can stack; the page unlocks only when the last one leaves.
 let scrollLockCount = 0;
 let previousHtmlOverflow = '';
@@ -140,54 +130,6 @@ function BaseDrawer({
   const [animate] = useDebounceFn(() => setHasAnimated(true), 1);
   const classes = className?.drawer ?? 'px-4 py-3';
   const isAnimating = !hasAnimated || isClosing;
-
-  // TEMP-DEBUG: on-screen geometry readout, revert before merge.
-  const [debugInfo, setDebugInfo] = useState('');
-  useEffect(() => {
-    if (!isFullScreen) {
-      return undefined;
-    }
-    try {
-      if (!window.localStorage.getItem('drawerDebug')) {
-        return undefined;
-      }
-    } catch {
-      return undefined;
-    }
-    const id = setInterval(() => {
-      const wrapper = container.current;
-      const overlay = wrapper?.parentElement;
-      if (!wrapper || !overlay) {
-        return;
-      }
-      const oc = getComputedStyle(overlay);
-      const or = overlay.getBoundingClientRect();
-      const wr = wrapper.getBoundingClientRect();
-      const rootStyle = getComputedStyle(document.documentElement);
-      setDebugInfo(
-        JSON.stringify({
-          oTop: oc.top,
-          oH: oc.height,
-          oRect: [Math.round(or.top), Math.round(or.bottom)],
-          wRect: [Math.round(wr.top), Math.round(wr.bottom)],
-          sat: rootStyle.getPropertyValue('--safe-area-top'),
-          satOff: overlay.style.getPropertyValue('--safe-area-top-offset'),
-          cls: document.documentElement.className,
-          vv: [
-            Math.round(window.visualViewport?.height ?? -1),
-            Math.round(window.visualViewport?.offsetTop ?? -1),
-          ],
-          sy: Math.round(window.scrollY),
-          ih: window.innerHeight,
-          underBody: overlay.parentElement === document.body,
-          par: overlay.parentElement?.tagName,
-          // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
-          bid: (window as any).__NEXT_DATA__?.buildId,
-        }),
-      );
-    }, 700);
-    return () => clearInterval(id);
-  }, [isFullScreen]);
 
   useEffect(() => {
     onAfterOpen?.();
@@ -353,34 +295,9 @@ function BaseDrawer({
         className?.overlay,
         isAnimating && 'opacity-0',
       )}
-      style={
-        debugInfo
-          ? { ...overlayKeyboardStyle, outline: '3px solid lime' }
-          : overlayKeyboardStyle
-      }
+      style={overlayKeyboardStyle}
       onClick={handleOverlayClick}
     >
-      {debugInfo && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 120,
-            left: 8,
-            right: 8,
-            zIndex: 2000,
-            background: '#000',
-            color: '#0f0',
-            fontSize: 11,
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            pointerEvents: 'none',
-            padding: 4,
-          }}
-        >
-          {debugInfo}
-        </div>
-      )}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         {...props}

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -309,10 +309,8 @@ function BaseDrawer({
         }
         tabIndex={-1}
         onKeyDown={trapFocus}
-        // iOS never shrinks the layout viewport for the keyboard, so the
-        // wrapper is sized to the visual viewport to keep the bottom actions
-        // above it. The height wins over `inset-0`'s bottom edge; without the
-        // inline variable the calc is invalid and `inset-0` takes over.
+        // The height below beats `inset-0`'s bottom edge only while this
+        // variable is set; without it the calc is invalid and `inset-0` wins.
         style={wrapperKeyboardStyle}
         className={classNames(
           'drawer-padding absolute flex w-full flex-col overflow-y-auto overscroll-contain bg-background-default transition-transform duration-300 ease-in-out',

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -131,6 +131,55 @@ function BaseDrawer({
   const classes = className?.drawer ?? 'px-4 py-3';
   const isAnimating = !hasAnimated || isClosing;
 
+  // TEMP-DEBUG: on-screen geometry readout, revert before merge.
+  const [debugInfo, setDebugInfo] = useState('');
+  useEffect(() => {
+    if (!isFullScreen) {
+      return undefined;
+    }
+    try {
+      if (window.location.search.includes('drawerDebug')) {
+        window.localStorage.setItem('drawerDebug', '1');
+      }
+      if (!window.localStorage.getItem('drawerDebug')) {
+        return undefined;
+      }
+    } catch {
+      return undefined;
+    }
+    const id = setInterval(() => {
+      const wrapper = container.current;
+      const overlay = wrapper?.parentElement;
+      if (!wrapper || !overlay) {
+        return;
+      }
+      const oc = getComputedStyle(overlay);
+      const or = overlay.getBoundingClientRect();
+      const wr = wrapper.getBoundingClientRect();
+      const rootStyle = getComputedStyle(document.documentElement);
+      setDebugInfo(
+        JSON.stringify({
+          oTop: oc.top,
+          oH: oc.height,
+          oRect: [Math.round(or.top), Math.round(or.bottom)],
+          wRect: [Math.round(wr.top), Math.round(wr.bottom)],
+          sat: rootStyle.getPropertyValue('--safe-area-top'),
+          satOff: overlay.style.getPropertyValue('--safe-area-top-offset'),
+          cls: document.documentElement.className,
+          vv: [
+            Math.round(window.visualViewport?.height ?? -1),
+            Math.round(window.visualViewport?.offsetTop ?? -1),
+          ],
+          sy: Math.round(window.scrollY),
+          ih: window.innerHeight,
+          // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/no-explicit-any
+          bid: (window as any).__NEXT_DATA__?.buildId,
+        }),
+      );
+    }, 700);
+    return () => clearInterval(id);
+  }, [isFullScreen]);
+
   useEffect(() => {
     onAfterOpen?.();
     return () => {
@@ -298,6 +347,27 @@ function BaseDrawer({
       style={overlayKeyboardStyle}
       onClick={handleOverlayClick}
     >
+      {debugInfo && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 120,
+            left: 8,
+            right: 8,
+            zIndex: 2000,
+            background: '#000',
+            color: '#0f0',
+            fontSize: 11,
+            fontFamily: 'monospace',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            pointerEvents: 'none',
+            padding: 4,
+          }}
+        >
+          {debugInfo}
+        </div>
+      )}
       {/* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */}
       <div
         {...props}

--- a/packages/shared/src/components/drawers/Drawer.tsx
+++ b/packages/shared/src/components/drawers/Drawer.tsx
@@ -120,10 +120,16 @@ function BaseDrawer({
       : undefined;
   // Only the wrapper tracks the visual viewport; the overlay keeps its full
   // layout height so the page never shows through the translucent keyboard.
+  // --keyboard-inset lets content cancel the stale safe-area-inset-bottom
+  // that WKWebView keeps reporting while the keyboard covers it.
   const wrapperKeyboardStyle =
     isFullScreen && viewportHeight
       ? ({
           '--drawer-viewport-height': `${viewportHeight}px`,
+          '--keyboard-inset': `${Math.max(
+            0,
+            (globalThis.window?.innerHeight ?? 0) - viewportHeight,
+          )}px`,
         } as React.CSSProperties)
       : undefined;
   const [hasAnimated, setHasAnimated] = useState(instantOpen);

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -5,7 +5,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import React, { forwardRef, useRef, useState } from 'react';
+import React, { forwardRef, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { defaultMarkdownCommands } from '../../../hooks/input';
 import type { RichTextInputRef } from '../RichTextInput';
@@ -122,6 +122,55 @@ export function CommentMarkdownInputComponent(
     ? 'Switch to rich text'
     : 'Switch to Markdown';
 
+  // TEMP-DEBUG: report the composer's dialog ancestry, revert before merge.
+  const debugRef = useRef<HTMLFormElement | null>(null);
+  const [debugInfo, setDebugInfo] = useState('');
+  useEffect(() => {
+    try {
+      if (!window.localStorage.getItem('drawerDebug')) {
+        return undefined;
+      }
+    } catch {
+      return undefined;
+    }
+    const id = setInterval(() => {
+      const el = debugRef.current;
+      if (!el) {
+        return;
+      }
+      const dialog = el.closest<HTMLElement>('[role="dialog"]');
+      const overlay = dialog?.parentElement;
+      const chain: string[] = [];
+      let cur: HTMLElement | null = el.parentElement;
+      while (cur && cur !== document.body && chain.length < 12) {
+        chain.push(
+          cur.tagName +
+            (cur.className && typeof cur.className === 'string'
+              ? `.${cur.className.split(' ').slice(0, 2).join('.')}`
+              : ''),
+        );
+        cur = cur.parentElement;
+      }
+      const rect = el.getBoundingClientRect();
+      setDebugInfo(
+        JSON.stringify({
+          fills,
+          formRect: [Math.round(rect.top), Math.round(rect.bottom)],
+          hasDialog: !!dialog,
+          dialogTop: dialog
+            ? Math.round(dialog.getBoundingClientRect().top)
+            : null,
+          overlayTop: overlay
+            ? Math.round(overlay.getBoundingClientRect().top)
+            : null,
+          overlayCls: overlay?.className?.slice(0, 80),
+          chain,
+        }),
+      );
+    }, 900);
+    return () => clearInterval(id);
+  }, [fills]);
+
   const onSubmitForm: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
 
@@ -170,8 +219,37 @@ export function CommentMarkdownInputComponent(
         className?.container,
       )}
       style={{ maxHeight }}
-      ref={ref}
+      ref={(node) => {
+        debugRef.current = node;
+        if (typeof ref === 'function') {
+          ref(node);
+        } else if (ref) {
+          // eslint-disable-next-line no-param-reassign
+          ref.current = node;
+        }
+      }}
     >
+      {debugInfo && (
+        <div
+          style={{
+            position: 'fixed',
+            top: 430,
+            left: 8,
+            right: 8,
+            zIndex: 2001,
+            background: '#000',
+            color: '#ff0',
+            fontSize: 11,
+            fontFamily: 'monospace',
+            whiteSpace: 'pre-wrap',
+            wordBreak: 'break-all',
+            pointerEvents: 'none',
+            padding: 4,
+          }}
+        >
+          {debugInfo}
+        </div>
+      )}
       <RichTextInput
         inputId={inputId}
         ref={(richTextRefInstance) => {

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -184,8 +184,11 @@ export function CommentMarkdownInputComponent(
           }
         }}
         className={{
+          // `overflow-clip`, not `overflow-hidden`: iOS's caret reveal
+          // scrolls hidden-overflow ancestors programmatically, pushing the
+          // header (with the close button) out of the clipped region.
           container: classNames(
-            '!min-h-0 flex-1 overflow-hidden',
+            '!min-h-0 flex-1 overflow-clip',
             fills
               ? '!rounded-none !bg-transparent'
               : 'border border-border-subtlest-tertiary',

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -5,7 +5,7 @@ import type {
   ReactElement,
   ReactNode,
 } from 'react';
-import React, { forwardRef, useEffect, useRef, useState } from 'react';
+import React, { forwardRef, useRef, useState } from 'react';
 import classNames from 'classnames';
 import { defaultMarkdownCommands } from '../../../hooks/input';
 import type { RichTextInputRef } from '../RichTextInput';
@@ -122,55 +122,6 @@ export function CommentMarkdownInputComponent(
     ? 'Switch to rich text'
     : 'Switch to Markdown';
 
-  // TEMP-DEBUG: report the composer's dialog ancestry, revert before merge.
-  const debugRef = useRef<HTMLFormElement | null>(null);
-  const [debugInfo, setDebugInfo] = useState('');
-  useEffect(() => {
-    try {
-      if (!window.localStorage.getItem('drawerDebug')) {
-        return undefined;
-      }
-    } catch {
-      return undefined;
-    }
-    const id = setInterval(() => {
-      const el = debugRef.current;
-      if (!el) {
-        return;
-      }
-      const dialog = el.closest<HTMLElement>('[role="dialog"]');
-      const overlay = dialog?.parentElement;
-      const chain: string[] = [];
-      let cur: HTMLElement | null = el.parentElement;
-      while (cur && cur !== document.body && chain.length < 12) {
-        chain.push(
-          cur.tagName +
-            (cur.className && typeof cur.className === 'string'
-              ? `.${cur.className.split(' ').slice(0, 2).join('.')}`
-              : ''),
-        );
-        cur = cur.parentElement;
-      }
-      const rect = el.getBoundingClientRect();
-      setDebugInfo(
-        JSON.stringify({
-          fills,
-          formRect: [Math.round(rect.top), Math.round(rect.bottom)],
-          hasDialog: !!dialog,
-          dialogTop: dialog
-            ? Math.round(dialog.getBoundingClientRect().top)
-            : null,
-          overlayTop: overlay
-            ? Math.round(overlay.getBoundingClientRect().top)
-            : null,
-          overlayCls: overlay?.className?.slice(0, 80),
-          chain,
-        }),
-      );
-    }, 900);
-    return () => clearInterval(id);
-  }, [fills]);
-
   const onSubmitForm: FormEventHandler<HTMLFormElement> = async (e) => {
     e.preventDefault();
 
@@ -219,37 +170,8 @@ export function CommentMarkdownInputComponent(
         className?.container,
       )}
       style={{ maxHeight }}
-      ref={(node) => {
-        debugRef.current = node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          // eslint-disable-next-line no-param-reassign
-          ref.current = node;
-        }
-      }}
+      ref={ref}
     >
-      {debugInfo && (
-        <div
-          style={{
-            position: 'fixed',
-            top: 430,
-            left: 8,
-            right: 8,
-            zIndex: 2001,
-            background: '#000',
-            color: '#ff0',
-            fontSize: 11,
-            fontFamily: 'monospace',
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            pointerEvents: 'none',
-            padding: 4,
-          }}
-        >
-          {debugInfo}
-        </div>
-      )}
       <RichTextInput
         inputId={inputId}
         ref={(richTextRefInstance) => {
@@ -297,7 +219,7 @@ export function CommentMarkdownInputComponent(
             <Switch
               inputId="push_notification-switch"
               name="push_notification"
-              className="flex-1"
+              className="min-w-0 flex-1"
               labelClassName="flex-1 font-normal"
               compact={false}
               checked={isEnabled}

--- a/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
+++ b/packages/shared/src/components/fields/MarkdownInput/CommentMarkdownInput.tsx
@@ -185,8 +185,7 @@ export function CommentMarkdownInputComponent(
         }}
         className={{
           // `overflow-clip`, not `overflow-hidden`: iOS's caret reveal
-          // scrolls hidden-overflow ancestors programmatically, pushing the
-          // header (with the close button) out of the clipped region.
+          // scrolls hidden-overflow ancestors programmatically.
           container: classNames(
             '!min-h-0 flex-1 overflow-clip',
             fills

--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -945,9 +945,11 @@ function RichTextInput(
       position={toolbarPosition}
       className={
         // The bar absorbs the device safe area itself; the drawer around it
-        // adds no bottom padding of its own (`!p-0`).
+        // adds no bottom padding of its own (`!p-0`). The keyboard covers the
+        // home indicator but WKWebView keeps reporting its inset, so the
+        // drawer's --keyboard-inset cancels it while the keyboard is up.
         isBottomToolbar
-          ? '!gap-3 !px-5 !pb-[max(1.25rem,env(safe-area-inset-bottom))] !pt-4'
+          ? '!gap-3 !px-5 !pb-[max(1.25rem,calc(env(safe-area-inset-bottom,0px)_-_var(--keyboard-inset,0px)))] !pt-4'
           : undefined
       }
       leadingActions={toolbarLeading}

--- a/packages/shared/src/components/fields/RichTextInput.tsx
+++ b/packages/shared/src/components/fields/RichTextInput.tsx
@@ -945,9 +945,9 @@ function RichTextInput(
       position={toolbarPosition}
       className={
         // The bar absorbs the device safe area itself; the drawer around it
-        // adds no bottom padding of its own (`!p-0`). The keyboard covers the
-        // home indicator but WKWebView keeps reporting its inset, so the
-        // drawer's --keyboard-inset cancels it while the keyboard is up.
+        // adds no bottom padding of its own (`!p-0`). --keyboard-inset
+        // cancels the home-indicator inset WKWebView still reports while the
+        // keyboard covers it.
         isBottomToolbar
           ? '!gap-3 !px-5 !pb-[max(1.25rem,calc(env(safe-area-inset-bottom,0px)_-_var(--keyboard-inset,0px)))] !pt-4'
           : undefined

--- a/packages/shared/src/components/modals/post/SmartComposerModal.tsx
+++ b/packages/shared/src/components/modals/post/SmartComposerModal.tsx
@@ -528,7 +528,7 @@ export function SmartComposerModal({
       inputId="smart_composer-push_notification-switch"
       name="push_notification"
       labelClassName="flex-1 font-normal"
-      className="py-1"
+      className="min-w-0 flex-1 py-1"
       compact={false}
       checked={isEnabled}
       onToggle={onToggle}

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -45,6 +45,7 @@ interface PostCommentsProps {
   removeTopSpacing?: boolean;
   canReply?: MainCommentProps['canReply'];
   onReplyBlocked?: MainCommentProps['onReplyBlocked'];
+  forceInlineComposer?: MainCommentProps['forceInlineComposer'];
   /**
    * Renders after the top-level comment at which the running total of
    * comments — replies included, every comment counts — crosses a multiple
@@ -75,6 +76,7 @@ export function PostComments({
   removeTopSpacing = false,
   canReply,
   onReplyBlocked,
+  forceInlineComposer,
   interleaveEvery,
   renderInterleaved,
 }: PostCommentsProps): ReactElement {
@@ -186,6 +188,7 @@ export function PostComments({
                 lazy={!commentHash && index >= lazyCommentThreshold}
                 canReply={canReply}
                 onReplyBlocked={onReplyBlocked}
+                forceInlineComposer={forceInlineComposer}
               />
               {shouldInterleave &&
                 renderInterleaved(Math.floor(seen / interleaveEvery))}

--- a/packages/shared/src/components/post/composer/TextForm.tsx
+++ b/packages/shared/src/components/post/composer/TextForm.tsx
@@ -217,7 +217,10 @@ export const TextForm = forwardRef<TextFormHandle, TextFormProps>(
           }}
           maxInputLength={BODY_MAX_LENGTH}
           allowBlockFormatting
-          minHeightClassName="min-h-[12rem]"
+          // No fixed floor: `editorBody`'s flex-1 already fills the scroll
+          // window, and a px floor larger than the keyboard-shrunk window
+          // gives an empty editor scroll range (the placeholder slides away).
+          minHeightClassName="min-h-0"
           toolbarPosition="bottom"
           toolbarLeading={toolbarLeading}
           toolbarRightActions={toolbarRightActions}

--- a/packages/shared/src/components/post/composer/TextForm.tsx
+++ b/packages/shared/src/components/post/composer/TextForm.tsx
@@ -217,9 +217,8 @@ export const TextForm = forwardRef<TextFormHandle, TextFormProps>(
           }}
           maxInputLength={BODY_MAX_LENGTH}
           allowBlockFormatting
-          // No fixed floor: `editorBody`'s flex-1 already fills the scroll
-          // window, and a px floor larger than the keyboard-shrunk window
-          // gives an empty editor scroll range (the placeholder slides away).
+          // A px floor taller than the keyboard-shrunk window would give an
+          // empty editor scroll range; `editorBody`'s flex-1 already fills it.
           minHeightClassName="min-h-0"
           toolbarPosition="bottom"
           toolbarLeading={toolbarLeading}

--- a/packages/shared/src/hooks/usePlusSale.spec.tsx
+++ b/packages/shared/src/hooks/usePlusSale.spec.tsx
@@ -6,6 +6,7 @@ import { useAuthContext } from '../contexts/AuthContext';
 import { iOSSupportsPlusPurchase } from '../lib/ios';
 import type { PlusSaleConfig } from '../lib/featureManagement';
 import { featurePlusSale } from '../lib/featureManagement';
+import { oneDay } from '../lib/dateFormat';
 
 jest.mock('./useConditionalFeature', () => ({
   useConditionalFeature: jest.fn(),
@@ -43,7 +44,9 @@ const runningSale: PlusSaleConfig = {
   label: '50% off',
   headline: 'Summer sale: 50% off Plus',
   description: 'Code SUMMER50 is already applied. Offer ends August 31.',
-  endDate: '2026-09-01T00:00:00.000Z',
+  // Relative so the fixture stays a *running* sale; a literal date turns
+  // every test below into a time bomb once it passes.
+  endDate: new Date(Date.now() + oneDay * 1000).toISOString(),
 };
 
 // Mirrors the real hook: the committed default (no discount) is returned until

--- a/packages/storybook/stories/components/comments/CommentInput.stories.tsx
+++ b/packages/storybook/stories/components/comments/CommentInput.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+import { fn } from 'storybook/test';
+import { BootDataProvider } from '@dailydotdev/shared/src/contexts/BootProvider';
+import { BootApp } from '@dailydotdev/shared/src/lib/boot';
+import CommentInput from '@dailydotdev/shared/src/components/comments/CommentInput';
+import post from '@dailydotdev/shared/__tests__/fixture/post';
+import { getBootMock } from '../../../mock/boot';
+
+const meta: Meta<typeof CommentInput> = {
+  title: 'Components/Comments/CommentInput',
+  component: CommentInput,
+  parameters: {
+    viewport: { defaultViewport: 'mobile2' },
+  },
+  render: (props) => {
+    const [queryClient] = useState(() => new QueryClient());
+    const [open, setOpen] = useState(false);
+    if (!document.getElementById('__next')) {
+      const appRoot = document.createElement('div');
+      appRoot.id = '__next';
+      document.body.appendChild(appRoot);
+    }
+    return (
+      <QueryClientProvider client={queryClient}>
+        <BootDataProvider
+          app={BootApp.Webapp}
+          deviceId="123"
+          getPage={fn()}
+          getRedirectUri={fn()}
+          version="pwa"
+          localBootData={getBootMock()}
+        >
+          {open ? (
+            <CommentInput {...props} post={post} onClose={() => setOpen(false)} />
+          ) : (
+            <button type="button" onClick={() => setOpen(true)}>
+              Open composer
+            </button>
+          )}
+        </BootDataProvider>
+      </QueryClientProvider>
+    );
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CommentInput>;
+
+export const NewCommentComposer: Story = {};
+
+export const ReplyComposer: Story = {
+  args: { replyTo: 'database-star', parentCommentId: 'c1' },
+};

--- a/packages/webapp/next.config.ts
+++ b/packages/webapp/next.config.ts
@@ -49,11 +49,6 @@ const noindexHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  // The default buildId is stable across deployments here, so the immutable
-  // /_next/static/<buildId>/_buildManifest.js URL never changes and clients
-  // (the iOS webview above all) keep an eternally stale route manifest,
-  // loading old page chunks on every client-side navigation.
-  generateBuildId: () => process.env.VERCEL_GIT_COMMIT_SHA ?? null,
   transpilePackages: ['@dailydotdev/shared'],
   allowedDevOrigins: ['app.local.fylla.dev', 'app.staging.daily.dev'],
   turbopack: {

--- a/packages/webapp/next.config.ts
+++ b/packages/webapp/next.config.ts
@@ -49,6 +49,11 @@ const noindexHeaders = [
 ];
 
 const nextConfig: NextConfig = {
+  // The default buildId is stable across deployments here, so the immutable
+  // /_next/static/<buildId>/_buildManifest.js URL never changes and clients
+  // (the iOS webview above all) keep an eternally stale route manifest,
+  // loading old page chunks on every client-side navigation.
+  generateBuildId: () => process.env.VERCEL_GIT_COMMIT_SHA ?? null,
   transpilePackages: ['@dailydotdev/shared'],
   allowedDevOrigins: ['app.local.fylla.dev', 'app.staging.daily.dev'],
   turbopack: {


### PR DESCRIPTION
Fixes the mobile composer regressions from #6417 on the native iOS app. Reproduced and verified on an iOS simulator and on a physical iPhone 16 Pro.

## The bugs

1. **Composer header and close button unreachable.** The full-screen drawer's inline visual-viewport style (`top: offsetTop; height: visualViewport.height`) overrode the `safeArea.css` positioning, so the header rendered under the opaque status-bar cover (`body::before`, z-index 1000 vs `z-modal` 100). Hit both the create-post composer and the comment/reply composer.
2. **The page behind kept scrolling.** WebKit's keyboard reveal scroll ignores the `html` overflow lock, and touch pans reach the native scroller even from unscrollable content.
3. **The page showed through the keyboard.** The overlay was sized to the visual viewport, leaving a translucent strip below it.
4. **The comment composer header disappeared after focus.** iOS's caret-reveal scroll moves `overflow: hidden` ancestors programmatically, scrolling the header out of the composer root.
5. **An empty editor was scrollable.** A `min-h-[12rem]` floor exceeded the keyboard-shrunk window, so "Share your thoughts" could be scrolled away on an empty composer.
6. **Toggle labels overflowed off-screen** in the comment composer and the create-post notification row.
7. **A dead gap sat between the action bar and the keyboard.** WKWebView keeps reporting the 34pt `env(safe-area-inset-bottom)` home indicator while the keyboard covers it, so the toolbar padding stacked on top of the keyboard.

## The fix

- **Safe area.** Feed the visual-viewport offset through `--safe-area-top-offset` so the existing `safeArea.css` rules position the overlay below the status bar. The overlay stays at full layout height with an opaque background; only the inner wrapper tracks the visual viewport, so the bottom toolbar sits above the keyboard and nothing shows through it.
- **Scroll lock.** Pin the body (`position: fixed`) while a full-screen drawer is open, removing the scrollable range entirely, and restore the scroll position on close. Undo any native reveal pan (`window.scrollTo(0, 0)` on scroll and visual-viewport events), and block `touchmove` on the overlay unless an inner scroller owns the gesture. Drawer stacking is respected: the page unlocks only when the last drawer leaves.
- **Caret reveal.** Switch the comment composer root to `overflow-clip`, which is unscrollable, so iOS cannot scroll the header away.
- **Empty editor.** Drop the fixed `min-h` floor; `editorBody`'s `flex-1` already fills the scroll window.
- **Keyboard gap.** Expose `--keyboard-inset` from the drawer and subtract it from the toolbar's home-indicator padding, so the frame is an even 20pt on all four sides while typing and only grows to clear the home indicator once the keyboard closes.
- **Toggle wrapping.** `min-w-0 flex-1` on the switches so long labels wrap instead of running off-screen.

## Also folded in (was #6559)

`forceInline` (added in `f05ccf974`) only covered the companion's top-level comment box. The reply and edit flows inside `PostComments` still mounted `CommentInput` without it, so below the Laptop breakpoint, tapping Reply/Edit on an existing comment in the extension sidebar opened the shared full-screen Drawer — covering the host article and scroll-locking the host page, exactly what `forceInline` was meant to prevent. This threads the flag as `forceInlineComposer` from `CompanionDiscussion` through `PostComments` → `MainComment`/`SubComment` to every `CommentInput` mount. Webapp behavior is unchanged: without the flag, the mobile full-screen drawer stays.

## Root cause

Predates the review follow-ups: introduced with the keyboard-safe drawer commit in #6417 itself (`7bdce249c`), not by any later review commit. It only reproduces in the native iOS shell (`:root.ios` sets a non-zero `--safe-area-top`), which is why browser testing missed it. The fix also repairs NavDrawer and every other full-screen drawer that previously relied on the safe-area CSS.

## Tests

New and updated specs on `Drawer` (safe-area custom properties, body pin and restore, reveal-scroll undo), `MainComment` (drawer by default, inline with the flag), plus a `CommentInput` Storybook harness covering the new-comment and reply composers.

## Unrelated CI unblock

`usePlusSale.spec.tsx` pinned its "running sale" fixture to a literal `endDate` of `2026-09-01T00:00:00.000Z`, so the suite started failing on `main` and on every open PR the moment that timestamp passed. The fixture is now relative to `Date.now()`, which is what the surrounding tests already do. Unrelated to the composer work, included here only because it was blocking this PR's checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-composer-layout-bugs-ipho.preview.app.daily.dev
