### PR TITLE
fix: wrap long tooltip content

### DIFF
--- a/packages/shared/src/components/VerifiedCompanyUserBadge.tsx
+++ b/packages/shared/src/components/VerifiedCompanyUserBadge.tsx
@@ -37,15 +37,18 @@ export const VerifiedCompanyUserBadge = ({
 
   return (
     <Tooltip
-      content={[
-        `Verified as a ${companies[0].name} employee.`,
-        ...(isVerified
-          ? []
-          : // eslint-disable-next-line react/jsx-key
-            [<br />, 'Get your company badge via account settings.']),
-      ]}
+      content={
+        <div className="min-w-0 text-center">
+          Verified as a {companies[0].name} employee.
+          {!isVerified && (
+            <>
+              <br />
+              Get your company badge via account settings.
+            </>
+          )}
+        </div>
+      }
       side="bottom"
-      className="text-center"
     >
       <div className="flex min-w-0 items-center justify-center gap-1">
         <ProfilePicture

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.spec.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.spec.tsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ReadingStreakPopup } from './ReadingStreakPopup';
+import type { UserStreak } from '../../../graphql/users';
+import { DayOfWeek } from '../../../lib/date';
+
+const mockCompleteAction = jest.fn();
+const mockLogEvent = jest.fn();
+const mockShowPrompt = jest.fn();
+const mockUpdateFlag = jest.fn();
+const mockOnTogglePermission = jest.fn();
+
+jest.mock('next/router', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+jest.mock('./DayStreak', () => ({
+  DayStreak: () => <div data-testid="day-streak" />,
+}));
+
+jest.mock('./StreakFreezeRow', () => ({
+  StreakFreezeRow: () => <div data-testid="streak-freeze-row" />,
+}));
+
+jest.mock('./StreakSection', () => ({
+  StreakSection: ({ label }: { label: string }) => <div>{label}</div>,
+}));
+
+jest.mock('../../tooltip/Tooltip', () => ({
+  Tooltip: ({
+    children,
+    content,
+  }: {
+    children: React.ReactNode;
+    content: React.ReactNode;
+  }) => (
+    <div>
+      <div data-testid="tooltip-content">{content}</div>
+      {children}
+    </div>
+  ),
+}));
+
+jest.mock('../../utilities/Link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => {
+    const ReactMock = jest.requireActual('react') as typeof React;
+
+    if (ReactMock.isValidElement(children)) {
+      return ReactMock.cloneElement(
+        children as React.ReactElement<
+          React.AnchorHTMLAttributes<HTMLAnchorElement>
+        >,
+        { href },
+      );
+    }
+
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  },
+}));
+
+jest.mock('../../../hooks', () => ({
+  useActions: () => ({
+    completeAction: mockCompleteAction,
+  }),
+  useViewSize: () => false,
+  ViewSize: {
+    MobileL: 'MobileL',
+  },
+}));
+
+jest.mock('../../../hooks/streaks/useStreakDays', () => ({
+  getStreak: () => 'pending',
+  getStreakDays: () => [new Date('2026-09-01T00:00:00.000Z')],
+  useReadingStreak30Days: () => [],
+  useStreakFreezeDates: () => [],
+}));
+
+jest.mock('../../../contexts/AuthContext', () => ({
+  useAuthContext: () => ({
+    user: {
+      id: 'u1',
+      timezone: 'America/Argentina/Buenos_Aires',
+    },
+  }),
+}));
+
+jest.mock('../../../hooks/streaks/useStreakTimezoneOk', () => ({
+  useStreakTimezoneOk: () => true,
+}));
+
+jest.mock('../../../hooks/usePrompt', () => ({
+  usePrompt: () => ({
+    showPrompt: mockShowPrompt,
+  }),
+}));
+
+jest.mock('../../../contexts/LogContext', () => ({
+  useLogContext: () => ({
+    logEvent: mockLogEvent,
+  }),
+}));
+
+jest.mock('../../../contexts/SettingsContext', () => ({
+  useSettingsContext: () => ({
+    flags: {},
+    updateFlag: mockUpdateFlag,
+  }),
+}));
+
+jest.mock('../../../hooks/notifications', () => ({
+  usePushNotificationMutation: () => ({
+    onTogglePermission: mockOnTogglePermission,
+    acceptedJustNow: false,
+  }),
+}));
+
+jest.mock('../../../contexts/PushNotificationContext', () => ({
+  usePushNotificationContext: () => ({
+    isSubscribed: true,
+    isInitialized: true,
+    isPushSupported: true,
+  }),
+}));
+
+jest.mock('../../../hooks/usePersistentContext', () => ({
+  __esModule: true,
+  default: () => [false, jest.fn()],
+  PersistentContextKeys: {
+    StreakAlertPushKey: 'StreakAlertPushKey',
+  },
+}));
+
+const streak: UserStreak = {
+  current: 3,
+  max: 7,
+  total: 42,
+  weekStart: DayOfWeek.Monday,
+  lastViewAt: new Date('2026-09-01T00:00:00.000Z'),
+  freezesAvailable: 0,
+};
+
+describe('ReadingStreakPopup', () => {
+  it('renders the timezone tooltip as wrapping prose and truncates long timezone labels', () => {
+    render(<ReadingStreakPopup streak={streak} />);
+
+    const tooltipContent = screen.getByText(
+      /We are showing your reading streak in your selected timezone/,
+    );
+    const timezoneLabel = screen.getByRole('link', {
+      name: 'America/Argentina/Buenos_Aires',
+    });
+
+    expect(tooltipContent).toHaveClass('min-w-0', 'text-center');
+    expect(tooltipContent).not.toHaveClass('flex');
+    expect(timezoneLabel).toHaveClass('min-w-0', 'truncate');
+  });
+});

