### PR TITLE
feat(auth): add a signupEmail action that opens the registration form directly

### DIFF
--- a/packages/shared/src/components/auth/common.tsx
+++ b/packages/shared/src/components/auth/common.tsx
@@ -85,6 +85,17 @@ export enum OnboardingActions {
   Login = 'login',
   Recover = 'recover',
   Signup = 'signup',
+  /**
+   * Straight to the account-details form, skipping the provider choice.
+   *
+   * `Signup` lands on `AuthDisplay.Default`, which offers the social buttons
+   * again alongside an email field — right for a link that means "sign up",
+   * wrong for one that means "sign up with email". The marketing homepage's
+   * hero has its own provider buttons and its own "Continue with email"; that
+   * button had no address to send anyone to, so it used `Signup` and asked the
+   * visitor to choose a second time.
+   */
+  SignupEmail = 'signupEmail',
   VerifyEmail = 'verify',
 }
 
@@ -93,6 +104,7 @@ export const actionToAuthDisplay: Record<OnboardingActions, AuthDisplay> = {
   [OnboardingActions.Login]: AuthDisplay.Default,
   [OnboardingActions.Recover]: AuthDisplay.ForgotPassword,
   [OnboardingActions.Signup]: AuthDisplay.Default,
+  [OnboardingActions.SignupEmail]: AuthDisplay.Registration,
   [OnboardingActions.VerifyEmail]: AuthDisplay.EmailVerification,
 } as const;
 


### PR DESCRIPTION
## What

Adds one member to `OnboardingActions` and its mapping:

```ts
SignupEmail = 'signupEmail'   →   AuthDisplay.Registration
```

Two lines in `packages/shared/src/components/auth/common.tsx`. The `Record<OnboardingActions, AuthDisplay>` type makes the enum member and its mapping a pair, so it cannot be half-added. Nothing existing changes behaviour — `signup` still means what it meant.

## Why

`daily.dev/` is getting a signup in the hero ([recruiter-landing#519](https://github.com/dailydotdev/recruiter-landing/pull/519)), behind a flag. It carries its own Google and GitHub buttons plus a "Continue with email", and that last one has nowhere good to send people.

In the app, "Continue with email" swaps the screen in place — `AuthDisplay.Default` → `AuthDisplay.Registration` — so **no URL reproduces it**. The closest existing action, `?action=signup`, maps to `AuthDisplay.Default`: the provider buttons all over again, plus an email field, shown to someone who has just chosen email. It works, but it asks the same question twice.

With this action the marketing page can link straight to the account-details form, and its button behaves like the app's.

## While you're in here — an unrelated bug this does not fix

**`/onboarding` renders a completely blank page for any action it does not recognise.** Verified on production just now:

| URL | Result |
|---|---|
| `/onboarding?action=signup` | renders normally |
| `/onboarding?action=signupEmail` (before this PR) | **blank body** |
| `/onboarding?action=banana` | **blank body** |

The cause looks like `packages/webapp/pages/onboarding.tsx`: the funnel effect reads the raw `router.query.action` and returns early on any truthy value, so `setFunnelReady(true)` never runs — while `useOnboardingAuth` only sets `isAuthenticating` for a *recognised* action, so the auth branch does not render either. Neither path takes it, and the component falls through to `return null`.

That bites a stale link, a typo, or a capitalised `?action=Signup` in a campaign URL. Left alone here because it is a change to the funnel's own control flow and deserves its own review — happy to send that separately if you want it.

## Test plan

- `?action=signupEmail` opens the account-details form (email, name, password, username, experience, captcha).
- `?action=signup`, `?action=login`, `?action=verify`, `?action=recover`, `?action=changePassword` unchanged.
- `packages/shared` typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://signup-email-deep-link-dailydotd.preview.app.daily.dev