### PR TITLE
fix(post): stop replacing a loaded post with the 404 when a query fails

### DIFF
--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -42,6 +42,7 @@ import {
   mockGraphQL,
 } from '@dailydotdev/shared/__tests__/helpers/graphql';
 import { SourceType } from '@dailydotdev/shared/src/graphql/sources';
+import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import { createTestSettings } from '@dailydotdev/shared/__tests__/fixture/settings';
 import type { AllTagCategoriesData } from '@dailydotdev/shared/src/graphql/feedSettings';
 import {
@@ -1224,5 +1225,45 @@ describe('isPostDetailPath (ad navigation boundary)', () => {
     expect(isPostDetailPath('/posts/upvoted')).toBe(false);
     expect(isPostDetailPath('/posts')).toBe(false);
     expect(isPostDetailPath('/my-feed')).toBe(false);
+  });
+});
+
+describe('post query failures', () => {
+  const createPostErrorMock = (
+    code: ApiError,
+  ): MockedGraphQLResponse<PostData> => ({
+    request: {
+      query: POST_BY_ID_QUERY,
+      variables: { id: '0e4005b2d3cf191f8c44c2718a457a1e' },
+    },
+    result: {
+      errors: [
+        {
+          message: 'Access denied!',
+          extensions: { code },
+        },
+      ] as never,
+    },
+  });
+
+  it('should render the private discussion screen for a forbidden post', async () => {
+    renderPost({}, [
+      createPostErrorMock(ApiError.Forbidden),
+      createCommentsMock(),
+    ]);
+
+    expect(
+      await screen.findByText('Oops! This link leads to a private discussion'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('notFound')).not.toBeInTheDocument();
+  });
+
+  it('should render 404 when the post is missing', async () => {
+    renderPost({}, [
+      createPostErrorMock(ApiError.NotFound),
+      createCommentsMock(),
+    ]);
+
+    expect(await screen.findByTestId('notFound')).toBeInTheDocument();
   });
 });

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -237,9 +237,9 @@ export const PostPage = ({
     },
   });
   const queryClient = useQueryClient();
