### PR TITLE
fix(search): tighten suggestion fetching and caching

### DIFF
--- a/packages/shared/src/components/PostsSearch.tsx
+++ b/packages/shared/src/components/PostsSearch.tsx
@@ -20,7 +20,9 @@ import { useDomPurify } from '../hooks/useDomPurify';
 import type { PopoverContentProps } from './popover/Popover';
 import { PopoverContent } from './popover/Popover';
 import { SearchIcon } from './icons';
-import { StaleTime } from '../lib/query';
+import { generateQueryKey, RequestKey, StaleTime } from '../lib/query';
+import { useAuthContext } from '../contexts/AuthContext';
+import { defaultSearchDebounceMs } from '../lib/func';
 
 const SEARCH_TYPES = {
   searchPostSuggestions: SEARCH_POST_SUGGESTIONS,
@@ -62,6 +64,7 @@ export default function PostsSearch({
   enableSuggestions = true,
 }: PostsSearchProps): ReactElement {
   const { time, contentCurationFilter } = useSearchContextProvider();
+  const { user } = useAuthContext();
   const searchBoxRef = useRef<HTMLDivElement>(null);
   const [query, setQuery] = useState<string>();
   const [items, setItems] = useState<string[]>([]);
@@ -76,11 +79,15 @@ export default function PostsSearch({
   const purify = useDomPurify();
   const [isFocused, setIsFocused] = useState(false);
   const initialQuery = useRef<string>(initialQueryProp || '');
+  // `query` only catches up after the suggestion debounce, so submitting has to
+  // read the raw input value or an early Enter would search for nothing.
+  const typedQuery = useRef<string>(initialQueryProp || '');
 
   const { data: searchResults, isPending } = useQuery<{
     [suggestionType: string]: { hits: { title: string }[] };
   }>({
-    queryKey: [suggestionType, query],
+    // Bookmark and reading-history suggestions are private per user.
+    queryKey: generateQueryKey(RequestKey.Search, user, suggestionType, query),
     queryFn: () =>
       gqlClient.request(SEARCH_URL, { query, version: searchVersion }),
     enabled: !!query && enableSuggestions,
@@ -99,7 +106,7 @@ export default function PostsSearch({
 
   const submitQuery = async (item?: string) => {
     const itemQuery = item?.replace?.(sanitizeSearchTitleMatch, '');
-    await onSubmitQuery(itemQuery || query || '', {
+    await onSubmitQuery(itemQuery || typedQuery.current || '', {
       filters: {
         time: time.toString(),
         contentCuration: contentCurationFilter,
@@ -107,6 +114,7 @@ export default function PostsSearch({
     });
     if (itemQuery) {
       initialQuery.current = itemQuery;
+      typedQuery.current = itemQuery;
     }
 
     setIsFocused(false);
@@ -115,9 +123,11 @@ export default function PostsSearch({
   const { selectedItemIndex, onKeyDown } = useAutoComplete(items, submitQuery);
   const [debounceQuery] = useDebounceFn<string>(
     (value) => setQuery(value),
-    100,
+    defaultSearchDebounceMs,
   );
   const onValueChanged = (value: string) => {
+    typedQuery.current = value;
+
     if (!value.length) {
       setQuery('');
       initialQuery.current = '';

--- a/packages/shared/src/components/search/SearchResults/SearchResultsLayout.spec.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsLayout.spec.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useRouter } from 'next/router';
+import { useSearchProviderSuggestions } from '../../../hooks/search';
+import { useSearchResultsLayout } from '../../../hooks/search/useSearchResultsLayout';
+import { SearchResultsLayout } from './SearchResultsLayout';
+
+jest.mock('../../../hooks/search', () => ({
+  useSearchProviderSuggestions: jest.fn(),
+}));
+
+jest.mock('../../../hooks/search/useSearchResultsLayout', () => ({
+  useSearchResultsLayout: jest.fn(),
+}));
+
+jest.mock('../../../hooks', () => ({
+  useFeedLayout: () => ({ isListMode: true }),
+}));
+
+jest.mock('../../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: jest.fn() }),
+}));
+
+jest.mock('../../utilities', () => ({
+  PageWidgets: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+jest.mock('../../feeds/FeedContainer', () => ({ gapClass: () => '' }));
+
+jest.mock('./SearchResultsTags', () => ({ SearchResultsTags: () => null }));
+jest.mock('./SearchResultsSources', () => ({
+  SearchResultsSources: () => null,
+}));
+jest.mock('./SearchResultsUsers', () => ({ SearchResultsUsers: () => null }));
+jest.mock('../SearchFilterTimeButton', () => () => null);
+jest.mock('../SearchFilterPostTypeButton', () => () => null);
+jest.mock('../../marketing/banners/AskSearchBanner', () => ({
+  AskSearchBanner: () => null,
+}));
+
+const mockedUseSuggestions = useSearchProviderSuggestions as jest.Mock;
+const mockedUseSearchResultsLayout = useSearchResultsLayout as jest.Mock;
+const mockedUseRouter = useRouter as jest.Mock;
+
+const suggestionCallsFor = ({
+  q,
+  isSearchPageLaptop,
+}: {
+  q?: string | string[];
+  isSearchPageLaptop: boolean;
+}) => {
+  mockedUseRouter.mockReturnValue({ query: { q }, push: jest.fn() });
+  mockedUseSearchResultsLayout.mockReturnValue({ isSearchPageLaptop });
+
+  render(
+    <SearchResultsLayout>
+      <div>results</div>
+    </SearchResultsLayout>,
+  );
+
+  return mockedUseSuggestions.mock.calls.map(([args]) => args);
+};
+
+describe('SearchResultsLayout suggestion fetching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSuggestions.mockReturnValue({
+      isLoading: false,
+      suggestions: { hits: [] },
+      queryKey: [],
+    });
+  });
+
+  it('passes an empty query when the route has no search term', () => {
+    const calls = suggestionCallsFor({
+      q: undefined,
+      isSearchPageLaptop: true,
+    });
+
+    expect(calls).toHaveLength(3);
+    calls.forEach((args) => expect(args.query).toBe(''));
+  });
+
+  it('passes the route search term through', () => {
+    const calls = suggestionCallsFor({ q: 'apples', isSearchPageLaptop: true });
+
+    calls.forEach((args) => expect(args.query).toBe('apples'));
+  });
+
+  it('disables the suggestion queries outside the laptop layout', () => {
+    const calls = suggestionCallsFor({
+      q: 'apples',
+      isSearchPageLaptop: false,
+    });
+
+    expect(calls).toHaveLength(3);
+    calls.forEach((args) => expect(args.enabled).toBe(false));
+  });
+});

--- a/packages/shared/src/components/search/SearchResults/SearchResultsLayout.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsLayout.tsx
@@ -29,33 +29,37 @@ export const SearchResultsLayout = (
   const { isSearchPageLaptop } = useSearchResultsLayout();
 
   const {
-    query: { q: query },
+    query: { q },
     push,
   } = useRouter();
   const { logEvent } = useLogContext();
+  const query = typeof q === 'string' ? q : '';
 
   const { isLoading: isTagsLoading, suggestions: suggestedTags } =
     useSearchProviderSuggestions({
-      query: `${query}`,
+      query,
       provider: SearchProviderEnum.Tags,
       limit: 10,
+      enabled: isSearchPageLaptop,
     });
   const tags = suggestedTags?.hits.flatMap(({ id }) => (id ? [id] : [])) ?? [];
 
   const { isLoading: isSourcesLoading, suggestions: suggestedSources } =
     useSearchProviderSuggestions({
-      query: `${query}`,
+      query,
       provider: SearchProviderEnum.Sources,
       limit: 10,
+      enabled: isSearchPageLaptop,
     });
   const sources = suggestedSources?.hits ?? [];
 
   const { isLoading: isUsersLoading, suggestions: suggestedUsers } =
     useSearchProviderSuggestions({
-      query: `${query}`,
+      query,
       provider: SearchProviderEnum.Users,
       limit: 10,
       includeContentPreference: true,
+      enabled: isSearchPageLaptop,
     });
 
   const users = suggestedUsers?.hits ?? [];

--- a/packages/shared/src/components/spotlight/Spotlight.tsx
+++ b/packages/shared/src/components/spotlight/Spotlight.tsx
@@ -459,7 +459,7 @@ export const Spotlight = ({
     },
     [onCommandRun, pushRecent, clearConfirm, onClose],
   );
-  const search = useSpotlightSearchCommands({ router, query });
+  const search = useSpotlightSearchCommands({ router, query, scope });
   useQuickKeyDispatch({
     query,
     setQuery,
@@ -697,6 +697,25 @@ export const Spotlight = ({
     return out;
   }, [isFiltering, grouped, suggested.length, recentCommands.length]);
 
+  const scopeSearch = useMemo(() => {
+    if (scope === SpotlightScope.Posts) {
+      return { commands: search.posts, isLoading: search.postsLoading };
+    }
+    if (scope === SpotlightScope.Squads) {
+      return { commands: search.sources, isLoading: search.sourcesLoading };
+    }
+    if (scope === SpotlightScope.People) {
+      return { commands: search.users, isLoading: search.usersLoading };
+    }
+    return { commands: search.tags, isLoading: search.tagsLoading };
+  }, [scope, search]);
+
+  const hasSearchResults =
+    search.users.length > 0 ||
+    search.sources.length > 0 ||
+    search.tags.length > 0 ||
+    search.posts.length > 0;
+
   const jumpToGroup = useCallback((group: SpotlightGroup) => {
     const heading = document.querySelector(
       `[cmdk-group][data-spotlight-group="${group}"]`,
@@ -906,7 +925,8 @@ export const Spotlight = ({
           >
             {scope !== SpotlightScope.All &&
               scope !== SpotlightScope.Actions &&
-              search.isLoading && (
+              scopeSearch.isLoading &&
+              scopeSearch.commands.length === 0 && (
                 <Command.Group heading={scopeMeta[scope].label}>
                   <SkeletonRows count={4} />
                 </Command.Group>
@@ -914,7 +934,7 @@ export const Spotlight = ({
 
             {scope !== SpotlightScope.All &&
               scope !== SpotlightScope.Actions &&
-              !search.isLoading && (
+              scopeSearch.commands.length > 0 && (
                 <Command.Group
                   heading={scopeMeta[scope].label}
                   data-spotlight-group={SpotlightGroup.Search}
@@ -922,18 +942,7 @@ export const Spotlight = ({
                 >
                   {renderRows({
                     ...commonRowProps,
-                    commands: (() => {
-                      if (scope === SpotlightScope.Posts) {
-                        return search.posts;
-                      }
-                      if (scope === SpotlightScope.Squads) {
-                        return search.sources;
-                      }
-                      if (scope === SpotlightScope.People) {
-                        return search.users;
-                      }
-                      return search.tags;
-                    })(),
+                    commands: scopeSearch.commands,
                   })}
                 </Command.Group>
               )}
@@ -1026,7 +1035,8 @@ export const Spotlight = ({
 
             {scope === SpotlightScope.All &&
               isFiltering &&
-              search.isLoading && (
+              search.isLoading &&
+              !hasSearchResults && (
                 <Command.Group
                   heading="Searching"
                   className={groupHeadingClass}
@@ -1037,7 +1047,6 @@ export const Spotlight = ({
 
             {scope === SpotlightScope.All &&
               isFiltering &&
-              !search.isLoading &&
               search.users.length > 0 && (
                 <Command.Group
                   heading="People"
@@ -1050,7 +1059,6 @@ export const Spotlight = ({
 
             {scope === SpotlightScope.All &&
               isFiltering &&
-              !search.isLoading &&
               search.sources.length > 0 && (
                 <Command.Group
                   heading="Squads & sources"
@@ -1063,7 +1071,6 @@ export const Spotlight = ({
 
             {scope === SpotlightScope.All &&
               isFiltering &&
-              !search.isLoading &&
               search.tags.length > 0 && (
                 <Command.Group
                   heading="Tags"
@@ -1076,7 +1083,6 @@ export const Spotlight = ({
 
             {scope === SpotlightScope.All &&
               isFiltering &&
-              !search.isLoading &&
               search.posts.length > 0 && (
                 <Command.Group
                   heading="Posts"
@@ -1113,32 +1119,34 @@ export const Spotlight = ({
                 </Command.Group>
               )}
 
-            <Command.Empty className="flex flex-col items-center gap-2 py-12 text-center">
-              <SearchIcon
-                size={IconSize.Medium}
-                className="text-text-tertiary"
-                aria-hidden
-              />
-              <p className="text-text-primary typo-callout">
-                {trimmedQuery
-                  ? `Nothing matches "${trimmedQuery}".`
-                  : 'No commands available.'}
-              </p>
-              <p className="text-text-tertiary typo-footnote">
-                Try a different word, or search posts on the web.
-              </p>
-              {trimmedQuery && (
-                <Button
-                  type="button"
-                  variant={ButtonVariant.Primary}
-                  size={ButtonSize.Small}
-                  onClick={handleFallthroughEnter}
-                  icon={<ClickIcon />}
-                >
-                  Search posts for &ldquo;{trimmedQuery}&rdquo;
-                </Button>
-              )}
-            </Command.Empty>
+            {!search.isLoading && (
+              <Command.Empty className="flex flex-col items-center gap-2 py-12 text-center">
+                <SearchIcon
+                  size={IconSize.Medium}
+                  className="text-text-tertiary"
+                  aria-hidden
+                />
+                <p className="text-text-primary typo-callout">
+                  {trimmedQuery
+                    ? `Nothing matches "${trimmedQuery}".`
+                    : 'No commands available.'}
+                </p>
+                <p className="text-text-tertiary typo-footnote">
+                  Try a different word, or search posts on the web.
+                </p>
+                {trimmedQuery && (
+                  <Button
+                    type="button"
+                    variant={ButtonVariant.Primary}
+                    size={ButtonSize.Small}
+                    onClick={handleFallthroughEnter}
+                    icon={<ClickIcon />}
+                  >
+                    Search posts for &ldquo;{trimmedQuery}&rdquo;
+                  </Button>
+                )}
+              </Command.Empty>
+            )}
           </Command.List>
         )}
 

--- a/packages/shared/src/components/spotlight/commands/search.spec.ts
+++ b/packages/shared/src/components/spotlight/commands/search.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../graphql/search';
 import { webappUrl } from '../../../lib/constants';
 import { useSearchProviderSuggestions } from '../../../hooks/search';
+import { SpotlightScope } from '../types';
 import { useSpotlightSearchCommands } from './search';
 
 jest.mock('../../../hooks/search', () => ({
@@ -60,5 +61,85 @@ describe('useSpotlightSearchCommands tag navigation', () => {
     result.current.tags[0].perform();
 
     expect(router.push).toHaveBeenCalledWith(`${webappUrl}tags/c%23`);
+  });
+});
+
+describe('useSpotlightSearchCommands provider fetching', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSuggestions.mockImplementation(() => ({
+      isLoading: false,
+      suggestions: { hits: [] },
+      queryKey: [],
+    }));
+  });
+
+  const enabledProvidersForScope = (scope: SpotlightScope) => {
+    renderHook(() =>
+      useSpotlightSearchCommands({
+        router: { push: jest.fn() },
+        query: 'elixir',
+        scope,
+      }),
+    );
+
+    return Object.fromEntries(
+      mockedUseSuggestions.mock.calls.map(([args]) => [
+        args.provider,
+        args.enabled,
+      ]),
+    );
+  };
+
+  it('fetches every provider in the all scope', () => {
+    expect(enabledProvidersForScope(SpotlightScope.All)).toEqual({
+      [SearchProviderEnum.Posts]: true,
+      [SearchProviderEnum.Tags]: true,
+      [SearchProviderEnum.Sources]: true,
+      [SearchProviderEnum.Users]: true,
+    });
+  });
+
+  it.each<[SpotlightScope, SearchProviderEnum]>([
+    [SpotlightScope.Posts, SearchProviderEnum.Posts],
+    [SpotlightScope.Squads, SearchProviderEnum.Sources],
+    [SpotlightScope.People, SearchProviderEnum.Users],
+    [SpotlightScope.Tags, SearchProviderEnum.Tags],
+  ])('only fetches the provider matching the %s scope', (scope, provider) => {
+    const enabledByProvider = enabledProvidersForScope(scope);
+
+    Object.entries(enabledByProvider).forEach(([current, enabled]) => {
+      expect(enabled).toBe(current === provider);
+    });
+  });
+
+  it('fetches no provider in the actions scope', () => {
+    const enabledByProvider = enabledProvidersForScope(SpotlightScope.Actions);
+
+    Object.values(enabledByProvider).forEach((enabled) => {
+      expect(enabled).toBe(false);
+    });
+  });
+
+  it('reports loading per provider instead of collapsing them', () => {
+    mockedUseSuggestions.mockImplementation(({ provider }) => ({
+      isLoading: provider === SearchProviderEnum.Posts,
+      suggestions: { hits: [] },
+      queryKey: [],
+    }));
+
+    const { result } = renderHook(() =>
+      useSpotlightSearchCommands({
+        router: { push: jest.fn() },
+        query: 'elixir',
+        scope: SpotlightScope.All,
+      }),
+    );
+
+    expect(result.current.postsLoading).toBe(true);
+    expect(result.current.tagsLoading).toBe(false);
+    expect(result.current.sourcesLoading).toBe(false);
+    expect(result.current.usersLoading).toBe(false);
+    expect(result.current.isLoading).toBe(true);
   });
 });

--- a/packages/shared/src/components/spotlight/commands/search.ts
+++ b/packages/shared/src/components/spotlight/commands/search.ts
@@ -19,14 +19,20 @@ import {
 interface SearchCommandsContext {
   router: Pick<NextRouter, 'push'>;
   query: string;
+  scope?: SpotlightScope;
 }
 
 export interface SpotlightSearchCommands {
+  /** True while any provider relevant to the active scope is still loading. */
   isLoading: boolean;
   posts: SpotlightCommand[];
+  postsLoading: boolean;
   tags: SpotlightCommand[];
+  tagsLoading: boolean;
   sources: SpotlightCommand[];
+  sourcesLoading: boolean;
   users: SpotlightCommand[];
+  usersLoading: boolean;
   /** Always-on fallthrough rows, shown even while suggestions are loading. */
   fallthrough: SpotlightCommand[];
 }
@@ -182,31 +188,51 @@ const buildFallthrough = (
   ];
 };
 
+const scopeProviders: Record<SpotlightScope, SearchProviderEnum[]> = {
+  [SpotlightScope.All]: [
+    SearchProviderEnum.Posts,
+    SearchProviderEnum.Tags,
+    SearchProviderEnum.Sources,
+    SearchProviderEnum.Users,
+  ],
+  [SpotlightScope.Actions]: [],
+  [SpotlightScope.Posts]: [SearchProviderEnum.Posts],
+  [SpotlightScope.Squads]: [SearchProviderEnum.Sources],
+  [SpotlightScope.People]: [SearchProviderEnum.Users],
+  [SpotlightScope.Tags]: [SearchProviderEnum.Tags],
+};
+
 export const useSpotlightSearchCommands = ({
   router,
   query,
+  scope = SpotlightScope.All,
 }: SearchCommandsContext): SpotlightSearchCommands => {
   const trimmed = query.trim();
+  const providers = scopeProviders[scope];
 
   const { suggestions: postHits, isLoading: postsLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Posts,
       query: trimmed,
+      enabled: providers.includes(SearchProviderEnum.Posts),
     });
   const { suggestions: tagHits, isLoading: tagsLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Tags,
       query: trimmed,
+      enabled: providers.includes(SearchProviderEnum.Tags),
     });
   const { suggestions: sourceHits, isLoading: sourcesLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Sources,
       query: trimmed,
+      enabled: providers.includes(SearchProviderEnum.Sources),
     });
   const { suggestions: userHits, isLoading: usersLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Users,
       query: trimmed,
+      enabled: providers.includes(SearchProviderEnum.Users),
     });
 
   return useMemo(() => {
@@ -224,26 +250,44 @@ export const useSpotlightSearchCommands = ({
     );
 
     const withSeeAll = (
-      scope: SeeAllScope,
+      seeAllScope: SeeAllScope,
       items: SpotlightCommand[],
     ): SpotlightCommand[] =>
       items.length > 0 && trimmed
-        ? [...items, buildSeeAllCommand(scope, trimmed, router)]
+        ? [...items, buildSeeAllCommand(seeAllScope, trimmed, router)]
         : items;
+
+    const isQueryLongEnough = trimmed.length >= minSearchQueryLength;
+    const loadingFor = (
+      provider: SearchProviderEnum,
+      isProviderLoading: boolean,
+    ) => isQueryLongEnough && providers.includes(provider) && isProviderLoading;
+
+    const isPostsLoading = loadingFor(SearchProviderEnum.Posts, postsLoading);
+    const isTagsLoading = loadingFor(SearchProviderEnum.Tags, tagsLoading);
+    const isSourcesLoading = loadingFor(
+      SearchProviderEnum.Sources,
+      sourcesLoading,
+    );
+    const isUsersLoading = loadingFor(SearchProviderEnum.Users, usersLoading);
 
     return {
       isLoading:
-        trimmed.length >= minSearchQueryLength &&
-        (postsLoading || tagsLoading || sourcesLoading || usersLoading),
+        isPostsLoading || isTagsLoading || isSourcesLoading || isUsersLoading,
       posts: withSeeAll(SpotlightScope.Posts, posts),
+      postsLoading: isPostsLoading,
       tags: withSeeAll(SpotlightScope.Tags, tags),
+      tagsLoading: isTagsLoading,
       sources: withSeeAll(SpotlightScope.Squads, sources),
+      sourcesLoading: isSourcesLoading,
       users: withSeeAll(SpotlightScope.People, users),
+      usersLoading: isUsersLoading,
       fallthrough: buildFallthrough(trimmed, router),
     };
   }, [
     trimmed,
     router,
+    providers,
     postHits,
     postsLoading,
     tagHits,

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -308,7 +308,7 @@ export type SearchSuggestionResult = {
   hits: SearchSuggestion[];
 };
 
-export const minSearchQueryLength = 1;
+export const minSearchQueryLength = 2;
 
 export const sanitizeSearchTitleMatch = /<(\/?)strong>/g;
 

--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.spec.tsx
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.spec.tsx
@@ -112,7 +112,119 @@ describe('useSearchProviderSuggestions hook', () => {
       },
     );
 
-    expect(result.current.isLoading).toBe(true);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.suggestions).toBeUndefined();
+  });
+
+  it('should not request until the debounced query settles', async () => {
+    let emptyQueryCalled = false;
+    let queryCalled = false;
+
+    mockGraphQL({
+      request: {
+        query: SEARCH_POST_SUGGESTIONS,
+        variables: {
+          query: '',
+          version: 2,
+          limit: defaultSearchSuggestionsLimit,
+        },
+      },
+      result: () => {
+        emptyQueryCalled = true;
+
+        return { data: { searchPostSuggestions: { hits: [] } } };
+      },
+    });
+
+    mockGraphQL({
+      request: {
+        query: SEARCH_POST_SUGGESTIONS,
+        variables: {
+          query: 'apples',
+          version: 2,
+          limit: defaultSearchSuggestionsLimit,
+        },
+      },
+      result: () => {
+        queryCalled = true;
+
+        return {
+          data: { searchPostSuggestions: { hits: [{ title: 'Apples' }] } },
+        };
+      },
+    });
+
+    const { rerender } = renderHook(
+      ({ query }: { query: string }) =>
+        useSearchProviderSuggestions({
+          provider: SearchProviderEnum.Posts,
+          query,
+        }),
+      {
+        initialProps: { query: '' },
+        wrapper: Wrapper,
+      },
+    );
+
+    rerender({ query: 'apples' });
+
+    await waitFor(() => expect(queryCalled).toBe(true), { timeout: 3000 });
+
+    expect(emptyQueryCalled).toBe(false);
+  });
+
+  it('should not request when disabled', async () => {
+    let queryCalled = false;
+
+    mockGraphQL({
+      request: {
+        query: SEARCH_POST_SUGGESTIONS,
+        variables: {
+          query: 'apples',
+          version: 2,
+          limit: defaultSearchSuggestionsLimit,
+        },
+      },
+      result: () => {
+        queryCalled = true;
+
+        return { data: { searchPostSuggestions: { hits: [] } } };
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useSearchProviderSuggestions({
+          provider: SearchProviderEnum.Posts,
+          query: 'apples',
+          enabled: false,
+        }),
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 100);
+    });
+
+    expect(queryCalled).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.suggestions).toBeUndefined();
+  });
+
+  it('should include the search version in the query key', () => {
+    const { result } = renderHook(
+      () =>
+        useSearchProviderSuggestions({
+          provider: SearchProviderEnum.Posts,
+          query: 'apples',
+        }),
+      {
+        wrapper: Wrapper,
+      },
+    );
+
+    expect(result.current.queryKey[3]).toMatchObject({ version: 2 });
   });
 });

--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
@@ -20,9 +20,12 @@ import {
   contentPreferenceMutationMatcher,
   mutationKeyToContentPreferenceStatusMap,
 } from '../contentPreference/types';
+import { feature } from '../../lib/featureManagement';
+import { useFeaturesReadyContext } from '../../components/GrowthBookProvider';
 
 export type UseSearchProviderSuggestionsProps = {
   limit?: number;
+  enabled?: boolean;
 } & UseSearchProviderProps;
 
 export type UseSearchProviderSuggestions = {
@@ -40,9 +43,12 @@ export const useSearchProviderSuggestions = ({
   limit = defaultSearchSuggestionsLimit,
   includeContentPreference,
   feedId,
+  enabled = true,
 }: UseSearchProviderSuggestionsProps): UseSearchProviderSuggestions => {
   const { user } = useAuthContext();
   const { getSuggestions } = useSearchProvider();
+  const { getFeatureValue } = useFeaturesReadyContext();
+  const version = getFeatureValue(feature.searchVersion);
   const debouncedQuery = useDebounce(query, defaultSearchDebounceMs);
   const queryKey = generateQueryKey(RequestKey.Search, user, 'suggestions', {
     provider,
@@ -50,9 +56,10 @@ export const useSearchProviderSuggestions = ({
     limit,
     includeContentPreference,
     feedId,
+    version,
   });
 
-  const { data, isPending } = useQuery({
+  const { data, isLoading: isQueryLoading } = useQuery({
     queryKey,
     queryFn: async () => {
       return getSuggestions({
@@ -63,7 +70,8 @@ export const useSearchProviderSuggestions = ({
         feedId,
       });
     },
-    enabled: query?.length >= minSearchQueryLength,
+    enabled: enabled && debouncedQuery?.length >= minSearchQueryLength,
+    placeholderData: keepPreviousData,
     staleTime: StaleTime.Default,
     select: useCallback(
       (currentData: SearchSuggestionResult) => {
@@ -126,8 +134,15 @@ export const useSearchProviderSuggestions = ({
     },
   });
 
+  // The debounce window is part of the wait from the user's point of view, so
+  // report it as loading to avoid an empty-state flash before the fetch starts.
+  const isDebouncePending =
+    enabled &&
+    query !== debouncedQuery &&
+    query?.length >= minSearchQueryLength;
+
   return {
-    isLoading: isPending,
+    isLoading: isQueryLoading || isDebouncePending,
     suggestions: data,
     queryKey,
   };


### PR DESCRIPTION
## What

Fixes a set of correctness and performance issues in the search suggestion frontend.

- **Empty-query requests.** `useSearchProviderSuggestions` gated `enabled` on the raw query while the request body used the debounced one, so every provider fired a request with an empty query on the first keystroke and again once the debounce settled. Both the gate and the min-length check now read the debounced value.
- **`"undefined"` searches and hidden mobile requests.** `SearchResultsLayout` built its query with a template literal over `router.query.q`, producing the literal string `"undefined"` when the param was missing. It also ran three suggestion queries before the mobile early return, so mobile fetched results that were never rendered. The query is now derived safely and the three queries are disabled outside the laptop layout (hooks stay unconditional).
- **Full-list flicker in Spotlight.** All four providers' loading states were OR'd into one flag and every result group was gated on it, so each keystroke collapsed the whole list into a skeleton until the slowest provider resolved. Loading is now reported per provider, each group renders as soon as its own results land, and `placeholderData: keepPreviousData` keeps previous hits visible while refetching. The skeleton only shows when nothing has landed yet, and the no-results state waits for every provider to settle.
- **Scope now narrows network work.** Spotlight passes its active scope down, so only the providers relevant to that scope fetch (All still fetches all four, Actions fetches none).
- **Cache key.** The `searchVersion` feature value is sent with the request but was missing from the query key, so results fetched before GrowthBook loaded shared a key with correct-version results for the whole stale window. It is part of the key now.
- **`minSearchQueryLength`** raised from 1 to 2 to match the backend guard.
- **Legacy `PostsSearch`.** The suggestion query key was not user scoped even though bookmark and reading-history suggestions are private per user; it now goes through `generateQueryKey`. Its debounce was aligned to the shared default, and submission reads the raw input value so pressing Enter before the debounce settles still searches for what was typed.

## Testing

- `pnpm --filter shared test`: 368 suites, 2675 tests passing
- `pnpm --filter webapp test`: 81 suites, 648 tests passing
- `node ./scripts/typecheck-strict-changed.js` and a full `pnpm --filter webapp typecheck` (remaining errors there are pre-existing, in unrelated test files)
- `pnpm --filter shared lint`

New coverage: debounced-gate and disabled-query behavior plus the version in the cache key, per-scope provider fetching and per-provider loading in the spotlight commands, and query derivation and mobile gating in `SearchResultsLayout`.

### Preview domain
https://fix-search-suggestions-orchestra.preview.app.daily.dev