### PR TITLE
fix(companion): keep reply and edit composers inline in the extension sidebar

### DIFF
--- a/packages/extension/src/companion/CompanionDiscussion.tsx
+++ b/packages/extension/src/companion/CompanionDiscussion.tsx
@@ -59,6 +59,7 @@ export function CompanionDiscussion({
         <PostComments
           post={post}
           origin={Origin.Companion}
+          forceInlineComposer
           onShare={(comment) => openShareComment(comment, post)}
           onClickUpvote={onShowUpvoted}
           modalParentSelector={getCompanionWrapper}

--- a/packages/shared/src/components/comments/MainComment.spec.tsx
+++ b/packages/shared/src/components/comments/MainComment.spec.tsx
@@ -209,6 +209,26 @@ it('should render the comment box', async () => {
   expect(commentBox).toBeInTheDocument();
 });
 
+it('opens the mobile reply composer as a full-screen drawer by default', async () => {
+  mockUseViewSize.mockImplementation(() => false);
+  renderLayout({}, loggedUser);
+  const el = await screen.findByLabelText('Reply');
+  el.click();
+
+  await screen.findAllByRole('textbox');
+  expect(screen.getByRole('dialog')).toBeInTheDocument();
+});
+
+it('keeps the mobile reply composer inline with forceInlineComposer', async () => {
+  mockUseViewSize.mockImplementation(() => false);
+  renderLayout({ forceInlineComposer: true }, loggedUser);
+  const el = await screen.findByLabelText('Reply');
+  el.click();
+
+  await screen.findAllByRole('textbox');
+  expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+});
+
 it('should block the reply composer and call onReplyBlocked when canReply is false', async () => {
   const onReplyBlocked = jest.fn();
   renderLayout({ canReply: false, onReplyBlocked }, loggedUser);

--- a/packages/shared/src/components/comments/MainComment.tsx
+++ b/packages/shared/src/components/comments/MainComment.tsx
@@ -53,6 +53,9 @@ export interface MainCommentProps
    */
   canReply?: boolean;
   onReplyBlocked?: () => void;
+  /** Inline reply/edit composers on small viewports too — the companion must
+   * not cover the host page. */
+  forceInlineComposer?: boolean;
 }
 
 const shouldShowBannerOnComment = (
@@ -77,6 +80,7 @@ export default function MainComment({
   isModalThread = false,
   canReply = true,
   onReplyBlocked,
+  forceInlineComposer = false,
   ...props
 }: MainCommentProps): ReactElement {
   const { user } = useContext(AuthContext);
@@ -210,6 +214,7 @@ export default function MainComment({
         <CommentInput
           {...editProps}
           post={props.post}
+          forceInline={forceInlineComposer}
           onCommented={(...params) => {
             onEdit(null);
             onCommented?.(...params);
@@ -223,6 +228,7 @@ export default function MainComment({
           <CommentInput
             {...replyProps}
             post={props.post}
+            forceInline={forceInlineComposer}
             onCommented={(...params) => {
               onReplyTo(null);
               onCommented?.(...params);
@@ -291,6 +297,7 @@ export default function MainComment({
               extendTopConnector={isModalThread && commentId === comment.id}
               canReply={canReply}
               onReplyBlocked={onReplyBlocked}
+              forceInlineComposer={forceInlineComposer}
             />
           ))}
         </div>

--- a/packages/shared/src/components/comments/SubComment.tsx
+++ b/packages/shared/src/components/comments/SubComment.tsx
@@ -23,6 +23,7 @@ export interface SubCommentProps
   extendTopConnector?: boolean;
   canReply?: boolean;
   onReplyBlocked?: () => void;
+  forceInlineComposer?: boolean;
 }
 
 function SubComment({
@@ -36,6 +37,7 @@ function SubComment({
   extendTopConnector = false,
   canReply = true,
   onReplyBlocked,
+  forceInlineComposer = false,
   ...props
 }: SubCommentProps): ReactElement {
   const { inputProps, commentId, onReplyTo } = useComments(props.post);
@@ -116,6 +118,7 @@ function SubComment({
         <CommentInput
           {...editProps}
           post={props.post}
+          forceInline={forceInlineComposer}
           onCommented={(data, isNew) => {
             onEdit(null);
             onCommented?.(data, isNew);
@@ -130,6 +133,7 @@ function SubComment({
             {...inputProps}
             className={className}
             post={props.post}
+            forceInline={forceInlineComposer}
             onCommented={(...params) => {
               onReplyTo(null);
               onCommented?.(...params);

--- a/packages/shared/src/components/post/PostComments.tsx
+++ b/packages/shared/src/components/post/PostComments.tsx
@@ -45,6 +45,7 @@ interface PostCommentsProps {
   removeTopSpacing?: boolean;
   canReply?: MainCommentProps['canReply'];
   onReplyBlocked?: MainCommentProps['onReplyBlocked'];
+  forceInlineComposer?: MainCommentProps['forceInlineComposer'];
   /**
    * Renders after the top-level comment at which the running total of
    * comments — replies included, every comment counts — crosses a multiple
@@ -75,6 +76,7 @@ export function PostComments({
   removeTopSpacing = false,
   canReply,
   onReplyBlocked,
+  forceInlineComposer,
   interleaveEvery,
   renderInterleaved,
 }: PostCommentsProps): ReactElement {
@@ -186,6 +188,7 @@ export function PostComments({
                 lazy={!commentHash && index >= lazyCommentThreshold}
                 canReply={canReply}
                 onReplyBlocked={onReplyBlocked}
+                forceInlineComposer={forceInlineComposer}
               />
               {shouldInterleave &&
                 renderInterleaved(Math.floor(seen / interleaveEvery))}


### PR DESCRIPTION
Follow-up to #6417: `forceInline` (added in `f05ccf974`) only covered the companion's top-level comment box. The reply and edit flows inside `PostComments` still mounted `CommentInput` without it, so with the browser window below the Laptop breakpoint, tapping Reply/Edit on an existing comment in the extension sidebar opened the shared full-screen Drawer — covering the host article and scroll-locking the host page, exactly what `forceInline` was meant to prevent.

Threads the flag as a prop (`forceInlineComposer`) from `CompanionDiscussion` through `PostComments` → `MainComment`/`SubComment` to every `CommentInput` mount. Webapp behavior is unchanged: without the flag, the mobile full-screen drawer stays.

Tests: new MainComment specs assert the mobile reply composer opens as a drawer by default and stays inline with the flag set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-companion-reply-inline.preview.app.daily.dev