--- a/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
+++ b/packages/shared/src/components/streak/popup/ReadingStreakPopup.tsx
@@ -162,7 +162,7 @@ export function ReadingStreakPopup({
             <Tooltip
               side="bottom"
               content={
-                <div className="flex text-center">
+                <div className="min-w-0 text-center">
                   {isTimezoneOk ? (
                     <>
                       We are showing your reading streak in your selected
@@ -176,11 +176,11 @@ export function ReadingStreakPopup({
                 </div>
               }
             >
-              <div className="m-auto flex items-center tablet:m-0">
+              <div className="m-auto flex min-w-0 items-center tablet:m-0">
                 {!isTimezoneOk && (
                   <WarningIcon className="text-raw-cheese-40" secondary />
                 )}
-                <div className="flex justify-center font-normal !text-text-quaternary underline decoration-raw-pepper-10 tablet:m-0 tablet:justify-start">
+                <div className="flex min-w-0 justify-center font-normal !text-text-quaternary underline decoration-raw-pepper-10 tablet:m-0 tablet:justify-start">
                   <Link
                     onClick={async (event) => {
                       const deviceTimezone =
@@ -241,7 +241,9 @@ export function ReadingStreakPopup({
                     }}
                     href={timezoneSettingsUrl}
                   >
-                    {isTimezoneOk ? timezone : 'Timezone mismatch'}
+                    <a className="min-w-0 truncate">
+                      {isTimezoneOk ? timezone : 'Timezone mismatch'}
+                    </a>
                   </Link>
                 </div>
               </div>

--- a/packages/shared/src/components/tooltip/Tooltip.spec.tsx
+++ b/packages/shared/src/components/tooltip/Tooltip.spec.tsx
@@ -36,6 +36,33 @@ describe('Tooltip', () => {
     ).toBeInTheDocument();
   });
 
+  it('keeps long multiline content shrinkable within the tooltip width cap', () => {
+    renderTooltip({
+      content: (
+        <div>
+          We are showing your reading streak in your selected timezone.
+          <br />
+          Click to adjust your timezone if needed or traveling.
+        </div>
+      ),
+    });
+
+    const content = screen.getAllByText(
+      /We are showing your reading streak in your selected timezone/,
+    )[0];
+    const tooltip = content.closest('[data-state="instant-open"]');
+
+    expect(tooltip).toHaveClass(
+      'min-w-0',
+      'max-w-[18rem]',
+      'whitespace-normal',
+      'break-words',
+      '[&>*]:min-w-0',
+      '[&>*]:whitespace-normal',
+      '[&>*]:break-words',
+    );
+  });
+
   it('renders the trigger without a tooltip when not visible', () => {
     const { baseElement } = renderTooltip({ visible: false });
     expect(screen.getByRole('button', { name: 'trigger' })).toBeInTheDocument();

--- a/packages/shared/src/components/tooltip/Tooltip.tsx
+++ b/packages/shared/src/components/tooltip/Tooltip.tsx
@@ -70,7 +70,7 @@ export function Tooltip({
             // surface via className; the flex wrapper is a no-op around one item.
             className={classNames(
               styles.TooltipContent,
-              'z-tooltip flex max-w-[18rem] items-center gap-1.5 rounded-8 border border-border-subtlest-tertiary bg-background-subtle px-2 py-1 font-medium text-text-primary shadow-2 typo-caption1',
+              'z-tooltip flex min-w-0 max-w-[18rem] items-center gap-1.5 whitespace-normal break-words rounded-8 border border-border-subtlest-tertiary bg-background-subtle px-2 py-1 font-medium text-text-primary shadow-2 typo-caption1 [&>*]:min-w-0 [&>*]:whitespace-normal [&>*]:break-words',
               className,
             )}
             sideOffset={5}

--- a/packages/storybook/stories/components/Tooltip.stories.tsx
+++ b/packages/storybook/stories/components/Tooltip.stories.tsx
@@ -57,6 +57,20 @@ export const WithCustomContent: Story = {
   },
 };
 
+export const LongMultiLineContent: Story = {
+  args: {
+    content: (
+      <div className="text-center">
+        We are showing your reading streak in your selected timezone.
+        <br />
+        Click to adjust your timezone if needed or traveling.
+      </div>
+    ),
+    open: true,
+    children: <button>Long tooltip content</button>,
+  },
+};
+
 export const Controlled: Story = {
   args: {
     content: 'This tooltip is controlled',


### PR DESCRIPTION
Fixes long and multi-line tooltip copy overflowing the width-capped tooltip surface in the reading streak popup.

Changes:
- Hardened the shared Tooltip surface so capped content remains shrinkable and wraps instead of spilling.
- Reworked the reading streak timezone tooltip and verified company badge tooltip as centered wrapping prose.
- Added RTL regression coverage for the tooltip contract and timezone label truncation, plus a Storybook long multi-line content story.

Key decisions:
- Kept the existing max-w-[18rem] cap; this wraps content instead of widening or truncating it.
- Preserved the existing flex/gap tooltip layout for icon, label, shortcut, and custom tooltip consumers.
- Left full E2E coverage out because there is no authenticated active-streak fixture; validation is covered by targeted tests, shared/webapp test runs, and Storybook build.

Closes ENG-2037

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-2037-feedback-ux-issue-timez.preview.app.daily.dev