### PR TITLE
fix(search): request source name and image for post suggestions

### DIFF
--- a/packages/shared/src/graphql/search.ts
+++ b/packages/shared/src/graphql/search.ts
@@ -113,6 +113,8 @@ export const SEARCH_POST_SUGGESTIONS = gql`
       hits {
         id
         title
+        subtitle
+        image
       }
     }
   }


### PR DESCRIPTION
The API returns `subtitle` (source name) and `image` (source image) for `searchPostSuggestions` (dailydotdev/daily-api#4215), and Spotlight's `buildPostCommand` already reads `hit.image` / `hit.subtitle` — but `SEARCH_POST_SUGGESTIONS` only selected `id` and `title`, so both were always undefined and the row rendered an avatar placeholder with no subtitle.

Verified against production: `searchPostSuggestions` returns a non-null `image` for every hit across a range of queries at both search versions.

### Preview domain
https://fix-post-suggestion-images.preview.app.daily.dev