### PR TITLE
fix(seo): 404 unknown tags and invite tokens, custom app not-found, respect api noindex

### DIFF
--- a/packages/shared/src/components/tags/TagTopicPage.tsx
+++ b/packages/shared/src/components/tags/TagTopicPage.tsx
@@ -90,11 +90,11 @@ const SUPPORTED_TYPES = [
 
 export interface TagTopicPageProps {
   tag: string;
-  initialData: Keyword | null;
+  initialData: Keyword;
   topPosts: TopPost[];
   recommendedTags: TagsData['tags'];
   topContributors: UserShortProfile[];
-  jsonLd?: string | null;
+  jsonLd?: string;
 }
 
 // Render the user/source cards in the same grid the post feed uses (same
@@ -249,9 +249,9 @@ export const TagTopicPage = ({
     showToastOnSuccess: false,
   });
 
-  const title = initialData?.flags?.title || formatKeyword(tag);
-  const followers = initialData?.followers;
-  const occurrences = initialData?.occurrences ?? 0;
+  const title = initialData.flags?.title || formatKeyword(tag);
+  const { followers } = initialData;
+  const occurrences = initialData.occurrences ?? 0;
 
   const topPostsQueryVariables = useMemo(
     () => ({ tag, ranking: 'POPULARITY', supportedTypes: SUPPORTED_TYPES }),
@@ -411,7 +411,7 @@ export const TagTopicPage = ({
                 </React.Fragment>
               ))}
             </Typography>
-            {initialData?.flags?.description && (
+            {initialData.flags?.description && (
               <Typography
                 type={TypographyType.Body}
                 color={TypographyColor.Secondary}
@@ -518,7 +518,7 @@ export const TagTopicPage = ({
             />
           )}
 
-          {showRoadmap && initialData?.flags?.roadmap && (
+          {showRoadmap && initialData.flags?.roadmap && (
             <section className="mb-10">
               <EntitySectionHeading>Roadmaps</EntitySectionHeading>
               <Link href={initialData.flags.roadmap} passHref prefetch={false}>

--- a/packages/shared/src/graphql/fragments.ts
+++ b/packages/shared/src/graphql/fragments.ts
@@ -374,6 +374,7 @@ export const SHARED_POST_INFO_FRAGMENT = gql`
     summary
     createdAt
     private
+    noindex
     upvoted
     commented
     bookmarked

--- a/packages/shared/src/graphql/posts.ts
+++ b/packages/shared/src/graphql/posts.ts
@@ -289,6 +289,7 @@ export interface Post {
   type: PostType;
   subType?: string;
   private?: boolean;
+  noindex?: boolean;
   feedMeta?: string;
   downvoted?: boolean;
   flags?: PostFlags;

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -112,6 +112,7 @@ export interface Source {
   currentMember?: SourceMember;
   privilegedMembers?: SourceMember[];
   public: boolean;
+  noindex?: boolean;
   headerImage?: string;
   color?: string;
   description?: string;

--- a/packages/shared/src/graphql/squads.ts
+++ b/packages/shared/src/graphql/squads.ts
@@ -355,6 +355,7 @@ export const SQUAD_STATIC_FIELDS_QUERY = gql`
       name
       handle
       public
+      noindex
       description
       image
       type
@@ -373,6 +374,7 @@ export type SquadStaticData = Pick<
   | 'name'
   | 'handle'
   | 'public'
+  | 'noindex'
   | 'description'
   | 'image'
   | 'type'

--- a/packages/webapp/__tests__/PostStaticProps.spec.ts
+++ b/packages/webapp/__tests__/PostStaticProps.spec.ts
@@ -28,8 +28,8 @@ type TestPost = {
   language: string;
   tags: string[];
   image?: string;
+  noindex?: boolean;
   author?: {
-    reputation?: number;
     permalink?: string;
   };
 };
@@ -37,11 +37,11 @@ type TestPost = {
 const createPost = ({
   type,
   upvotes,
-  reputation = 11,
+  noindex = false,
 }: {
   type: PostType;
   upvotes: number;
-  reputation?: number;
+  noindex?: boolean;
 }): TestPost => ({
   id: `${type}-${upvotes}`,
   type,
@@ -53,8 +53,8 @@ const createPost = ({
   language: 'en',
   tags: ['seo'],
   image: 'https://example.com/post.png',
+  noindex,
   author: {
-    reputation,
     permalink: 'https://example.com/@author',
   },
 });
@@ -110,7 +110,32 @@ describe('post static props seo', () => {
     });
   });
 
+  it('should noindex a post the API flags as noindex', async () => {
+    mockRequest
+      .mockResolvedValueOnce({
+        post: createPost({
+          type: PostType.Article,
+          upvotes: 10,
+          noindex: true,
+        }),
+      })
+      .mockResolvedValueOnce({ topComments: [] });
+
+    const result = await getStaticProps({
+      params: { id: 'post-id' },
+    } as never);
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          noindex: true,
+        },
+      },
+    });
+  });
+
   it.each([
+    ['the API flags the post as noindex', { noindex: true }],
     ['the post is private', { private: true }],
     ['the source is not public', { source: { public: false } }],
   ])('should noindex when %s', (_, overrides) => {
@@ -143,7 +168,9 @@ describe('post static props seo', () => {
     });
   });
 
-  it('should preserve indexed status when the author reputation is missing', () => {
+  // Author reputation is the API's call now, so a post it did not flag stays
+  // indexable no matter who wrote it.
+  it('should keep a post the API did not flag indexable', () => {
     expect(
       shouldNoindexPost({
         ...createPost({ type: PostType.Article, upvotes: 10 }),

--- a/packages/webapp/__tests__/SquadPageStaticProps.spec.ts
+++ b/packages/webapp/__tests__/SquadPageStaticProps.spec.ts
@@ -31,7 +31,7 @@ const mockRequest = gqlClient.request as jest.Mock;
 const mockStaticFields = getSquadStaticFields as jest.Mock;
 const mockGetSquad = getSquad as jest.Mock;
 
-const createSquad = (isPublic: boolean) => ({
+const createSquad = (isPublic: boolean, noindex = false) => ({
   id: 'squad-id',
   handle: 'my-squad',
   name: 'My Squad',
@@ -40,6 +40,7 @@ const createSquad = (isPublic: boolean) => ({
   image: 'https://media.daily.dev/squad.png',
   membersCount: 3,
   public: isPublic,
+  noindex,
 });
 
 const runGssp = () =>
@@ -85,6 +86,22 @@ describe('squad page getServerSideProps seo', () => {
         seo: {
           noindex: false,
           nofollow: false,
+        },
+      },
+    });
+  });
+
+  it('marks a public squad the API flags as noindex', async () => {
+    mockStaticFields.mockResolvedValue(createSquad(true, true));
+    mockGetSquad.mockResolvedValue(createSquad(true, true));
+
+    const result = await runGssp();
+
+    expect(result).toMatchObject({
+      props: {
+        seo: {
+          noindex: true,
+          nofollow: true,
         },
       },
     });

--- a/packages/webapp/__tests__/SquadTokenStaticProps.spec.ts
+++ b/packages/webapp/__tests__/SquadTokenStaticProps.spec.ts
@@ -1,0 +1,60 @@
+import { getSquadInvitation } from '@dailydotdev/shared/src/graphql/squads';
+import { getStaticProps } from '../pages/squads/[handle]/[token]';
+
+jest.mock('@dailydotdev/shared/src/graphql/squads', () => {
+  const actual = jest.requireActual('@dailydotdev/shared/src/graphql/squads');
+
+  return {
+    ...actual,
+    getSquadInvitation: jest.fn(),
+  };
+});
+
+const mockInvitation = getSquadInvitation as jest.Mock;
+
+const runStaticProps = () =>
+  getStaticProps({
+    params: { handle: 'my-squad', token: 'null' },
+  } as never);
+
+describe('squad invitation static props', () => {
+  beforeEach(() => {
+    mockInvitation.mockReset();
+  });
+
+  it('should 404 an invitation that does not resolve', async () => {
+    mockInvitation.mockResolvedValue(null);
+
+    const result = await runStaticProps();
+
+    expect(result).toEqual({ notFound: true, revalidate: 60 });
+  });
+
+  it('should 404 when the invitation request throws', async () => {
+    mockInvitation.mockRejectedValue(new Error('nope'));
+
+    const result = await runStaticProps();
+
+    expect(result).toEqual({ notFound: true, revalidate: 60 });
+  });
+
+  it('should keep a valid invitation out of the index', async () => {
+    mockInvitation.mockResolvedValue({
+      user: { name: 'Ido', username: 'ido' },
+      source: { name: 'My Squad', handle: 'my-squad', description: 'A squad' },
+    });
+
+    const result = await runStaticProps();
+
+    expect(result).toMatchObject({
+      props: {
+        handle: 'my-squad',
+        seo: {
+          title: 'Ido invited you to My Squad',
+          noindex: true,
+          nofollow: true,
+        },
+      },
+    });
+  });
+});

--- a/packages/webapp/__tests__/TagPageStaticProps.spec.ts
+++ b/packages/webapp/__tests__/TagPageStaticProps.spec.ts
@@ -69,6 +69,30 @@ describe('tag page static props', () => {
     });
   });
 
+  it('should 404 an unknown tag instead of serving an empty page', async () => {
+    mockRequest
+      .mockResolvedValueOnce({ keyword: null })
+      .mockResolvedValueOnce({ page: { edges: [] } })
+      .mockResolvedValueOnce({ recommendedTags: { tags: [] } })
+      .mockResolvedValueOnce({ topCreatorsByTag: [] });
+
+    const result = await getStaticProps({
+      params: { tag: 'not-a-real-tag' },
+    } as never);
+
+    expect(result).toEqual({ notFound: true, revalidate: 3600 });
+  });
+
+  it('should 404 when the keyword request fails', async () => {
+    mockRequest.mockRejectedValue(new Error('nope'));
+
+    const result = await getStaticProps({
+      params: { tag: 'javascript' },
+    } as never);
+
+    expect(result).toEqual({ notFound: true, revalidate: 3600 });
+  });
+
   it('should scope company tags to developer news', async () => {
     mockTagRequests({
       value: 'google',

--- a/packages/webapp/app/layout.tsx
+++ b/packages/webapp/app/layout.tsx
@@ -1,0 +1,17 @@
+import type { ReactElement, ReactNode } from 'react';
+import React from 'react';
+import '@dailydotdev/shared/src/styles/globals.css';
+
+// The App Router only exists here for the service worker and the shared
+// not-found page, so this root layout stays as thin as the framework allows.
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}): ReactElement {
+  return (
+    <html lang="en" translate="no">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/packages/webapp/app/not-found-content.tsx
+++ b/packages/webapp/app/not-found-content.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+import type { ReactElement } from 'react';
+import React from 'react';
+import Custom404 from '@dailydotdev/shared/src/components/Custom404';
+
+export const NotFoundContent = (): ReactElement => (
+  <Custom404 showRecoveryLinks />
+);

--- a/packages/webapp/app/not-found.tsx
+++ b/packages/webapp/app/not-found.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import type { ReactElement } from 'react';
+import React from 'react';
+import { NotFoundContent } from './not-found-content';
+
+export const metadata: Metadata = {
+  title: 'Page not found',
+  robots: { index: false, follow: false },
+};
+
+// Pages Router routes that return `notFound` are served by the App Router's
+// not-found in a hybrid app, so this has to match pages/404.tsx.
+export default function NotFound(): ReactElement {
+  return <NotFoundContent />;
+}

--- a/packages/webapp/lib/postMarkdown.ts
+++ b/packages/webapp/lib/postMarkdown.ts
@@ -40,11 +40,12 @@ export interface PostMarkdownPost
     | 'tags'
     | 'language'
     | 'private'
+    | 'noindex'
     | 'numUpvotes'
     | 'numComments'
   > {
   url?: string;
-  author?: { name?: string; username?: string; reputation?: number };
+  author?: { name?: string; username?: string };
   source?: { handle?: string; name?: string; public?: boolean };
   sharedPost?: { title?: string; url?: string; summary?: string };
   communitySentiment?: CommunitySentimentPost | null;
@@ -84,12 +85,12 @@ export const POST_MARKDOWN_QUERY = gql`
       tags
       language
       private
+      noindex
       numUpvotes
       numComments
       author {
         name
         username
-        reputation
       }
       source {
         handle

--- a/packages/webapp/lib/seo.ts
+++ b/packages/webapp/lib/seo.ts
@@ -43,23 +43,21 @@ const THIN_NOINDEX_POST_TYPES = [PostType.Brief, PostType.SocialTwitter];
 /** Structural subset of {@link Post} so non-page callers can reuse the gate. */
 export interface NoindexPostFields {
   type: Post['type'];
+  noindex?: boolean;
   private?: boolean;
   source?: { public?: boolean };
-  author?: { reputation?: number };
 }
 
 export const shouldNoindexPost = (post: NoindexPostFields): boolean => {
-  // Posts in private squads normally fail the unauthenticated ISR fetch, but a
-  // cached page can outlive a squad turning private, so fail closed here too.
-  if (post?.private || post?.source?.public === false) {
+  // The API owns the full gate: banned, deleted, private, vordr and
+  // low-reputation or shadow-banned authors and scouts.
+  if (post?.noindex) {
     return true;
   }
 
-  const hasLowReputationAuthor =
-    typeof post?.author?.reputation === 'number' &&
-    post.author.reputation <= 10;
-
-  if (hasLowReputationAuthor) {
+  // Posts in private squads normally fail the unauthenticated ISR fetch, but a
+  // cached page can outlive a squad turning private, so fail closed here too.
+  if (post?.private || post?.source?.public === false) {
     return true;
   }
 

--- a/packages/webapp/pages/api/md/posts/[id].ts
+++ b/packages/webapp/pages/api/md/posts/[id].ts
@@ -51,8 +51,9 @@ const handler = async (
       { id },
     );
 
-    // The same gate the HTML page uses for `noindex`. Private posts, private
-    // squads, low-reputation authors and thin post types get no markdown twin.
+    // The same gate the HTML page uses for `noindex`: whatever the API marks
+    // as noindex, private posts, private squads and thin post types get no
+    // markdown twin.
     if (!post || shouldNoindexPost(post)) {
       sendNotFound(res, id);
       return;

--- a/packages/webapp/pages/squads/[handle]/[token].tsx
+++ b/packages/webapp/pages/squads/[handle]/[token].tsx
@@ -301,7 +301,22 @@ export async function getStaticProps({
   GetStaticPropsResult<SquadReferralProps>
 > {
   const { handle, token } = params;
-  const initialData = await getSquadInvitation(token);
+
+  // getSquadInvitation swallows request failures into null, so an invalid
+  // token leaves nothing to destructure and nothing worth serving.
+  const notFoundResponse = { notFound: true as const, revalidate: 60 };
+
+  let initialData: SourceMember | null = null;
+  try {
+    initialData = await getSquadInvitation(token);
+  } catch (error) {
+    return notFoundResponse;
+  }
+
+  if (!initialData) {
+    return notFoundResponse;
+  }
+
   const { user, source } = initialData;
 
   if (!source || !user) {

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -697,8 +697,10 @@ export async function getServerSideProps({
     ]);
 
     // Fail closed: anything we can't positively confirm as a public squad stays
-    // out of the index.
+    // out of the index. The API's own gate covers inactive, vordr and tiny
+    // squads on top of that.
     const isPublicSquad = squad?.public === true;
+    const noindex = !isPublicSquad || squad?.noindex === true;
 
     const seoUsers = isPublicSquad
       ? await getSquad(handle)
@@ -720,8 +722,8 @@ export async function getServerSideProps({
         ...squadSeoTitles.openGraph,
         ...getSquadOpenGraph({ squad }),
       },
-      nofollow: !isPublicSquad,
-      noindex: !isPublicSquad,
+      nofollow: noindex,
+      noindex,
     };
 
     return {

--- a/packages/webapp/pages/tags/[tag].tsx
+++ b/packages/webapp/pages/tags/[tag].tsx
@@ -33,7 +33,7 @@ const appOrigin = getAppOrigin();
 
 interface TagPageProps extends DynamicSeoProps {
   tag: string;
-  initialData: Keyword | null;
+  initialData: Keyword;
   topPosts: TopPost[];
   recommendedTags: TagsData['tags'];
   topContributors: UserShortProfile[];
@@ -113,22 +113,16 @@ const TagPage = ({
   topPosts,
   recommendedTags,
   topContributors,
-}: TagPageProps): ReactElement => {
-  const jsonLd = initialData
-    ? getTagPageJsonLd({ tag, initialData, topPosts })
-    : null;
-
-  return (
-    <TagTopicPage
-      tag={tag}
-      initialData={initialData}
-      topPosts={topPosts}
-      recommendedTags={recommendedTags}
-      topContributors={topContributors}
-      jsonLd={jsonLd}
-    />
-  );
-};
+}: TagPageProps): ReactElement => (
+  <TagTopicPage
+    tag={tag}
+    initialData={initialData}
+    topPosts={topPosts}
+    recommendedTags={recommendedTags}
+    topContributors={topContributors}
+    jsonLd={getTagPageJsonLd({ tag, initialData, topPosts })}
+  />
+);
 
 TagPage.getLayout = getLayout;
 TagPage.layoutProps = mainFeedLayoutProps;
@@ -174,22 +168,14 @@ export async function getStaticProps({
 }: GetStaticPropsContext<TagPageParams>): Promise<
   GetStaticPropsResult<TagPageProps>
 > {
+  // An unknown tag has no content to rank: a 404 that revalidates in an hour
+  // beats an indexable empty page.
+  const notFoundResponse = { notFound: true as const, revalidate: 3600 };
+
   const tag = params?.tag;
   if (!tag) {
-    return { notFound: true, revalidate: 3600 };
+    return notFoundResponse;
   }
-
-  const notFoundResponse = {
-    revalidate: 3600,
-    props: {
-      tag,
-      initialData: null,
-      topPosts: [],
-      recommendedTags: [],
-      topContributors: [],
-      seo: getSeoData(tag, formatKeyword(tag)),
-    },
-  };
 
   try {
     const [
@@ -254,7 +240,6 @@ export async function getStaticProps({
       revalidate: 3600,
     };
   } catch (error) {
-    // Return fallback props for any request failure in getStaticProps.
     return notFoundResponse;
   }
 }


### PR DESCRIPTION
**Do not merge until https://github.com/dailydotdev/daily-api/pull/4203 (expose `noindex` on Post and Source) is deployed.** The shared post fragment and the squad static-fields query request `noindex`, so against an API without those fields every post and squad query fails validation.

Five crawl fixes, all reproduced on the live daily.dev host.

### 1. `/tags/<unknown>` returned 200

`getStaticProps` answered every keyword miss (and every request failure) with a 200 and `initialData: null`, so unknown tags shipped as indexable empty pages. Both paths now return `{ notFound: true, revalidate: 3600 }`. `initialData` is never null after that, so `TagTopicPage`'s null handling and the `jsonLd` null branch are gone (the webapp tag page is its only caller).

### 2. `/squads/<handle>/null` returned 500

`getSquadInvitation` swallows request failures into `null`, and the destructuring right after it blew up out of ISR. Wrapped in a try/catch plus a null guard, both returning `{ notFound: true, revalidate: 60 }`. The existing "invitation without source or user" branch is untouched.

### 3. `notFound` served Next's stock 404

`app/sw.ts` makes this a hybrid App/Pages app, so Pages Router `notFound` results were answered by the App Router's default not-found: `next-error-h1`, "404: This page could not be found.", zero links. Added `app/not-found.tsx` (plus the root `app/layout.tsx` the App Router requires) rendering the same shared `Custom404 showRecoveryLinks` as `pages/404.tsx`, with `noindex, nofollow`. `/404` itself still renders `pages/404.tsx`.

Verified against a production build (`next build` + `next start`, API pointed at `api.daily.dev`):

```
/404                                 -> HTTP 404 | 'Other places to go' x1 | next-error-h1 x0 | <meta name="robots" content="noindex,nofollow">
/posts/null                          -> HTTP 404 | 'Other places to go' x1 | next-error-h1 x0 | <title>Page not found</title> | robots noindex, nofollow
/tags/definitely-not-a-real-tag-xyz  -> HTTP 404 | 'Other places to go' x1 | next-error-h1 x0 | <title>Page not found</title> | robots noindex, nofollow
/squads/some-squad/null              -> HTTP 404 | 'Other places to go' x1 | next-error-h1 x0 | <title>Page not found</title> | robots noindex, nofollow
/definitely-not-a-user-xyz           -> HTTP 404 | 'Other places to go' x1 | next-error-h1 x0 | <title>Page not found</title> | robots noindex, nofollow
```

```
$ curl -sD - -o /dev/null http://localhost:5099/squads/some-squad/null | head -1
HTTP/1.1 404 Not Found
$ grep -o '<h1[^>]*>[^<]*</h1>' body.html
<h1 class="font-bold typo-large-title">Why are you here?</h1>
```

### 4. Respect the API's `noindex`

- `noindex` added to `SHARED_POST_INFO_FRAGMENT`, to the squad static-fields query and `SquadStaticData`, and to the `Post` / `Source` types.
- `shouldNoindexPost` returns true on `post.noindex`, keeps the fail-closed `private` / `source.public === false` checks and the thin post-type list, and drops the author-reputation check the API now owns. The markdown twin route follows the same gate, so `POST_MARKDOWN_QUERY` swapped `author.reputation` for `noindex`.
- The squad page's `noindex` / `nofollow` become `!isPublicSquad || squad.noindex === true`, keeping the fail-closed `public === true` check.

### 5. `pages/posts/[id]/index.tsx`

Unchanged.

### Tests

`shared`: 369 suites / 2696 tests. `webapp`: 82 suites / 656 tests, including new cases for the tag 404, the invite-token 404 and both API-driven noindex paths.


### Preview domain
https://seo-404-noindex-fixes.preview.app.daily.dev