### PR TITLE
fix(post): stop the post modal's top strip repeating the content's actions

### DIFF
--- a/packages/shared/src/components/modals/ArticlePostModal.tsx
+++ b/packages/shared/src/components/modals/ArticlePostModal.tsx
@@ -41,6 +41,7 @@ export default function ArticlePostModal({
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
       navigationRedesign={showRedesign}
+      navigationContentOwnsActions={!showRedesign}
       onRequestClose={onRequestClose}
       postType={PostType.Article}
       source={post.source}

--- a/packages/shared/src/components/modals/BasePostModal.tsx
+++ b/packages/shared/src/components/modals/BasePostModal.tsx
@@ -32,6 +32,14 @@ interface BasePostModalProps extends ModalProps {
   navigationContainerClassName?: string;
   navigationHideSubscribeAction?: boolean;
   /**
+   * The classic content layouts render their own action group (menu, boost,
+   * collection subscribe) from laptop up, next to the source line. Set this so
+   * the top strip drops its copy at that breakpoint rather than stacking a
+   * second, identical set right above it. Below laptop the content hides its
+   * group, so the strip stays the only home for these actions.
+   */
+  navigationContentOwnsActions?: boolean;
+  /**
    * Redesign top-bar behavior: hide the top strip's "…" menu (it lives in the
    * focus-card header) and, once scrolled, float a fixed bar with the post
    * stats + "…" menu + close.
@@ -55,6 +63,7 @@ function BasePostModal({
   navigationCustomActions,
   navigationContainerClassName,
   navigationHideSubscribeAction,
+  navigationContentOwnsActions,
   navigationRedesign,
   loadingChildren,
   post,
@@ -145,6 +154,9 @@ function BasePostModal({
                     navigationRedesign && 'sticky top-0 z-postNavigation',
                     navigationContainerClassName,
                   ),
+                  actions: navigationContentOwnsActions
+                    ? 'laptop:hidden'
+                    : undefined,
                 }}
                 postPosition={postPosition}
                 onPreviousPost={onPreviousPost}

--- a/packages/shared/src/components/modals/CollectionPostModal.tsx
+++ b/packages/shared/src/components/modals/CollectionPostModal.tsx
@@ -43,6 +43,7 @@ export default function CollectionPostModal({
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
       navigationRedesign={showRedesign}
+      navigationContentOwnsActions={!showRedesign}
       onRequestClose={onRequestClose}
       postType={PostType.Collection}
       source={post.source}

--- a/packages/shared/src/components/modals/PollPostModal.tsx
+++ b/packages/shared/src/components/modals/PollPostModal.tsx
@@ -40,6 +40,7 @@ export default function PollPostModal({
       size={Modal.Size.XLarge}
       onRequestClose={onRequestClose}
       postType={PostType.Poll}
+      navigationContentOwnsActions
       source={post.source}
       loadingClassName="!pb-2 tablet:pb-0"
       postPosition={postPosition}

--- a/packages/shared/src/components/modals/PollPostModal.tsx
+++ b/packages/shared/src/components/modals/PollPostModal.tsx
@@ -38,9 +38,9 @@ export default function PollPostModal({
       post={post}
       onAfterOpen={onLoad}
       size={Modal.Size.XLarge}
+      navigationContentOwnsActions
       onRequestClose={onRequestClose}
       postType={PostType.Poll}
-      navigationContentOwnsActions
       source={post.source}
       loadingClassName="!pb-2 tablet:pb-0"
       postPosition={postPosition}

--- a/packages/shared/src/components/modals/SharePostModal.tsx
+++ b/packages/shared/src/components/modals/SharePostModal.tsx
@@ -43,6 +43,7 @@ export default function PostModal({
       size={showRedesign ? Modal.Size.Large : Modal.Size.XLarge}
       className={showRedesign ? 'laptop:!overflow-clip' : undefined}
       navigationRedesign={showRedesign}
+      navigationContentOwnsActions={!showRedesign}
       onRequestClose={onRequestClose}
       postType={PostType.Share}
       source={post.source}

--- a/packages/shared/src/components/modals/SocialTwitterPostModal.tsx
+++ b/packages/shared/src/components/modals/SocialTwitterPostModal.tsx
@@ -38,6 +38,7 @@ export default function SocialTwitterPostModal({
       size={Modal.Size.XLarge}
       onRequestClose={onRequestClose}
       postType={PostType.SocialTwitter}
+      navigationContentOwnsActions
       source={post.source}
       loadingClassName="!pb-2 tablet:pb-0"
       postPosition={postPosition}

--- a/packages/shared/src/components/modals/SocialTwitterPostModal.tsx
+++ b/packages/shared/src/components/modals/SocialTwitterPostModal.tsx
@@ -36,9 +36,9 @@ export default function SocialTwitterPostModal({
       post={post}
       onAfterOpen={onLoad}
       size={Modal.Size.XLarge}
+      navigationContentOwnsActions
       onRequestClose={onRequestClose}
       postType={PostType.SocialTwitter}
-      navigationContentOwnsActions
       source={post.source}
       loadingClassName="!pb-2 tablet:pb-0"
       postPosition={postPosition}

--- a/packages/shared/src/components/post/PostSourceInfo.tsx
+++ b/packages/shared/src/components/post/PostSourceInfo.tsx
@@ -75,67 +75,70 @@ function PostSourceInfo({
       )}
     >
       {!isUnknown && (
-        <>
-          <div className="flex flex-row items-center">
-            {!isUserSource && (
-              <Link href={sourcePermalink}>
-                <a className="text-text-secondary typo-callout">
-                  {sourceName || sourceHandle}
-                </a>
-              </Link>
-            )}
-            {showActionBtn && (
-              <>
-                {!isUserSource && <Separator className="flex tablet:hidden" />}
-                {source?.type !== SourceType.Squad && !isUserSource && (
-                  <FollowButton
-                    variant={ButtonVariant.Tertiary}
-                    followedVariant={ButtonVariant.Tertiary}
-                    buttonClassName={classNames(
-                      'flex min-w-min !px-0 tablet:hidden',
-                      !isFollowing && 'text-text-link',
-                    )}
-                    entityId={sourceId}
-                    status={contentPreferenceStatus}
-                    type={ContentPreferenceType.Source}
-                    entityName={sourceName}
-                    showSubscribe={false}
+        <div className="flex flex-row items-center">
+          {!isUserSource && (
+            <Link href={sourcePermalink}>
+              <a className="text-text-secondary typo-callout">
+                {sourceName || sourceHandle}
+              </a>
+            </Link>
+          )}
+          {showActionBtn && (
+            <>
+              {!isUserSource && <Separator className="flex tablet:hidden" />}
+              {source?.type !== SourceType.Squad && !isUserSource && (
+                <FollowButton
+                  variant={ButtonVariant.Tertiary}
+                  followedVariant={ButtonVariant.Tertiary}
+                  buttonClassName={classNames(
+                    'flex min-w-min !px-0 tablet:hidden',
+                    !isFollowing && 'text-text-link',
+                  )}
+                  entityId={sourceId}
+                  status={contentPreferenceStatus}
+                  type={ContentPreferenceType.Source}
+                  entityName={sourceName}
+                  showSubscribe={false}
+                />
+              )}
+              {source?.type === SourceType.Squad &&
+                !isLoadingSquad &&
+                squad && (
+                  <SquadActionButton
+                    buttonVariants={[ButtonVariant.Tertiary]}
+                    size={ButtonSize.XSmall}
+                    className={{
+                      button: classNames(
+                        'flex min-w-min !px-0 tablet:hidden',
+                        !squad?.currentMember && 'text-text-link',
+                      ),
+                    }}
+                    squad={squad}
+                    copy={{
+                      join: 'Join',
+                    }}
+                    origin={Origin.PostContent}
                   />
                 )}
-                {source?.type === SourceType.Squad &&
-                  !isLoadingSquad &&
-                  squad && (
-                    <SquadActionButton
-                      buttonVariants={[ButtonVariant.Tertiary]}
-                      size={ButtonSize.XSmall}
-                      className={{
-                        button: classNames(
-                          'flex min-w-min !px-0 tablet:hidden',
-                          !squad?.currentMember && 'text-text-link',
-                        ),
-                      }}
-                      squad={squad}
-                      copy={{
-                        join: 'Join',
-                      }}
-                      origin={Origin.PostContent}
-                    />
-                  )}
-              </>
-            )}
-          </div>
-          {showActions && (
-            <PostHeaderActions
-              post={post}
-              onClose={onClose}
-              onReadArticle={onReadArticle}
-              hideSubscribeAction={hideSubscribeAction}
-              className="ml-auto hidden laptop:flex"
-              contextMenuId="post-widgets-context"
-              buttonSize={ButtonSize.Small}
-            />
+            </>
           )}
-        </>
+        </div>
+      )}
+      {/* Outside the `isUnknown` branch on purpose: a post whose source is the
+          "unknown" placeholder still needs its menu. The post modal's top strip
+          hides its own copy of these actions from laptop up and defers to this
+          one, so nesting them here would leave such a post with no menu at
+          all. */}
+      {showActions && (
+        <PostHeaderActions
+          post={post}
+          onClose={onClose}
+          onReadArticle={onReadArticle}
+          hideSubscribeAction={hideSubscribeAction}
+          className="ml-auto hidden laptop:flex"
+          contextMenuId="post-widgets-context"
+          buttonSize={ButtonSize.Small}
+        />
       )}
       {!!date && (
         <>


### PR DESCRIPTION
## Changes

Every classic post modal renders **two identical action groups** from laptop up, one directly above the other:

1. the modal's top strip — `BasePostModal` → `PostNavigation` → `PostHeaderActions`
2. the content's own group next to the source line, which is `hidden laptop:flex`

On a collection post that means **Subscribe and "…" twice** (this is what was reported); on articles, shares, polls and social posts it's **"…" and Boost twice**.

`BasePostModal` now takes `navigationContentOwnsActions`, which drops the strip's copy at the laptop breakpoint.

It's a *responsive hide* rather than an outright removal on purpose: below laptop the content hides its own group, so the strip is the only place Subscribe / "…" / Boost live there — and the modal is still reachable under laptop for reader-eligible posts. Nothing is lost at any width.

### Audit of every post modal

| Modal | Was duplicated | Result |
|---|---|---|
| `CollectionPostModal` (classic) | Subscribe + "…" | fixed |
| `ArticlePostModal` (also Video / Digest) | "…" + Boost | fixed |
| `SharePostModal` (Share / Freeform / Welcome) | "…" + Boost | fixed |
| `SocialTwitterPostModal` | "…" + Boost | fixed |
| `PollPostModal` | "…" + Boost | fixed |
| `BriefPostModal` | — | untouched: its content renders a settings gear, not a menu, so the strip's "…" is the only one |
| Redesign layout (`post_redesign`) | — | untouched: already deduped via `hideOptions` + boost suppressed in `PostFocusCard` |
| `ReaderPostModal` | — | untouched: own layout, already gated |

The three redesign-capable modals pass the flag as `!showRedesign`, so the redesign keeps its strip actions (its only ones).

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Ran the webapp against the prod API and opened a real collection post modal:

- **1020px+ (1440px)** — top strip is now just ←/→/✕. One Subscribe and one "…", both in the content. The strip's action group measures `visible: false`.
- **MobileL (420px)** — the strip's group is back and visible, the content's is hidden. Still exactly one of each.

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [ ] Have you done sanity checks in the extension?
- [ ] Does this not break anything in companion?

The extension and companion render the same shared modals; the change is one responsive utility class on an existing `className` path, so behaviour there follows the same breakpoint.

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [ ] Tablet (656px)
- [x] Laptop (1020px)

Full local run of what CI runs on `shared`: `lint` clean, `typecheck:strict:changed` clean, and the whole Jest suite green — **377 suites / 2757 tests**, including `PostContent.spec.tsx`. `webapp`'s `PostPage` suite passes too (55 tests).

## Follow-up found in review

Deferring to the content's group exposed a latent gap in `PostSourceInfo`: its action group was nested inside the `!isUnknown` branch, so a post carrying the **`unknown` source placeholder** (social posts resolve to it by design — see `UNKNOWN_SOURCE_ID`) rendered no group at all. With the strip now standing down from laptop up, such a post would have had no "…" menu until the fixed nav appeared on scroll.

Second commit moves that group out one level so it no longer depends on the source being known. **The `PostSourceInfo` diff looks large but is almost all re-indentation** — dropping the wrapper fragment forces it. `git diff -w` shows the real change:

```
packages/shared/src/components/post/PostSourceInfo.tsx | 9 ++++++---
```

It also fixes the same gap on the `/articles/[id]` page, which renders the component through `ReadPostContent`. `PostModerationModal` passes `showActions={false}` and is unaffected.

### Note for the reviewer

`BasePostModal` also declares `navigationHideSubscribeAction`, which no modal has ever passed — dead plumbing. Left alone here to keep the diff to the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://postmodal-duplicate-buttons-dail.preview.app.daily.dev