### PR TITLE
fix(extension): stop the new tab page stealing the address bar's caret

### DIFF
--- a/packages/extension/src/newtab/index.tsx
+++ b/packages/extension/src/newtab/index.tsx
@@ -11,12 +11,18 @@ import { get as getCache } from 'idb-keyval';
 import browser from 'webextension-polyfill';
 import type { DndSettings } from '@dailydotdev/shared/src/contexts/DndContext';
 import App from './App';
+import { preventFocusSteal } from './preventFocusSteal';
 
 declare global {
   interface Window {
     windowLoaded: boolean;
   }
 }
+
+// Before React, and before any dependency gets a chance to register its own
+// focus bookkeeping, so no `focus()` on this page can pull the caret out of
+// Chrome's address bar.
+preventFocusSteal();
 
 window.addEventListener(
   'load',

--- a/packages/extension/src/newtab/preventFocusSteal.spec.ts
+++ b/packages/extension/src/newtab/preventFocusSteal.spec.ts
@@ -1,0 +1,60 @@
+import { preventFocusSteal } from './preventFocusSteal';
+
+const originalFocus = HTMLElement.prototype.focus;
+
+describe('preventFocusSteal', () => {
+  let input: HTMLInputElement;
+  let hasFocus: jest.SpyInstance<boolean, []>;
+  let warn: jest.SpyInstance;
+
+  beforeAll(() => {
+    preventFocusSteal();
+  });
+
+  afterAll(() => {
+    HTMLElement.prototype.focus = originalFocus;
+  });
+
+  beforeEach(() => {
+    input = document.createElement('input');
+    document.body.appendChild(input);
+    hasFocus = jest.spyOn(document, 'hasFocus');
+    // The guard warns outside production; the blocked cases expect it.
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    input.remove();
+    hasFocus.mockRestore();
+    warn.mockRestore();
+  });
+
+  it('focuses normally while the page holds the keyboard', () => {
+    hasFocus.mockReturnValue(true);
+
+    input.focus();
+
+    expect(input).toHaveFocus();
+  });
+
+  it('drops focus() while the keyboard belongs to browser chrome', () => {
+    hasFocus.mockReturnValue(false);
+
+    input.focus();
+
+    expect(input).not.toHaveFocus();
+  });
+
+  it('stays a single layer when installed more than once', () => {
+    preventFocusSteal();
+    hasFocus.mockReturnValue(false);
+
+    input.focus();
+    expect(input).not.toHaveFocus();
+
+    hasFocus.mockReturnValue(true);
+
+    input.focus();
+    expect(input).toHaveFocus();
+  });
+});

--- a/packages/extension/src/newtab/preventFocusSteal.ts
+++ b/packages/extension/src/newtab/preventFocusSteal.ts
@@ -1,0 +1,68 @@
+/**
+ * The new tab page shares a keyboard with Chrome's address bar. On a fresh tab
+ * the omnibox holds the caret while this page renders, and the user can click
+ * back into it at any moment. `document.hasFocus()` is false in exactly those
+ * moments: the tab is visible and painted, but the keyboard belongs to browser
+ * chrome, not to us.
+ *
+ * A programmatic `focus()` made in that state does not "restore" anything — it
+ * drags the caret out of the address bar and into the page, so the next thing
+ * the user types goes nowhere. From their side the address bar simply stops
+ * accepting input until something resets whatever is doing the pulling.
+ *
+ * Nothing on this page needs to focus an element while the page itself is
+ * unfocused, but several dependencies do it as a side effect of their own focus
+ * bookkeeping. react-modal is the clearest: its scoped-focus helper arms a flag
+ * on every window `blur` (which is what clicking the address bar is) and then
+ * pulls focus into the modal element on the next focus event in the document.
+ * It also never removes its `focus` listener — it is registered in the capture
+ * phase and removed without the capture flag — and its teardown is skipped
+ * entirely when a modal unmounts before its open state commits, which leaves
+ * that pull armed with no modal on screen. Radix focus scopes and the embedded
+ * ad measurement frames have their own variants of the same move. That is why
+ * the symptom is intermittent, survives across interactions, and clears as soon
+ * as a real modal is opened and closed (react-modal's teardown finally runs).
+ *
+ * Rather than chase each one, refuse the whole move: drop programmatic focus
+ * while the document does not have focus. User gestures are unaffected —
+ * clicking or tabbing into the page hands focus over before any handler runs,
+ * so `hasFocus()` is already true by then.
+ */
+
+let isInstalled = false;
+
+const logBlockedFocus = (target: unknown): void => {
+  if (process.env.NODE_ENV === 'production') {
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.warn(
+    '[newtab] blocked a focus() call made while the page was unfocused — ' +
+      'it would have stolen the caret from the address bar.',
+    target,
+    new Error().stack,
+  );
+};
+
+export const preventFocusSteal = (): void => {
+  if (isInstalled || typeof HTMLElement === 'undefined') {
+    return;
+  }
+
+  isInstalled = true;
+
+  const original = HTMLElement.prototype.focus;
+
+  HTMLElement.prototype.focus = function guardedFocus(
+    this: HTMLElement,
+    options?: FocusOptions,
+  ): void {
+    if (!document.hasFocus()) {
+      logBlockedFocus(this);
+      return;
+    }
+
+    original.call(this, options);
+  };
+};


### PR DESCRIPTION
## Changes

Fixes a long-standing, roughly-once-a-day bug on the extension's new tab page: you click Chrome's address bar, the caret lands there, and typing does nothing. The page scrolls and clicks normally throughout. Opening any post modal clears it.

That last detail is the tell. The cause is a **focus steal**: something in the page waits for the window to lose focus — which is exactly what clicking the address bar is — and then calls `focus()` on one of its own elements, dragging the caret back into the page. Everything typed afterwards goes into the page, where nothing is listening.

The clearest source is **react-modal's global focus manager** (`react-modal@3.16.3`, `lib/helpers/focusManager.js`):

- `handleBlur` arms a module-global `needToFocus` flag on every `window` blur.
- `handleFocus` then pulls focus into `modalElement` on the next focus event in the document, with no check that the page actually holds the keyboard.
- `teardownScopedFocus` never removes that listener — it is registered on `document` in the **capture** phase and removed without the capture flag, so `removeEventListener` doesn't match.
- Teardown is skipped entirely when a modal unmounts before its `isOpen` state commits (`componentWillUnmount` guards on `this.state.isOpen`), leaving `modalElement` pointing at a node no longer on screen with the pull still armed.

That is also why opening and closing a card's modal fixes it: `afterClose` finally reaches `teardownScopedFocus()`, which nulls `modalElement` and disarms the whole thing.

### The fix

`preventFocusSteal()` runs at the top of the new tab entry, before React and before any dependency registers its own focus bookkeeping. It drops programmatic `focus()` while `document.hasFocus()` is false — true in exactly the moments the keyboard belongs to browser chrome (address bar, devtools, another window) rather than to us.

User gestures are unaffected: clicking or tabbing into the page hands focus over before any handler runs, so `hasFocus()` is already true by then.

### Why the class and not just react-modal

Two reasons worth a reviewer's attention:

1. This bug shows up about once a day and I could not reproduce it on demand, so I could not prove a react-modal-specific patch actually fixed it.
2. react-modal is not the only candidate. Radix focus scopes (`FocusScope`'s MutationObserver refocuses its container when `document.activeElement === document.body`, which is the state while the address bar has focus) and the embedded ad measurement frames have their own variants of the same move.

Refusing the move once, in one place, covers all of them. The tradeoff is a monkey-patch on `HTMLElement.prototype.focus`, scoped to the new tab entry only — not the webapp, not the companion.

**Known gap:** if the culprit turns out to be inside the ad measurement iframe, that is a separate origin and this guard cannot reach it. The tell would be the bug recurring with nothing logged. The same guard would then need to go into the measurement frame page.

### Diagnostics

Outside production the guard logs a warning with a stack trace every time it blocks a steal, so the culprit names itself if it ever fires.

## Events

No new tracking events.

## Experiment

No new experiments.

## Manual Testing

Extension only — the webapp and companion entries are untouched.

- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion? (companion entry not touched)

Verified: 3 new unit tests, full extension suite passes (55 tests, 7 suites), lint clean, production build succeeds. The one pre-existing `tsc` error in `ShortcutLinks.spec.tsx` is present on `main` and unrelated.

> [!NOTE]
> Opened as a draft. The only real verification for a once-a-day bug is running a dev build for a few days and confirming it does not recur — and that the guard's dev warning either names a culprit or stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Preview domain
https://newtab-focus-steal-dailydotdev.preview.app.daily.dev