### PR TITLE
fix: show source images in spotlight post results

### DIFF
--- a/packages/shared/src/components/spotlight/commands/search.spec.ts
+++ b/packages/shared/src/components/spotlight/commands/search.spec.ts
@@ -64,6 +64,44 @@ describe('useSpotlightSearchCommands tag navigation', () => {
   });
 });
 
+describe('useSpotlightSearchCommands post metadata', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseSuggestions.mockImplementation(({ provider }) => ({
+      isLoading: false,
+      suggestions:
+        provider === SearchProviderEnum.Posts
+          ? {
+              hits: [
+                {
+                  id: 'post-id',
+                  title: 'Post title',
+                  subtitle: 'Source name',
+                  image: 'https://daily.dev/source.png',
+                },
+              ],
+            }
+          : { hits: [] },
+      queryKey: [],
+    }));
+  });
+
+  it('uses the source image for post result rows', () => {
+    const { result } = renderHook(() =>
+      useSpotlightSearchCommands({
+        router: { push: jest.fn() },
+        query: 'source',
+      }),
+    );
+
+    expect(result.current.posts[0].meta).toMatchObject({
+      kind: 'post',
+      sourceImage: 'https://daily.dev/source.png',
+      sourceName: 'Source name',
+    });
+  });
+});
+
 describe('useSpotlightSearchCommands provider fetching', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -113,6 +113,8 @@ export const SEARCH_POST_SUGGESTIONS = gql`
       hits {
         id
         title
+        subtitle
+        image
       }
     }
   }


### PR DESCRIPTION
Updates Spotlight post suggestions to request and carry source metadata so post result rows render the source image instead of falling back to the user avatar placeholder.

Key decisions:
- Keep the row rendering contract unchanged and pass the source image through existing post metadata.
- Pair this frontend query change with the daily-api response change that returns source name and image for post suggestions.

Closes ENG-2046

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-2046-feedback-bug-report-spo.preview.app.daily.dev