### PR TITLE
fix(analytics): move feed_item_index into the event extra

### DIFF
--- a/packages/shared/src/lib/feed.spec.ts
+++ b/packages/shared/src/lib/feed.spec.ts
@@ -1,4 +1,5 @@
-import { getAdSlotIndex } from './feed';
+import type { Post } from '../graphql/posts';
+import { getAdSlotIndex, postLogEvent } from './feed';
 
 describe('getAdSlotIndex', () => {
   const seed = '["feed","my-feed"]';
@@ -130,5 +131,51 @@ describe('getAdSlotIndex', () => {
         expect(hits[i] - hits[i - 1]).toBeGreaterThanOrEqual(2);
       }
     });
+  });
+});
+
+describe('postLogEvent', () => {
+  const post = { id: 'p1', title: 'A post' } as Post;
+
+  it('reports feed_item_index inside extra so ingest keeps it', () => {
+    const event = postLogEvent('impression', post, {
+      columns: 3,
+      column: 1,
+      row: 2,
+      index: 7,
+      extra: { search_id: 's1', search_version: 4 },
+    });
+
+    expect(event).not.toHaveProperty('feed_item_index');
+    expect(JSON.parse(event.extra as string)).toEqual({
+      search_id: 's1',
+      search_version: 4,
+      feed_item_index: 7,
+    });
+  });
+
+  it('keeps the grid coordinates top-level', () => {
+    const event = postLogEvent('impression', post, {
+      columns: 3,
+      column: 1,
+      row: 2,
+      index: 7,
+    });
+
+    expect(event.feed_grid_columns).toEqual(3);
+    expect(event.feed_item_grid_column).toEqual(1);
+    expect(event.feed_item_grid_row).toEqual(2);
+  });
+
+  it('reports the first item as index 0 rather than dropping it', () => {
+    const event = postLogEvent('click', post, { index: 0 });
+
+    expect(JSON.parse(event.extra as string).feed_item_index).toEqual(0);
+  });
+
+  it('omits feed_item_index when the caller has no index', () => {
+    const event = postLogEvent('go to link', post, { columns: 3 });
+
+    expect(event.extra).toBeUndefined();
   });
 });

--- a/packages/shared/src/lib/feed.ts
+++ b/packages/shared/src/lib/feed.ts
@@ -32,7 +32,6 @@ interface FeedItemLogEvent extends LogEvent {
   feed_grid_columns?: number;
   feed_item_grid_column?: number;
   feed_item_grid_row?: number;
-  feed_item_index?: number;
   feed_item_meta?: string;
   feed_item_image?: string;
   feed_item_target_url?: string;
@@ -112,9 +111,12 @@ export function postLogEvent(
   post: Post | ReadHistoryPost | PostBootData,
   opts?: PostLogEventFnOptions,
 ): PostItemLogEvent {
+  // Lives in `extra` rather than top-level: unmapped top-level event fields are
+  // dropped at analytics ingest, while the `extra` blob is stored intact.
   const extra: Record<string, unknown> = {
     ...opts?.extra,
     ...(opts?.is_ad && { is_ad: true }),
+    ...(typeof opts?.index === 'number' && { feed_item_index: opts.index }),
   };
 
   if (typeof window !== 'undefined') {
@@ -132,7 +134,6 @@ export function postLogEvent(
     feed_grid_columns: opts?.columns,
     feed_item_grid_column: opts?.column,
     feed_item_grid_row: opts?.row,
-    feed_item_index: opts?.index,
     feed_item_image: post.image,
     feed_item_target_url: post.permalink,
     feed_item_title: post.title,


### PR DESCRIPTION
Follow-up to #6585.

`feed_item_index` was added there as a **top-level** event field. Analytics ingest drops unmapped top-level fields, so it never reaches the warehouse: 0 occurrences in ClickHouse and BigQuery, while the other fields that PR added flow through fine. The `extra` JSON blob is stored intact, so the index moves in there.

## Change

`postLogEvent` now emits the index inside `extra` instead of as a sibling of the grid coordinates:

```diff
   const extra: Record<string, unknown> = {
     ...opts?.extra,
     ...(opts?.is_ad && { is_ad: true }),
+    ...(typeof opts?.index === 'number' && { feed_item_index: opts.index }),
   };
```

Every feed engagement event is built through that one function, so `impression`, `click` and `go to link` all pick it up with no call-site changes.

The mapped grid fields (`feed_grid_columns`, `feed_item_grid_column`, `feed_item_grid_row`) are untouched and stay top-level.

## Resulting shape for a search-feed event

| Placement | Fields |
| --- | --- |
| Top-level (mapped) | `event_name`, `target_id`, `target_type`, `feed_grid_columns`, `feed_item_grid_column`, `feed_item_grid_row`, `feed_item_*`, `post_*` |
| `extra` (JSON) | `origin`, `feed`, `ranking?`, `search_id`, `search_version`, **`feed_item_index`**, `scroll_y` (impressions), `feedback?`, `clickbait_badge?` |

On non-search feeds the `extra` blob is the same minus `search_id` / `search_version`.

`typeof opts?.index === 'number'` rather than a truthiness check, so the first item is reported as `feed_item_index: 0` instead of being dropped. When a caller passes no index the key is absent, and `extra` still collapses to `undefined` when nothing else is in it.

## Tests

New `postLogEvent` cases in `packages/shared/src/lib/feed.spec.ts` covering: index lands in `extra` and is absent top-level, grid coordinates stay top-level, index `0` survives, and no key when the caller has no index. Nothing in the repo asserted the field top-level, so no existing test needed updating.

- `pnpm --filter @dailydotdev/shared test`: 375 suites / 2738 tests pass
- `pnpm --filter webapp test`: 86 suites / 685 tests pass
- `pnpm --filter extension test`: 6 suites / 52 tests pass
- `node ./scripts/typecheck-strict-changed.js`: clean


### Preview domain
https://fix-feed-item-index-extra.preview.app.daily.dev