### PR TITLE
docs(snapshot): document hot take and reading history share placements

### DIFF
--- a/packages/shared/src/components/history/ReadingHistory.spec.tsx
+++ b/packages/shared/src/components/history/ReadingHistory.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { subDays } from 'date-fns';
 import type { RenderResult } from '@testing-library/react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import nock from 'nock';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { PostItemCardProps } from '../post/PostItemCard';
@@ -197,6 +197,26 @@ describe('PostItemCard component', () => {
       'src',
       defaultHistory.post.source?.image,
     );
+  });
+
+  it('should copy the post link and confirm on the button itself', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    renderCard({ showCopyLink: true });
+
+    fireEvent.click(await screen.findByLabelText('Copy link'));
+
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(post.commentsPermalink),
+    );
+    await screen.findByLabelText('Link copied');
+  });
+
+  it('should not render the copy link button by default', async () => {
+    renderCard();
+    await screen.findByText(postTitle);
+    expect(screen.queryByLabelText('Copy link')).not.toBeInTheDocument();
   });
 
   it('should call onHide on close button clicked', async () => {

--- a/packages/shared/src/components/history/ReadingHistoryList.tsx
+++ b/packages/shared/src/components/history/ReadingHistoryList.tsx
@@ -23,37 +23,43 @@ export default function ReadHistoryList({
     let currentDate: Date;
 
     return data?.pages.map((page, pageIndex) =>
-      page.readHistory.edges.reduce((dom, { node: history }, edgeIndex) => {
-        const { timestamp } = history;
-        const date = new Date(timestamp);
+      page.readHistory.edges.reduce<ReactElement[]>(
+        (dom, { node: history }, edgeIndex) => {
+          const { timestamp } = history;
+          // Optional only because PostItem is shared with surfaces that carry
+          // no timestamp; every reading-history edge has one.
+          const date = new Date(timestamp as Date);
 
-        if (!currentDate || !isDateOnlyEqual(currentDate, date)) {
-          currentDate = date;
+          if (!currentDate || !isDateOnlyEqual(currentDate, date)) {
+            currentDate = date;
+            dom.push(
+              <DateFormat
+                key={date.toISOString()}
+                date={date}
+                type={TimeFormatType.ReadHistory}
+                className="my-3 px-6 text-text-tertiary typo-body first:mt-0"
+              />,
+            );
+          }
+
+          const indexes = { page: pageIndex, edge: edgeIndex };
+
           dom.push(
-            <DateFormat
-              key={date.toISOString()}
-              date={date}
-              type={TimeFormatType.ReadHistory}
-              className="my-3 px-6 text-text-tertiary typo-body first:mt-0"
+            <PostItemCard
+              key={`${history.post.id}-${timestamp}`}
+              postItem={history}
+              indexes={indexes}
+              onHide={(params) => onHide({ ...params, ...indexes })}
+              showVoteActions
+              showCopyLink
+              logOrigin={Origin.History}
             />,
           );
-        }
 
-        const indexes = { page: pageIndex, edge: edgeIndex };
-
-        dom.push(
-          <PostItemCard
-            key={`${history.post.id}-${timestamp}`}
-            postItem={history}
-            indexes={indexes}
-            onHide={(params) => onHide({ ...params, ...indexes })}
-            showVoteActions
-            logOrigin={Origin.History}
-          />,
-        );
-
-        return dom;
-      }, []),
+          return dom;
+        },
+        [],
+      ),
     );
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/shared/src/components/icons/Snapshot/filled.svg
+++ b/packages/shared/src/components/icons/Snapshot/filled.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <title>Icon/Snapshot/Filled</title>
+    <g id="Icon/Snapshot/Filled" fill="none" fill-rule="evenodd">
+        <g stroke="#FFFFFF" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M4.2,8.6 L4.2,6.4 C4.2,5.18497355 5.18497355,4.2 6.4,4.2 L8.6,4.2"></path>
+            <path d="M15.4,4.2 L17.6,4.2 C18.8150264,4.2 19.8,5.18497355 19.8,6.4 L19.8,8.6"></path>
+            <path d="M19.8,15.4 L19.8,17.6 C19.8,18.8150264 18.8150264,19.8 17.6,19.8 L15.4,19.8"></path>
+            <path d="M8.6,19.8 L6.4,19.8 C5.18497355,19.8 4.2,18.8150264 4.2,17.6 L4.2,15.4"></path>
+        </g>
+        <circle fill="#FFFFFF" cx="12" cy="12" r="4"></circle>
+    </g>
+</svg>

--- a/packages/shared/src/components/icons/Snapshot/index.tsx
+++ b/packages/shared/src/components/icons/Snapshot/index.tsx
@@ -1,0 +1,10 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import type { IconProps } from '../../Icon';
+import Icon from '../../Icon';
+import OutlinedIcon from './outlined.svg';
+import FilledIcon from './filled.svg';
+
+export const SnapshotIcon = (props: IconProps): ReactElement => (
+  <Icon {...props} IconPrimary={OutlinedIcon} IconSecondary={FilledIcon} />
+);

--- a/packages/shared/src/components/icons/Snapshot/outlined.svg
+++ b/packages/shared/src/components/icons/Snapshot/outlined.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="24px" height="24px" viewBox="0 0 24 24" version="1.1" xmlns="http://www.w3.org/2000/svg">
+    <title>Icon/Snapshot/Outline</title>
+    <g id="Icon/Snapshot/Outline" stroke="#FFFFFF" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" fill="none" fill-rule="evenodd">
+        <path d="M3.75,9 L3.75,6.25 C3.75,4.86928813 4.86928813,3.75 6.25,3.75 L9,3.75"></path>
+        <path d="M15,3.75 L17.75,3.75 C19.1307119,3.75 20.25,4.86928813 20.25,6.25 L20.25,9"></path>
+        <path d="M20.25,15 L20.25,17.75 C20.25,19.1307119 19.1307119,20.25 17.75,20.25 L15,20.25"></path>
+        <path d="M9,20.25 L6.25,20.25 C4.86928813,20.25 3.75,19.1307119 3.75,17.75 L3.75,15"></path>
+        <circle cx="12" cy="12" r="3.6"></circle>
+    </g>
+</svg>

--- a/packages/shared/src/components/icons/index.ts
+++ b/packages/shared/src/components/icons/index.ts
@@ -150,6 +150,7 @@ export * from './Shortcuts';
 export * from './Sidebar';
 export * from './Sites';
 export * from './Slack';
+export * from './Snapshot';
 export * from './Sort';
 export * from './Source';
 export * from './Sparkle';

--- a/packages/shared/src/components/post/PostItemCard.tsx
+++ b/packages/shared/src/components/post/PostItemCard.tsx
@@ -24,6 +24,8 @@ import { isSourceUserSource } from '../../graphql/sources';
 
 import { ReadingHistoryOptionsMenu } from '../history/ReadingHistoryOptionsMenu';
 import type { QueryIndexes } from '../../hooks/useReadingHistory';
+import { useCopyPostLink } from '../../hooks/useCopyPostLink';
+import { CopyStateIcon } from '../share/CopyStateIcon';
 
 export interface PostItemCardProps {
   className?: string;
@@ -32,6 +34,7 @@ export interface PostItemCardProps {
   clickable?: boolean;
   onHide?: (params: HidePostItemCardProps) => Promise<unknown>;
   showVoteActions?: boolean;
+  showCopyLink?: boolean;
   logOrigin?: Origin;
   indexes?: QueryIndexes;
 }
@@ -48,6 +51,7 @@ export default function PostItemCard({
   onHide,
   className,
   showVoteActions = false,
+  showCopyLink = false,
   logOrigin = Origin.Feed,
   indexes,
 }: PostItemCardProps): ReactElement {
@@ -66,6 +70,7 @@ export default function PostItemCard({
   const isUserSource = isSourceUserSource(source);
 
   const { toggleUpvote, toggleDownvote } = useReadHistoryVotePost();
+  const [copying, copyLink] = useCopyPostLink(post.commentsPermalink);
 
   const classes = classNames(
     'relative flex w-full flex-row py-3 pl-9 pr-5',
@@ -183,6 +188,19 @@ export default function PostItemCard({
                   className="hidden laptop:flex"
                   icon={<XIcon />}
                   onClick={onHideClick}
+                />
+              )}
+              {showButtons && showCopyLink && (
+                <Button
+                  size={ButtonSize.Small}
+                  variant={ButtonVariant.Tertiary}
+                  aria-label={copying ? 'Link copied' : 'Copy link'}
+                  icon={<CopyStateIcon copied={copying} />}
+                  onClick={(e: React.MouseEvent) => {
+                    e.stopPropagation();
+                    e.preventDefault();
+                    copyLink();
+                  }}
                 />
               )}
               {showButtons && (

--- a/packages/shared/src/components/share/CopyStateIcon.tsx
+++ b/packages/shared/src/components/share/CopyStateIcon.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import classNames from 'classnames';
+import { CopyIcon, VIcon } from '../icons';
+import type { IconProps } from '../Icon';
+
+/**
+ * easeOutExpo — the curve the design-system dropdown animates on. It
+ * decelerates into the target with no overshoot, which is what keeps a swap
+ * from reading as a wobble.
+ */
+export const EASE_OUT_EXPO = 'ease-[cubic-bezier(0.16,1,0.3,1)]';
+
+/**
+ * Both glyphs share one grid cell so nothing beside them shifts mid-swap, and
+ * the transition collapses to an instant swap under `prefers-reduced-motion`.
+ */
+export const CopyStateIcon = ({
+  copied,
+  className,
+  ...props
+}: IconProps & { copied: boolean }): ReactElement => {
+  const layer = classNames(
+    className,
+    'col-start-1 row-start-1 transition-[opacity,transform,filter] duration-200 motion-reduce:transition-none',
+    EASE_OUT_EXPO,
+  );
+
+  return (
+    <span className="inline-grid">
+      <CopyIcon
+        {...props}
+        className={classNames(layer, copied && 'scale-50 opacity-0 blur-[2px]')}
+      />
+      <VIcon
+        {...props}
+        secondary
+        className={classNames(
+          layer,
+          'text-status-success',
+          !copied && 'scale-50 opacity-0 blur-[2px]',
+        )}
+      />
+    </span>
+  );
+};

--- a/packages/storybook/stories/features/snapshot/surfaceChrome.tsx
+++ b/packages/storybook/stories/features/snapshot/surfaceChrome.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  LinkIcon,
+  ShareIcon,
+  SnapshotIcon,
+} from '@dailydotdev/shared/src/components/icons';
+
+type LeadAction = 'Link' | 'Snapshot';
+
+export const AVATAR =
+  'https://res.cloudinary.com/daily-now/image/upload/s--O0TOmw4y--/f_auto/v1715772965/public/noProfile';
+
+/* ------------------------------------------------------------------ prose */
+
+const H1 = ({ children }: { children: React.ReactNode }) => (
+  <h1 className="font-bold text-text-primary typo-mega3">{children}</h1>
+);
+
+const P = ({ children }: { children: React.ReactNode }) => (
+  <p className="max-w-[54rem] text-text-secondary typo-body">{children}</p>
+);
+
+const Note = ({ children }: { children: React.ReactNode }) => (
+  <p className="max-w-[54rem] rounded-12 border border-border-subtlest-tertiary bg-surface-float p-4 text-text-secondary typo-callout">
+    {children}
+  </p>
+);
+
+/* ---------------------------------------------------------------- controls */
+
+const ICONS: Record<LeadAction, React.ReactElement> = {
+  Link: <LinkIcon />,
+  Snapshot: <SnapshotIcon />,
+};
+
+const LABELS: Record<LeadAction, string> = {
+  Link: 'Copy link',
+  Snapshot: 'Snapshot',
+};
+
+/**
+ * Inert on purpose: the page compares where a control sits inside a real
+ * screen, not what it does when pressed.
+ */
+export const Control = ({
+  action,
+  className,
+  label,
+  size = ButtonSize.Small,
+  variant = ButtonVariant.Tertiary,
+}: {
+  action: LeadAction;
+  className?: string;
+  label?: boolean;
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+}) => (
+  <Button
+    aria-label={LABELS[action]}
+    className={className}
+    icon={ICONS[action]}
+    size={size}
+    variant={variant}
+  >
+    {label ? LABELS[action] : undefined}
+  </Button>
+);
+
+/* ---------------------------------------------------------- page furniture */
+
+export const OverflowMenu = ({
+  items,
+  highlight,
+  className,
+}: {
+  items: string[];
+  /** The share item, whatever this surface actually calls it. */
+  highlight?: string;
+  className?: string;
+}) => (
+  <div
+    className={`absolute z-20 flex w-56 flex-col rounded-12 border border-border-subtlest-tertiary bg-background-popover p-1 shadow-2 ${
+      className ?? 'right-3 top-10'
+    }`}
+  >
+    {items.map((item) => {
+      const isShare = item === highlight;
+
+      return (
+        <span
+          key={item}
+          className={`flex items-center gap-3 rounded-8 px-3 py-2 typo-callout ${
+            isShare
+              ? 'bg-surface-float font-bold text-text-primary'
+              : 'text-text-tertiary'
+          }`}
+        >
+          {isShare && <ShareIcon />}
+          {item}
+        </span>
+      );
+    })}
+  </div>
+);
+
+export type DeviceName = 'Desktop' | 'Tablet' | 'Mobile';
+
+/** A control that only works at one of these widths is not a recommendation. */
+const DEVICES: Record<DeviceName, { width: number; viewport: string }> = {
+  Desktop: { width: 680, viewport: '1020px and up' },
+  Tablet: { width: 560, viewport: '768px' },
+  Mobile: { width: 375, viewport: '375px' },
+};
+
+/** A surface drawn at one real viewport width, so density is comparable. */
+export const Device = ({
+  name,
+  children,
+}: {
+  name: DeviceName;
+  children: React.ReactNode;
+}) => (
+  <div className="flex shrink-0 flex-col gap-2">
+    <span className="font-bold uppercase text-text-quaternary typo-caption2">
+      {name} · {DEVICES[name].viewport}
+    </span>
+    <div
+      className="relative shrink-0 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-background-default"
+      style={{ width: DEVICES[name].width }}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+/** Devices sit in a scroller rather than wrapping, so widths stay honest. */
+export const Rail = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex w-full items-start gap-6 overflow-x-auto pb-3">
+    {children}
+  </div>
+);
+
+export const Variant = ({
+  step,
+  headline,
+  note,
+  children,
+}: {
+  step: string;
+  headline: string;
+  note: string;
+  children: React.ReactNode;
+}) => (
+  // Full width so a device rail can scroll across the whole canvas.
+  <div className="flex w-full flex-col gap-3">
+    <div className="flex flex-col gap-1">
+      <span className="font-bold uppercase text-text-quaternary typo-caption2">
+        {step}
+      </span>
+      <span className="font-bold text-text-primary typo-callout">
+        {headline}
+      </span>
+      <span className="text-text-tertiary typo-footnote">{note}</span>
+    </div>
+    {children}
+  </div>
+);
+
+export const Category = ({
+  title,
+  covers,
+  verdict,
+  children,
+}: {
+  title: string;
+  covers: string;
+  verdict: string;
+  children: React.ReactNode;
+}) => (
+  <section className="flex flex-col gap-6 border-t border-border-subtlest-tertiary pt-10">
+    <div className="flex flex-col gap-2">
+      <h2 className="font-bold text-text-primary typo-mega3">{title}</h2>
+      <span className="text-text-tertiary typo-footnote">{covers}</span>
+      <p className="max-w-[54rem] text-text-secondary typo-callout">
+        {verdict}
+      </p>
+    </div>
+    <div className="flex flex-col gap-10">{children}</div>
+  </section>
+);
+
+/** Every category page opens with the same header, so they read as a set. */
+export const SurfacePage = ({
+  title,
+  intro,
+  map,
+  children,
+}: {
+  title: string;
+  intro: string;
+  map: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-6 p-8">
+    <div className="flex flex-col gap-3">
+      <H1>{title}</H1>
+      <P>{intro}</P>
+      <Note>{map}</Note>
+    </div>
+    {children}
+  </div>
+);

--- a/packages/storybook/stories/features/snapshot/surfaceChrome.tsx
+++ b/packages/storybook/stories/features/snapshot/surfaceChrome.tsx
@@ -6,7 +6,6 @@ import {
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import {
   LinkIcon,
-  ShareIcon,
   SnapshotIcon,
 } from '@dailydotdev/shared/src/components/icons';
 
@@ -72,41 +71,6 @@ export const Control = ({
 );
 
 /* ---------------------------------------------------------- page furniture */
-
-export const OverflowMenu = ({
-  items,
-  highlight,
-  className,
-}: {
-  items: string[];
-  /** The share item, whatever this surface actually calls it. */
-  highlight?: string;
-  className?: string;
-}) => (
-  <div
-    className={`absolute z-20 flex w-56 flex-col rounded-12 border border-border-subtlest-tertiary bg-background-popover p-1 shadow-2 ${
-      className ?? 'right-3 top-10'
-    }`}
-  >
-    {items.map((item) => {
-      const isShare = item === highlight;
-
-      return (
-        <span
-          key={item}
-          className={`flex items-center gap-3 rounded-8 px-3 py-2 typo-callout ${
-            isShare
-              ? 'bg-surface-float font-bold text-text-primary'
-              : 'text-text-tertiary'
-          }`}
-        >
-          {isShare && <ShareIcon />}
-          {item}
-        </span>
-      );
-    })}
-  </div>
-);
 
 export type DeviceName = 'Desktop' | 'Tablet' | 'Mobile';
 

--- a/packages/storybook/stories/features/snapshot/surfaces/HotTakesAndHistory.stories.tsx
+++ b/packages/storybook/stories/features/snapshot/surfaces/HotTakesAndHistory.stories.tsx
@@ -19,29 +19,23 @@ import {
   Category,
   Control,
   Device,
-  OverflowMenu,
   Rail,
   SurfacePage,
   Variant,
 } from '../surfaceChrome';
 
-/** What ships today, against the placement this page argues for. */
-type Placement = 'today' | 'chosen';
-
-type ScreenProps = { device: DeviceName; placement: Placement };
+type ScreenProps = { device: DeviceName };
 
 const DEVICE_ORDER: DeviceName[] = ['Desktop', 'Tablet', 'Mobile'];
 
 const Rails = ({
   screen: Screen,
-  placement,
 }: {
   screen: React.ComponentType<ScreenProps>;
-  placement: Placement;
 }) => (
   <Rail>
     {DEVICE_ORDER.map((device) => (
-      <Screen key={device} device={device} placement={placement} />
+      <Screen key={device} device={device} />
     ))}
   </Rail>
 );
@@ -54,7 +48,7 @@ const REACTIONS = [
   { glyph: '🔥', label: 'Hot take - upvote', className: '!size-14' },
 ];
 
-const HotTakeModalScreen = ({ device, placement }: ScreenProps) => (
+const HotTakeModalScreen = ({ device }: ScreenProps) => (
   <Device name={device}>
     <div className="flex flex-col bg-background-popover">
       <div className="flex items-center justify-between px-4 py-4">
@@ -92,12 +86,8 @@ const HotTakeModalScreen = ({ device, placement }: ScreenProps) => (
               </span>
               <Control
                 action="Snapshot"
-                label={placement === 'chosen'}
-                variant={
-                  placement === 'chosen'
-                    ? ButtonVariant.Primary
-                    : ButtonVariant.Float
-                }
+                label
+                variant={ButtonVariant.Primary}
               />
             </div>
           </div>
@@ -173,13 +163,7 @@ const TAKES = [
   },
 ];
 
-const HotTakeRow = ({
-  take,
-  placement,
-}: {
-  take: (typeof TAKES)[number];
-  placement: Placement;
-}) => (
+const HotTakeRow = ({ take }: { take: (typeof TAKES)[number] }) => (
   <div className="flex items-center gap-4 rounded-16 bg-surface-float p-4">
     <div className="flex size-12 shrink-0 items-center justify-center rounded-14 bg-overlay-quaternary-cabbage">
       <span className="text-2xl">{take.emoji}</span>
@@ -191,9 +175,7 @@ const HotTakeRow = ({
       <span className="text-text-tertiary typo-footnote">{take.subtitle}</span>
     </div>
     <div className="flex items-center gap-1">
-      {placement === 'chosen' && (
-        <Control action="Snapshot" size={ButtonSize.XSmall} />
-      )}
+      <Control action="Snapshot" size={ButtonSize.XSmall} />
       <Button
         icon={<UpvoteIcon />}
         size={ButtonSize.XSmall}
@@ -205,12 +187,12 @@ const HotTakeRow = ({
   </div>
 );
 
-const HotTakeListScreen = ({ device, placement }: ScreenProps) => (
+const HotTakeListScreen = ({ device }: ScreenProps) => (
   <Device name={device}>
     <div className="flex flex-col gap-3 p-4">
       <span className="font-bold text-text-primary typo-title3">Hot takes</span>
       {TAKES.map((take) => (
-        <HotTakeRow key={take.title} placement={placement} take={take} />
+        <HotTakeRow key={take.title} take={take} />
       ))}
     </div>
   </Device>
@@ -227,13 +209,9 @@ const HISTORY = [
 const HistoryRow = ({
   title,
   device,
-  placement,
-  menuOpen,
 }: {
   title: string;
   device: DeviceName;
-  placement: Placement;
-  menuOpen?: boolean;
 }) => (
   <div className="flex items-center rounded-16 px-2 py-3">
     <div className="relative">
@@ -269,40 +247,25 @@ const HistoryRow = ({
           />
         </>
       )}
-      {placement === 'chosen' && <Control action="Link" />}
-      <div className="relative">
-        <Button
-          aria-label="Options"
-          icon={<MenuIcon />}
-          size={ButtonSize.Small}
-          variant={ButtonVariant.Tertiary}
-        />
-        {menuOpen && (
-          <OverflowMenu
-            className="right-0 top-9"
-            highlight="Share post via..."
-            items={['Share post via...', 'Save to bookmarks', 'Remove post']}
-          />
-        )}
-      </div>
+      <Control action="Link" />
+      <Button
+        aria-label="Options"
+        icon={<MenuIcon />}
+        size={ButtonSize.Small}
+        variant={ButtonVariant.Tertiary}
+      />
     </div>
   </div>
 );
 
-const HistoryScreen = ({ device, placement }: ScreenProps) => (
+const HistoryScreen = ({ device }: ScreenProps) => (
   <Device name={device}>
     <div className="flex flex-col p-4">
       <span className="mb-2 font-bold text-text-primary typo-title3">
         Reading history
       </span>
-      {HISTORY.map((title, index) => (
-        <HistoryRow
-          key={title}
-          device={device}
-          menuOpen={placement === 'today' && index === 0}
-          placement={placement}
-          title={title}
-        />
+      {HISTORY.map((title) => (
+        <HistoryRow key={title} device={device} title={title} />
       ))}
     </div>
   </Device>
@@ -319,63 +282,42 @@ const HotTakesAndHistory = () => (
     <Category
       covers="HotAndColdModal.tsx"
       title="Hot takes — the swipe modal"
-      verdict="Where people actually meet a hot take, and the snapshot already ships on it: top card only, at Float, beside the upvote pill. Decided: promote it to labeled and filled."
+      verdict="Where people actually meet a hot take. The snapshot already ships on it — top card only, at Float, beside the upvote pill — and is promoted here to labeled and filled."
     >
       <Variant
-        headline="Snapshot at Float, beside the pill"
-        note="What ships. Emoji tile, centred Title3, the quote in Body-tertiary, the upvote pill and a bordered author footer, with ❄️ 😐 🔥 and ‘Add your own hot take’ beneath. `isTop` only, so it never renders on the cards stacked behind."
-        step="Today"
-      >
-        <Rails placement="today" screen={HotTakeModalScreen} />
-      </Variant>
-      <Variant
         headline="Snapshot labeled and filled"
-        note="Decided. The card has the width for a label and nothing else in that row competes with it. The trade we accepted: a swipe surface gains a button people are meant to press rather than swipe past."
-        step="Chosen"
+        note="The card has the width for a label and nothing else in that row competes with it. The trade we accepted: a swipe surface gains a button people are meant to press rather than swipe past."
+        step="Shipping"
       >
-        <Rails placement="chosen" screen={HotTakeModalScreen} />
+        <Rails screen={HotTakeModalScreen} />
       </Variant>
     </Category>
 
     <Category
       covers="HotTakeItem.tsx"
       title="Hot takes — the profile list"
-      verdict="The same content in a different frame: an emoji tile, title, subtitle and an upvote counter in a surface-float row. No ⋯ menu and no snapshot, so unlike the modal this list has no share route at all."
+      verdict="The same content in a different frame: an emoji tile, title, subtitle and an upvote counter in a surface-float row. It has no ⋯ menu, so unlike the modal this list had no share route at all."
     >
       <Variant
-        headline="Nothing to share, and no menu to bury it in"
-        note="Edit and delete exist but are owner-only and hover-revealed, so the only control a visitor sees is the upvote."
-        step="Today"
-      >
-        <Rails placement="today" screen={HotTakeListScreen} />
-      </Variant>
-      <Variant
         headline="Snapshot beside the upvote"
-        note="Decided. XSmall to match the upvote counter it sits next to, and placed before it so the count stays at the edge. It produces the card the modal already produces, so this is a placement rather than a new feature."
-        step="Chosen"
+        note="XSmall to match the upvote counter it sits next to, and placed before it so the count stays at the edge. It produces the card the modal already produces, so this is a placement rather than a new feature."
+        step="Shipping"
       >
-        <Rails placement="chosen" screen={HotTakeListScreen} />
+        <Rails screen={HotTakeListScreen} />
       </Variant>
     </Category>
 
     <Category
       covers="PostItemCard.tsx · ReadingHistoryOptionsMenu.tsx"
       title="Reading history"
-      verdict="Each row is just a post, so the payload question never arises — only reach does. Decided: an icon-only copy link, always visible."
+      verdict="Each row is just a post, so the payload question never arises — only reach does. An icon-only copy link, always visible."
     >
       <Variant
-        headline="⋯ → Share post via..."
-        note="A 64px thumbnail with the source avatar overlapping it, a two-line title, then votes and the menu. Sharing is two taps, and the wording differs from every other menu in the product."
-        step="Today"
-      >
-        <Rails placement="today" screen={HistoryScreen} />
-      </Variant>
-      <Variant
         headline="Copy link icon, before the menu"
-        note="Decided, and no label: the row already drops its vote buttons below laptop, and a label would push the title to a third line on mobile. Always visible rather than hover-gated, so it survives touch."
-        step="Chosen"
+        note="No label: the row already drops its vote buttons below laptop, and a label would push the title to a third line on mobile. Always visible rather than hover-gated, so it survives touch."
+        step="Shipping"
       >
-        <Rails placement="chosen" screen={HistoryScreen} />
+        <Rails screen={HistoryScreen} />
       </Variant>
     </Category>
   </SurfacePage>

--- a/packages/storybook/stories/features/snapshot/surfaces/HotTakesAndHistory.stories.tsx
+++ b/packages/storybook/stories/features/snapshot/surfaces/HotTakesAndHistory.stories.tsx
@@ -1,0 +1,392 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  DownvoteIcon,
+  HotIcon,
+  MenuIcon,
+  MiniCloseIcon,
+  ReputationIcon,
+  UpvoteIcon,
+} from '@dailydotdev/shared/src/components/icons';
+import type { DeviceName } from '../surfaceChrome';
+import {
+  AVATAR,
+  Category,
+  Control,
+  Device,
+  OverflowMenu,
+  Rail,
+  SurfacePage,
+  Variant,
+} from '../surfaceChrome';
+
+/** What ships today, against the placement this page argues for. */
+type Placement = 'today' | 'chosen';
+
+type ScreenProps = { device: DeviceName; placement: Placement };
+
+const DEVICE_ORDER: DeviceName[] = ['Desktop', 'Tablet', 'Mobile'];
+
+const Rails = ({
+  screen: Screen,
+  placement,
+}: {
+  screen: React.ComponentType<ScreenProps>;
+  placement: Placement;
+}) => (
+  <Rail>
+    {DEVICE_ORDER.map((device) => (
+      <Screen key={device} device={device} placement={placement} />
+    ))}
+  </Rail>
+);
+
+/* --------------------------------------------------------- the swipe modal */
+
+const REACTIONS = [
+  { glyph: '❄️', label: 'Cold take - downvote', className: '!size-14' },
+  { glyph: '😐', label: 'Skip hot take', className: '!size-12' },
+  { glyph: '🔥', label: 'Hot take - upvote', className: '!size-14' },
+];
+
+const HotTakeModalScreen = ({ device, placement }: ScreenProps) => (
+  <Device name={device}>
+    <div className="flex flex-col bg-background-popover">
+      <div className="flex items-center justify-between px-4 py-4">
+        <span className="font-bold text-text-primary typo-title3">
+          Hot Takes
+        </span>
+        <Button
+          aria-label="Close"
+          icon={<MiniCloseIcon />}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+        />
+      </div>
+
+      <div className="px-4">
+        <div className="flex select-none flex-col rounded-16 border border-border-subtlest-tertiary bg-background-subtle shadow-2">
+          <div className="flex flex-col items-center justify-center gap-3 break-words p-6">
+            <div className="flex size-16 items-center justify-center rounded-16 bg-overlay-quaternary-cabbage text-[2.5rem]">
+              😐
+            </div>
+            <span className="w-full break-words text-center font-bold text-text-primary typo-title3">
+              Most developers have a talent for turning simple problems into
+              overengineered nightmares.
+            </span>
+            <span className="w-full break-words text-center text-text-tertiary typo-body">
+              &ldquo;Simplicity is prerequisite for reliability&rdquo; - Edsger
+              W. Dijkstra
+            </span>
+            <div className="flex items-center gap-2">
+              <span className="flex items-center gap-1 rounded-10 bg-surface-hover px-3 py-1">
+                <HotIcon className="text-accent-cabbage-default" />
+                <span className="font-bold text-text-secondary typo-footnote">
+                  587
+                </span>
+              </span>
+              <Control
+                action="Snapshot"
+                label={placement === 'chosen'}
+                variant={
+                  placement === 'chosen'
+                    ? ButtonVariant.Primary
+                    : ButtonVariant.Float
+                }
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 border-t border-border-subtlest-tertiary p-4">
+            <img
+              alt=""
+              className="size-10 rounded-full object-cover"
+              src={AVATAR}
+            />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="flex min-w-0 items-center gap-1">
+                <span className="min-w-0 truncate font-bold text-text-primary typo-callout">
+                  James Davis
+                </span>
+                <span className="min-w-0 truncate text-text-tertiary typo-footnote">
+                  @jamesdavis7
+                </span>
+              </span>
+              <span className="flex items-center gap-1 text-text-tertiary typo-footnote">
+                <ReputationIcon className="text-accent-onion-default" />
+                11.4K
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-center gap-4 p-4 pt-3">
+        {REACTIONS.map(({ glyph, label, className }) => (
+          <Button
+            key={label}
+            aria-label={label}
+            className={`${className} rounded-full`}
+            icon={
+              <span aria-hidden className="text-[1.375rem] leading-none">
+                {glyph}
+              </span>
+            }
+            size={ButtonSize.Large}
+            variant={ButtonVariant.Float}
+          />
+        ))}
+      </div>
+
+      <div className="px-4 pb-4">
+        <Button
+          className="w-full"
+          size={ButtonSize.Medium}
+          variant={ButtonVariant.Tertiary}
+        >
+          Add your own hot take
+        </Button>
+      </div>
+    </div>
+  </Device>
+);
+
+/* -------------------------------------------------------- the profile list */
+
+const TAKES = [
+  {
+    emoji: '🔥',
+    title: 'Microservices were a mistake for most teams',
+    subtitle: 'Distributed systems are a tax, not a feature',
+    upvotes: 128,
+  },
+  {
+    emoji: '🧊',
+    title: 'Code review is mostly theatre',
+    subtitle: 'Two approvals, forty seconds of reading',
+    upvotes: 64,
+  },
+];
+
+const HotTakeRow = ({
+  take,
+  placement,
+}: {
+  take: (typeof TAKES)[number];
+  placement: Placement;
+}) => (
+  <div className="flex items-center gap-4 rounded-16 bg-surface-float p-4">
+    <div className="flex size-12 shrink-0 items-center justify-center rounded-14 bg-overlay-quaternary-cabbage">
+      <span className="text-2xl">{take.emoji}</span>
+    </div>
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <span className="font-bold text-text-primary typo-body">
+        {take.title}
+      </span>
+      <span className="text-text-tertiary typo-footnote">{take.subtitle}</span>
+    </div>
+    <div className="flex items-center gap-1">
+      {placement === 'chosen' && (
+        <Control action="Snapshot" size={ButtonSize.XSmall} />
+      )}
+      <Button
+        icon={<UpvoteIcon />}
+        size={ButtonSize.XSmall}
+        variant={ButtonVariant.Tertiary}
+      >
+        {take.upvotes}
+      </Button>
+    </div>
+  </div>
+);
+
+const HotTakeListScreen = ({ device, placement }: ScreenProps) => (
+  <Device name={device}>
+    <div className="flex flex-col gap-3 p-4">
+      <span className="font-bold text-text-primary typo-title3">Hot takes</span>
+      {TAKES.map((take) => (
+        <HotTakeRow key={take.title} placement={placement} take={take} />
+      ))}
+    </div>
+  </Device>
+);
+
+/* -------------------------------------------------------- reading history */
+
+const HISTORY = [
+  'Why iconic tech brands lost their dominance',
+  'The case against microservices',
+  'Postgres is all you need, again',
+];
+
+const HistoryRow = ({
+  title,
+  device,
+  placement,
+  menuOpen,
+}: {
+  title: string;
+  device: DeviceName;
+  placement: Placement;
+  menuOpen?: boolean;
+}) => (
+  <div className="flex items-center rounded-16 px-2 py-3">
+    <div className="relative">
+      <div className="size-16 rounded-16 bg-surface-float" />
+      <img
+        alt=""
+        className="absolute -bottom-1 left-6 size-6 rounded-full border-2 border-background-default object-cover"
+        src={AVATAR}
+      />
+    </div>
+    <div className="ml-4 flex min-w-0 flex-1 flex-col">
+      <h3 className="mr-6 line-clamp-2 break-words text-left text-text-primary typo-callout">
+        {title}
+      </h3>
+      <span className="text-text-tertiary typo-footnote">
+        4 min read · 128 upvotes
+      </span>
+    </div>
+    <div className="ml-4 flex items-center">
+      {device === 'Desktop' && (
+        <>
+          <Button
+            aria-label="Upvote"
+            icon={<UpvoteIcon />}
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+          />
+          <Button
+            aria-label="Downvote"
+            icon={<DownvoteIcon />}
+            size={ButtonSize.Small}
+            variant={ButtonVariant.Tertiary}
+          />
+        </>
+      )}
+      {placement === 'chosen' && <Control action="Link" />}
+      <div className="relative">
+        <Button
+          aria-label="Options"
+          icon={<MenuIcon />}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+        />
+        {menuOpen && (
+          <OverflowMenu
+            className="right-0 top-9"
+            highlight="Share post via..."
+            items={['Share post via...', 'Save to bookmarks', 'Remove post']}
+          />
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+const HistoryScreen = ({ device, placement }: ScreenProps) => (
+  <Device name={device}>
+    <div className="flex flex-col p-4">
+      <span className="mb-2 font-bold text-text-primary typo-title3">
+        Reading history
+      </span>
+      {HISTORY.map((title, index) => (
+        <HistoryRow
+          key={title}
+          device={device}
+          menuOpen={placement === 'today' && index === 0}
+          placement={placement}
+          title={title}
+        />
+      ))}
+    </div>
+  </Device>
+);
+
+/* -------------------------------------------------------------------- page */
+
+const HotTakesAndHistory = () => (
+  <SurfacePage
+    intro="A hot take is a self-contained opinion with nowhere to link to, and it appears in two very different frames — the swipe modal and the profile list. A reading-history row is the opposite: a pointer back to a post."
+    map="Sharing map: Snapshot leads on hot takes (#6365) — an opinion is quotable and the row is the whole payload. Copy link leads on reading history (#6361), where each row is just a post."
+    title="Hot takes & reading history"
+  >
+    <Category
+      covers="HotAndColdModal.tsx"
+      title="Hot takes — the swipe modal"
+      verdict="Where people actually meet a hot take, and the snapshot already ships on it: top card only, at Float, beside the upvote pill. Decided: promote it to labeled and filled."
+    >
+      <Variant
+        headline="Snapshot at Float, beside the pill"
+        note="What ships. Emoji tile, centred Title3, the quote in Body-tertiary, the upvote pill and a bordered author footer, with ❄️ 😐 🔥 and ‘Add your own hot take’ beneath. `isTop` only, so it never renders on the cards stacked behind."
+        step="Today"
+      >
+        <Rails placement="today" screen={HotTakeModalScreen} />
+      </Variant>
+      <Variant
+        headline="Snapshot labeled and filled"
+        note="Decided. The card has the width for a label and nothing else in that row competes with it. The trade we accepted: a swipe surface gains a button people are meant to press rather than swipe past."
+        step="Chosen"
+      >
+        <Rails placement="chosen" screen={HotTakeModalScreen} />
+      </Variant>
+    </Category>
+
+    <Category
+      covers="HotTakeItem.tsx"
+      title="Hot takes — the profile list"
+      verdict="The same content in a different frame: an emoji tile, title, subtitle and an upvote counter in a surface-float row. No ⋯ menu and no snapshot, so unlike the modal this list has no share route at all."
+    >
+      <Variant
+        headline="Nothing to share, and no menu to bury it in"
+        note="Edit and delete exist but are owner-only and hover-revealed, so the only control a visitor sees is the upvote."
+        step="Today"
+      >
+        <Rails placement="today" screen={HotTakeListScreen} />
+      </Variant>
+      <Variant
+        headline="Snapshot beside the upvote"
+        note="Decided. XSmall to match the upvote counter it sits next to, and placed before it so the count stays at the edge. It produces the card the modal already produces, so this is a placement rather than a new feature."
+        step="Chosen"
+      >
+        <Rails placement="chosen" screen={HotTakeListScreen} />
+      </Variant>
+    </Category>
+
+    <Category
+      covers="PostItemCard.tsx · ReadingHistoryOptionsMenu.tsx"
+      title="Reading history"
+      verdict="Each row is just a post, so the payload question never arises — only reach does. Decided: an icon-only copy link, always visible."
+    >
+      <Variant
+        headline="⋯ → Share post via..."
+        note="A 64px thumbnail with the source avatar overlapping it, a two-line title, then votes and the menu. Sharing is two taps, and the wording differs from every other menu in the product."
+        step="Today"
+      >
+        <Rails placement="today" screen={HistoryScreen} />
+      </Variant>
+      <Variant
+        headline="Copy link icon, before the menu"
+        note="Decided, and no label: the row already drops its vote buttons below laptop, and a label would push the title to a third line on mobile. Always visible rather than hover-gated, so it survives touch."
+        step="Chosen"
+      >
+        <Rails placement="chosen" screen={HistoryScreen} />
+      </Variant>
+    </Category>
+  </SurfacePage>
+);
+
+const meta: Meta<typeof HotTakesAndHistory> = {
+  title: 'Features/Snapshot/Surfaces/Hot takes & history',
+  component: HotTakesAndHistory,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+export const Variations: StoryObj<typeof HotTakesAndHistory> = {};


### PR DESCRIPTION
One Storybook page — **Features / Snapshot / Surfaces / Hot takes & history** — recording where a share control belongs on the three surfaces that carry a hot take or a reading-history row.

No production surface changes. The controls on the page are inert: it compares placement, not behaviour.

## What it records

Each surface is drawn at desktop, tablet and mobile, with what ships today beside the placement the page argues for.

- **Hot takes — the swipe modal** (`HotAndColdModal.tsx`): where people actually meet a hot take. The snapshot already ships on the top card, at Float beside the upvote pill. Decided: promote it to labeled and filled.
- **Hot takes — the profile list** (`HotTakeItem.tsx`): the same opinion in a different frame, with no ⋯ menu and no share route at all. Decided: snapshot at XSmall, before the upvote counter.
- **Reading history** (`PostItemCard.tsx`): the opposite case — each row is a pointer back to a post, so Copy link leads and the snapshot does not (#6361).

## What comes with it

- `SnapshotIcon` (3 files + one barrel export), which the page draws and which is not yet on `main`. Nothing in production imports it yet.
- `surfaceChrome.tsx`, the shared page furniture for this family of surface pages. It has one consumer today; the sibling pages in #6556 are the rest of the set, so it is deliberately not inlined.

Split out of #6556, which carries the post-page surface and the live capture path.

### Preview domain
https://claude-snapshot-hot-takes-histor.preview.app.daily.dev