### PR TITLE
fix: restore hot take creation affordance

### DIFF
--- a/packages/shared/src/features/profile/components/hotTakes/HotTakeItem.tsx
+++ b/packages/shared/src/features/profile/components/hotTakes/HotTakeItem.tsx
@@ -70,9 +70,10 @@ function HotTakeItemV1({
       </div>
       <div className="flex items-center gap-1">
         {isOwner && (
-          <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <div className="flex gap-1">
             {onEdit && (
               <Button
+                type="button"
                 variant={ButtonVariant.Tertiary}
                 size={ButtonSize.XSmall}
                 icon={<EditIcon />}
@@ -82,6 +83,7 @@ function HotTakeItemV1({
             )}
             {onDelete && (
               <Button
+                type="button"
                 variant={ButtonVariant.Tertiary}
                 size={ButtonSize.XSmall}
                 icon={<TrashIcon />}

--- a/packages/shared/src/features/profile/components/hotTakes/HotTakeItem.v2.tsx
+++ b/packages/shared/src/features/profile/components/hotTakes/HotTakeItem.v2.tsx
@@ -66,9 +66,10 @@ export function HotTakeItem({
       </div>
       <div className="flex items-center gap-1">
         {isOwner && (
-          <div className="flex gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <div className="flex gap-1">
             {onEdit && (
               <ButtonV2
+                type="button"
                 variant={ButtonVariant.Tertiary}
                 size={ButtonSize.XSmall}
                 icon={<EditIcon />}
@@ -78,6 +79,7 @@ export function HotTakeItem({
             )}
             {onDelete && (
               <ButtonV2
+                type="button"
                 variant={ButtonVariant.Tertiary}
                 size={ButtonSize.XSmall}
                 icon={<TrashIcon />}

--- a/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.spec.tsx
+++ b/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.spec.tsx
@@ -1,20 +1,28 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import type { PublicProfile } from '../../../../lib/user';
 import type { HotTake } from '../../../../graphql/user/userHotTake';
-import { useHotTakes } from '../../hooks/useHotTakes';
+import {
+  HOT_TAKE_LIMIT_REACHED_MESSAGE,
+  MAX_HOT_TAKES,
+  useHotTakes,
+} from '../../hooks/useHotTakes';
 import { useToastNotification } from '../../../../hooks/useToastNotification';
 import { usePrompt } from '../../../../hooks/usePrompt';
 import { useVoteHotTake } from '../../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../../contexts/LogContext';
 import { LogEvent } from '../../../../lib/log';
+import { useEngagementBarV2 } from '../../../../hooks/useEngagementBarV2';
 import { ProfileUserHotTakes } from './ProfileUserHotTakes';
 
 jest.mock('../../hooks/useHotTakes', () => ({
   HOT_TAKE_LIMIT_REACHED_MESSAGE:
     'You already have all 5 hot takes. Remove one to add a new one.',
+  MAX_HOT_TAKES: 5,
   useHotTakes: jest.fn(),
 }));
 
@@ -35,14 +43,12 @@ jest.mock('../../../../contexts/LogContext', () => ({
   useLogContext: jest.fn(),
 }));
 
-jest.mock('./HotTakeModal', () => ({
-  HotTakeModal: () => <div data-testid="hot-take-modal" />,
+jest.mock('../../../../hooks/useEngagementBarV2', () => ({
+  useEngagementBarV2: jest.fn(),
 }));
 
-jest.mock('./HotTakeItem', () => ({
-  HotTakeItem: ({ item }: { item: { title: string } }) => (
-    <div>{item.title}</div>
-  ),
+jest.mock('./HotTakeModal', () => ({
+  HotTakeModal: () => <div data-testid="hot-take-modal" />,
 }));
 
 const mockedUseRouter = useRouter as jest.Mock;
@@ -51,6 +57,7 @@ const mockedUseToastNotification = useToastNotification as jest.Mock;
 const mockedUsePrompt = usePrompt as jest.Mock;
 const mockedUseVoteHotTake = useVoteHotTake as jest.Mock;
 const mockedUseLogContext = useLogContext as jest.Mock;
+const mockedUseEngagementBarV2 = useEngagementBarV2 as jest.Mock;
 
 const user: PublicProfile = {
   id: 'user-1',
@@ -86,6 +93,35 @@ const mockRouter = (query: NextRouter['query'] = {}) => {
   return { replace };
 };
 
+const renderProfileUserHotTakes = () =>
+  render(
+    <QueryClientProvider client={new QueryClient()}>
+      <ProfileUserHotTakes user={user} />
+    </QueryClientProvider>,
+  );
+
+const mockHotTakes = ({
+  hotTakes = [],
+  isOwner = true,
+  canAddMore = true,
+  isLoading = false,
+}: {
+  hotTakes?: HotTake[];
+  isOwner?: boolean;
+  canAddMore?: boolean;
+  isLoading?: boolean;
+} = {}) => {
+  mockedUseHotTakes.mockReturnValue({
+    hotTakes,
+    isOwner,
+    canAddMore,
+    isLoading,
+    add: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  });
+};
+
 describe('ProfileUserHotTakes', () => {
   const displayToast = jest.fn();
   const logEvent = jest.fn();
@@ -107,15 +143,8 @@ describe('ProfileUserHotTakes', () => {
     mockedUseLogContext.mockReturnValue({
       logEvent,
     });
-    mockedUseHotTakes.mockReturnValue({
-      hotTakes: [],
-      isOwner: true,
-      canAddMore: true,
-      isLoading: false,
-      add: jest.fn(),
-      update: jest.fn(),
-      remove: jest.fn(),
-    });
+    mockedUseEngagementBarV2.mockReturnValue(false);
+    mockHotTakes();
   });
 
   it('should open the add hot take modal from the profile query param', async () => {
@@ -125,7 +154,7 @@ describe('ProfileUserHotTakes', () => {
       addHotTake: '1',
     });
 
-    render(<ProfileUserHotTakes user={user} />);
+    renderProfileUserHotTakes();
 
     expect(await screen.findByTestId('hot-take-modal')).toBeVisible();
     expect(logEvent).toHaveBeenCalledWith({
@@ -144,28 +173,122 @@ describe('ProfileUserHotTakes', () => {
       userId: 'tester',
       addHotTake: '1',
     });
-    mockedUseHotTakes.mockReturnValue({
+    mockHotTakes({
       hotTakes: Array.from({ length: 5 }, (_, index) =>
         createHotTake(index + 1),
       ),
       isOwner: true,
       canAddMore: false,
       isLoading: false,
-      add: jest.fn(),
-      update: jest.fn(),
-      remove: jest.fn(),
     });
 
-    render(<ProfileUserHotTakes user={user} />);
+    renderProfileUserHotTakes();
 
     await waitFor(() => {
-      expect(displayToast).toHaveBeenCalledWith(
-        'You already have all 5 hot takes. Remove one to add a new one.',
-      );
+      expect(displayToast).toHaveBeenCalledWith(HOT_TAKE_LIMIT_REACHED_MESSAGE);
     });
     expect(screen.queryByTestId('hot-take-modal')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
     expect(replace).toHaveBeenCalledWith('/tester#hot-takes', undefined, {
       shallow: true,
     });
+  });
+
+  it('shows a disabled add control and cap copy for owners at the limit', () => {
+    mockHotTakes({
+      hotTakes: Array.from({ length: MAX_HOT_TAKES }, (_, index) =>
+        createHotTake(index + 1),
+      ),
+      canAddMore: false,
+    });
+
+    renderProfileUserHotTakes();
+
+    expect(screen.getByText(`${MAX_HOT_TAKES}/${MAX_HOT_TAKES}`)).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Add' })).toBeDisabled();
+    expect(screen.getByLabelText(HOT_TAKE_LIMIT_REACHED_MESSAGE)).toBeVisible();
+  });
+
+  it('does not open the modal or log a start event from the disabled add control', async () => {
+    mockHotTakes({
+      hotTakes: Array.from({ length: MAX_HOT_TAKES }, (_, index) =>
+        createHotTake(index + 1),
+      ),
+      canAddMore: false,
+    });
+
+    renderProfileUserHotTakes();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(screen.queryByTestId('hot-take-modal')).not.toBeInTheDocument();
+    expect(logEvent).not.toHaveBeenCalledWith({
+      event_name: LogEvent.StartAddHotTake,
+    });
+  });
+
+  it('opens the modal and logs a start event from the enabled add control', async () => {
+    mockHotTakes({
+      hotTakes: [createHotTake(1), createHotTake(2), createHotTake(3)],
+      canAddMore: true,
+    });
+
+    renderProfileUserHotTakes();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    expect(screen.getByTestId('hot-take-modal')).toBeVisible();
+    expect(logEvent).toHaveBeenCalledWith({
+      event_name: LogEvent.StartAddHotTake,
+    });
+  });
+
+  it('does not show owner-only controls or the cap indicator for visitors', () => {
+    mockHotTakes({
+      hotTakes: [createHotTake(1)],
+      isOwner: false,
+    });
+
+    renderProfileUserHotTakes();
+
+    expect(
+      screen.queryByRole('button', { name: 'Add' }),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(`1/${MAX_HOT_TAKES}`)).not.toBeInTheDocument();
+    expect(screen.getByText('Hot take 1')).toBeVisible();
+  });
+
+  it('renders the hot takes anchor while loading for visitors', () => {
+    mockHotTakes({
+      isOwner: false,
+      isLoading: true,
+    });
+
+    renderProfileUserHotTakes();
+
+    expect(document.getElementById('hot-takes')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['v1', false],
+    ['v2', true],
+  ])('keeps owner item controls visible without hover in %s', (_, useV2) => {
+    mockedUseEngagementBarV2.mockReturnValue(useV2);
+    mockHotTakes({
+      hotTakes: [createHotTake(1)],
+    });
+
+    renderProfileUserHotTakes();
+
+    const editButton = screen.getByRole('button', { name: 'Edit hot take' });
+    const deleteButton = screen.getByRole('button', {
+      name: 'Delete hot take',
+    });
+    const controls = editButton.parentElement;
+
+    expect(editButton).toBeVisible();
+    expect(deleteButton).toBeVisible();
+    expect(controls).not.toHaveClass('opacity-0');
+    expect(controls).not.toHaveClass('group-hover:opacity-100');
   });
 });

--- a/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.tsx
+++ b/packages/shared/src/features/profile/components/hotTakes/ProfileUserHotTakes.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import type { PublicProfile } from '../../../../lib/user';
 import {
   HOT_TAKE_LIMIT_REACHED_MESSAGE,
+  MAX_HOT_TAKES,
   useHotTakes,
 } from '../../hooks/useHotTakes';
 import {
@@ -28,6 +29,7 @@ import { usePrompt } from '../../../../hooks/usePrompt';
 import { useVoteHotTake } from '../../../../hooks/vote/useVoteHotTake';
 import { useLogContext } from '../../../../contexts/LogContext';
 import { LogEvent, Origin } from '../../../../lib/log';
+import { Tooltip } from '../../../../components/tooltip/Tooltip';
 import {
   HOT_TAKES_ANCHOR,
   isOpenAddHotTakeQuery,
@@ -179,33 +181,65 @@ export function ProfileUserHotTakes({
     [toggleUpvote],
   );
 
-  const hasItems = hotTakes.length > 0;
+  const hotTakeCount = hotTakes.length;
+  const hasItems = hotTakeCount > 0;
+  const hotTakesAnchor = (
+    // eslint-disable-next-line jsx-a11y/anchor-has-content
+    <a id={HOT_TAKES_ANCHOR} />
+  );
 
   if (!hasItems && !isOwner) {
-    return null;
+    return hotTakesAnchor;
   }
 
   return (
     <div className="flex flex-col gap-4 py-4">
-      {/* eslint-disable-next-line jsx-a11y/anchor-has-content */}
-      <a id={HOT_TAKES_ANCHOR} />
+      {hotTakesAnchor}
       <div className="flex items-center justify-between">
-        <Typography
-          type={TypographyType.Body}
-          color={TypographyColor.Primary}
-          bold
-        >
-          Hot Takes
-        </Typography>
-        {isOwner && canAddMore && (
-          <Button
-            variant={ButtonVariant.Tertiary}
-            size={ButtonSize.Small}
-            icon={<PlusIcon />}
-            onClick={handleOpenModal}
+        {isOwner ? (
+          <div className="flex items-center gap-2">
+            <Typography
+              type={TypographyType.Body}
+              color={TypographyColor.Primary}
+              bold
+            >
+              Hot Takes
+            </Typography>
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              {hotTakeCount}/{MAX_HOT_TAKES}
+            </Typography>
+          </div>
+        ) : (
+          <Typography
+            type={TypographyType.Body}
+            color={TypographyColor.Primary}
+            bold
           >
-            Add
-          </Button>
+            Hot Takes
+          </Typography>
+        )}
+        {isOwner && (
+          <Tooltip
+            content={HOT_TAKE_LIMIT_REACHED_MESSAGE}
+            side="bottom"
+            visible={!canAddMore}
+          >
+            <span className="inline-flex">
+              <Button
+                type="button"
+                variant={ButtonVariant.Tertiary}
+                size={ButtonSize.Small}
+                icon={<PlusIcon />}
+                onClick={handleOpenModal}
+                disabled={!canAddMore}
+              >
+                Add
+              </Button>
+            </span>
+          </Tooltip>
         )}
       </div>
       {hasItems ? (
@@ -243,6 +277,7 @@ export function ProfileUserHotTakes({
               </Typography>
             </div>
             <Button
+              type="button"
               variant={ButtonVariant.Secondary}
               size={ButtonSize.Small}
               icon={<PlusIcon />}


### PR DESCRIPTION
Restores the profile hot takes creation affordance so owners can see how to add or make room for a new hot take.

Changes:
- Keeps the owner Add control mounted in the hot takes section and disables it at the 5-item cap with the existing limit message in a shared tooltip.
- Shows an owner-only n/5 count beside the Hot Takes heading.
- Makes owner edit/delete row controls visible without hover in both hot take item variants.
- Keeps the #hot-takes anchor rendered while visitor showcase data is loading so hash links can land correctly.

Key decisions:
- Kept the backend/query contract unchanged and preserved the existing deep-link limit toast.
- Scoped the fix to the profile hot takes section rather than changing sibling capped sections or wider Hot Takes navigation.

Closes ENG-2034

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-2034-feedback-bug-report-the.preview.app.daily.dev