-  const postError = (
-    isError ? queryClient.getQueryState(getPostByIdKey(id))?.error : undefined
-  ) as unknown as ApiErrorResult;
+  const postError = (isError
+    ? queryClient.getQueryState(getPostByIdKey(id))?.error
+    : undefined) as unknown as ApiErrorResult;
   const isRedesignEligible = isPostRedesignEligible(post);
   const { value: isRedesignFlagOn } = useConditionalFeature({
     feature: featurePostRedesign,

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -52,7 +52,14 @@ import {
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
 import { usePrivateSourceJoin } from '@dailydotdev/shared/src/hooks/source/usePrivateSourceJoin';
-import { ApiError, gqlClient } from '@dailydotdev/shared/src/graphql/common';
+import { useQueryClient } from '@tanstack/react-query';
+import { getPostByIdKey } from '@dailydotdev/shared/src/lib/query';
+import type { ApiErrorResult } from '@dailydotdev/shared/src/graphql/common';
+import {
+  ApiError,
+  getApiError,
+  gqlClient,
+} from '@dailydotdev/shared/src/graphql/common';
 import PostLoadingSkeleton from '@dailydotdev/shared/src/components/post/PostLoadingSkeleton';
 import classNames from 'classnames';
 import { useOnboardingActions } from '@dailydotdev/shared/src/hooks/auth/useOnboardingActions';
@@ -229,6 +236,10 @@ export const PostPage = ({
       retry: false,
     },
   });
+  const queryClient = useQueryClient();
+  const postError = (
+    isError ? queryClient.getQueryState(getPostByIdKey(id))?.error : undefined
+  ) as unknown as ApiErrorResult;
   const isRedesignEligible = isPostRedesignEligible(post);
   const { value: isRedesignFlagOn } = useConditionalFeature({
     feature: featurePostRedesign,
@@ -387,9 +398,15 @@ export const PostPage = ({
   }
 
   const Content = CONTENT_MAP[post?.type];
+  // A post deleted while the page is open still has to disappear, so NOT_FOUND
+  // overrides the cached copy. Any other error leaves the post on screen.
+  const isPostGone = !!getApiError(postError, ApiError.NotFound);
 
-  if (!Content || isError) {
-    if (error === ApiError.Forbidden) {
+  if (!Content || isPostGone) {
+    if (
+      error === ApiError.Forbidden ||
+      getApiError(postError, ApiError.Forbidden)
+    ) {
       return <Unauthorized />;
     }
     return <Custom404 />;


### PR DESCRIPTION
## Changes

Fixes a user-reported bug: *"I try to read post on iOS and get redirected to why are you here page after a minute."*

The post page rendered `Custom404` whenever the post query reported an error — including a **failed background refetch on a page that already had the post loaded and on screen**. A momentary session lapse while reading replaced the post with "Why are you here?".

Two defects, both on the same guard in `pages/posts/[id]/index.tsx`:

- **`isError` covers refetch errors, not just a missing post.** In query-core the `"error"` action sets `status: "error"` unconditionally — that is precisely what `isRefetchError` (`isError && hasData`) is defined as. So a page holding perfectly good data reported `isError === true` after any failed background refetch. The guard now keys off *whether there is a post to render*, plus an explicit `NOT_FOUND` check so a post deleted while the page is open still disappears.
- **The Forbidden branch tested the wrong error.** It read the `error` prop from `getStaticProps`, so a client-side `FORBIDDEN` fell through to the 404 instead of the `<Unauthorized />` "this link leads to a private discussion" screen that exists for exactly that case. The page now also consults the query error.

The client error is read from the query cache (gated on `isError`, which is what re-renders the page) rather than by extending `usePostById` — touching that file would pull its 9 pre-existing strict-type errors into `typecheck_strict_changed`.

### Why a lapsed session produces a hard error

`POST_BY_ID_QUERY` is a two-root document — `post(id)` **and** a sibling `relatedCollectionPosts`. Verified against production from two independent clients (including a fresh anonymous session):

```
{"data":null,"errors":[{"path":["relatedCollectionPosts"],"extensions":{"code":"FORBIDDEN"}}]}
```

`post` resolves fine, but the permission error on the non-nullable sibling **nulls the entire response**. So a request without a valid session doesn't degrade — it takes the whole post down.

Worth noting for a follow-up: `BootProvider` already watches for `FORBIDDEN` and refetches boot to refresh the token, but it never re-runs the failed query. The page had already swapped to the 404, so the user stayed on it even after the session silently recovered. This PR makes that recovery invisible instead of terminal.

### Deliberately not changed

`retry: false` on this query is kept. With the guard fixed it no longer turns a blip into a 404, and retrying would add ~7s of pointless attempts before showing the 404 for a genuinely deleted post.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Reproduced the original bug on a live production post page by driving the post query into an error state — the loaded post was instantly replaced by "Why are you here?". The fixed guard keeps it on screen.

Two regression tests added in `__tests__/PostPage.tsx`, both confirmed to **fail against the old guard**:
- a client-side `FORBIDDEN` renders the private-discussion screen
- a missing post still renders the 404 (guards against over-correcting)

`Tests: 65 passed` across `PostPage` and `PostStaticProps`; lint clean; `typecheck_strict_changed` clean; `next build` type-checks clean.

> [!NOTE]
> One test I wrote for *"keeps the post when a refetch fails"* passed against the broken code too, so I removed it rather than leave false assurance. The jest harness does not propagate a refetch error to the page component when `initialData` is present, and I could not determine why. That behaviour is verified in the live production reproduction above but is **not** covered by a test — worth a follow-up.

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?


### Preview domain
https://claude-ios-404-deeplink-bug-75fd.preview.app.daily.dev