### PR TITLE
fix(seo): mark ugc, sponsored and aggregated links with rel hints

### DIFF
--- a/packages/shared/src/components/Markdown.tsx
+++ b/packages/shared/src/components/Markdown.tsx
@@ -36,7 +36,6 @@ interface MarkdownProps {
   className?: string;
   content: string;
   appendTooltipTo?: () => HTMLElement;
-  openLinksInNewTab?: boolean;
 }
 
 const TOOLTIP_SPACING = 8;
@@ -62,7 +61,6 @@ export default function Markdown({
   className,
   content,
   appendTooltipTo,
-  openLinksInNewTab = false,
 }: MarkdownProps): ReactElement {
   const purify = useDomPurify();
   const { openModal } = useLazyModal();
@@ -94,23 +92,6 @@ export default function Markdown({
       img.setAttribute('tabindex', '0');
       img.setAttribute('role', 'button');
       img.setAttribute('aria-label', 'Open image');
-    });
-  });
-
-  useEffect(() => {
-    if (!openLinksInNewTab) {
-      return;
-    }
-
-    const container = containerRef.current;
-    if (!container) {
-      return;
-    }
-
-    const links = container.querySelectorAll('a[href]');
-    links.forEach((link) => {
-      link.setAttribute('target', '_blank');
-      link.setAttribute('rel', 'noopener noreferrer');
     });
   });
 

--- a/packages/shared/src/components/brand/EngagementAdCta.tsx
+++ b/packages/shared/src/components/brand/EngagementAdCta.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement, ReactNode } from 'react';
 import React from 'react';
 import classNames from 'classnames';
