### PR TITLE
docs(share): review the Share my feed placements on the app

### DIFF
--- a/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.spec.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.spec.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { GrowthBook } from '@growthbook/growthbook-react';
+import { render, screen } from '@testing-library/react';
+import { TestBootProvider } from '../../../../../__tests__/helpers/boot';
+import defaultUser from '../../../../../__tests__/fixture/loggedUser';
+import { defaultQueryClientTestingConfig } from '../../../../../__tests__/helpers/tanstack-query';
+import { FeedSettingsEditContext } from '../FeedSettingsEditContext';
+import type { FeedSettingsEditContextValue } from '../types';
+import { FeedType } from '../../../../graphql/feed';
+import { featureShareMyFeed } from '../../../../lib/featureManagement';
+import { FeedSettingsGeneralSection } from './FeedSettingsGeneralSection';
+
+jest.mock('../../../../hooks/useFeedSettings', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ isLoading: false })),
+}));
+
+const SHARE_HEADING = 'Share this feed';
+
+const getGrowthBook = (shareMyFeed: boolean): GrowthBook => {
+  const gb = new GrowthBook();
+  gb.setFeatures({ [featureShareMyFeed.id]: { defaultValue: shareMyFeed } });
+
+  return gb;
+};
+
+const renderComponent = ({
+  type = FeedType.Custom,
+  shareMyFeed = false,
+}: { type?: FeedType; shareMyFeed?: boolean } = {}) =>
+  render(
+    <TestBootProvider
+      client={new QueryClient(defaultQueryClientTestingConfig)}
+      auth={{ user: defaultUser }}
+      gb={getGrowthBook(shareMyFeed)}
+    >
+      <FeedSettingsEditContext.Provider
+        value={
+          {
+            feed: { id: 'f1', type, flags: { name: 'My feed' } },
+            data: { name: 'My feed' },
+            setData: jest.fn(),
+            onSubmit: jest.fn(),
+            isSubmitPending: false,
+            onDelete: jest.fn(),
+            deleteStatus: 'idle',
+            onTagClick: jest.fn(),
+            onDiscard: jest.fn(),
+            isDirty: false,
+            onBackToFeed: jest.fn(),
+            editFeedSettings: jest.fn(),
+            isNewFeed: false,
+          } as unknown as FeedSettingsEditContextValue
+        }
+      >
+        <FeedSettingsGeneralSection />
+      </FeedSettingsEditContext.Provider>
+    </TestBootProvider>,
+  );
+
+describe('FeedSettingsGeneralSection', () => {
+  it('should not offer sharing while the flag is off', () => {
+    renderComponent();
+
+    expect(screen.queryByText(SHARE_HEADING)).not.toBeInTheDocument();
+  });
+
+  it('should offer sharing on a custom feed when the flag is on', async () => {
+    renderComponent({ shareMyFeed: true });
+
+    expect(await screen.findByText(SHARE_HEADING)).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Copy link' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not offer sharing on the main feed, which nobody built', async () => {
+    renderComponent({ type: FeedType.Main, shareMyFeed: true });
+
+    // The default-feed block is main-feed only, so the section has rendered.
+    expect(
+      await screen.findByText('Set as your default feed'),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(SHARE_HEADING)).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.tsx
+++ b/packages/shared/src/components/feeds/FeedSettings/sections/FeedSettingsGeneralSection.tsx
@@ -1,17 +1,20 @@
 import type { ReactElement } from 'react';
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import classNames from 'classnames';
 import Link from '../../../utilities/Link';
 import { FeedSettingsEditContext } from '../FeedSettingsEditContext';
 import { Button } from '../../../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../../../buttons/common';
-import { LockIcon, StarIcon, TrashIcon, VIcon } from '../../../icons';
+import { LinkIcon, LockIcon, StarIcon, TrashIcon, VIcon } from '../../../icons';
 import {
   Typography,
   TypographyType,
   TypographyColor,
 } from '../../../typography/Typography';
-import { webappUrl } from '../../../../lib/constants';
+import { isPreviewHost, webappUrl } from '../../../../lib/constants';
+import { featureShareMyFeed } from '../../../../lib/featureManagement';
+import { useConditionalFeature } from '../../../../hooks/useConditionalFeature';
+import { useCopyLink } from '../../../../hooks/useCopy';
 import { TextField } from '../../../fields/TextField';
 import { EmojiPicker } from '../../../fields/EmojiPicker';
 import { Divider } from '../../../utilities';
@@ -53,6 +56,25 @@ export const FeedSettingsGeneralSection = (): ReactElement => {
   const isDefaultFeed = isMainFeed
     ? user.defaultFeedId === null
     : user.defaultFeedId === feed.id;
+
+  const { value: shareMyFeedFlag } = useConditionalFeature({
+    feature: featureShareMyFeed,
+    shouldEvaluate: isCustomFeed,
+  });
+  // After mount, not during render: the server cannot know the host the page
+  // will be served from, and disagreeing with it would break hydration.
+  const [isPreview, setIsPreview] = useState(false);
+  useEffect(() => {
+    setIsPreview(isPreviewHost());
+  }, []);
+  const canShareFeed = isCustomFeed && (shareMyFeedFlag || isPreview);
+
+  // Feeds are user-scoped, so nothing resolves this route for a non-owner yet:
+  // the shareable token is backend work the flag is waiting on.
+  const shareFeedLink = feed?.id
+    ? `${webappUrl}feeds/shared/${feed.id}`
+    : undefined;
+  const [, copyShareFeedLink] = useCopyLink(() => shareFeedLink);
 
   return (
     <>
@@ -186,6 +208,42 @@ export const FeedSettingsGeneralSection = (): ReactElement => {
             </Tooltip>
           )}
         </div>
+      )}
+      {canShareFeed && (
+        <>
+          <Divider className="my-1 bg-border-subtlest-tertiary" />
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1">
+              <Typography bold type={TypographyType.Body}>
+                Share this feed
+              </Typography>
+              <Typography
+                type={TypographyType.Callout}
+                color={TypographyColor.Tertiary}
+              >
+                Anyone who opens your link gets this feed added to their own,
+                tags and sources included.
+              </Typography>
+            </div>
+            <div className="flex w-full items-center gap-2 rounded-14 border border-border-subtlest-secondary px-3 py-2 tablet:max-w-70">
+              <Typography
+                className="min-w-0 flex-1 truncate"
+                type={TypographyType.Body}
+              >
+                {shareFeedLink}
+              </Typography>
+              <Button
+                type="button"
+                size={ButtonSize.Small}
+                variant={ButtonVariant.Primary}
+                icon={<LinkIcon />}
+                onClick={() => copyShareFeedLink()}
+              >
+                Copy link
+              </Button>
+            </div>
+          </div>
+        </>
       )}
       <Divider className="my-1 bg-border-subtlest-tertiary" />
       <div className="flex flex-col gap-4">

--- a/packages/shared/src/lib/constants.ts
+++ b/packages/shared/src/lib/constants.ts
@@ -49,6 +49,18 @@ export const isTesting =
   process.env.NODE_ENV === 'test' || (!isDevelopment && !isProduction);
 export const isGBDevMode = process.env.NEXT_PUBLIC_GB_DEV_MODE === 'true';
 
+/**
+ * Branch preview deployments, e.g. my-branch.preview.app.daily.dev. They run
+ * NODE_ENV=production against the production API, so neither `isDevelopment`
+ * nor GrowthBook's dev tools are available to open a flag for review — the
+ * host is the only thing that distinguishes them from app.daily.dev.
+ */
+export const PREVIEW_HOST_SUFFIX = '.preview.app.daily.dev';
+
+export const isPreviewHost = (): boolean =>
+  typeof window !== 'undefined' &&
+  window.location.hostname.endsWith(PREVIEW_HOST_SUFFIX);
+
 export const isBrave = (): boolean => {
   if (typeof window === 'undefined' || !window.Promise) {
     return false;

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -339,3 +339,9 @@ export const featurePlusSale = new Feature<PlusSaleConfig>(
 // warning, bad creative or revenue anomaly can be stopped without a deploy
 // and an ISR revalidation cycle. Never ramp or target with this flag.
 export const featureReadAdsense = new Feature('read_adsense', true);
+
+// Sharing a custom feed: a link in the feed settings General tab that adds the
+// feed to whoever opens it. Experiment default is the off state — the rollout
+// is a GrowthBook decision. Branch previews force it on (see `isPreviewHost`),
+// because a preview runs as production and has no way to open a flag.
+export const featureShareMyFeed = new Feature('share_my_feed', false);

--- a/packages/webapp/pages/dev/share-my-feed.tsx
+++ b/packages/webapp/pages/dev/share-my-feed.tsx
@@ -1,0 +1,682 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useEffect, useState } from 'react';
+import { NextSeo } from 'next-seo';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  AiIcon,
+  AlertIcon,
+  ArrowIcon,
+  BlockIcon,
+  CopyIcon,
+  EditIcon,
+  FilterIcon,
+  HashtagIcon,
+  LinkIcon,
+  MiniCloseIcon,
+  PlusIcon,
+  PlusUserIcon,
+  StarIcon,
+  TrashIcon,
+} from '@dailydotdev/shared/src/components/icons';
+import { isDevelopment } from '@dailydotdev/shared/src/lib/constants';
+
+/**
+ * /dev/share-my-feed — the Share my feed placement review, on the app rather
+ * than in Storybook, so the surfaces are read against real app CSS and the
+ * app's own theme switch.
+ *
+ * Controls are inert: this compares placement and copy, not behaviour. Nothing
+ * here is wired to a feed, and no production surface changes.
+ */
+
+const AVATAR =
+  'https://res.cloudinary.com/daily-now/image/upload/s--O0TOmw4y--/f_auto/v1715772965/public/noProfile';
+
+const useTheme = (initial: 'dark' | 'light') => {
+  const [theme, setTheme] = useState<'dark' | 'light'>(initial);
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+    const root = document.documentElement;
+    if (theme === 'light') {
+      root.classList.add('light');
+    } else {
+      root.classList.remove('light');
+    }
+  }, [theme]);
+  return [theme, setTheme] as const;
+};
+
+/* ------------------------------------------------------------------ chrome */
+
+type DeviceName = 'Desktop' | 'Tablet' | 'Mobile';
+
+const DEVICES: Record<DeviceName, { width: number; viewport: string }> = {
+  Desktop: { width: 680, viewport: '1020px and up' },
+  Tablet: { width: 560, viewport: '768px' },
+  Mobile: { width: 375, viewport: '375px' },
+};
+
+/** A surface drawn at one real viewport width, so density is comparable. */
+const Device = ({
+  name,
+  children,
+}: {
+  name: DeviceName;
+  children: ReactNode;
+}) => (
+  <div className="flex shrink-0 flex-col gap-2">
+    <span className="font-bold uppercase text-text-quaternary typo-caption2">
+      {name} · {DEVICES[name].viewport}
+    </span>
+    <div
+      className="relative shrink-0 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-background-default"
+      style={{ width: DEVICES[name].width }}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+/** Devices sit in a scroller rather than wrapping, so widths stay honest. */
+const Rail = ({ children }: { children: ReactNode }) => (
+  <div className="flex w-full items-start gap-6 overflow-x-auto pb-3">
+    {children}
+  </div>
+);
+
+const Variant = ({
+  step,
+  headline,
+  note,
+  children,
+}: {
+  step: string;
+  headline: string;
+  note: string;
+  children: ReactNode;
+}) => (
+  <div className="flex w-full flex-col gap-3">
+    <div className="flex flex-col gap-1">
+      <span className="font-bold uppercase text-text-quaternary typo-caption2">
+        {step}
+      </span>
+      <span className="font-bold text-text-primary typo-callout">
+        {headline}
+      </span>
+      <span className="text-text-tertiary typo-footnote">{note}</span>
+    </div>
+    {children}
+  </div>
+);
+
+const Category = ({
+  title,
+  covers,
+  verdict,
+  children,
+}: {
+  title: string;
+  covers: string;
+  verdict: string;
+  children: ReactNode;
+}) => (
+  <section className="flex flex-col gap-6 border-t border-border-subtlest-tertiary pt-10">
+    <div className="flex flex-col gap-2">
+      <h2 className="font-bold text-text-primary typo-mega3">{title}</h2>
+      <span className="text-text-tertiary typo-footnote">{covers}</span>
+      <p className="max-w-[54rem] text-text-secondary typo-callout">
+        {verdict}
+      </p>
+    </div>
+    <div className="flex flex-col gap-10">{children}</div>
+  </section>
+);
+
+/* ----------------------------------------------------------- the sharer UI */
+
+type Spot = 'today' | 'section' | 'list';
+
+const MENU: [string, ReactElement][] = [
+  ['General', <EditIcon key="general" />],
+  ['Tags', <HashtagIcon key="tags" />],
+  ['Content sources', <PlusUserIcon key="sources" />],
+  ['Content preferences', <FilterIcon key="preferences" />],
+  ['AI superpowers', <AiIcon key="ai" />],
+  ['Filters', <FilterIcon key="filters" />],
+  ['Blocked content', <BlockIcon key="blocking" />],
+];
+
+const Field = ({
+  label,
+  value,
+  counter,
+}: {
+  label: string;
+  value: string;
+  counter?: string;
+}) => (
+  <div className="flex w-full items-center gap-2 rounded-14 border border-border-subtlest-secondary px-3 py-2 tablet:max-w-70">
+    <span className="flex min-w-0 flex-1 flex-col">
+      <span className="text-text-tertiary typo-caption1">{label}</span>
+      <span className="truncate text-text-primary typo-body">{value}</span>
+    </span>
+    {counter && (
+      <span className="text-text-quaternary typo-callout">{counter}</span>
+    )}
+  </div>
+);
+
+const Block = ({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description?: string;
+  children?: ReactNode;
+}) => (
+  <div className="flex flex-col gap-4">
+    <div className="flex flex-col gap-1">
+      <span className="font-bold text-text-primary typo-body">{title}</span>
+      {description && (
+        <span className="text-text-tertiary typo-callout">{description}</span>
+      )}
+    </div>
+    {children}
+  </div>
+);
+
+const Divider = () => (
+  <hr className="my-1 h-px border-0 bg-border-subtlest-tertiary" />
+);
+
+/**
+ * FeedSettingsGeneralSection inside the feed settings modal. Feed name,
+ * emoji picker, default-feed toggle, Happening Now placement and delete are
+ * all `isCustomFeed`-gated already — the export belongs in the same set.
+ */
+const FeedSettingsScreen = ({
+  device,
+  spot,
+}: {
+  device: DeviceName;
+  spot: Spot;
+}) => (
+  <Device name={device}>
+    <div className="flex flex-col bg-background-popover">
+      <div className="flex items-center gap-3 border-b border-border-subtlest-tertiary px-4 py-3">
+        <HashtagIcon className="text-text-primary" />
+        <span className="flex-1 font-bold text-text-primary typo-title3">
+          My new feed
+        </span>
+        <Button
+          size={ButtonSize.Small}
+          type="button"
+          variant={ButtonVariant.Tertiary}
+        >
+          Cancel
+        </Button>
+        <Button
+          disabled
+          size={ButtonSize.Small}
+          type="button"
+          variant={ButtonVariant.Primary}
+        >
+          Save
+        </Button>
+      </div>
+
+      <div className="flex">
+        {device !== 'Mobile' && (
+          <nav className="flex w-56 shrink-0 flex-col gap-1 border-r border-border-subtlest-tertiary p-2">
+            {MENU.map(([label, icon], index) => (
+              <span
+                key={label}
+                className={`flex items-center gap-3 rounded-12 px-3 py-2 typo-callout ${
+                  index === 0
+                    ? 'bg-surface-float font-bold text-text-primary'
+                    : 'text-text-tertiary'
+                }`}
+              >
+                {icon}
+                <span className="flex-1">{label}</span>
+                <ArrowIcon className="rotate-90 text-text-quaternary" />
+              </span>
+            ))}
+          </nav>
+        )}
+
+        <div className="flex min-w-0 flex-1 flex-col gap-6 p-4">
+          <Block
+            description="Choose a name that reflects the focus of your feed."
+            title="Feed name"
+          >
+            <Field counter="39" label="Enter feed name" value="My new feed" />
+          </Block>
+
+          <Block title="Choose an icon">
+            <Button
+              className="w-fit"
+              size={ButtonSize.Small}
+              type="button"
+              variant={ButtonVariant.Secondary}
+            >
+              Pick emoji
+            </Button>
+          </Block>
+
+          <Block
+            description="Make this feed the first one you see every time you open daily.dev."
+            title="Set as your default feed"
+          >
+            <Button
+              className="w-40"
+              icon={<StarIcon />}
+              size={ButtonSize.Small}
+              type="button"
+              variant={ButtonVariant.Secondary}
+            >
+              Make default
+            </Button>
+          </Block>
+
+          {spot !== 'today' && (
+            <>
+              <Divider />
+              <Block
+                description="Anyone who opens your link gets this feed added to their own, tags and sources included."
+                title="Share this feed"
+              >
+                <div className="flex flex-col gap-2">
+                  <div className="flex items-center gap-2 rounded-14 border border-border-subtlest-secondary px-3 py-2 tablet:max-w-70">
+                    <span className="min-w-0 flex-1 truncate text-text-primary typo-body">
+                      dly.to/f/tomer-frontend
+                    </span>
+                    <Button
+                      icon={<LinkIcon />}
+                      size={ButtonSize.Small}
+                      type="button"
+                      variant={ButtonVariant.Primary}
+                    >
+                      Copy link
+                    </Button>
+                  </div>
+                  {spot === 'list' && (
+                    <Button
+                      className="w-fit"
+                      icon={<CopyIcon />}
+                      size={ButtonSize.Small}
+                      type="button"
+                      variant={ButtonVariant.Float}
+                    >
+                      Copy top 20 as a list
+                    </Button>
+                  )}
+                </div>
+              </Block>
+            </>
+          )}
+
+          <Divider />
+
+          <Block
+            description="Choose where the Happening Now card appears in your feed, or hide it entirely."
+            title="Happening Now placement"
+          >
+            <div className="flex w-full items-center gap-2 rounded-14 bg-surface-float px-3 py-3 tablet:max-w-70">
+              <span className="flex-1 text-text-primary typo-body">
+                Default
+              </span>
+              <ArrowIcon className="rotate-180 text-text-tertiary" />
+            </div>
+          </Block>
+
+          <Divider />
+
+          <Block
+            description="Permanently remove this feed and all its settings. This action cannot be undone."
+            title="Delete feed"
+          >
+            <Button
+              className="w-40"
+              icon={<TrashIcon />}
+              size={ButtonSize.Small}
+              type="button"
+              variant={ButtonVariant.Float}
+            >
+              Delete feed
+            </Button>
+          </Block>
+        </div>
+      </div>
+    </div>
+  </Device>
+);
+
+/* -------------------------------------------------------- the recipient UI */
+
+type LandingSpot = 'preview' | 'added' | 'signin' | 'limit';
+
+const TAGS = [
+  '#typescript',
+  '#react',
+  '#webdev',
+  '#css',
+  '#nextjs',
+  '#tooling',
+];
+
+const SAMPLE_POSTS = [
+  'Why iconic tech brands lost their dominance',
+  'The case against microservices',
+  'Postgres is all you need, again',
+];
+
+/**
+ * The recipient's landing. `/feeds/new?entityId=&entityType=` already creates
+ * a feed and follows one entity into it — this is the same flow with a set
+ * rather than a single tag, so the precedent exists in FeedSettingsCreate.
+ */
+const LandingScreen = ({
+  device,
+  spot,
+}: {
+  device: DeviceName;
+  spot: LandingSpot;
+}) => (
+  <Device name={device}>
+    <div className="flex flex-col items-center gap-4 p-6 text-center">
+      <img alt="" className="size-14 rounded-full object-cover" src={AVATAR} />
+
+      {spot === 'added' && (
+        <>
+          <h1 className="font-bold text-text-primary typo-title2">
+            Tomer&apos;s feed is yours now
+          </h1>
+          <p className="text-text-tertiary typo-callout">
+            It is in your sidebar as a new feed. Rename it, add tags, or delete
+            it — from here it is your feed, not a copy of theirs.
+          </p>
+        </>
+      )}
+      {spot === 'signin' && (
+        <>
+          <h1 className="font-bold text-text-primary typo-title2">
+            Sign in to add Tomer&apos;s feed
+          </h1>
+          <p className="text-text-tertiary typo-callout">
+            A feed lives in an account, so there is nowhere to put this one yet.
+            Sign in or sign up, then open the link again.
+          </p>
+        </>
+      )}
+      {(spot === 'preview' || spot === 'limit') && (
+        <>
+          <h1 className="font-bold text-text-primary typo-title2">
+            Tomer shared a feed with you
+          </h1>
+          <p className="text-text-tertiary typo-callout">
+            6 tags and 4 sources. Adding it creates a new feed in your account
+            called <span className="text-text-primary">Tomer&apos;s feed</span>.
+          </p>
+        </>
+      )}
+
+      <div className="flex flex-wrap justify-center gap-2">
+        {TAGS.slice(0, device === 'Mobile' ? 4 : 6).map((tag) => (
+          <span
+            key={tag}
+            className="rounded-8 bg-surface-float px-2 py-1 text-text-tertiary typo-caption1"
+          >
+            {tag}
+          </span>
+        ))}
+      </div>
+
+      <div className="mt-2 flex flex-col items-center gap-2">
+        {spot === 'added' && (
+          <Button
+            size={ButtonSize.Medium}
+            type="button"
+            variant={ButtonVariant.Primary}
+          >
+            Open the feed
+          </Button>
+        )}
+        {spot === 'signin' && (
+          <Button
+            size={ButtonSize.Medium}
+            type="button"
+            variant={ButtonVariant.Primary}
+          >
+            Sign in
+          </Button>
+        )}
+        {(spot === 'preview' || spot === 'limit') && (
+          <Button
+            icon={<PlusIcon />}
+            size={ButtonSize.Medium}
+            type="button"
+            variant={ButtonVariant.Primary}
+          >
+            Add to my feeds
+          </Button>
+        )}
+      </div>
+
+      {spot === 'limit' && (
+        <div className="invert mt-2 flex w-full flex-row items-center gap-2.5 rounded-12 border border-border-subtlest-tertiary bg-background-default py-2 pl-3 pr-2 shadow-3">
+          <AlertIcon className="shrink-0 text-status-error" />
+          <span className="min-w-0 flex-1 text-left font-medium text-text-primary typo-subhead">
+            You&apos;ve reached the maximum number of feeds. Delete one or
+            upgrade to Plus to add this feed.
+          </span>
+          <Button
+            aria-label="Close"
+            icon={<MiniCloseIcon />}
+            size={ButtonSize.XSmall}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          />
+        </div>
+      )}
+
+      {/* A sample of what the feed holds, not a reading surface: nothing here
+          is a link, so the only way in is to add the feed. */}
+      <div
+        aria-hidden
+        className="opacity-60 pointer-events-none mt-2 flex w-full flex-col gap-2 text-left"
+      >
+        {SAMPLE_POSTS.map((title) => (
+          <div key={title} className="flex items-center gap-3">
+            <div className="size-10 shrink-0 rounded-10 bg-surface-float" />
+            <span className="min-w-0 flex-1 truncate text-text-primary typo-footnote">
+              {title}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  </Device>
+);
+
+const LandingRails = ({ spot }: { spot: LandingSpot }) => (
+  <Rail>
+    <LandingScreen device="Desktop" spot={spot} />
+    <LandingScreen device="Tablet" spot={spot} />
+    <LandingScreen device="Mobile" spot={spot} />
+  </Rail>
+);
+
+const Rails = ({ spot }: { spot: Spot }) => (
+  <Rail>
+    <FeedSettingsScreen device="Desktop" spot={spot} />
+    <FeedSettingsScreen device="Tablet" spot={spot} />
+    <FeedSettingsScreen device="Mobile" spot={spot} />
+  </Rail>
+);
+
+const ProductionGate = ({ children }: { children: ReactNode }) => {
+  if (!isDevelopment) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-background-default p-12">
+        <p className="text-text-secondary typo-callout">
+          The Share my feed review page is only available in development.
+        </p>
+      </div>
+    );
+  }
+  return <>{children}</>;
+};
+
+const ShareMyFeedDevPage = (): ReactElement => {
+  const [theme, setTheme] = useTheme('dark');
+
+  return (
+    <ProductionGate>
+      <NextSeo nofollow noindex title="Share my feed · daily.dev dev" />
+      <div className="min-h-screen bg-background-default text-text-primary">
+        <div className="sticky top-0 z-header flex flex-wrap items-center gap-4 border-b border-border-subtlest-tertiary bg-background-default px-8 py-3">
+          <h1 className="font-bold typo-callout">Share my feed · placements</h1>
+          <Button
+            onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+            size={ButtonSize.XSmall}
+            type="button"
+            variant={ButtonVariant.Float}
+          >
+            {theme === 'dark' ? 'Light theme' : 'Dark theme'}
+          </Button>
+        </div>
+
+        <div className="flex flex-col gap-6 p-8">
+          <div className="flex flex-col gap-3">
+            <h2 className="font-bold text-text-primary typo-mega3">
+              Share my feed
+            </h2>
+            <p className="max-w-[54rem] text-text-secondary typo-body">
+              Custom feeds only, and not a snapshot. A custom feed is something
+              you built — a name, an icon, a tag set — so the thing worth
+              sending is the feed itself, not a picture of its posts. Opening a
+              shared link adds the feed to the recipient&apos;s account, named
+              after whoever shared it.
+            </p>
+            <p className="max-w-[54rem] rounded-12 border border-border-subtlest-tertiary bg-surface-float p-4 text-text-secondary typo-callout">
+              Revised from the sharing map (#6362), which had this down as
+              snapshot-only on the assumption there was nothing to link to.
+              There is, if the link creates something: Copy link leads, with a
+              text list as the fallback for anywhere a link will not do.
+            </p>
+          </div>
+
+          <Category
+            covers="FeedSettingsGeneralSection.tsx · FeedSettingsMenu types.ts"
+            title="The sharer: in the feed settings modal"
+            verdict="The General tab already gates feed name, the emoji picker, the default-feed toggle and delete behind `isCustomFeed`. Sharing belongs in exactly that set — it is a property of a feed you built, configured where everything else about it is configured."
+          >
+            <Variant
+              headline="Name, icon, default, placement, delete"
+              note="Seven tabs down the left, General open. Every custom-feed-only block already lives here, and none of them offers a way to get the feed out."
+              step="Today"
+            >
+              <Rails spot="today" />
+            </Variant>
+            <Variant
+              headline="A share link, with what it does stated"
+              note="Recommended. The description does the work: ‘anyone who opens your link gets this feed added to their own’. Without that sentence a feed link reads as a link to your private feed, which is the one thing it cannot be."
+              step="Recommended"
+            >
+              <Rails spot="section" />
+            </Variant>
+            <Variant
+              headline="Plus a text list, for where a link will not do"
+              note="The top 20 posts as plain text, for a Slack channel or a newsletter — the original #6362 idea, kept as the fallback rather than the feature. Float weight, because the link is the offer."
+              step="Also"
+            >
+              <Rails spot="list" />
+            </Variant>
+          </Category>
+
+          <Category
+            covers="FeedSettingsCreate.tsx · CREATE_FEED_MUTATION · needs backend"
+            title="The recipient: opening the link"
+            verdict="This is the part that makes it worth building, and the pattern already exists: /feeds/new?entityId=&entityType= creates a feed and follows one entity into it. A shared feed is the same flow with a set instead of a single tag — plus a way for a non-owner to read the feed's tags and sources, which is the backend work."
+          >
+            <Variant
+              headline="Tomer shared a feed with you"
+              note="Names what will happen before it happens: a new feed called ‘Tomer's feed’, with 6 tags and 4 sources. One action only — the posts underneath are a sample of what the feed holds, dimmed and not pressable, so adding the feed is the only way in."
+              step="Preview"
+            >
+              <LandingRails spot="preview" />
+            </Variant>
+            <Variant
+              headline="Added, and now theirs"
+              note="The copy has to make ownership obvious — rename it, add tags, delete it. A feed that still feels like someone else's is one people leave untouched and never open again."
+              step="Added"
+            >
+              <LandingRails spot="added" />
+            </Variant>
+            <Variant
+              headline="Not signed in"
+              note="Decided: a feed lives in an account, so there is nowhere to put a shared one without a session. Sign in or sign up, then open the link again. No read-only preview — which is also why the sample posts below are not links."
+              step="No session"
+            >
+              <LandingRails spot="signin" />
+            </Variant>
+            <Variant
+              headline="Out of feed slots — an error toast"
+              note="Decided: the button stays live and the failure comes back as an error toast that says why, naming both ways out. Nothing is disabled up front — we cannot know the recipient is at their cap until they press, and a dead button explains nothing. FeedSettingsCreate already turns this API error into a toast today."
+              step="Feed limit"
+            >
+              <LandingRails spot="limit" />
+            </Variant>
+          </Category>
+
+          <Category
+            covers="decisions and what is still open"
+            title="Decisions"
+            verdict="All four answered. Only the first is work we do not own — the rest are product calls, now made."
+          >
+            <Variant
+              headline="A shareable representation of a private feed"
+              note="Still the whole feature, and it is backend. Feeds are user-scoped today, so sharing one needs a token or slug that resolves to its tags and sources for someone who does not own it — read-only, revocable, and not leaking the owner's other feeds."
+              step="1 · Backend"
+            >
+              <div />
+            </Variant>
+            <Variant
+              headline="A copy, taken at the moment it is added"
+              note="Decided. Not a live subscription: the recipient's feed is theirs to rename and edit from the moment they add it, and the sharer's later edits never reach into other people's accounts. It also means the sharer can delete their feed without breaking anyone else's."
+              step="2 · Decided"
+            >
+              <div />
+            </Variant>
+            <Variant
+              headline="Sign-in required, no logged-out preview"
+              note="Decided. Anyone without a session gets the sign-in state above and opens the link again afterwards. Worth building the redirect back to the link into the auth flow anyway — asking someone to find the message again is where most of them will drop."
+              step="3 · Decided"
+            >
+              <div />
+            </Variant>
+            <Variant
+              headline="An added feed uses a feed slot"
+              note="Decided: it counts, like any feed you made yourself, and hitting the cap surfaces as the error toast above rather than a special case. One kind of feed, one limit, one message. Worth watching once it ships: heavy recipients are the same people the feature spreads through, so if the cap starts biting them we will see it in add-rate before anyone reports it."
+              step="4 · Decided"
+            >
+              <div />
+            </Variant>
+          </Category>
+        </div>
+      </div>
+    </ProductionGate>
+  );
+};
+
+ShareMyFeedDevPage.getLayout = (page: ReactNode): ReactNode => page;
+
+export default ShareMyFeedDevPage;

--- a/packages/webapp/pages/dev/share-my-feed.tsx
+++ b/packages/webapp/pages/dev/share-my-feed.tsx
@@ -22,7 +22,6 @@ import {
   StarIcon,
   TrashIcon,
 } from '@dailydotdev/shared/src/components/icons';
-import { isDevelopment } from '@dailydotdev/shared/src/lib/constants';
 
 /**
  * /dev/share-my-feed — the Share my feed placement review, on the app rather
@@ -522,12 +521,31 @@ const Rails = ({ spot }: { spot: Spot }) => (
   </Rail>
 );
 
-const ProductionGate = ({ children }: { children: ReactNode }) => {
-  if (!isDevelopment) {
+const useIsAllowedHost = () => {
+  const [allowed, setAllowed] = useState(true);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const { hostname } = window.location;
+    // Block the canonical production hosts only; allow localhost and the
+    // *.preview.app.daily.dev preview deployments so reviewers can open it.
+    setAllowed(hostname !== 'app.daily.dev' && hostname !== 'www.daily.dev');
+  }, []);
+
+  return allowed;
+};
+
+const HostGate = ({ children }: { children: ReactNode }) => {
+  const allowed = useIsAllowedHost();
+
+  if (!allowed) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-background-default p-12">
         <p className="text-text-secondary typo-callout">
-          The Share my feed review page is only available in development.
+          The Share my feed review page is not available on production.
         </p>
       </div>
     );
@@ -539,7 +557,7 @@ const ShareMyFeedDevPage = (): ReactElement => {
   const [theme, setTheme] = useTheme('dark');
 
   return (
-    <ProductionGate>
+    <HostGate>
       <NextSeo nofollow noindex title="Share my feed · daily.dev dev" />
       <div className="min-h-screen bg-background-default text-text-primary">
         <div className="sticky top-0 z-header flex flex-wrap items-center gap-4 border-b border-border-subtlest-tertiary bg-background-default px-8 py-3">
@@ -673,7 +691,7 @@ const ShareMyFeedDevPage = (): ReactElement => {
           </Category>
         </div>
       </div>
-    </ProductionGate>
+    </HostGate>
   );
 };
 


### PR DESCRIPTION
Puts the **Share my feed** placement into the real feed settings modal, behind a flag, and keeps the placement review that argues for it as a dev page.

## What ships

**The real surface** — `FeedSettingsGeneralSection.tsx`

Custom feeds get a **Share this feed** block between the default-feed toggle and the Happening Now placement. That tab already gates feed name, the emoji picker, the default-feed toggle and delete behind `isCustomFeed`; sharing is the same kind of thing — a property of a feed you built — so it goes in that set rather than into a share menu.

The description carries the part the link cannot say for itself: *"anyone who opens your link gets this feed added to their own, tags and sources included."* Without that sentence a feed link reads as a link to your private feed, which is the one thing it cannot be.

**Flagging** — `share_my_feed`, default `false`

Merging changes nothing on `app.daily.dev`; the rollout stays a GrowthBook decision. Branch previews force it on through the new `isPreviewHost()` helper, because a preview runs `NODE_ENV=production` against the production API and has no dev mode or GrowthBook tooling to open a flag from the browser. Evaluated via `useConditionalFeature` with `shouldEvaluate: isCustomFeed`, so the flag is only read where the block could render.

**The placement review** — `/dev/share-my-feed`

The full argument, drawn at desktop/tablet/mobile: the sharer's three states, the recipient's four, and the four decisions. Host-gated (localhost + `*.preview.app.daily.dev`, blocked on `app.daily.dev`/`www.daily.dev`) and `noindex`/`nofollow`.

## What is deliberately not real yet

- **The link does not resolve.** Feeds are user-scoped, so `feeds/shared/<id>` has nothing behind it for a non-owner. The shareable token — read-only, revocable, not leaking the owner's other feeds — is backend work, and it is the whole reason the flag stays off. The button copies the shape the feature needs so the placement and copy can be judged now.
- **The recipient's landing is not built** — preview, added, no-session and feed-limit states live on the dev page only, since they cannot be wired without the above.
- **The top-20 text list** (the original #6362 idea) is on the dev page as the `Also` variant, not in the modal. The link is the offer; the list is the fallback for where a link will not do.

## Decisions on the record

Feed sharing is **not a snapshot** — a custom feed is a name, an icon and a tag set, so the thing worth sending is the feed itself, not a picture of its posts. This revises the sharing map (#6362), which had it down as snapshot-only on the assumption there was nothing to link to. The recipient gets a **copy taken at add time**, not a live subscription; **sign-in is required** with no logged-out preview; and an added feed **uses a feed slot**, with the cap surfacing as an error toast rather than a disabled button.

## Events

None.

## Experiment

`share_my_feed`, default off.

## Testing

- New `FeedSettingsGeneralSection.spec.tsx`: no share block while the flag is off, block plus a `Copy link` button on a custom feed when it is on, and nothing on the main feed.
- `pnpm --filter shared test src/components/feeds` — 7 suites / 21 tests pass.
- `pnpm --filter webapp test` — 81 suites / 648 tests pass (shared component touched).
- eslint clean on every touched file; `node ./scripts/typecheck-strict-changed.js` clean.
- `/dev/share-my-feed` verified on the preview's production build: all seven states, no Tailwind purge, hydration and theme toggle working, clean console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-share-my-feed-surface.preview.app.daily.dev
