### PR TITLE
feat(analytics): instrument search for the search_version experiment

### DIFF
--- a/packages/extension/src/newtab/MainFeedPage.tsx
+++ b/packages/extension/src/newtab/MainFeedPage.tsx
@@ -16,6 +16,8 @@ import { useSettingsContext } from '@dailydotdev/shared/src/contexts/SettingsCon
 import { SearchProviderEnum } from '@dailydotdev/shared/src/graphql/search';
 import { LogEvent } from '@dailydotdev/shared/src/lib/log';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
+import { useFeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 import { useFeedLayout } from '@dailydotdev/shared/src/hooks';
 import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
 import { useShortcutLinks } from '@dailydotdev/shared/src/features/shortcuts/hooks/useShortcutLinks';
@@ -71,6 +73,7 @@ const MainFeedPageInner = ({
   shortcuts,
 }: MainFeedPageProps): ReactElement => {
   const { logEvent } = useLogContext();
+  const { getFeatureValue } = useFeaturesReadyContext();
   const [isSearchOn, setIsSearchOn] = useState(false);
   const { user, loadingUser } = useContext(AuthContext);
   const [feedName, setFeedName] = useState<string>(() =>
@@ -188,6 +191,7 @@ const MainFeedPageInner = ({
                       extra: JSON.stringify({
                         query,
                         provider: SearchProviderEnum.Posts,
+                        search_version: getFeatureValue(feature.searchVersion),
                         ...extraFlags,
                       }),
                     });

--- a/packages/shared/src/components/Feed.tsx
+++ b/packages/shared/src/components/Feed.tsx
@@ -27,6 +27,7 @@ import FeedItemComponent, { getFeedItemKey } from './FeedItemComponent';
 import type { FeaturedWideColSpan } from './cards/common/featuredWide';
 import { useLogContext } from '../contexts/LogContext';
 import { feedLogExtra, postLogEvent } from '../lib/feed';
+import type { SearchLogExtra } from '../lib/searchLog';
 import { usePostModalNavigation } from '../hooks/usePostModalNavigation';
 import { useSharePost } from '../hooks/useSharePost';
 import { LogEvent, Origin, TargetId } from '../lib/log';
@@ -119,6 +120,13 @@ export interface FeedProps<T>
    */
   hideTags?: boolean;
   topContent?: ReactNode;
+  /**
+   * Search feeds only: correlation id for the query execution and the backend
+   * search version behind it. Both ride along on every engagement event so the
+   * search experiment can be measured per query.
+   */
+  searchId?: string;
+  searchVersion?: number;
 }
 
 interface RankVariables {
@@ -214,6 +222,8 @@ export default function Feed<T>({
   hideSource = false,
   hideTags = false,
   topContent: topContentProp,
+  searchId,
+  searchVersion,
 }: FeedProps<T>): ReactElement {
   const origin = Origin.Feed;
   const { logEvent } = useLogContext();
@@ -369,6 +379,8 @@ export default function Feed<T>({
         staticAd,
         adPostLength: isSquadFeed ? 2 : undefined,
         feedName,
+        searchId,
+        searchVersion,
       },
     },
   );
@@ -536,6 +548,14 @@ export default function Feed<T>({
 
   const { ranking } = (variables as RankVariables) || {};
 
+  const searchLogExtra = useMemo<SearchLogExtra | undefined>(() => {
+    if (!searchId && searchVersion === undefined) {
+      return undefined;
+    }
+
+    return { search_id: searchId, search_version: searchVersion };
+  }, [searchId, searchVersion]);
+
   const infiniteScrollRef = useFeedInfiniteScroll({
     fetchPage,
     canFetchMore: canFetchMore && feedQueryKey?.[0] !== RequestKey.FeedPreview,
@@ -559,32 +579,36 @@ export default function Feed<T>({
 
   useFeedContentPreferenceMutationSubscription({ feedQueryKey });
 
-  const onPostClick = useFeedOnPostClick(
+  const onPostClick = useFeedOnPostClick({
     items,
     updatePost,
-    virtualizedNumCards,
+    columns: virtualizedNumCards,
     feedName,
     ranking,
-  );
+    searchLogExtra,
+  });
 
-  const onReadArticleClick = useFeedOnPostClick(
+  const onReadArticleClick = useFeedOnPostClick({
     items,
     updatePost,
-    virtualizedNumCards,
+    columns: virtualizedNumCards,
     feedName,
     ranking,
-    'go to link',
-  );
+    eventName: 'go to link',
+    searchLogExtra,
+  });
 
   const trackFinishFeed = useCallback(() => {
     if (!canFetchMore) {
       logEvent({
         event_name: LogEvent.FinishFeed,
-        extra: JSON.stringify(feedLogExtra(feedName, ranking).extra),
+        extra: JSON.stringify(
+          feedLogExtra(feedName, ranking, searchLogExtra).extra,
+        ),
         ...logOpts,
       });
     }
-  }, [canFetchMore, feedName, logEvent, logOpts, ranking]);
+  }, [canFetchMore, feedName, logEvent, logOpts, ranking, searchLogExtra]);
 
   const { openSharePost, copyLink } = useSharePost(origin);
 
@@ -695,7 +719,8 @@ export default function Feed<T>({
         columns: virtualizedNumCards,
         column,
         row,
-        ...feedLogExtra(feedName, ranking),
+        index,
+        ...feedLogExtra(feedName, ranking, searchLogExtra),
         is_ad: isAd,
       }),
     );
@@ -785,6 +810,7 @@ export default function Feed<T>({
                   virtualizedNumCards={virtualizedNumCards}
                   disableAdRefresh={disableAdRefresh}
                   wideColSpan={wideColSpan}
+                  searchLogExtra={searchLogExtra}
                 />
               );
 

--- a/packages/shared/src/components/FeedItemComponent.tsx
+++ b/packages/shared/src/components/FeedItemComponent.tsx
@@ -11,6 +11,7 @@ import type { LoggedUser } from '../lib/user';
 import useLogImpression from '../hooks/feed/useLogImpression';
 import type { FeedPostClick } from '../hooks/feed/useFeedOnPostClick';
 import { LogEvent, Origin, TargetType } from '../lib/log';
+import type { SearchLogExtra } from '../lib/searchLog';
 import type { UseVotePost } from '../hooks';
 import { useFeedLayout } from '../hooks';
 import { CollectionList } from './cards/collection/CollectionList';
@@ -102,6 +103,8 @@ export type FeedItemComponentProps = {
    * types with an active `hero`.
    */
   wideColSpan?: FeaturedWideColSpan;
+  /** Set on search feeds so impressions can be joined to the query. */
+  searchLogExtra?: SearchLogExtra;
 } & Pick<UseVotePost, 'toggleUpvote' | 'toggleDownvote'> &
   Pick<UseBookmarkPost, 'toggleBookmark'>;
 
@@ -278,9 +281,10 @@ function FeedItemComponent({
   onReadArticleClick,
   virtualizedNumCards,
   wideColSpan,
+  searchLogExtra,
 }: FeedItemComponentProps): ReactElement | null {
   const { logEvent } = useLogContext();
-  const inViewRef = useLogImpression(
+  const inViewRef = useLogImpression({
     item,
     index,
     columns,
@@ -288,8 +292,9 @@ function FeedItemComponent({
     row,
     feedName,
     ranking,
-    wideColSpan,
-  );
+    highlightColSpan: wideColSpan,
+    searchLogExtra,
+  });
 
   const { shouldUseListFeedLayout, shouldUseListMode } = useFeedLayout();
   const { boostedBy } = useFeedCardContext();

--- a/packages/shared/src/components/MainFeedLayout.tsx
+++ b/packages/shared/src/components/MainFeedLayout.tsx
@@ -46,7 +46,7 @@ import { generateQueryKey, OtherFeedPage, RequestKey } from '../lib/query';
 import SettingsContext from '../contexts/SettingsContext';
 import usePersistentContext from '../hooks/usePersistentContext';
 import AlertContext from '../contexts/AlertContext';
-import { useFeature, useFeaturesReadyContext } from './GrowthBookProvider';
+import { useFeature } from './GrowthBookProvider';
 import {
   algorithms,
   DEFAULT_ALGORITHM_INDEX,
@@ -87,6 +87,7 @@ import { ExploreTabs, tabToUrl, urlToTab } from './header';
 import { FeedExploreTabs } from './header/FeedExploreTabs';
 import { QueryStateKeys, useQueryState } from '../hooks/utils/useQueryState';
 import { useSearchResultsLayout } from '../hooks/search/useSearchResultsLayout';
+import { useSearchId } from '../hooks/search/useSearchId';
 import useCustomDefaultFeed from '../hooks/feed/useCustomDefaultFeed';
 import { useSearchContextProvider } from '../contexts/search/SearchContext';
 import { isDevelopment, isProductionAPI, webappUrl } from '../lib/constants';
@@ -240,7 +241,6 @@ export default function MainFeedLayout({
   const { numCards: feedSpacinessCards } = useContext(FeedContext);
   const router = useRouter();
   const [tab, setTab] = useState(ExploreTabs.Popular);
-  const { getFeatureValue } = useFeaturesReadyContext();
   const feedName = getFeedName(feedNameProp, {
     hasFiltered: !alerts?.filter,
     hasUser: !!user,
@@ -321,6 +321,22 @@ export default function MainFeedLayout({
     feature: customFeedVersion,
     shouldEvaluate: feedName === SharedFeedPage.Custom,
   });
+
+  const isPostSearch = isSearchOn && !!searchQuery;
+  const { value: searchVersion } = useConditionalFeature({
+    feature: feature.searchVersion,
+    shouldEvaluate: isPostSearch,
+  });
+  const searchId = useSearchId(
+    isPostSearch
+      ? [
+          searchQuery,
+          searchVersion,
+          contentCurationFilter.join(','),
+          time,
+        ].join('|')
+      : '',
+  );
 
   const isChipStripPage =
     router.pathname === '/' ||
@@ -553,7 +569,6 @@ export default function MainFeedLayout({
     }
 
     if (isSearchOn && searchQuery) {
-      const searchVersion = getFeatureValue(feature.searchVersion);
       return {
         feedName: SharedFeedPage.Search,
         feedQueryKey: generateQueryKey(
@@ -570,6 +585,8 @@ export default function MainFeedLayout({
           contentCuration: contentCurationFilter,
           time,
         },
+        searchId,
+        searchVersion,
         emptyScreen: <SearchEmptyScreen />,
       };
     }
@@ -649,7 +666,8 @@ export default function MainFeedLayout({
     selectedAlgo,
     handleSelectedAlgoChange,
     defaultFeedId,
-    getFeatureValue,
+    searchId,
+    searchVersion,
     contentCurationFilter,
     time,
     tab,

--- a/packages/shared/src/components/search/SearchResults/SearchResultsLayout.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsLayout.tsx
@@ -9,6 +9,7 @@ import { useSearchResultsLayout } from '../../../hooks/search/useSearchResultsLa
 import { LogEvent, Origin, TargetType } from '../../../lib/log';
 import { useLogContext } from '../../../contexts/LogContext';
 import { webappUrl } from '../../../lib/constants';
+import { searchRecommendationLogExtra } from '../../../lib/searchLog';
 import { SearchResultsTags } from './SearchResultsTags';
 import { SearchResultsSources } from './SearchResultsSources';
 import { useSearchProviderSuggestions } from '../../../hooks/search';
@@ -35,36 +36,48 @@ export const SearchResultsLayout = (
   const { logEvent } = useLogContext();
   const query = typeof q === 'string' ? q : '';
 
-  const { isLoading: isTagsLoading, suggestions: suggestedTags } =
-    useSearchProviderSuggestions({
-      query,
-      provider: SearchProviderEnum.Tags,
-      limit: 10,
-      enabled: isSearchPageLaptop,
-    });
+  const {
+    isLoading: isTagsLoading,
+    suggestions: suggestedTags,
+    searchId: tagsSearchId,
+    searchVersion: tagsSearchVersion,
+  } = useSearchProviderSuggestions({
+    query,
+    provider: SearchProviderEnum.Tags,
+    limit: 10,
+    enabled: isSearchPageLaptop,
+  });
   const tags = suggestedTags?.hits.flatMap(({ id }) => (id ? [id] : [])) ?? [];
 
-  const { isLoading: isSourcesLoading, suggestions: suggestedSources } =
-    useSearchProviderSuggestions({
-      query,
-      provider: SearchProviderEnum.Sources,
-      limit: 10,
-      enabled: isSearchPageLaptop,
-    });
+  const {
+    isLoading: isSourcesLoading,
+    suggestions: suggestedSources,
+    searchId: sourcesSearchId,
+    searchVersion: sourcesSearchVersion,
+  } = useSearchProviderSuggestions({
+    query,
+    provider: SearchProviderEnum.Sources,
+    limit: 10,
+    enabled: isSearchPageLaptop,
+  });
   const sources = suggestedSources?.hits ?? [];
 
-  const { isLoading: isUsersLoading, suggestions: suggestedUsers } =
-    useSearchProviderSuggestions({
-      query,
-      provider: SearchProviderEnum.Users,
-      limit: 10,
-      includeContentPreference: true,
-      enabled: isSearchPageLaptop,
-    });
+  const {
+    isLoading: isUsersLoading,
+    suggestions: suggestedUsers,
+    searchId: usersSearchId,
+    searchVersion: usersSearchVersion,
+  } = useSearchProviderSuggestions({
+    query,
+    provider: SearchProviderEnum.Users,
+    limit: 10,
+    includeContentPreference: true,
+    enabled: isSearchPageLaptop,
+  });
 
   const users = suggestedUsers?.hits ?? [];
 
-  const onTagClick = (suggestion: SearchSuggestion) => {
+  const onTagClick = (suggestion: SearchSuggestion, position: number) => {
     const tag = suggestion.id || suggestion.title.toLowerCase();
 
     logEvent({
@@ -72,10 +85,15 @@ export const SearchResultsLayout = (
       target_type: TargetType.SearchRecommendation,
       target_id: tag,
       feed_item_title: tag,
-      extra: JSON.stringify({
-        origin: Origin.SearchPage,
-        provider: SearchProviderEnum.Tags,
-      }),
+      extra: JSON.stringify(
+        searchRecommendationLogExtra({
+          origin: Origin.SearchPage,
+          provider: SearchProviderEnum.Tags,
+          position,
+          searchId: tagsSearchId,
+          searchVersion: tagsSearchVersion,
+        }),
+      ),
     });
 
     push(`${webappUrl}tags/${tag}`);
@@ -132,14 +150,24 @@ export const SearchResultsLayout = (
                 target_type: TargetType.SearchRecommendation,
                 target_id: source.id,
                 feed_item_title: source.name,
-                extra: JSON.stringify({
-                  origin: Origin.SearchPage,
-                  provider: SearchProviderEnum.Sources,
-                }),
+                extra: JSON.stringify(
+                  searchRecommendationLogExtra({
+                    origin: Origin.SearchPage,
+                    provider: SearchProviderEnum.Sources,
+                    position: sources.findIndex((hit) => hit.id === source.id),
+                    searchId: sourcesSearchId,
+                    searchVersion: sourcesSearchVersion,
+                  }),
+                ),
               });
             }}
           />
-          <SearchResultsUsers isLoading={isUsersLoading} items={users} />
+          <SearchResultsUsers
+            isLoading={isUsersLoading}
+            items={users}
+            searchId={usersSearchId}
+            searchVersion={usersSearchVersion}
+          />
         </PageWidgets>
       </div>
     </section>

--- a/packages/shared/src/components/search/SearchResults/SearchResultsTags.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsTags.tsx
@@ -8,7 +8,7 @@ import type { SearchSuggestion } from '../../../graphql/search';
 interface SearchResultsTagsProps {
   items: string[];
   isLoading: boolean;
-  onTagClick: (suggestion: SearchSuggestion) => void;
+  onTagClick: (suggestion: SearchSuggestion, position: number) => void;
 }
 
 export const SearchResultsTags = (
@@ -24,14 +24,14 @@ export const SearchResultsTags = (
     <WidgetCard heading="Related tags" data-testid="related-tags">
       {!!items?.length && (
         <div className="flex flex-wrap gap-3" role="list">
-          {items.map((tag) => (
+          {items.map((tag, position) => (
             <TagLink
               key={tag}
               tag={tag}
               buttonProps={{
                 onClick: (e) => {
                   e.preventDefault();
-                  onTagClick({ title: tag });
+                  onTagClick({ title: tag }, position);
                 },
               }}
             />

--- a/packages/shared/src/components/search/SearchResults/SearchResultsUsers.spec.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsUsers.spec.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Origin, TargetType } from '../../../lib/log';
+import { SearchProviderEnum } from '../../../graphql/search';
+import { SearchResultsUsers } from './SearchResultsUsers';
+
+const mockLogEvent = jest.fn();
+
+jest.mock('../../../contexts/LogContext', () => ({
+  useLogContext: () => ({ logEvent: mockLogEvent }),
+}));
+
+jest.mock('../../widgets/WidgetCard', () => ({
+  WidgetCard: ({ children }: React.PropsWithChildren) => <div>{children}</div>,
+}));
+
+jest.mock('../../widgets/PostUsersHighlights', () => ({
+  UserHighlight: ({ name }: { name: string }) => <span>{name}</span>,
+}));
+
+jest.mock('../../widgets/ListItemPlaceholder', () => ({
+  ListItemPlaceholder: () => null,
+}));
+
+jest.mock('../../contentPreference/FollowButton', () => ({
+  FollowButton: () => null,
+}));
+
+const items = [
+  { id: 'u1', title: 'Ada', subtitle: 'ada' },
+  { id: 'u2', title: 'Linus', subtitle: 'linus' },
+];
+
+describe('SearchResultsUsers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs the query identity and row position on a click', async () => {
+    render(
+      <SearchResultsUsers
+        items={items}
+        isLoading={false}
+        searchId="search-1"
+        searchVersion={4}
+      />,
+    );
+
+    await userEvent.click(screen.getByText('Linus'));
+
+    expect(mockLogEvent).toHaveBeenCalledTimes(1);
+    expect(mockLogEvent.mock.calls[0][0]).toMatchObject({
+      target_type: TargetType.SearchRecommendation,
+      target_id: 'u2',
+    });
+    expect(JSON.parse(mockLogEvent.mock.calls[0][0].extra)).toEqual({
+      origin: Origin.SearchPage,
+      provider: SearchProviderEnum.Users,
+      position: 1,
+      search_id: 'search-1',
+      search_version: 4,
+    });
+  });
+});

--- a/packages/shared/src/components/search/SearchResults/SearchResultsUsers.tsx
+++ b/packages/shared/src/components/search/SearchResults/SearchResultsUsers.tsx
@@ -10,25 +10,40 @@ import { LogEvent, Origin, TargetType } from '../../../lib/log';
 import { FollowButton } from '../../contentPreference/FollowButton';
 import { ContentPreferenceType } from '../../../graphql/contentPreference';
 import type { LoggedUser } from '../../../lib/user';
+import { searchRecommendationLogExtra } from '../../../lib/searchLog';
+import { fallbackImages } from '../../../lib/config';
 
 interface SearchResultsUsersProps {
   items: SearchSuggestion[];
   isLoading: boolean;
+  /** Identity of the suggestion fetch that produced `items`. */
+  searchId?: string;
+  searchVersion?: number;
 }
 
 export const SearchResultsUsers = ({
   items,
   isLoading,
-}: SearchResultsUsersProps): ReactElement => {
+  searchId,
+  searchVersion,
+}: SearchResultsUsersProps): ReactElement | null => {
   const { logEvent } = useLogContext();
-  const users = items.map(({ id, subtitle, image, title, ...rest }) => ({
-    id,
-    name: title,
-    image,
-    username: subtitle,
-    permalink: `/${subtitle}`,
-    ...rest,
-  }));
+  // A hit without an id cannot be followed or linked to, so it never makes a
+  // usable row.
+  const users = items.flatMap(({ id, subtitle, image, title, ...rest }) =>
+    id
+      ? [
+          {
+            id,
+            name: title,
+            image: image ?? fallbackImages.avatar,
+            username: subtitle ?? '',
+            permalink: `/${subtitle}`,
+            ...rest,
+          },
+        ]
+      : [],
+  );
 
   if (!isLoading && !items.length) {
     return null;
@@ -38,7 +53,7 @@ export const SearchResultsUsers = ({
     <WidgetCard heading="Related users">
       {!!users?.length && (
         <ul className="flex flex-col gap-4">
-          {users.map((user) => (
+          {users.map((user, position) => (
             <li
               key={user.id}
               className="flex gap-2"
@@ -48,10 +63,15 @@ export const SearchResultsUsers = ({
                   target_type: TargetType.SearchRecommendation,
                   target_id: user.id,
                   feed_item_title: user.id,
-                  extra: JSON.stringify({
-                    origin: Origin.SearchPage,
-                    provider: SearchProviderEnum.Users,
-                  }),
+                  extra: JSON.stringify(
+                    searchRecommendationLogExtra({
+                      origin: Origin.SearchPage,
+                      provider: SearchProviderEnum.Users,
+                      position,
+                      searchId,
+                      searchVersion,
+                    }),
+                  ),
                 });
               }}
             >

--- a/packages/shared/src/components/spotlight/Spotlight.tsx
+++ b/packages/shared/src/components/spotlight/Spotlight.tsx
@@ -21,13 +21,20 @@ import { useAuthContext } from '../../contexts/AuthContext';
 import { AuthTriggers } from '../../lib/auth';
 import { isExtension, isInExtensionIframe } from '../../lib/func';
 import { fallbackImages } from '../../lib/config';
+import { minSearchQueryLength } from '../../graphql/search';
+import { feature } from '../../lib/featureManagement';
+import { useConditionalFeature } from '../../hooks/useConditionalFeature';
+import { useSearchId } from '../../hooks/search/useSearchId';
 import {
   groupLabels,
   groupOrder,
   scopeMeta,
   scopeOrder,
+  type SpotlightCloseDetails,
   type SpotlightCommand,
+  type SpotlightCommandRunDetails,
   SpotlightGroup,
+  type SpotlightResultsImpressionDetails,
   SpotlightScope,
 } from './types';
 import { useSpotlight } from './SpotlightContext';
@@ -390,9 +397,16 @@ interface SpotlightDialogProps {
   isOpen: boolean;
   onClose: () => void;
   /** Optional analytics callback. Injected by Phase 1's wiring. */
-  onCommandRun?: (command: SpotlightCommand) => void;
+  onCommandRun?: (
+    command: SpotlightCommand,
+    details: SpotlightCommandRunDetails,
+  ) => void;
   /** Fires when the user opens via Cmd+K. */
   onOpenViaShortcut?: () => void;
+  /** Fires once per settled result set so suggestions get an impression. */
+  onResultsImpression?: (details: SpotlightResultsImpressionDetails) => void;
+  /** Fires right before the palette closes, with the session's outcome. */
+  onCloseLog?: (details: SpotlightCloseDetails) => void;
 }
 
 const Hint = ({ label, combo }: { label: string; combo: string }) => (
@@ -409,6 +423,8 @@ export const Spotlight = ({
   onClose,
   onCommandRun,
   onOpenViaShortcut,
+  onResultsImpression,
+  onCloseLog,
 }: SpotlightDialogProps): ReactElement | null => {
   const router = useRouter();
   const { isLoggedIn, showLogin } = useAuthContext();
@@ -437,9 +453,90 @@ export const Spotlight = ({
     popScope,
     clearScope,
   } = spotlight;
+  const trimmedQuery = query.trim();
+  const isFiltering = trimmedQuery.length > 0;
+  const isSearching = isOpen && trimmedQuery.length >= minSearchQueryLength;
+  const { value: searchVersion } = useConditionalFeature({
+    feature: feature.searchVersion,
+    shouldEvaluate: isSearching,
+  });
+  const searchId = useSearchId(
+    isSearching ? [trimmedQuery, searchVersion, scope].join('|') : '',
+  );
+  const search = useSpotlightSearchCommands({
+    router,
+    query,
+    scope,
+    searchId,
+  });
+  const hasSearchResults =
+    search.users.length > 0 ||
+    search.sources.length > 0 ||
+    search.tags.length > 0 ||
+    search.posts.length > 0;
+
+  const openedAtRef = useRef(0);
+  const ranCommandRef = useRef(false);
+  const closeLoggedRef = useRef(false);
+  const loggedImpressionRef = useRef<string | null>(null);
+
+  const handleClose = useCallback(() => {
+    if (!closeLoggedRef.current) {
+      closeLoggedRef.current = true;
+      onCloseLog?.({
+        searchId,
+        query: trimmedQuery,
+        scope,
+        searchVersion,
+        resultCount: resultCount ?? undefined,
+        hadResults: hasSearchResults,
+        ranCommand: ranCommandRef.current,
+        timeOpenMs: openedAtRef.current ? Date.now() - openedAtRef.current : 0,
+      });
+    }
+    onClose();
+  }, [
+    onClose,
+    onCloseLog,
+    searchId,
+    trimmedQuery,
+    scope,
+    searchVersion,
+    resultCount,
+    hasSearchResults,
+  ]);
+
+  // Positions come from the DOM rather than the render tree: cmdk hides rows
+  // that fail its filter, so only the list itself knows the visible order.
+  const getRenderedPosition = useCallback(
+    (commandId: string): number | undefined => {
+      const nodes = listRef.current?.querySelectorAll('[data-command-id]');
+
+      if (!nodes) {
+        return undefined;
+      }
+
+      const position = Array.from(nodes).findIndex(
+        (node) => node.getAttribute('data-command-id') === commandId,
+      );
+
+      return position === -1 ? undefined : position;
+    },
+    [],
+  );
+
   const runCommand = useCallback(
-    (command: SpotlightCommand) => {
-      onCommandRun?.(command);
+    (command: SpotlightCommand, details?: { fallthrough?: boolean }) => {
+      ranCommandRef.current = true;
+      onCommandRun?.(command, {
+        searchId,
+        query: trimmedQuery,
+        scope,
+        searchVersion,
+        position: getRenderedPosition(command.id),
+        hadResults: hasSearchResults,
+        ...details,
+      });
       pushRecent(command.id);
       Promise.resolve(command.perform()).then(
         (result) => {
@@ -447,19 +544,29 @@ export const Spotlight = ({
           const keepOpen =
             !!result && typeof result === 'object' && result.keepOpen === true;
           if (!keepOpen) {
-            onClose();
+            handleClose();
           }
         },
         (error) => {
           clearConfirm();
-          onClose();
+          handleClose();
           throw error;
         },
       );
     },
-    [onCommandRun, pushRecent, clearConfirm, onClose],
+    [
+      onCommandRun,
+      pushRecent,
+      clearConfirm,
+      handleClose,
+      searchId,
+      trimmedQuery,
+      scope,
+      searchVersion,
+      getRenderedPosition,
+      hasSearchResults,
+    ],
   );
-  const search = useSpotlightSearchCommands({ router, query, scope });
   useQuickKeyDispatch({
     query,
     setQuery,
@@ -486,7 +593,7 @@ export const Spotlight = ({
       }
       event.preventDefault();
       if (isOpen) {
-        onClose();
+        handleClose();
         return;
       }
       spotlight.open();
@@ -496,13 +603,65 @@ export const Spotlight = ({
     return () => {
       window.removeEventListener('keydown', handleKeydown);
     };
-  }, [isOpen, onClose, spotlight, onOpenViaShortcut]);
+  }, [isOpen, handleClose, spotlight, onOpenViaShortcut]);
 
   useEffect(() => {
     if (isOpen) {
       refreshRecent();
     }
   }, [isOpen, refreshRecent]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    openedAtRef.current = Date.now();
+    ranCommandRef.current = false;
+    closeLoggedRef.current = false;
+    loggedImpressionRef.current = null;
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || !isFiltering || search.isLoading || resultCount === null) {
+      return;
+    }
+
+    const { counts } = search;
+    const impressionKey = [
+      searchId,
+      scope,
+      resultCount,
+      counts.posts,
+      counts.tags,
+      counts.sources,
+      counts.users,
+    ].join('|');
+
+    if (loggedImpressionRef.current === impressionKey) {
+      return;
+    }
+
+    loggedImpressionRef.current = impressionKey;
+    onResultsImpression?.({
+      searchId,
+      query: trimmedQuery,
+      scope,
+      searchVersion,
+      resultCount,
+      counts,
+    });
+  }, [
+    isOpen,
+    isFiltering,
+    search,
+    resultCount,
+    searchId,
+    scope,
+    searchVersion,
+    trimmedQuery,
+    onResultsImpression,
+  ]);
 
   // When the query changes or async search results land, anchor the list
   // back to the top AND move cmdk's selection onto the new first item.
@@ -552,9 +711,6 @@ export const Spotlight = ({
     });
     return out;
   }, [commands]);
-
-  const trimmedQuery = query.trim();
-  const isFiltering = trimmedQuery.length > 0;
 
   const suggested = useMemo(
     () =>
@@ -615,28 +771,28 @@ export const Spotlight = ({
    * query with multi-type results). Idle modal renders nothing here.
    */
   const handleSelect = useCallback(
-    (command: SpotlightCommand) => {
+    (command: SpotlightCommand, details?: { fallthrough?: boolean }) => {
       if (command.requiresAuth && !isLoggedIn) {
         showLogin({ trigger: AuthTriggers.SearchInput });
-        onClose();
+        handleClose();
         return;
       }
       if (command.plusBadge && !env.isPlus) {
         // Same friendly behavior — bounce to upgrade flow on the Plus page.
         router.push('/plus');
-        onClose();
+        handleClose();
         return;
       }
       if (command.destructive && pendingConfirmId !== command.id) {
         requestConfirm(command.id);
         return;
       }
-      runCommand(command);
+      runCommand(command, details);
     },
     [
       isLoggedIn,
       showLogin,
-      onClose,
+      handleClose,
       env.isPlus,
       router,
       pendingConfirmId,
@@ -651,7 +807,7 @@ export const Spotlight = ({
     }
     const fallthrough = search.fallthrough[0];
     if (fallthrough) {
-      handleSelect(fallthrough);
+      handleSelect(fallthrough, { fallthrough: true });
     }
   }, [trimmedQuery, search.fallthrough, handleSelect]);
 
@@ -709,12 +865,6 @@ export const Spotlight = ({
     }
     return { commands: search.tags, isLoading: search.tagsLoading };
   }, [scope, search]);
-
-  const hasSearchResults =
-    search.users.length > 0 ||
-    search.sources.length > 0 ||
-    search.tags.length > 0 ||
-    search.posts.length > 0;
 
   const jumpToGroup = useCallback((group: SpotlightGroup) => {
     const heading = document.querySelector(
@@ -774,7 +924,7 @@ export const Spotlight = ({
               clearConfirm();
               return;
             }
-            onClose();
+            handleClose();
             return;
           }
           if (
@@ -885,7 +1035,7 @@ export const Spotlight = ({
                   variant={ButtonVariant.Subtle}
                   size={ButtonSize.Small}
                   className="border border-border-subtlest-tertiary"
-                  onClick={onClose}
+                  onClick={handleClose}
                 >
                   Close
                 </Button>
@@ -1167,7 +1317,7 @@ export const Spotlight = ({
       <Drawer
         isOpen
         position={DrawerPosition.Bottom}
-        onClose={onClose}
+        onClose={handleClose}
         appendOnRoot
         className={{
           drawer: 'p-0',
@@ -1186,7 +1336,7 @@ export const Spotlight = ({
   return (
     <ReactModal
       isOpen
-      onRequestClose={onClose}
+      onRequestClose={handleClose}
       shouldCloseOnOverlayClick
       shouldCloseOnEsc
       shouldReturnFocusAfterClose

--- a/packages/shared/src/components/spotlight/SpotlightHost.tsx
+++ b/packages/shared/src/components/spotlight/SpotlightHost.tsx
@@ -1,11 +1,15 @@
 import type { ReactElement } from 'react';
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import dynamic from 'next/dynamic';
 import { useLogContext } from '../../contexts/LogContext';
-import useLogEventOnce from '../../hooks/log/useLogEventOnce';
 import { LogEvent, TargetId, TargetType } from '../../lib/log';
 import { useSpotlight } from './SpotlightContext';
-import type { SpotlightCommand } from './types';
+import type {
+  SpotlightCloseDetails,
+  SpotlightCommand,
+  SpotlightCommandRunDetails,
+  SpotlightResultsImpressionDetails,
+} from './types';
 
 const Spotlight = dynamic(
   () => import(/* webpackChunkName: "spotlight" */ './Spotlight'),
@@ -13,21 +17,24 @@ const Spotlight = dynamic(
 );
 
 /**
- * Mounts the Spotlight dialog globally and owns its telemetry. Impression
- * logs once per session via {@link useLogEventOnce}; per-command engagement
- * is tracked separately via the click event below.
+ * Mounts the Spotlight dialog globally and owns its telemetry. The dialog
+ * itself stays log-free and reports through the callbacks below so the
+ * Spotlight context never depends on the logging stack.
  */
 export const SpotlightHost = (): ReactElement => {
   const { logEvent } = useLogContext();
   const { isOpen, close } = useSpotlight();
 
-  useLogEventOnce(
-    () => ({
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    logEvent({
       event_name: LogEvent.Impression,
       target_type: TargetType.Spotlight,
-    }),
-    { condition: isOpen },
-  );
+    });
+  }, [isOpen, logEvent]);
 
   const handleOpenViaShortcut = useCallback(() => {
     logEvent({
@@ -37,11 +44,60 @@ export const SpotlightHost = (): ReactElement => {
   }, [logEvent]);
 
   const handleCommandRun = useCallback(
-    (command: SpotlightCommand) => {
+    (command: SpotlightCommand, details: SpotlightCommandRunDetails) => {
       logEvent({
         event_name: LogEvent.Click,
         target_type: TargetType.SpotlightCommand,
         target_id: command.id,
+        extra: JSON.stringify({
+          search_id: details.searchId,
+          query: details.query,
+          scope: details.scope,
+          provider: command.meta?.kind,
+          group: command.group,
+          position: details.position,
+          search_version: details.searchVersion,
+          had_results: details.hadResults,
+          ...(details.fallthrough && { fallthrough: true }),
+        }),
+      });
+    },
+    [logEvent],
+  );
+
+  const handleResultsImpression = useCallback(
+    (details: SpotlightResultsImpressionDetails) => {
+      logEvent({
+        event_name: LogEvent.Impression,
+        target_type: TargetType.SpotlightCommand,
+        extra: JSON.stringify({
+          search_id: details.searchId,
+          query: details.query,
+          scope: details.scope,
+          result_count: details.resultCount,
+          counts: details.counts,
+          search_version: details.searchVersion,
+        }),
+      });
+    },
+    [logEvent],
+  );
+
+  const handleCloseLog = useCallback(
+    (details: SpotlightCloseDetails) => {
+      logEvent({
+        event_name: LogEvent.CloseSearch,
+        target_type: TargetType.Spotlight,
+        extra: JSON.stringify({
+          search_id: details.searchId,
+          query: details.query,
+          scope: details.scope,
+          result_count: details.resultCount,
+          had_results: details.hadResults,
+          ran_command: details.ranCommand,
+          time_open_ms: details.timeOpenMs,
+          search_version: details.searchVersion,
+        }),
       });
     },
     [logEvent],
@@ -53,6 +109,8 @@ export const SpotlightHost = (): ReactElement => {
       onClose={close}
       onCommandRun={handleCommandRun}
       onOpenViaShortcut={handleOpenViaShortcut}
+      onResultsImpression={handleResultsImpression}
+      onCloseLog={handleCloseLog}
     />
   );
 };

--- a/packages/shared/src/components/spotlight/SpotlightTrigger.tsx
+++ b/packages/shared/src/components/spotlight/SpotlightTrigger.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import React from 'react';
+import React, { useCallback } from 'react';
 import classNames from 'classnames';
 import { AiIcon } from '../icons';
 import { IconSize } from '../Icon';
@@ -7,6 +7,8 @@ import { isAppleDevice } from '../../lib/func';
 import { KeyboadShortcutLabel } from '../KeyboardShortcutLabel';
 import { useSpotlight } from './SpotlightContext';
 import { ViewSize, useViewSize } from '../../hooks';
+import { useLogContext } from '../../contexts/LogContext';
+import { LogEvent, TargetId, TargetType } from '../../lib/log';
 
 interface SpotlightTriggerProps {
   className?: string;
@@ -24,7 +26,17 @@ export const SpotlightTrigger = ({
   className,
 }: SpotlightTriggerProps): ReactElement => {
   const { open } = useSpotlight();
+  const { logEvent } = useLogContext();
   const isLaptop = useViewSize(ViewSize.Laptop);
+
+  const onOpen = useCallback(() => {
+    logEvent({
+      event_name: LogEvent.Click,
+      target_type: TargetType.Spotlight,
+      target_id: TargetId.SpotlightOpen,
+    });
+    open();
+  }, [logEvent, open]);
 
   return (
     <button
@@ -32,7 +44,7 @@ export const SpotlightTrigger = ({
       data-testid="spotlight-trigger"
       aria-label="Open search"
       aria-keyshortcuts={isLaptop ? shortcutKeys.join('+') : undefined}
-      onClick={open}
+      onClick={onOpen}
       className={classNames(
         // Sizing, color, and shape match the production SearchPanel field.
         'relative flex h-12 w-full items-center overflow-hidden rounded-12 border border-transparent bg-background-subtle px-3 text-left transition-colors',

--- a/packages/shared/src/components/spotlight/commands/search.ts
+++ b/packages/shared/src/components/spotlight/commands/search.ts
@@ -20,6 +20,8 @@ interface SearchCommandsContext {
   router: Pick<NextRouter, 'push'>;
   query: string;
   scope?: SpotlightScope;
+  /** Correlation id for the current palette query, minted by Spotlight. */
+  searchId?: string;
 }
 
 export interface SpotlightSearchCommands {
@@ -35,6 +37,8 @@ export interface SpotlightSearchCommands {
   usersLoading: boolean;
   /** Always-on fallthrough rows, shown even while suggestions are loading. */
   fallthrough: SpotlightCommand[];
+  /** Backend hit counts per provider, excluding the "see all" rows. */
+  counts: { posts: number; tags: number; sources: number; users: number };
 }
 
 const buildPostCommand = (
@@ -206,6 +210,7 @@ export const useSpotlightSearchCommands = ({
   router,
   query,
   scope = SpotlightScope.All,
+  searchId,
 }: SearchCommandsContext): SpotlightSearchCommands => {
   const trimmed = query.trim();
   const providers = scopeProviders[scope];
@@ -215,24 +220,32 @@ export const useSpotlightSearchCommands = ({
       provider: SearchProviderEnum.Posts,
       query: trimmed,
       enabled: providers.includes(SearchProviderEnum.Posts),
+      searchId,
+      scope,
     });
   const { suggestions: tagHits, isLoading: tagsLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Tags,
       query: trimmed,
       enabled: providers.includes(SearchProviderEnum.Tags),
+      searchId,
+      scope,
     });
   const { suggestions: sourceHits, isLoading: sourcesLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Sources,
       query: trimmed,
       enabled: providers.includes(SearchProviderEnum.Sources),
+      searchId,
+      scope,
     });
   const { suggestions: userHits, isLoading: usersLoading } =
     useSearchProviderSuggestions({
       provider: SearchProviderEnum.Users,
       query: trimmed,
       enabled: providers.includes(SearchProviderEnum.Users),
+      searchId,
+      scope,
     });
 
   return useMemo(() => {
@@ -283,6 +296,12 @@ export const useSpotlightSearchCommands = ({
       users: withSeeAll(SpotlightScope.People, users),
       usersLoading: isUsersLoading,
       fallthrough: buildFallthrough(trimmed, router),
+      counts: {
+        posts: posts.length,
+        tags: tags.length,
+        sources: sources.length,
+        users: users.length,
+      },
     };
   }, [
     trimmed,

--- a/packages/shared/src/components/spotlight/types.ts
+++ b/packages/shared/src/components/spotlight/types.ts
@@ -187,6 +187,35 @@ export const scopeMeta: Record<
   },
 };
 
+/** Query-level identity shared by every Spotlight telemetry payload. */
+export interface SpotlightSearchLogContext {
+  searchId?: string;
+  query?: string;
+  scope?: SpotlightScope;
+  searchVersion?: number;
+}
+
+export interface SpotlightResultsImpressionDetails
+  extends SpotlightSearchLogContext {
+  resultCount: number;
+  counts: { posts: number; tags: number; sources: number; users: number };
+}
+
+export interface SpotlightCommandRunDetails extends SpotlightSearchLogContext {
+  /** Zero-based position among the rendered rows, when the row was in the list. */
+  position?: number;
+  /** Set on the "Search posts for …" escape hatch (enter key or empty-state CTA). */
+  fallthrough?: boolean;
+  hadResults?: boolean;
+}
+
+export interface SpotlightCloseDetails extends SpotlightSearchLogContext {
+  resultCount?: number;
+  hadResults: boolean;
+  ranCommand: boolean;
+  timeOpenMs: number;
+}
+
 export interface RecentCommandEntry {
   commandId: string;
   lastUsedAt: number;

--- a/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
+++ b/packages/shared/src/hooks/feed/useFeedOnPostClick.ts
@@ -5,6 +5,7 @@ import type { FeedItem } from '../useFeed';
 import { isBoostedPostAd } from '../useFeed';
 import useOnPostClick from '../useOnPostClick';
 import { updateFeedAndAdsCache } from '../../lib/query';
+import type { SearchLogExtra } from '../../lib/searchLog';
 
 interface PostClickOptionalProps {
   skipPostUpdate?: boolean;
@@ -18,27 +19,40 @@ export type FeedPostClick = (
   optional?: PostClickOptionalProps,
 ) => Promise<void>;
 
-export default function useFeedOnPostClick(
-  items: FeedItem[],
-  updatePost: (page: number, index: number, post: Post) => void,
-  columns: number,
-  feedName: string,
-  ranking?: string,
+export interface UseFeedOnPostClickProps {
+  items: FeedItem[];
+  updatePost: (page: number, index: number, post: Post) => void;
+  columns: number;
+  feedName: string;
+  ranking?: string;
+  eventName?: string;
+  feedQueryKey?: unknown[];
+  searchLogExtra?: SearchLogExtra;
+}
+
+export default function useFeedOnPostClick({
+  items,
+  updatePost,
+  columns,
+  feedName,
+  ranking,
   eventName = 'click',
-  feedQueryKey?: unknown[],
-): FeedPostClick {
+  feedQueryKey,
+  searchLogExtra,
+}: UseFeedOnPostClickProps): FeedPostClick {
   const queryClient = useQueryClient();
   const onPostClick = useOnPostClick({
     eventName,
     columns,
     feedName,
     ranking,
+    searchLogExtra,
   });
 
   return useMemo(
     () =>
       async (post, index, row, column, optional): Promise<void> => {
-        await onPostClick({ post, row, column, optional });
+        await onPostClick({ post, row, column, index, optional });
 
         if (optional?.skipPostUpdate) {
           return;
@@ -55,6 +69,6 @@ export default function useFeedOnPostClick(
       },
     // @NOTE see https://dailydotdev.atlassian.net/l/cp/dK9h1zoM
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [items, updatePost, columns, feedName, ranking],
+    [items, updatePost, columns, feedName, ranking, searchLogExtra],
   );
 }

--- a/packages/shared/src/hooks/feed/useLogImpression.ts
+++ b/packages/shared/src/hooks/feed/useLogImpression.ts
@@ -9,6 +9,7 @@ import {
 } from '../../lib/feed';
 import type { Origin } from '../../lib/log';
 import { LogEvent } from '../../lib/log';
+import type { SearchLogExtra } from '../../lib/searchLog';
 import { useLogContext } from '../../contexts/LogContext';
 import type { FeedItem } from '../useFeed';
 import { isShareLikePost, PostType } from '../../graphql/posts';
@@ -22,17 +23,31 @@ export const generateAdLogEventKey = (index: number): string => `ai-${index}`;
 export const generatePostLogEventKey = (id: string): string => `pi-${id}`;
 export const generateHighlightLogEventKey = (id: string): string => `hi-${id}`;
 
-export default function useLogImpression(
-  item: FeedItem,
-  index: number,
-  columns: number,
-  column: number,
-  row: number,
-  feedName: string,
-  ranking?: string,
-  highlightColSpan?: number,
-  origin?: Origin,
-): (node?: Element | null) => void {
+export interface UseLogImpressionProps {
+  item: FeedItem;
+  index: number;
+  columns: number;
+  column: number;
+  row: number;
+  feedName: string;
+  ranking?: string;
+  highlightColSpan?: number;
+  origin?: Origin;
+  searchLogExtra?: SearchLogExtra;
+}
+
+export default function useLogImpression({
+  item,
+  index,
+  columns,
+  column,
+  row,
+  feedName,
+  ranking,
+  highlightColSpan,
+  origin,
+  searchLogExtra,
+}: UseLogImpressionProps): (node?: Element | null) => void {
   const { logEventStart, logEventEnd } = useLogContext();
   const postLogEvent = usePostLogEvent();
   const { ref: inViewRef, inView } = useInView({
@@ -50,11 +65,12 @@ export default function useLogImpression(
             columns,
             column,
             row,
+            index,
             extra: {
               ...feedLogExtra(
                 feedName,
                 ranking,
-                { scroll_y: window.scrollY },
+                { scroll_y: window.scrollY, ...searchLogExtra },
                 origin,
               ).extra,
               clickbait_badge: isShareLikePost(item.post)
@@ -89,7 +105,7 @@ export default function useLogImpression(
             columns,
             column,
             row,
-            ...feedLogExtra(feedName, ranking, undefined, origin),
+            ...feedLogExtra(feedName, ranking, searchLogExtra, origin),
           }),
         );
         // eslint-disable-next-line no-param-reassign

--- a/packages/shared/src/hooks/search/useSearchId.spec.ts
+++ b/packages/shared/src/hooks/search/useSearchId.spec.ts
@@ -1,0 +1,38 @@
+import { renderHook } from '@testing-library/react';
+import { useSearchId } from './useSearchId';
+
+describe('useSearchId hook', () => {
+  it('keeps the same id while the key is unchanged', () => {
+    const { result, rerender } = renderHook(({ key }) => useSearchId(key), {
+      initialProps: { key: 'react|4|all' },
+    });
+
+    const first = result.current;
+    rerender({ key: 'react|4|all' });
+
+    expect(result.current).toEqual(first);
+  });
+
+  it('mints a new id when the key changes', () => {
+    const { result, rerender } = renderHook(({ key }) => useSearchId(key), {
+      initialProps: { key: 'react|4|all' },
+    });
+
+    const first = result.current;
+    rerender({ key: 'react|4|posts' });
+
+    expect(result.current).not.toEqual(first);
+  });
+
+  it('does not reuse an id after the key returns to a previous value', () => {
+    const { result, rerender } = renderHook(({ key }) => useSearchId(key), {
+      initialProps: { key: 'react' },
+    });
+
+    const first = result.current;
+    rerender({ key: 'vue' });
+    rerender({ key: 'react' });
+
+    expect(result.current).not.toEqual(first);
+  });
+});

--- a/packages/shared/src/hooks/search/useSearchId.ts
+++ b/packages/shared/src/hooks/search/useSearchId.ts
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+import { generateSearchId } from '../../lib/searchLog';
+
+/**
+ * Mints a fresh search id whenever `key` changes, and keeps it stable while it
+ * doesn't. `key` must encode everything that makes a distinct search execution
+ * (query, backend version, filters) so a re-run gets its own id.
+ */
+export const useSearchId = (key: string): string => {
+  const current = useRef<{ key: string; id: string } | null>(null);
+
+  if (!current.current || current.current.key !== key) {
+    current.current = { key, id: generateSearchId() };
+  }
+
+  return current.current.id;
+};

--- a/packages/shared/src/hooks/search/useSearchProvider.spec.tsx
+++ b/packages/shared/src/hooks/search/useSearchProvider.spec.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/router';
 import { AlertContextProvider } from '../../contexts/AlertContext';
 import { AuthContextProvider } from '../../contexts/AuthContext';
 import type { Alerts } from '../../graphql/alerts';
+import { feature } from '../../lib/featureManagement';
 import { useSearchProvider } from './useSearchProvider';
 import {
   SEARCH_POST_SUGGESTIONS,
@@ -42,6 +43,10 @@ const Wrapper = ({ children }: React.PropsWithChildren) => {
 };
 
 const routerPush = jest.fn();
+
+// Derived from the flag rather than hardcoded: the committed default is the
+// control arm and moves when the experiment does.
+const searchVersion = feature.searchVersion.defaultValue;
 
 describe('useSearchProvider hook', () => {
   beforeEach(() => {
@@ -104,7 +109,7 @@ describe('useSearchProvider hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: 'apples',
-          version: 2,
+          version: searchVersion,
           limit: defaultSearchSuggestionsLimit,
         },
       },

--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.spec.tsx
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.spec.tsx
@@ -10,6 +10,7 @@ import {
   defaultSearchSuggestionsLimit,
 } from '../../graphql/search';
 import { mockGraphQL } from '../../../__tests__/helpers/graphql';
+import { feature } from '../../lib/featureManagement';
 import { useSearchProviderSuggestions } from './useSearchProviderSuggestions';
 
 const client = new QueryClient();
@@ -39,6 +40,10 @@ const Wrapper = ({ children }: React.PropsWithChildren) => {
   );
 };
 
+// Derived from the flag rather than hardcoded: the committed default is the
+// control arm and moves when the experiment does.
+const searchVersion = feature.searchVersion.defaultValue;
+
 describe('useSearchProviderSuggestions hook', () => {
   beforeEach(() => {
     client.clear();
@@ -62,7 +67,7 @@ describe('useSearchProviderSuggestions hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: 'apples',
-          version: 2,
+          version: searchVersion,
           limit: defaultSearchSuggestionsLimit,
         },
       },
@@ -125,7 +130,7 @@ describe('useSearchProviderSuggestions hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: '',
-          version: 2,
+          version: searchVersion,
           limit: defaultSearchSuggestionsLimit,
         },
       },
@@ -141,7 +146,7 @@ describe('useSearchProviderSuggestions hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: 'apples',
-          version: 2,
+          version: searchVersion,
           limit: defaultSearchSuggestionsLimit,
         },
       },
@@ -181,7 +186,7 @@ describe('useSearchProviderSuggestions hook', () => {
         query: SEARCH_POST_SUGGESTIONS,
         variables: {
           query: 'apples',
-          version: 2,
+          version: searchVersion,
           limit: defaultSearchSuggestionsLimit,
         },
       },
@@ -225,6 +230,8 @@ describe('useSearchProviderSuggestions hook', () => {
       },
     );
 
-    expect(result.current.queryKey[3]).toMatchObject({ version: 2 });
+    expect(result.current.queryKey[3]).toMatchObject({
+      version: searchVersion,
+    });
   });
 });

--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
@@ -46,6 +46,9 @@ export type UseSearchProviderSuggestions = {
     | undefined;
 } & {
   queryKey: unknown[];
+  /** Identity of the fetch behind `suggestions`, for joining engagement to it. */
+  searchId: string;
+  searchVersion: number;
 };
 
 export const useSearchProviderSuggestions = ({
@@ -84,6 +87,7 @@ export const useSearchProviderSuggestions = ({
   const { data, isLoading: isQueryLoading } = useQuery({
     queryKey,
     queryFn: async () => {
+      const requestStartedAt = performance.now();
       const result = await getSuggestions({
         provider,
         query: debouncedQuery,
@@ -99,6 +103,7 @@ export const useSearchProviderSuggestions = ({
           provider,
           searchVersion: version,
           resultCount: result?.hits?.length ?? 0,
+          latencyMs: Math.round(performance.now() - requestStartedAt),
           scope,
         }),
       );
@@ -180,5 +185,7 @@ export const useSearchProviderSuggestions = ({
     isLoading: isQueryLoading || isDebouncePending,
     suggestions: data,
     queryKey,
+    searchId: activeSearchId,
+    searchVersion: version,
   };
 };

--- a/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
+++ b/packages/shared/src/hooks/search/useSearchProviderSuggestions.ts
@@ -21,11 +21,22 @@ import {
   mutationKeyToContentPreferenceStatusMap,
 } from '../contentPreference/types';
 import { feature } from '../../lib/featureManagement';
-import { useFeaturesReadyContext } from '../../components/GrowthBookProvider';
+import { useConditionalFeature } from '../useConditionalFeature';
+import { useLogContext } from '../../contexts/LogContext';
+import { searchResultsLogEvent } from '../../lib/searchLog';
+import { useSearchId } from './useSearchId';
 
 export type UseSearchProviderSuggestionsProps = {
   limit?: number;
   enabled?: boolean;
+  /**
+   * Correlation id shared with the surface that renders these suggestions, so
+   * its impressions and clicks join back to this fetch. Minted internally when
+   * the caller has no surface-level id of its own.
+   */
+  searchId?: string;
+  /** Surface-level scope (e.g. the Spotlight scope) reported with results. */
+  scope?: string;
 } & UseSearchProviderProps;
 
 export type UseSearchProviderSuggestions = {
@@ -44,12 +55,23 @@ export const useSearchProviderSuggestions = ({
   includeContentPreference,
   feedId,
   enabled = true,
+  searchId,
+  scope,
 }: UseSearchProviderSuggestionsProps): UseSearchProviderSuggestions => {
   const { user } = useAuthContext();
+  const { logEvent } = useLogContext();
   const { getSuggestions } = useSearchProvider();
-  const { getFeatureValue } = useFeaturesReadyContext();
-  const version = getFeatureValue(feature.searchVersion);
   const debouncedQuery = useDebounce(query, defaultSearchDebounceMs);
+  const isQueryable = enabled && debouncedQuery?.length >= minSearchQueryLength;
+  // Spotlight mounts this hook on every page, so the flag must only be
+  // evaluated once a real suggestion request is about to run. Evaluating it
+  // unconditionally enrolls every pageview in the search experiment.
+  const { value: version } = useConditionalFeature({
+    feature: feature.searchVersion,
+    shouldEvaluate: isQueryable,
+  });
+  const ownSearchId = useSearchId(`${provider}:${version}:${debouncedQuery}`);
+  const activeSearchId = searchId ?? ownSearchId;
   const queryKey = generateQueryKey(RequestKey.Search, user, 'suggestions', {
     provider,
     debouncedQuery,
@@ -62,15 +84,28 @@ export const useSearchProviderSuggestions = ({
   const { data, isLoading: isQueryLoading } = useQuery({
     queryKey,
     queryFn: async () => {
-      return getSuggestions({
+      const result = await getSuggestions({
         provider,
         query: debouncedQuery,
         limit,
         includeContentPreference,
         feedId,
       });
+
+      logEvent(
+        searchResultsLogEvent({
+          searchId: activeSearchId,
+          query: debouncedQuery,
+          provider,
+          searchVersion: version,
+          resultCount: result?.hits?.length ?? 0,
+          scope,
+        }),
+      );
+
+      return result;
     },
-    enabled: enabled && debouncedQuery?.length >= minSearchQueryLength,
+    enabled: isQueryable,
     placeholderData: keepPreviousData,
     staleTime: StaleTime.Default,
     select: useCallback(

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -337,6 +337,7 @@ export default function useFeed<T>(
         throw new Error('useFeed query is required');
       }
 
+      const requestStartedAt = performance.now();
       const rawResult = await gqlClient.request<
         FeedData | FeedItemData | FeedV2Data
       >(query, {
@@ -346,6 +347,7 @@ export default function useFeed<T>(
         loggedIn: !!user,
         columns: virtualizedNumCards,
       });
+      const requestLatencyMs = Math.round(performance.now() - requestStartedAt);
       const res = normalizeFeedPage(rawResult);
 
       const isEmpty =
@@ -385,6 +387,7 @@ export default function useFeed<T>(
             provider: SearchProviderEnum.Posts,
             searchVersion: settings?.searchVersion,
             resultCount: res.page.edges.length,
+            latencyMs: requestLatencyMs,
             filters: {
               time: searchVariables.time,
               content_curation: searchVariables.contentCuration,

--- a/packages/shared/src/hooks/useFeed.ts
+++ b/packages/shared/src/hooks/useFeed.ts
@@ -35,6 +35,8 @@ import type { ResolvedCreative } from '../lib/engagementAds';
 import { EngagementPlacement } from '../lib/engagementAds';
 import type { FeedAdTemplate } from '../lib/feed';
 import { getAdSlotIndex } from '../lib/feed';
+import { searchResultsLogEvent } from '../lib/searchLog';
+import { SearchProviderEnum } from '../graphql/search';
 import {
   briefFeedEntrypointPage,
   featureFeedAdTemplate,
@@ -206,7 +208,15 @@ type UseFeedSettingParams = {
   disableAds?: boolean;
   feedName?: string;
   staticAd?: { ad: Ad; index: number };
+  /** Set on search feeds so every fetch can be logged as a search execution. */
+  searchId?: string;
+  searchVersion?: number;
 };
+
+const searchFeedNames = new Set<string>([
+  SharedFeedPage.Search,
+  OtherFeedPage.SearchSquad,
+]);
 
 // 0-based grid row where the campaign-specific engagement strip breaks the
 // feed. Picking a whole row (not an item index) keeps the row above it full.
@@ -353,6 +363,34 @@ export default function useFeed<T>(
         if (onEmptyFeed) {
           onEmptyFeed();
         }
+      }
+
+      // Only the first page counts as a search execution; pagination reuses the
+      // same `search_id` through the feed engagement events instead.
+      if (
+        !pageParam &&
+        settings?.feedName &&
+        searchFeedNames.has(settings.feedName)
+      ) {
+        const searchVariables = (variables ?? {}) as {
+          query?: string;
+          time?: string;
+          contentCuration?: string[];
+        };
+
+        logEvent(
+          searchResultsLogEvent({
+            searchId: settings?.searchId,
+            query: searchVariables.query ?? '',
+            provider: SearchProviderEnum.Posts,
+            searchVersion: settings?.searchVersion,
+            resultCount: res.page.edges.length,
+            filters: {
+              time: searchVariables.time,
+              content_curation: searchVariables.contentCuration,
+            },
+          }),
+        );
       }
 
       fetchTranslations(

--- a/packages/shared/src/hooks/useOnPostClick.ts
+++ b/packages/shared/src/hooks/useOnPostClick.ts
@@ -15,6 +15,7 @@ import type { Post } from '../graphql/posts';
 import { PostType } from '../graphql/posts';
 import { getFeedApiItemPost } from '../graphql/feed';
 import type { Origin } from '../lib/log';
+import type { SearchLogExtra } from '../lib/searchLog';
 import { ActiveFeedContext } from '../contexts';
 import {
   findIndexOfPostInData,
@@ -35,11 +36,13 @@ export type FeedPostClick = ({
   post,
   row,
   column,
+  index,
   optional,
 }: {
   post: Post;
   row?: number;
   column?: number;
+  index?: number;
   optional?: PostClickOptionalProps;
 }) => Promise<void>;
 
@@ -89,6 +92,7 @@ interface UseOnPostClickProps {
   feedName?: string;
   ranking?: string;
   origin?: Origin;
+  searchLogExtra?: SearchLogExtra;
 }
 
 export default function useOnPostClick({
@@ -97,6 +101,7 @@ export default function useOnPostClick({
   feedName,
   ranking,
   origin,
+  searchLogExtra,
 }: UseOnPostClickProps): FeedPostClick {
   const client = useQueryClient();
   const { logEvent } = useLogContext();
@@ -109,17 +114,18 @@ export default function useOnPostClick({
 
   return useMemo(
     () =>
-      async ({ post, row, column, optional }): Promise<void> => {
+      async ({ post, row, column, index, optional }): Promise<void> => {
         logEvent(
           postLogEvent(eventName, post, {
             columns,
             column,
             row,
+            index,
             extra: {
               ...feedLogExtra(
                 feedName ?? '',
                 ranking,
-                undefined,
+                searchLogExtra,
                 origin,
                 undefined,
                 optional?.parent_id,
@@ -185,9 +191,13 @@ export default function useOnPostClick({
                 queryKey,
               ) as InfiniteData<FeedData>;
 
-              const { post: foundPost, page, index } = findPost(data, id);
+              const {
+                post: foundPost,
+                page,
+                index: foundIndex,
+              } = findPost(data, id);
               if (foundPost) {
-                updateFeedPost(page, index, {
+                updateFeedPost(page, foundIndex, {
                   ...foundPost,
                   ...mutationHandler(),
                 });
@@ -211,6 +221,7 @@ export default function useOnPostClick({
       items,
       ranking,
       origin,
+      searchLogExtra,
       logEvent,
       postLogEvent,
     ],

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -13,7 +13,7 @@ const feature = {
   showError: new Feature('show_error', false),
   feedVersion: new Feature('feed_version', 15),
   feedAdSpot: new Feature('feed_ad_spot', 2),
-  searchVersion: new Feature('search_version2', 3),
+  searchVersion: new Feature('search_version', 2),
   featureTheme: new Feature('feature_theme', {}),
   showRoadmap: new Feature('show_roadmap', true),
   showCodeSnippets: new Feature('show_code_snippets', false),

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -13,7 +13,7 @@ const feature = {
   showError: new Feature('show_error', false),
   feedVersion: new Feature('feed_version', 15),
   feedAdSpot: new Feature('feed_ad_spot', 2),
-  searchVersion: new Feature('search_version', 2),
+  searchVersion: new Feature('search_version2', 3),
   featureTheme: new Feature('feature_theme', {}),
   showRoadmap: new Feature('show_roadmap', true),
   showCodeSnippets: new Feature('show_code_snippets', false),

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -5,6 +5,7 @@ import type { Ad, Post, ReadHistoryPost } from '../graphql/posts';
 import type { LogEvent } from '../hooks/log/useLogQueue';
 import type { PostBootData } from './boot';
 import { Origin, TargetType } from './log';
+import type { SearchLogExtra } from './searchLog';
 import { SharedFeedPage } from '../components/utilities';
 import type { AllFeedPages } from './query';
 import { OtherFeedPage } from './query';
@@ -31,6 +32,7 @@ interface FeedItemLogEvent extends LogEvent {
   feed_grid_columns?: number;
   feed_item_grid_column?: number;
   feed_item_grid_row?: number;
+  feed_item_index?: number;
   feed_item_meta?: string;
   feed_item_image?: string;
   feed_item_target_url?: string;
@@ -62,6 +64,8 @@ interface FeedLogExtra {
     ranking?: string;
     variant?: string;
     parent_id?: string;
+    search_id?: string;
+    search_version?: number;
   };
 }
 
@@ -71,7 +75,7 @@ export function feedLogExtra(
   extra?: {
     scroll_y?: number;
     gen_id?: string;
-  },
+  } & SearchLogExtra,
   origin?: Origin,
   variant?: string,
   parent_id?: string,
@@ -97,6 +101,8 @@ export interface FeedItemPosition {
 export type PostLogEventFnOptions = FeedItemPosition & {
   extra?: Record<string, unknown>;
   is_ad?: boolean;
+  /** Absolute position of the item in the feed, ads and placeholders included. */
+  index?: number;
 };
 
 const feedPathWithIdMatcher = /^\/feeds\/(?<feedId>[A-z0-9]{9})\/?$/;
@@ -126,6 +132,7 @@ export function postLogEvent(
     feed_grid_columns: opts?.columns,
     feed_item_grid_column: opts?.column,
     feed_item_grid_row: opts?.row,
+    feed_item_index: opts?.index,
     feed_item_image: post.image,
     feed_item_target_url: post.permalink,
     feed_item_title: post.title,

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -210,6 +210,8 @@ export enum LogEvent {
   // search start
   FocusSearch = 'focus search',
   SubmitSearch = 'submit search',
+  SearchResults = 'search results',
+  CloseSearch = 'close search',
   OpenSearchHistory = 'open search history',
   UpvoteSearch = 'upvote search',
   DownvoteSearch = 'downvote search',

--- a/packages/shared/src/lib/searchLog.spec.ts
+++ b/packages/shared/src/lib/searchLog.spec.ts
@@ -1,0 +1,61 @@
+import { LogEvent } from './log';
+import { generateSearchId, searchResultsLogEvent } from './searchLog';
+
+describe('generateSearchId', () => {
+  it('mints a distinct id per call', () => {
+    expect(generateSearchId()).not.toEqual(generateSearchId());
+  });
+});
+
+describe('searchResultsLogEvent', () => {
+  const parse = (event: ReturnType<typeof searchResultsLogEvent>) =>
+    JSON.parse(event.extra as string);
+
+  it('builds the search results payload', () => {
+    const event = searchResultsLogEvent({
+      searchId: 'search-1',
+      query: 'react',
+      provider: 'posts',
+      searchVersion: 4,
+      resultCount: 3,
+      scope: 'all',
+      filters: { time: '7d', content_curation: ['article'] },
+    });
+
+    expect(event.event_name).toEqual(LogEvent.SearchResults);
+    expect(parse(event)).toEqual({
+      search_id: 'search-1',
+      query: 'react',
+      provider: 'posts',
+      search_version: 4,
+      result_count: 3,
+      scope: 'all',
+      filters: { time: '7d', content_curation: ['article'] },
+      is_zero_result: false,
+    });
+  });
+
+  it('flags zero result searches', () => {
+    const event = searchResultsLogEvent({
+      searchId: 'search-2',
+      query: 'nothing here',
+      provider: 'posts',
+      resultCount: 0,
+    });
+
+    expect(parse(event).is_zero_result).toBe(true);
+  });
+
+  it('omits scope and filters when not provided', () => {
+    const payload = parse(
+      searchResultsLogEvent({
+        query: 'react',
+        provider: 'tags',
+        resultCount: 1,
+      }),
+    );
+
+    expect(payload).not.toHaveProperty('scope');
+    expect(payload).not.toHaveProperty('filters');
+  });
+});

--- a/packages/shared/src/lib/searchLog.spec.ts
+++ b/packages/shared/src/lib/searchLog.spec.ts
@@ -1,5 +1,9 @@
 import { LogEvent } from './log';
-import { generateSearchId, searchResultsLogEvent } from './searchLog';
+import {
+  generateSearchId,
+  searchRecommendationLogExtra,
+  searchResultsLogEvent,
+} from './searchLog';
 
 describe('generateSearchId', () => {
   it('mints a distinct id per call', () => {
@@ -18,6 +22,7 @@ describe('searchResultsLogEvent', () => {
       provider: 'posts',
       searchVersion: 4,
       resultCount: 3,
+      latencyMs: 128,
       scope: 'all',
       filters: { time: '7d', content_curation: ['article'] },
     });
@@ -29,10 +34,24 @@ describe('searchResultsLogEvent', () => {
       provider: 'posts',
       search_version: 4,
       result_count: 3,
+      latency_ms: 128,
       scope: 'all',
       filters: { time: '7d', content_curation: ['article'] },
       is_zero_result: false,
     });
+  });
+
+  it('reports a zero latency measurement rather than dropping it', () => {
+    const payload = parse(
+      searchResultsLogEvent({
+        query: 'react',
+        provider: 'posts',
+        resultCount: 1,
+        latencyMs: 0,
+      }),
+    );
+
+    expect(payload.latency_ms).toBe(0);
   });
 
   it('flags zero result searches', () => {
@@ -57,5 +76,35 @@ describe('searchResultsLogEvent', () => {
 
     expect(payload).not.toHaveProperty('scope');
     expect(payload).not.toHaveProperty('filters');
+  });
+});
+
+describe('searchRecommendationLogExtra', () => {
+  it('carries the query identity and rail position', () => {
+    expect(
+      searchRecommendationLogExtra({
+        origin: 'search page',
+        provider: 'tags',
+        position: 2,
+        searchId: 'search-1',
+        searchVersion: 4,
+      }),
+    ).toEqual({
+      origin: 'search page',
+      provider: 'tags',
+      position: 2,
+      search_id: 'search-1',
+      search_version: 4,
+    });
+  });
+
+  it('keeps the first position as 0', () => {
+    expect(
+      searchRecommendationLogExtra({
+        origin: 'search page',
+        provider: 'users',
+        position: 0,
+      }).position,
+    ).toBe(0);
   });
 });

--- a/packages/shared/src/lib/searchLog.ts
+++ b/packages/shared/src/lib/searchLog.ts
@@ -36,6 +36,8 @@ export interface SearchResultsLogEventProps {
   provider: string;
   searchVersion?: number;
   resultCount: number;
+  /** Wall-clock duration of the search request itself, excluding render. */
+  latencyMs?: number;
   scope?: string;
   filters?: SearchFilterLogExtra;
 }
@@ -46,6 +48,7 @@ export const searchResultsLogEvent = ({
   provider,
   searchVersion,
   resultCount,
+  latencyMs,
   scope,
   filters,
 }: SearchResultsLogEventProps): LogEventPayload => ({
@@ -56,8 +59,36 @@ export const searchResultsLogEvent = ({
     provider,
     search_version: searchVersion,
     result_count: resultCount,
+    latency_ms: latencyMs,
     ...(scope && { scope }),
     ...(filters && { filters }),
     is_zero_result: resultCount === 0,
   }),
+});
+
+export interface SearchRecommendationLogExtraProps {
+  origin: string;
+  provider: string;
+  /** Row index within its rail, so CTR can be read per position. */
+  position: number;
+  searchId?: string;
+  searchVersion?: number;
+}
+
+/**
+ * `extra` for the search results page recommendation rails (tags, sources,
+ * users). Shared so all three rails stay joinable to the same query execution.
+ */
+export const searchRecommendationLogExtra = ({
+  origin,
+  provider,
+  position,
+  searchId,
+  searchVersion,
+}: SearchRecommendationLogExtraProps): Record<string, unknown> => ({
+  origin,
+  provider,
+  position,
+  search_id: searchId,
+  search_version: searchVersion,
 });

--- a/packages/shared/src/lib/searchLog.ts
+++ b/packages/shared/src/lib/searchLog.ts
@@ -1,0 +1,63 @@
+import type { LogEvent as LogEventPayload } from '../hooks/log/useLogQueue';
+import { LogEvent } from './log';
+
+/**
+ * Correlation id for a single search execution. Every event produced by that
+ * execution (results, impressions, clicks, close) carries it so a funnel can be
+ * rebuilt per query instead of per session.
+ */
+export const generateSearchId = (): string => {
+  const cryptoApi = globalThis.crypto as Crypto | undefined;
+
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+};
+
+/**
+ * Fields attached to engagement events fired inside a search feed so clicks and
+ * impressions can be joined back to the query that produced them.
+ */
+export interface SearchLogExtra {
+  search_id?: string;
+  search_version?: number;
+}
+
+export interface SearchFilterLogExtra {
+  time?: string;
+  content_curation?: string[];
+}
+
+export interface SearchResultsLogEventProps {
+  searchId?: string;
+  query: string;
+  provider: string;
+  searchVersion?: number;
+  resultCount: number;
+  scope?: string;
+  filters?: SearchFilterLogExtra;
+}
+
+export const searchResultsLogEvent = ({
+  searchId,
+  query,
+  provider,
+  searchVersion,
+  resultCount,
+  scope,
+  filters,
+}: SearchResultsLogEventProps): LogEventPayload => ({
+  event_name: LogEvent.SearchResults,
+  extra: JSON.stringify({
+    search_id: searchId,
+    query,
+    provider,
+    search_version: searchVersion,
+    result_count: resultCount,
+    ...(scope && { scope }),
+    ...(filters && { filters }),
+    is_zero_result: resultCount === 0,
+  }),
+});

--- a/packages/webapp/components/RouterPostsSearch.tsx
+++ b/packages/webapp/components/RouterPostsSearch.tsx
@@ -10,6 +10,8 @@ import {
   SearchProviderEnum,
 } from '@dailydotdev/shared/src/graphql/search';
 import { useSearchContextProvider } from '@dailydotdev/shared/src/contexts/search/SearchContext';
+import { useFeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
+import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
 
 export default function RouterPostsSearch(
   props: Omit<PostsSearchProps, 'onSubmitQuery'>,
@@ -17,6 +19,7 @@ export default function RouterPostsSearch(
   const router = useRouter();
   const { time, contentCurationFilter } = useSearchContextProvider();
   const { logEvent } = useLogContext();
+  const { getFeatureValue } = useFeaturesReadyContext();
 
   const onSubmitQuery = (query: string): Promise<boolean> => {
     logEvent({
@@ -24,6 +27,7 @@ export default function RouterPostsSearch(
       extra: JSON.stringify({
         query,
         provider: SearchProviderEnum.Posts,
+        search_version: getFeatureValue(feature.searchVersion),
         filters: { time, contentCuration: contentCurationFilter },
       }),
     });

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -19,8 +19,9 @@ import {
   supportedTypesForPrivateSources,
 } from '@dailydotdev/shared/src/graphql/feed';
 import { SearchProviderEnum } from '@dailydotdev/shared/src/graphql/search';
-import { useFeaturesReadyContext } from '@dailydotdev/shared/src/components/GrowthBookProvider';
 import { feature } from '@dailydotdev/shared/src/lib/featureManagement';
+import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditionalFeature';
+import { useSearchId } from '@dailydotdev/shared/src/hooks/search/useSearchId';
 import { useAuthContext } from '@dailydotdev/shared/src/contexts/AuthContext';
 import { SquadPageHeader } from '@dailydotdev/shared/src/components/squads/SquadPageHeader';
 import { SquadHeaderBar } from '@dailydotdev/shared/src/components/squads/SquadHeaderBar';
@@ -390,7 +391,13 @@ const SquadPage = ({
   const searchQuery =
     typeof router.query?.q === 'string' ? router.query.q.trim() : '';
   const isSearching = searchQuery.length > 0;
-  const { getFeatureValue } = useFeaturesReadyContext();
+  const { value: searchVersion } = useConditionalFeature({
+    feature: feature.searchVersion,
+    shouldEvaluate: isSearching,
+  });
+  const searchId = useSearchId(
+    isSearching ? [squadId, searchQuery, searchVersion].join('|') : '',
+  );
 
   const feedProps = useMemo<FeedProps<unknown>>(() => {
     if (isSearching) {
@@ -407,8 +414,10 @@ const SquadPage = ({
           source: squadId,
           query: searchQuery,
           supportedTypes: supportedTypesForPrivateSources,
-          version: getFeatureValue(feature.searchVersion),
+          version: searchVersion,
         },
+        searchId,
+        searchVersion,
         emptyScreen: <SearchEmptyScreen />,
       };
     }
@@ -430,7 +439,8 @@ const SquadPage = ({
     squadId,
     queryVariables,
     user?.id,
-    getFeatureValue,
+    searchId,
+    searchVersion,
   ]);
 
   // Search submit/clear write `q` to the URL. Cannot reuse `router.pathname`


### PR DESCRIPTION
Instrumentation groundwork for the upcoming `search_version` A/B test (control 2/3, treatment 4). Today we cannot measure that experiment: there is no per-query event to use as a denominator, clicks carry no query identity, `search_version` is absent from every engagement payload, client-observed latency is invisible per arm, and the Spotlight palette (our primary search surface) logs almost nothing.

**This should merge and bake before the `search_version` flag is flipped**, so the treatment arm has a full set of events from day one.

No backend or GraphQL changes.

The experiment flag moves to a new key in this PR: `searchVersion` is now `new Feature('search_version2', 3)`. The old `search_version` key's exposure data is polluted by the every-pageview enrollment bug fixed below, and released extension builds keep evaluating the old key long after release, so a new key is what guarantees only clients with corrected exposure semantics enrol. The committed default `3` is the control arm on the current mimir path (and avoids the dead version-2 registry entry).

> **Correction after merge:** `feed_item_index` originally shipped here as a *top-level* event field, where analytics ingest silently drops it (0 rows in ClickHouse/BigQuery). It was moved into the `extra` blob in #6595. The table above reflects the corrected placement.

## Events

| Event | Where it fires | `extra` payload |
| --- | --- | --- |
| `search results` (new) | Search feed `queryFn` (first page only) for `search` / `search-squad`; suggestion `queryFn` for the palette and the results-page rails | `search_id`, `query`, `provider`, `search_version`, `result_count`, `latency_ms`, `is_zero_result`, `scope?`, `filters?: { time, content_curation }` |
| `close search` (new) | Spotlight close (esc, overlay, close button, or after running a command) | `search_id`, `query`, `scope`, `result_count`, `had_results`, `ran_command`, `time_open_ms`, `search_version` |
| `impression` / `target_type: spotlight command` (new) | Once per settled Spotlight result set | `search_id`, `query`, `scope`, `result_count`, `counts: { posts, tags, sources, users }`, `search_version` |
| `impression` / `target_type: spotlight` (changed) | Now once **per open** instead of once per page load | unchanged |
| `click` / `target_type: spotlight command` (extended) | Spotlight row selection | adds `search_id`, `query`, `scope`, `provider` (from `command.meta.kind`, not parsed out of `target_id`), `group`, `position` (visible row index), `search_version`, `had_results`, `fallthrough` |
| `click` / `target_type: spotlight` (new) | `SpotlightTrigger` mouse open (previously unlogged) | `target_id: spotlight open` |
| `click` / `target_type: search rec` (extended) | Search results page rails: related tags, sources, users | keeps `origin` + `provider`, adds `search_id`, `search_version`, `position` (row index in its rail). Event name and target type unchanged so existing dashboards keep working. |
| `impression`, `click`, `go to link`, `comments click`, `finish feed` (extended) | Feed | adds `search_id` + `search_version` inside `extra` on search feeds, and `feed_item_index` inside `extra` on **all** feeds |
| `submit search` (extended) | Webapp + extension post search | adds `search_version` |

`search_id` is a uuid minted per query execution, keyed on query + search version + filters (and squad id for squad search). Changing a filter produces a new id and a fresh `search results` event, which is what makes filter changes measurable without extra instrumentation.

`latency_ms` is wall-clock around the request only (`performance.now()` either side of the GraphQL call), so it stays comparable between arms and is not polluted by render or debounce time.

## Exposure hygiene (experiment-critical)

`useSearchProviderSuggestions` called `getFeatureValue(feature.searchVersion)` unconditionally on every render. Spotlight is mounted globally, so **every pageview was enrolling the user in the search experiment**, which would have made the treatment/control split meaningless. It now uses `useConditionalFeature` gated on a suggestion request actually being about to run (enabled + debounced query at least `minSearchQueryLength`). This changes only when the flag is *evaluated*, never when a search is *possible*.

`useSearchProvider.getSuggestions`, `MainFeedLayout` and the squad page were each verified to evaluate the flag only on a real search; the latter two moved to `useConditionalFeature` so the value can also feed the `search_id` key.

## Notable refactors

- `useLogImpression` and `useFeedOnPostClick` moved from long positional argument lists to options objects (single and double call sites respectively) rather than growing to 10 positional parameters.
- `feedLogExtra` accepts optional `search_id` / `search_version` through its existing extra bag.
- `useSearchProviderSuggestions` now returns the `searchId` / `searchVersion` of the fetch behind its data, so the results-page rails and the palette read the same identity.
- `SearchResultsUsers` had pre-existing strict type errors; editing it pulls it under the changed-file typecheck guard, so they are fixed here (id-less hits are dropped rather than rendering an unfollowable row, and the avatar falls back to the same image `LazyImage` would have shown).
- `useSearchProvider.spec.tsx` and `useSearchProviderSuggestions.spec.tsx` pinned the search version literal; they now read `feature.searchVersion.defaultValue` so a future default change does not break the suite. The `extra.search_version` field in event payloads is unrelated to the flag key and unchanged.

## Tests

- New unit tests for the `search results` payload builder (including `latency_ms`), the `search rec` extra builder, `useSearchId` memoization/reset semantics, and the enriched users-rail click.
- `pnpm --filter @dailydotdev/shared test`: 371 suites / 2693 tests pass.
- `pnpm --filter webapp test`: 81 suites / 648 tests pass.
- `pnpm --filter extension test`: 6 suites / 52 tests pass.
- `node ./scripts/typecheck-strict-changed.js` clean; `pnpm --filter webapp build` compiles and typechecks clean (the local run only fails prerendering `/gear`, which needs a reachable API host).

## Deliberately out of scope

- Server-side (daily-api) work and new GraphQL fields.
- Click logging on `SearchFilterTimeButton` / `SearchFilterPostTypeButton`: a filter change already re-keys the feed query and re-fires `search results` with the new filters and a new `search_id`, which covers the quality metric. Adding button-level clicks would mean inventing a new `TargetType` for a signal we already have.


### Preview domain
https://search-analytics-instrumentation.preview.app.daily.dev