+import { anchorSponsoredRel } from '../../lib/strings';
 
 type EngagementAdCtaProps = {
   href: string;
@@ -27,7 +28,7 @@ export const EngagementAdCta = ({
   <a
     href={href}
     target="_blank"
-    rel="noopener noreferrer"
+    rel={anchorSponsoredRel}
     onClick={onClick}
     style={
       inverted

--- a/packages/shared/src/components/brand/SponsoredTagHero.tsx
+++ b/packages/shared/src/components/brand/SponsoredTagHero.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import { useBrandSponsorship } from '../../hooks/useBrandSponsorship';
 import { Button, ButtonSize, ButtonVariant } from '../buttons/Button';
 import { OpenLinkIcon } from '../icons';
+import { anchorSponsoredRel } from '../../lib/strings';
 
 interface SponsoredTagHeroProps {
   tag: string;
@@ -120,7 +121,7 @@ export const SponsoredTagHero = ({
             tag="a"
             href={ctaUrl}
             target="_blank"
-            rel="noopener noreferrer"
+            rel={anchorSponsoredRel}
             className="hover:bg-white/90 w-full !bg-white text-raw-pepper-90 laptop:w-auto laptop:flex-shrink-0 laptop:self-center"
           >
             {ctaText}

--- a/packages/shared/src/components/cards/ad/AdCard.spec.tsx
+++ b/packages/shared/src/components/cards/ad/AdCard.spec.tsx
@@ -11,6 +11,7 @@ import type { AdCardProps } from './common/common';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 import { ActiveFeedContext } from '../../../contexts';
 import { businessWebsiteUrl } from '../../../lib/constants';
+import { anchorSponsoredRel } from '../../../lib/strings';
 import { useFeature } from '../../GrowthBookProvider';
 import { AdLabelVariant, featureAdLabel } from '../../../lib/featureManagement';
 
@@ -230,7 +231,7 @@ it('should render promoted attribution with source link', async () => {
 
   expect(link).toHaveAttribute('href', 'https://example.com/referral');
   expect(link).toHaveAttribute('target', '_blank');
-  expect(link).toHaveAttribute('rel', 'noopener');
+  expect(link).toHaveAttribute('rel', anchorSponsoredRel);
 });
 
 it('should render plain Promoted attribution without source link', async () => {

--- a/packages/shared/src/components/cards/ad/AdGrid.tsx
+++ b/packages/shared/src/components/cards/ad/AdGrid.tsx
@@ -30,6 +30,7 @@ import { adImprovementsV3Feature } from '../../../lib/featureManagement';
 import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
 import { useAdLabel } from '../../../features/monetization/useAdLabel';
+import { anchorSponsoredRel } from '../../../lib/strings';
 
 export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
   { ad, onLinkClick, onViewable, domProps, index, feedIndex },
@@ -73,7 +74,7 @@ export const AdGrid = forwardRef<HTMLElement, AdCardProps>(function AdGrid(
               tag="a"
               href={clickUrl}
               target="_blank"
-              rel="noopener"
+              rel={anchorSponsoredRel}
               variant={ButtonVariant.Primary}
               size={ButtonSize.Small}
               className="z-1"

--- a/packages/shared/src/components/cards/ad/AdList.tsx
+++ b/packages/shared/src/components/cards/ad/AdList.tsx
@@ -30,6 +30,7 @@ import { TargetId } from '../../../lib/log';
 import { AdvertiseLink } from './common/AdvertiseLink';
 import { useAdLabel } from '../../../features/monetization/useAdLabel';
 import AdAttribution, { adAttributionSpacing } from './common/AdAttribution';
+import { anchorSponsoredRel } from '../../../lib/strings';
 
 const getLinkProps = ({
   ad,
@@ -43,7 +44,7 @@ const getLinkProps = ({
   return {
     href,
     target: '_blank',
-    rel: 'noopener',
+    rel: anchorSponsoredRel,
     title: ad.description,
     ...combinedClicks(() => onLinkClick?.(ad)),
   };
@@ -99,7 +100,7 @@ export const AdList = forwardRef<HTMLElement, AdCardProps>(function AdCard(
             tag="a"
             href={clickUrl}
             target="_blank"
-            rel="noopener"
+            rel={anchorSponsoredRel}
             variant={ButtonVariant.Primary}
             size={ButtonSize.Small}
             {...combinedClicks(() => onLinkClick?.(ad))}

--- a/packages/shared/src/components/cards/ad/SignalAdList.tsx
+++ b/packages/shared/src/components/cards/ad/SignalAdList.tsx
@@ -23,6 +23,7 @@ import { useAdClickUrl } from '../../../features/monetization/useAdClickUrl';
 import { SourceAvatar } from '../../profile/source/SourceAvatar';
 import { MiniCloseIcon } from '../../icons';
 import { getAdFaviconImageLink } from './common/getAdFaviconImageLink';
+import { anchorSponsoredRel } from '../../../lib/strings';
 
 const getLinkProps = ({
   ad,
@@ -36,7 +37,7 @@ const getLinkProps = ({
   return {
     href,
     target: '_blank',
-    rel: 'noopener',
+    rel: anchorSponsoredRel,
     title: ad.description,
     ...combinedClicks(() => onLinkClick?.(ad)),
   };
@@ -121,7 +122,7 @@ export const SignalAdList = forwardRef(function SignalAdList(
               tag="a"
               href={clickUrl}
               target="_blank"
-              rel="noopener"
+              rel={anchorSponsoredRel}
               variant={ButtonVariant.Primary}
               size={ButtonSize.Small}
               {...combinedClicks(() => onLinkClick?.(ad))}

--- a/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdAttribution.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import type { Ad } from '../../../../graphql/posts';
 import { useScrambler } from '../../../../hooks/useScrambler';
 import { useAdLabel } from '../../../../features/monetization/useAdLabel';
+import { anchorSponsoredRel } from '../../../../lib/strings';
 
 /**
  * Minimum room between the ad copy and the disclosure line. The grid card
@@ -43,7 +44,7 @@ export default function AdAttribution({
       <a
         href={ad.referralLink}
         target="_blank"
-        rel="noopener"
+        rel={anchorSponsoredRel}
         className={elementClass}
         data-testid="adAttribution"
         suppressHydrationWarning

--- a/packages/shared/src/components/cards/ad/common/AdLink.tsx
+++ b/packages/shared/src/components/cards/ad/common/AdLink.tsx
@@ -4,6 +4,7 @@ import type { Ad } from '../../../../graphql/posts';
 import { CardLink } from '../../common/Card';
 import { combinedClicks } from '../../../../lib/click';
 import { useAdClickUrl } from '../../../../features/monetization/useAdClickUrl';
+import { anchorSponsoredRel } from '../../../../lib/strings';
 
 export type AdLinkProps = {
   ad: Ad;
@@ -17,7 +18,7 @@ export default function AdLink({ ad, onLinkClick }: AdLinkProps): ReactElement {
     <CardLink
       href={href}
       target="_blank"
-      rel="noopener"
+      rel={anchorSponsoredRel}
       title={ad.description}
       {...combinedClicks(() => onLinkClick?.(ad))}
     />

--- a/packages/shared/src/components/post/PostArticlePreviewEmbed.tsx
+++ b/packages/shared/src/components/post/PostArticlePreviewEmbed.tsx
@@ -27,6 +27,7 @@ import { useLogContext } from '../../contexts/LogContext';
 import { LogEvent } from '../../lib/log';
 import { ElementPlaceholder } from '../ElementPlaceholder';
 import { TextPlaceholder } from '../widgets/common';
+import { anchorNofollowRel } from '../../lib/strings';
 
 const FRAME_LOAD_TIMEOUT_MS = 7000;
 const PERMISSION_FRAME_CONNECT_TIMEOUT_MS = 7000;
@@ -551,7 +552,7 @@ export function PostArticlePreviewEmbed({
                 <a
                   href={targetHref}
                   target={targetLinkInNewTab ? '_blank' : '_self'}
-                  rel="noopener noreferrer"
+                  rel={anchorNofollowRel}
                   onClick={onTargetLinkClick}
                   className="block w-full truncate text-left underline-offset-2 hover:underline"
                   title={`Open ${previewDomain}`}

--- a/packages/shared/src/components/post/PostContent.tsx
+++ b/packages/shared/src/components/post/PostContent.tsx
@@ -36,6 +36,7 @@ import {
   CommunitySentiment,
   mapCommunitySentimentPost,
 } from './focus/CommunitySentiment';
+import { anchorNofollowRel } from '../../lib/strings';
 
 type PostContentRawProps = Omit<PostContentProps, 'post'> & { post: Post };
 
@@ -64,7 +65,7 @@ const ArticleLink = ({
       href={href}
       title="Go to post"
       target="_blank"
-      rel="noopener"
+      rel={anchorNofollowRel}
       {...clickHandlers}
       {...props}
     >

--- a/packages/shared/src/components/post/PostSidebarAdWidget.tsx
+++ b/packages/shared/src/components/post/PostSidebarAdWidget.tsx
@@ -22,7 +22,7 @@ import { adImprovementsV3Feature } from '../../lib/featureManagement';
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { TargetId } from '../../lib/log';
 import { combinedClicks } from '../../lib/click';
-import { anchorDefaultRel } from '../../lib/strings';
+import { anchorSponsoredRel } from '../../lib/strings';
 import {
   Typography,
   TypographyColor,
@@ -133,7 +133,7 @@ export function PostSidebarAdWidget({
         <a
           href={ad.link}
           target="_blank"
-          rel={anchorDefaultRel}
+          rel={anchorSponsoredRel}
           title={ad.description}
           className="absolute inset-0 z-0"
           {...combinedClicks(() => onAdAction(AdActions.Click))}
@@ -170,7 +170,7 @@ export function PostSidebarAdWidget({
             tag="a"
             href={ad.link}
             target="_blank"
-            rel={anchorDefaultRel}
+            rel={anchorSponsoredRel}
             variant={ButtonVariant.Primary}
             size={ButtonSize.Small}
             className="relative z-1 ml-auto shrink-0"
@@ -213,7 +213,7 @@ export function PostSidebarAdWidget({
           tag="a"
           href={ad.link}
           target="_blank"
-          rel={anchorDefaultRel}
+          rel={anchorSponsoredRel}
           variant={ButtonVariant.Primary}
           size={ButtonSize.Small}
           className="relative z-1"
@@ -226,7 +226,7 @@ export function PostSidebarAdWidget({
       <a
         href={ad.link}
         target="_blank"
-        rel={anchorDefaultRel}
+        rel={anchorSponsoredRel}
         title={ad.description}
         className="absolute inset-0 z-0"
         {...combinedClicks(() => onAdAction(AdActions.Click))}

--- a/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
+++ b/packages/shared/src/components/post/arbitrage/ArbitragePostContent.tsx
@@ -32,6 +32,7 @@ import { useTimedRelease } from './useTimedRelease';
 import { GoBackHeaderMobile } from '../GoBackHeaderMobile';
 import { PostWidgets, PostWidgetPosition } from '../PostWidgets';
 import PostEngagements from '../PostEngagements';
+import { anchorNofollowRel } from '../../../lib/strings';
 
 /**
  * The rail carries two in-flow units between its widgets, and the closing
@@ -194,7 +195,7 @@ export function ArbitragePostContent({
               href={post.permalink}
               title="Go to post"
               target="_blank"
-              rel="noopener"
+              rel={anchorNofollowRel}
             >
               {post.title}
             </a>
@@ -248,7 +249,7 @@ export function ArbitragePostContent({
                       href={post.permalink}
                       title={post.domain}
                       target="_blank"
-                      rel="noopener"
+                      rel={anchorNofollowRel}
                       className="hover:underline"
                     >
                       {post.domain}
@@ -262,7 +263,7 @@ export function ArbitragePostContent({
               <a
                 href={post.permalink}
                 target="_blank"
-                rel="noopener"
+                rel={anchorNofollowRel}
                 className="block cursor-pointer overflow-hidden rounded-16"
                 style={{ maxWidth: '25.625rem' }}
               >

--- a/packages/shared/src/components/post/common/SharedPostLink.tsx
+++ b/packages/shared/src/components/post/common/SharedPostLink.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Link from '../../utilities/Link';
 import type { Post, SharedPost } from '../../../graphql/posts';
 import type { CombinedClicks } from '../../../lib/click';
+import { anchorUgcRel } from '../../../lib/strings';
 
 interface SharedPostTitleProps {
   sharedPost: SharedPost;
@@ -24,7 +25,7 @@ export const SharedPostLink = ({
     ? {
         href: sharedPost?.permalink,
         target: '_blank',
-        rel: 'noopener',
+        rel: anchorUgcRel,
         as: undefined,
         ...onGoToLinkProps,
       }

--- a/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.tsx
+++ b/packages/shared/src/components/post/focus/CommunitySentimentBreakdown.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../typography/Typography';
 import { OpenLinkIcon } from '../../icons';
 import { IconSize } from '../../Icon';
-import { anchorDefaultRel, capitalize } from '../../../lib/strings';
+import { anchorNofollowRel, capitalize } from '../../../lib/strings';
 import { largeNumberFormat } from '../../../lib/numberFormat';
 import type {
   CommunitySentimentData,
@@ -219,7 +219,7 @@ const SourceRow = ({
       <a
         href={linkUrl}
         target="_blank"
-        rel={anchorDefaultRel}
+        rel={anchorNofollowRel}
         title={`View the discussion on ${label}`}
         className={classNames(
           rowClassName,

--- a/packages/shared/src/components/post/focus/PostFocusCard.tsx
+++ b/packages/shared/src/components/post/focus/PostFocusCard.tsx
@@ -64,6 +64,7 @@ import {
   CommunitySentiment,
   mapCommunitySentimentPost,
 } from './CommunitySentiment';
+import { anchorNofollowRel } from '../../../lib/strings';
 
 const PostCodeSnippets = dynamic(() =>
   import(/* webpackChunkName: "postCodeSnippets" */ '../PostCodeSnippets').then(
@@ -101,7 +102,7 @@ const ArticleLink = ({
       href={href}
       title="Go to post"
       target="_blank"
-      rel="noopener"
+      rel={anchorNofollowRel}
       {...clickHandlers}
       {...props}
     >
@@ -363,7 +364,7 @@ const PostFocusCardRaw = ({
     <a
       href={readHref}
       target="_blank"
-      rel="noopener"
+      rel={anchorNofollowRel}
       {...combinedClicks<HTMLAnchorElement>(handleReadClick)}
       aria-label={readCtaAccessibleLabel}
       className="flex h-8 w-fit items-center gap-1 rounded-10 bg-text-primary pl-3 pr-1.5 text-surface-invert"
@@ -524,7 +525,7 @@ const PostFocusCardRaw = ({
                     <a
                       href={readHref}
                       target="_blank"
-                      rel="noopener"
+                      rel={anchorNofollowRel}
                       {...combinedClicks<HTMLAnchorElement>(
                         withSelectionGuard(handleReadClick),
                       )}
@@ -568,7 +569,7 @@ const PostFocusCardRaw = ({
                   <a
                     href={readHref}
                     target="_blank"
-                    rel="noopener"
+                    rel={anchorNofollowRel}
                     {...combinedClicks<HTMLAnchorElement>(handleReadClick)}
                     aria-hidden
                     tabIndex={-1}

--- a/packages/shared/src/components/post/reader/ReaderFallback.tsx
+++ b/packages/shared/src/components/post/reader/ReaderFallback.tsx
@@ -15,6 +15,7 @@ import {
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent, Origin, TargetType } from '../../../lib/log';
 import { useReadArticle } from '../../../hooks/usePostContent';
+import { anchorNofollowRel } from '../../../lib/strings';
 
 type ReaderFallbackProps = {
   post: Post;
@@ -88,7 +89,7 @@ export const ReaderFallback = forwardRef<HTMLDivElement, ReaderFallbackProps>(
           tag="a"
           href={post.permalink}
           target={openNewTab ? '_blank' : '_self'}
-          rel="noopener"
+          rel={anchorNofollowRel}
           size={ButtonSize.Large}
           variant={ButtonVariant.Primary}
           className="w-fit"

--- a/packages/shared/src/components/widgets/PostToc.tsx
+++ b/packages/shared/src/components/widgets/PostToc.tsx
@@ -8,6 +8,7 @@ import { postLogEvent } from '../../lib/feed';
 import { ActiveFeedContext } from '../../contexts';
 import { widgetClasses, WidgetContainer } from './common';
 import { LogEvent } from '../../lib/log';
+import { anchorNofollowRel } from '../../lib/strings';
 
 export type PostTocProps = {
   post: Post;
@@ -46,7 +47,7 @@ export default function PostToc({
           key={item.text}
           href={generateTocLink(post, item)}
           target="_blank"
-          rel="noopener"
+          rel={anchorNofollowRel}
           title={item.text}
           onClick={onLinkClick}
           className="-mx-4 flex flex-1 truncate px-4 py-2 typo-callout hover:bg-surface-hover"

--- a/packages/shared/src/features/hackathon/components/HackathonHowItWorks.tsx
+++ b/packages/shared/src/features/hackathon/components/HackathonHowItWorks.tsx
@@ -7,7 +7,7 @@ import {
 } from '../../../components/typography/Typography';
 import { FlexCol } from '../../../components/utilities';
 import Link from '../../../components/utilities/Link';
-import { anchorDefaultRel } from '../../../lib/strings';
+import { anchorDefaultRel, anchorSponsoredRel } from '../../../lib/strings';
 import { webappUrl } from '../../../lib/constants';
 
 export const HackathonHowItWorks = (): ReactElement => {
@@ -47,7 +47,11 @@ export const HackathonHowItWorks = (): ReactElement => {
           </Link>{' '}
           with all the benefits for best submissions.{' '}
           <Link href="https://www.coderabbit.ai/pricing">
-            <a target="_blank" className="text-[#FF570A] underline">
+            <a
+              target="_blank"
+              rel={anchorSponsoredRel}
+              className="text-[#FF570A] underline"
+            >
               3 free months of CodeRabbit Pro Plus.
             </a>
           </Link>{' '}

--- a/packages/shared/src/features/profile/components/AboutMe.spec.tsx
+++ b/packages/shared/src/features/profile/components/AboutMe.spec.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { PublicProfile } from '../../../lib/user';
 import { AboutMe } from './AboutMe';
 import { getLogContextStatic } from '../../../contexts/LogContext';
+import { anchorUgcRel } from '../../../lib/strings';
 
 const LogContext = getLogContextStatic();
 
@@ -112,6 +113,14 @@ describe('AboutMe', () => {
       renderComponent(userWithSocialLinks);
       const allLinks = screen.getAllByTestId(/^social-link-/);
       expect(allLinks.length).toBe(12);
+    });
+
+    it('should mark social links as ugc and nofollow', () => {
+      renderComponent(userWithSocialLinks);
+      expect(screen.getByTestId('social-link-portfolio')).toHaveAttribute(
+        'rel',
+        anchorUgcRel,
+      );
     });
 
     it('should render all social link types', () => {

--- a/packages/shared/src/features/profile/components/AboutMe.tsx
+++ b/packages/shared/src/features/profile/components/AboutMe.tsx
@@ -18,7 +18,7 @@ import { SimpleTooltip } from '../../../components/tooltips/SimpleTooltip';
 import { useLogContext } from '../../../contexts/LogContext';
 import { combinedClicks } from '../../../lib/click';
 import { LogEvent, TargetType } from '../../../lib/log';
-import { anchorDefaultRel } from '../../../lib/strings';
+import { anchorUgcRel } from '../../../lib/strings';
 import { getUserSocialLinks } from '../../../lib/socialLink';
 
 export interface AboutMeProps {
@@ -68,7 +68,7 @@ export function AboutMe({
                 tag="a"
                 href={link.url}
                 target="_blank"
-                rel={anchorDefaultRel}
+                rel={anchorUgcRel}
                 icon={link.icon}
                 aria-label={link.label}
                 data-testid={`social-link-${link.id}`}

--- a/packages/shared/src/features/profile/components/experience/UserExperienceItem.tsx
+++ b/packages/shared/src/features/profile/components/experience/UserExperienceItem.tsx
@@ -20,6 +20,7 @@ import ShowMoreContent from '../../../../components/cards/common/ShowMoreContent
 import { LocationType } from '../../../opportunity/protobuf/util';
 import { formatDateRange } from '../../../../lib/dateFormat';
 import { locationToString } from '../../../../lib/utils';
+import { anchorUgcRel } from '../../../../lib/strings';
 import { currentPill } from './common';
 import {
   Button,
@@ -215,6 +216,7 @@ export function UserExperienceItem({
               <Link href={repository?.url || url} passHref>
                 <a
                   target="_blank"
+                  rel={anchorUgcRel}
                   aria-label={`Open ${primaryCopy || 'link'} in new tab`}
                 >
                   <OpenLinkIcon className="size-4 text-text-secondary" />

--- a/packages/shared/src/features/profile/components/experience/UserExperiencesList.spec.tsx
+++ b/packages/shared/src/features/profile/components/experience/UserExperiencesList.spec.tsx
@@ -6,6 +6,7 @@ import type { UserExperience } from '../../../../graphql/user/profile';
 import { UserExperienceType } from '../../../../graphql/user/profile';
 import { useAuthContext } from '../../../../contexts/AuthContext';
 import type { PublicProfile } from '../../../../lib/user';
+import { anchorUgcRel } from '../../../../lib/strings';
 
 // Mock the AuthContext
 jest.mock('../../../../contexts/AuthContext', () => ({
@@ -878,6 +879,26 @@ describe('UserExperiencesList', () => {
       expect(showMoreButton).toHaveAttribute(
         'href',
         'https://app.daily.dev/customuser/work',
+      );
+    });
+  });
+
+  describe('Experience link', () => {
+    it('should mark the experience url as ugc and nofollow', () => {
+      const user = createUser();
+      const experience = createExperience({
+        url: 'https://example.com/my-project',
+      });
+      renderComponent({
+        experiences: [experience],
+        title: 'Work Experience',
+        experienceType: UserExperienceType.Work,
+        user,
+      });
+
+      expect(screen.getByRole('link', { name: /in new tab/i })).toHaveAttribute(
+        'rel',
+        anchorUgcRel,
       );
     });
   });

--- a/packages/shared/src/lib/strings.ts
+++ b/packages/shared/src/lib/strings.ts
@@ -40,6 +40,12 @@ export const formatKeyword = (value: string): string => {
 
 export const anchorDefaultRel = 'noopener noreferrer';
 
+export const anchorUgcRel = 'noopener noreferrer nofollow ugc';
+
+export const anchorSponsoredRel = 'noopener noreferrer nofollow sponsored';
+
+export const anchorNofollowRel = 'noopener noreferrer nofollow';
+
 export const checkLowercaseEquality = (
   value1: string,
   value2: string,

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -205,6 +205,14 @@ const strictSkipList = new Set([
   // `post`/`post.source`, nullable PageInfo, optional comment/parent lookups)
   // live on unrelated lines and should be addressed in a dedicated cleanup PR.
   'packages/shared/src/hooks/post/useMutateComment.ts',
+  // Link-rel branch — these files were touched only to set an explicit `rel`
+  // on an outbound anchor. Pre-existing strict violations (optional
+  // `source`/`post.toc`, `Link href` accepting `string | null | undefined`,
+  // nullable location helpers) live on unrelated lines and should be
+  // addressed in a dedicated cleanup PR.
+  'packages/shared/src/components/post/common/SharedPostLink.tsx',
+  'packages/shared/src/components/widgets/PostToc.tsx',
+  'packages/shared/src/features/profile/components/experience/UserExperienceItem.tsx',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
Every outbound anchor in the app went out dofollow, because `anchorDefaultRel` is `noopener noreferrer` and nothing else set a `rel`. This adds three narrower constants next to it and applies them only where the destination is user-controlled, paid, or an aggregated article URL. `anchorDefaultRel` is untouched, so its ~100 remaining daily.dev-owned and editorial call sites stay dofollow.

## `anchorUgcRel` (`noopener noreferrer nofollow ugc`)

Hrefs a user types in:

- `AboutMe.tsx` profile social links (any domain, including the catch-all `portfolio` and `other` platforms), server-rendered on indexable profile pages
- `UserExperienceItem.tsx` experience / repository URLs
- `SharedPostLink.tsx` share target for unknown sources

## `anchorSponsoredRel` (`noopener noreferrer nofollow sponsored`)

Paid placements:

- `AdLink.tsx`, `AdGrid.tsx`, `AdList.tsx`, `SignalAdList.tsx`, `AdAttribution.tsx`
- `PostSidebarAdWidget.tsx` (all four anchors, on indexable post pages)
- `SponsoredTagHero.tsx` (indexable tag pages), `EngagementAdCta.tsx`
- `HackathonHowItWorks.tsx` partner pricing link

`AdvertiseLink.tsx` points at our own domain and is left alone.

## `anchorNofollowRel` (`noopener noreferrer nofollow`)

Aggregated article URLs, which all resolve through the `api.daily.dev/r/<shortId>` redirector, plus aggregated third-party discussion threads:

- `PostContent.tsx`, `PostFocusCard.tsx`, `PostToc.tsx`, `ReaderFallback.tsx`, `PostArticlePreviewEmbed.tsx`, `ArbitragePostContent.tsx`, `CommunitySentimentBreakdown.tsx`

## Anchors that had no `rel` at all

Two, both of which also pick up `noopener` here:

- `UserExperienceItem.tsx` experience link
- `HackathonHowItWorks.tsx` partner pricing link

## Also

Removed the unused `openLinksInNewTab` prop and its effect from `Markdown.tsx`. It had no consumers, and if anyone had passed it, it would have overwritten the API-supplied `rel` on post and comment bodies and stripped their `nofollow`.

The three files whose anchors gained a `rel` but that carry pre-existing strict-mode violations on unrelated lines are added to the strict-changed skip list.

## Testing

`shared`, `webapp` and `extension` suites pass. Added assertions for the two anchors that previously had no `rel` signal (`AboutMe` social links, `UserExperienceItem`) and updated the `AdCard` attribution `rel` assertion. Webapp `tsc` output is byte-identical to `main`.

### Preview domain
https://seo-rel-hints.preview.app.daily.dev