### PR TITLE
feat(onboarding): the invite step, previewable on the real funnel chrome

### DIFF
--- a/packages/storybook/stories/features/snapshot/surfaceChrome.tsx
+++ b/packages/storybook/stories/features/snapshot/surfaceChrome.tsx
@@ -1,0 +1,137 @@
+import React from 'react';
+
+export const AVATAR =
+  'https://res.cloudinary.com/daily-now/image/upload/s--O0TOmw4y--/f_auto/v1715772965/public/noProfile';
+
+/* ------------------------------------------------------------------ prose */
+
+export const H1 = ({ children }: { children: React.ReactNode }) => (
+  <h1 className="font-bold text-text-primary typo-mega3">{children}</h1>
+);
+
+export const P = ({ children }: { children: React.ReactNode }) => (
+  <p className="max-w-[54rem] text-text-secondary typo-body">{children}</p>
+);
+
+export const Note = ({ children }: { children: React.ReactNode }) => (
+  <p className="max-w-[54rem] rounded-12 border border-border-subtlest-tertiary bg-surface-float p-4 text-text-secondary typo-callout">
+    {children}
+  </p>
+);
+
+/* ---------------------------------------------------------- page furniture */
+
+export type DeviceName = 'Desktop' | 'Tablet' | 'Mobile';
+
+/**
+ * Breakpoints matter more than usual here. A recommendation that only works
+ * on one of the three is not a recommendation.
+ */
+export const DEVICES: Record<DeviceName, { width: number; viewport: string }> =
+  {
+    Desktop: { width: 680, viewport: '1020px and up' },
+    Tablet: { width: 560, viewport: '768px' },
+    Mobile: { width: 375, viewport: '375px' },
+  };
+
+/** A surface drawn at one real viewport width, so density is comparable. */
+export const Device = ({
+  name,
+  children,
+  height,
+}: {
+  name: DeviceName;
+  children: React.ReactNode;
+  /** Mobile surfaces pin a floating bar, so the frame needs a known height. */
+  height?: number;
+}) => (
+  <div className="flex shrink-0 flex-col gap-2">
+    <span className="font-bold uppercase text-text-quaternary typo-caption2">
+      {name} · {DEVICES[name].viewport}
+    </span>
+    <div
+      className="relative shrink-0 overflow-hidden rounded-16 border border-border-subtlest-tertiary bg-background-default"
+      style={{ width: DEVICES[name].width, height }}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+/** Devices sit in a scroller rather than wrapping, so widths stay honest. */
+export const Rail = ({ children }: { children: React.ReactNode }) => (
+  <div className="flex w-full items-start gap-6 overflow-x-auto pb-3">
+    {children}
+  </div>
+);
+
+export const Variant = ({
+  step,
+  headline,
+  note,
+  children,
+}: {
+  step: string;
+  headline: string;
+  note: string;
+  children: React.ReactNode;
+}) => (
+  // Full width so a device rail can scroll across the whole canvas.
+  <div className="flex w-full flex-col gap-3">
+    <div className="flex flex-col gap-1">
+      <span className="font-bold uppercase text-text-quaternary typo-caption2">
+        {step}
+      </span>
+      <span className="font-bold text-text-primary typo-callout">
+        {headline}
+      </span>
+      <span className="text-text-tertiary typo-footnote">{note}</span>
+    </div>
+    {children}
+  </div>
+);
+
+export const Category = ({
+  title,
+  covers,
+  verdict,
+  children,
+}: {
+  title: string;
+  covers: string;
+  verdict: string;
+  children: React.ReactNode;
+}) => (
+  <section className="flex flex-col gap-6 border-t border-border-subtlest-tertiary pt-10">
+    <div className="flex flex-col gap-2">
+      <h2 className="font-bold text-text-primary typo-mega3">{title}</h2>
+      <span className="text-text-tertiary typo-footnote">{covers}</span>
+      <p className="max-w-[54rem] text-text-secondary typo-callout">
+        {verdict}
+      </p>
+    </div>
+    <div className="flex flex-col gap-10">{children}</div>
+  </section>
+);
+
+/** Every category page opens with the same header, so they read as a set. */
+export const SurfacePage = ({
+  title,
+  intro,
+  map,
+  children,
+}: {
+  title: string;
+  intro: string;
+  map: string;
+  children: React.ReactNode;
+}) => (
+  <div className="flex flex-col gap-6 p-8">
+    <div className="flex flex-col gap-3">
+      <H1>{title}</H1>
+      <P>{intro}</P>
+      <Note>{map}</Note>
+    </div>
+    {children}
+  </div>
+);

--- a/packages/storybook/stories/features/snapshot/surfaces/InviteOnboarding.stories.tsx
+++ b/packages/storybook/stories/features/snapshot/surfaces/InviteOnboarding.stories.tsx
@@ -1,0 +1,279 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  Button,
+  ButtonIconPosition,
+  ButtonSize,
+  ButtonVariant,
+} from '@dailydotdev/shared/src/components/buttons/Button';
+import {
+  MoveToIcon,
+  PlusIcon,
+  VIcon,
+} from '@dailydotdev/shared/src/components/icons';
+import type { DeviceName } from '../surfaceChrome';
+import {
+  AVATAR,
+  Category,
+  Device,
+  Rail,
+  SurfacePage,
+  Variant,
+} from '../surfaceChrome';
+
+type Spot = 'settings' | 'step' | 'progress';
+
+const TARGETS = [
+  ['X', 'bg-text-primary'],
+  ['WhatsApp', 'bg-accent-avocado-default'],
+  ['Facebook', 'bg-accent-bun-default'],
+  ['Reddit', 'bg-accent-ketchup-default'],
+  ['LinkedIn', 'bg-accent-blueCheese-default'],
+  ['Telegram', 'bg-accent-water-default'],
+  ['Email', 'bg-accent-burger-default'],
+];
+
+/* ---------------------------------------------------------- today: settings */
+
+/**
+ * /settings/invite as it ships: three AccountContentSections, a TextField
+ * labelled "Your unique invite URL" with a Primary Copy link action button,
+ * then "or invite via" and the SocialShareList row.
+ */
+const SettingsScreen = ({ device }: { device: DeviceName }) => (
+  <Device name={device}>
+    <div className="flex flex-col gap-6 p-4">
+      <h1 className="font-bold text-text-primary typo-title2">
+        Invite friends
+      </h1>
+
+      <section className="flex flex-col gap-1">
+        <h2 className="font-bold text-text-primary typo-body">
+          Grow the community
+        </h2>
+        <p className="text-text-tertiary typo-callout">
+          Share daily.dev with developers you know. When they join through your
+          link, they&apos;ll show up in your referrals list below.
+        </p>
+      </section>
+
+      <section className="flex flex-col gap-1">
+        <h2 className="font-bold text-text-primary typo-body">
+          Share your invite link
+        </h2>
+        <p className="text-text-tertiary typo-callout">
+          Copy your personal link or share it directly on social platforms.
+        </p>
+        <div className="mt-4 flex flex-col gap-1">
+          <span className="text-text-tertiary typo-caption1">
+            Your unique invite URL
+          </span>
+          <div className="flex items-center gap-2 rounded-14 border border-border-subtlest-secondary px-3 py-2">
+            <span className="min-w-0 flex-1 truncate text-text-primary typo-body">
+              dly.to/tomer
+            </span>
+            <Button size={ButtonSize.Small} variant={ButtonVariant.Primary}>
+              Copy link
+            </Button>
+          </div>
+        </div>
+        <span className="my-4 block p-0.5 font-bold text-text-tertiary typo-callout">
+          or invite via
+        </span>
+        <div className="flex flex-row flex-wrap gap-2 gap-y-4">
+          {TARGETS.slice(0, device === 'Mobile' ? 5 : 7).map(
+            ([label, tone]) => (
+              <div key={label} className="flex w-16 flex-col items-center gap-1">
+                <span className={`size-10 rounded-full ${tone}`} />
+                <span className="text-text-tertiary typo-caption2">
+                  {label}
+                </span>
+              </div>
+            ),
+          )}
+        </div>
+      </section>
+    </div>
+  </Device>
+);
+
+/* ------------------------------------------------------- proposed: the step */
+
+const Slot = ({ filled }: { filled?: boolean }) =>
+  filled ? (
+    <div className="relative">
+      <img alt="" className="size-14 rounded-full object-cover" src={AVATAR} />
+      <span className="absolute -bottom-0.5 -right-0.5 flex size-5 items-center justify-center rounded-full bg-accent-avocado-default">
+        <VIcon className="size-3 text-white" />
+      </span>
+    </div>
+  ) : (
+    <span className="flex size-14 items-center justify-center rounded-full border border-dashed border-border-subtlest-tertiary text-text-quaternary">
+      <PlusIcon />
+    </span>
+  );
+
+/**
+ * FunnelStepCtaWrapper's glass branch: a sticky top bar with the logo and
+ * Skip, the step content on the 32rem rail, then a scrim, the glass bar with
+ * a Medium Primary CTA, and the step dots.
+ */
+const StepScreen = ({
+  device,
+  spot,
+}: {
+  device: DeviceName;
+  spot: Spot;
+}) => (
+  <Device name={device}>
+    <div className="flex flex-col">
+      <div className="flex w-full items-center px-6 pt-6">
+        <span className="flex-1 font-bold text-text-primary typo-callout">
+          daily.dev
+        </span>
+        <Button
+          icon={<MoveToIcon />}
+          iconPosition={ButtonIconPosition.Right}
+          size={ButtonSize.Small}
+          variant={ButtonVariant.Tertiary}
+        >
+          Skip
+        </Button>
+      </div>
+
+      <div className="mx-auto flex w-full max-w-[32rem] flex-col gap-4 px-6 py-8 text-center">
+        <h2 className="font-bold text-text-primary typo-title1">
+          Invite 3 friends, get a month of Plus
+        </h2>
+        <p className="text-text-primary typo-body">
+          They get daily.dev, you both get Plus. It counts as soon as they sign
+          up with your link.
+        </p>
+
+        <div className="my-2 flex items-center justify-center gap-4">
+          <Slot filled={spot === 'progress'} />
+          <Slot />
+          <Slot />
+        </div>
+
+        {spot === 'progress' && (
+          <span className="text-text-tertiary typo-footnote">
+            1 of 3 joined
+          </span>
+        )}
+
+        <div className="flex items-center gap-2 rounded-14 border border-border-subtlest-secondary px-3 py-2 text-left">
+          <span className="min-w-0 flex-1 truncate text-text-primary typo-body">
+            dly.to/tomer
+          </span>
+          <Button size={ButtonSize.Small} variant={ButtonVariant.Primary}>
+            Copy link
+          </Button>
+        </div>
+
+        <div className="flex flex-row flex-wrap justify-center gap-2 gap-y-4">
+          {TARGETS.slice(0, device === 'Mobile' ? 5 : 7).map(
+            ([label, tone]) => (
+              <div key={label} className="flex w-16 flex-col items-center gap-1">
+                <span className={`size-10 rounded-full ${tone}`} />
+                <span className="text-text-tertiary typo-caption2">
+                  {label}
+                </span>
+              </div>
+            ),
+          )}
+        </div>
+      </div>
+
+      <div className="mx-auto flex w-full max-w-[32rem] flex-col gap-3 px-6 pb-6 pt-6">
+        <div className="flex rounded-16 border border-border-subtlest-tertiary bg-surface-float p-2">
+          <Button
+            className="flex-1 whitespace-nowrap"
+            size={ButtonSize.Medium}
+            variant={ButtonVariant.Primary}
+          >
+            Continue
+          </Button>
+        </div>
+        <div className="flex justify-center gap-1">
+          {[0, 1, 2, 3, 4].map((dot) => (
+            <span
+              key={dot}
+              className={`h-1.5 rounded-50 ${
+                dot === 3
+                  ? 'w-6 bg-text-primary'
+                  : 'w-1.5 bg-border-subtlest-tertiary'
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  </Device>
+);
+
+/* -------------------------------------------------------------------- page */
+
+const InviteOnboarding = () => (
+  <SurfacePage
+    intro="The one surface on this board where the recommendation is placement, not payload. The invite already has the most complete share UI in the product — it is simply in settings, which is the last place a new account goes."
+    map="Sharing map: Copy link leads (#6366). An image of a referral cannot be clicked, so snapshot has nothing to add here and is deliberately absent from every variation below."
+    title="Invite friends — onboarding step"
+  >
+    <Category
+      covers="pages/settings/invite.tsx · InviteLinkInput.tsx · SocialShareList.tsx"
+      title="Where it lives today"
+      verdict="Complete, and unreachable. A labelled TextField with a Primary Copy link button, then the full seven-target row — buried three levels into settings, long after the moment when a new user is most willing to bring someone with them."
+    >
+      <Variant
+        headline="/settings/invite"
+        note="Nothing about this page is wrong. The problem is that reaching it requires already wanting to invite someone, which is the thing the page is supposed to cause."
+        step="Today"
+      >
+        <Rail>
+          <SettingsScreen device="Desktop" />
+          <SettingsScreen device="Tablet" />
+          <SettingsScreen device="Mobile" />
+        </Rail>
+      </Variant>
+    </Category>
+
+    <Category
+      covers="#6366 · blocked on backend · FunnelStepCtaWrapper.tsx · StepHeadline.tsx"
+      title="The proposed onboarding step"
+      verdict="Same controls, moved to the moment the reward still means something. Built on the funnel step chrome: the logo and Skip in the sticky top bar, content on the 32rem rail, then the glass bar with a Medium Primary CTA and the step dots."
+    >
+      <Variant
+        headline="Invite 3 friends, get a month of Plus"
+        note="Three empty slots, the invite link and the same target row. Skip stays in the top bar, so the step never blocks the funnel. Needs the funnel JSON step and a Plus-grant mechanism — the frontend cannot ship alone."
+        step="Proposed"
+      >
+        <Rail>
+          <StepScreen device="Desktop" spot="step" />
+          <StepScreen device="Tablet" spot="step" />
+          <StepScreen device="Mobile" spot="step" />
+        </Rail>
+      </Variant>
+      <Variant
+        headline="One joined, two to go"
+        note="The state that makes the step worth building: a filled slot turns an ask into a streak someone wants to finish. It also needs somewhere to live after onboarding ends, since the third friend rarely joins during signup."
+        step="Progress"
+      >
+        <Rail>
+          <StepScreen device="Desktop" spot="progress" />
+          <StepScreen device="Mobile" spot="progress" />
+        </Rail>
+      </Variant>
+    </Category>
+  </SurfacePage>
+);
+
+const meta: Meta<typeof InviteOnboarding> = {
+  title: 'Features/Snapshot/Surfaces/Invite onboarding',
+  component: InviteOnboarding,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+
+export const Variations: StoryObj<typeof InviteOnboarding> = {};

--- a/packages/webapp/pages/onboarding/invite-preview.tsx
+++ b/packages/webapp/pages/onboarding/invite-preview.tsx
@@ -1,0 +1,191 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useEffect, useState } from 'react';
+import { NextSeo } from 'next-seo';
+import { useRouter } from 'next/router';
+import { PlusIcon, VIcon } from '@dailydotdev/shared/src/components/icons';
+import { InviteLinkInput } from '@dailydotdev/shared/src/components/referral';
+import { SocialShareList } from '@dailydotdev/shared/src/components/widgets/SocialShareList';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '@dailydotdev/shared/src/components/typography/Typography';
+import { FunnelStepCtaWrapper } from '@dailydotdev/shared/src/features/onboarding/shared/FunnelStepCtaWrapper';
+import { FunnelProgressContext } from '@dailydotdev/shared/src/features/onboarding/shared/FunnelStepDots';
+import { StepHeadline } from '@dailydotdev/shared/src/features/onboarding/shared/StepHeadline';
+import {
+  ReferralCampaignKey,
+  useReferralCampaign,
+} from '@dailydotdev/shared/src/hooks';
+import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
+import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
+import { labels } from '@dailydotdev/shared/src/lib';
+import { link as links } from '@dailydotdev/shared/src/lib/links';
+import {
+  LogEvent,
+  TargetId,
+  TargetType,
+} from '@dailydotdev/shared/src/lib/log';
+import type { ShareProvider } from '@dailydotdev/shared/src/lib/share';
+import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+
+/**
+ * /onboarding/invite-preview — internal review surface for the invite step
+ * proposed in #6366: the same controls that ship on /settings/invite, moved
+ * to the moment in onboarding when the reward still means something.
+ *
+ * Drawn on the production funnel chrome and wired to the real referral link,
+ * so it renders as the step would in the funnel rather than as a mockup of
+ * it. `?state=progress` shows the one-of-three state. It sits outside
+ * `/dev/*` because that tree short-circuits the app shell, and these controls
+ * need auth and log context. Carries `noindex`/`nofollow`; reachable on
+ * preview + local but blocked on the canonical production hosts.
+ */
+
+const NO_PROFILE =
+  'https://res.cloudinary.com/daily-now/image/upload/s--O0TOmw4y--/f_auto/v1715772965/public/noProfile';
+
+type Spot = 'step' | 'progress';
+
+const useReviewAllowed = (): boolean => {
+  const [allowed, setAllowed] = useState(true);
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const { hostname } = window.location;
+    setAllowed(hostname !== 'app.daily.dev' && hostname !== 'www.daily.dev');
+  }, []);
+  return allowed;
+};
+
+const Slot = ({ filled, image }: { filled?: boolean; image?: string }) => {
+  if (!filled) {
+    return (
+      <span className="flex size-14 items-center justify-center rounded-full border border-dashed border-border-subtlest-tertiary text-text-quaternary">
+        <PlusIcon />
+      </span>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <img
+        alt=""
+        className="size-14 rounded-full object-cover"
+        src={image || NO_PROFILE}
+      />
+      <span className="absolute -bottom-0.5 -right-0.5 flex size-5 items-center justify-center rounded-full bg-accent-avocado-default">
+        <VIcon className="size-3 text-white" />
+      </span>
+    </div>
+  );
+};
+
+const InviteStep = ({ spot }: { spot: Spot }): ReactElement => {
+  const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
+  const { url } = useReferralCampaign({
+    campaignKey: ReferralCampaignKey.Generic,
+  });
+  const inviteLink = url || links.referral.defaultUrl;
+  const [, onShareOrCopyLink] = useShareOrCopyLink({
+    text: labels.referral.generic.inviteText,
+    link: inviteLink,
+    logObject: () => ({
+      event_name: LogEvent.CopyReferralLink,
+      target_id: TargetId.InviteFriendsPage,
+    }),
+  });
+
+  const onLogShare = (provider: ShareProvider) =>
+    logEvent({
+      event_name: LogEvent.InviteReferral,
+      target_id: provider,
+      target_type: TargetType.InviteFriendsPage,
+    });
+
+  return (
+    <FunnelStepCtaWrapper
+      cta={{ label: 'Continue' }}
+      isGlass
+      skip={{ cta: 'Skip' }}
+    >
+      <div className="mx-auto flex w-full max-w-[32rem] flex-col gap-4 px-6 py-8">
+        <StepHeadline
+          description="They get daily.dev, you both get Plus. It counts as soon as they sign up with your link."
+          heading="Invite 3 friends, get a month of Plus"
+        />
+
+        <div className="my-2 flex items-center justify-center gap-4">
+          <Slot filled={spot === 'progress'} image={user?.image} />
+          <Slot />
+          <Slot />
+        </div>
+
+        {spot === 'progress' && (
+          <Typography
+            className="text-center"
+            color={TypographyColor.Tertiary}
+            tag={TypographyTag.Span}
+            type={TypographyType.Footnote}
+          >
+            1 of 3 joined
+          </Typography>
+        )}
+
+        <InviteLinkInput
+          link={inviteLink}
+          logProps={{
+            event_name: LogEvent.CopyReferralLink,
+            target_id: TargetId.InviteFriendsPage,
+          }}
+        />
+
+        <div className="flex flex-row flex-wrap justify-center gap-2 gap-y-4">
+          <SocialShareList
+            description={labels.referral.generic.inviteText}
+            link={inviteLink}
+            onClickSocial={onLogShare}
+            onNativeShare={onShareOrCopyLink}
+            shortenUrl={false}
+          />
+        </div>
+      </div>
+    </FunnelStepCtaWrapper>
+  );
+};
+
+// Five steps with the invite fourth, matching the position #6366 proposes.
+const PROGRESS = {
+  chapters: [{ steps: 5 }],
+  position: { chapter: 0, step: 3 },
+  isOnboarding: true,
+};
+
+const InviteOnboardingPreviewPage = (): ReactElement => {
+  const router = useRouter();
+  const allowed = useReviewAllowed();
+
+  if (!allowed) {
+    return <NextSeo nofollow noindex />;
+  }
+
+  return (
+    <>
+      <NextSeo nofollow noindex title="Invite onboarding step" />
+      <div className="flex min-h-dvh min-w-full flex-col">
+        <FunnelProgressContext.Provider value={PROGRESS}>
+          <InviteStep
+            spot={router.query.state === 'progress' ? 'progress' : 'step'}
+          />
+        </FunnelProgressContext.Provider>
+      </div>
+    </>
+  );
+};
+
+InviteOnboardingPreviewPage.getLayout = (page: ReactNode): ReactNode => page;
+
+export default InviteOnboardingPreviewPage;


### PR DESCRIPTION
Lifts the **Invite onboarding** surface out of #6544 on its own. Nothing else from that stack comes with it — no snapshot components, no icons, no sharing map.

## Changes

- **The argument, in Storybook** — `Features/Snapshot/Surfaces/Invite onboarding`, unchanged from #6544: today's `/settings/invite` beside the proposed step, each at Desktop / Tablet / Mobile. The settings page is complete and unreachable — a labelled TextField, a Primary Copy link and the seven-target row, buried three levels into settings, long after the moment a new account is most willing to bring someone with them. The invite is not a payload problem, it is a placement one.
- **Trimmed chrome** — `surfaceChrome.tsx` carries only what this one surface uses. The snapshot control, the sharing-map types and the `SnapshotIcon` are all left behind; snapshot is deliberately absent from this surface anyway, since an image of a referral cannot be clicked.
- **`/onboarding/invite-preview`** — the same step drawn in the app rather than as a mockup of it: `FunnelStepCtaWrapper`'s glass branch, `StepHeadline`, and the production `InviteLinkInput` and `SocialShareList` wired to the real referral link, so copy and share behave as they would in the funnel. `?state=progress` shows the one-of-three state.

It sits outside `/dev/*` on purpose: that tree short-circuits the app shell (`isDevReviewRoute` in `_app.tsx`), and these controls need auth and log context. It carries `noindex`/`nofollow` and is blocked on `app.daily.dev` / `www.daily.dev`, so it is reachable on preview and local only.

## Not in this PR

Design review only. The step is not registered in the funnel — it needs the funnel JSON step and a Plus-grant mechanism, so the frontend cannot ship it alone. No feature flag, no backend, no data wiring beyond the referral link the settings page already uses.

## One thing the app preview surfaced

Storybook drew the seven share targets as one row. In the funnel's real 32rem rail they do not fit and wrap 6+1 on desktop, 4+3 on mobile. Left as-is rather than resized, because the fix belongs in `SocialShareList` and that is a shared component this PR should not be touching. Worth a decision before the step is built for real.

## Events

None. The two existing referral events (`CopyReferralLink`, `InviteReferral`) fire from the reused components with the same target ids the settings page sends.

## Experiment

None.

## Testing

- `typecheck-strict-changed` clean; eslint clean on every touched file.
- Verified in the running webapp at both states and at desktop and mobile widths — real funnel chrome, working Copy link, real share targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-invite-onboarding-draft-p.preview.app.daily.dev