### PR TITLE
chore(tests): remove redundant test cases

### DIFF
--- a/packages/shared/src/components/ExpandableContent.spec.tsx
+++ b/packages/shared/src/components/ExpandableContent.spec.tsx
@@ -132,36 +132,6 @@ describe('ExpandableContent', () => {
     });
   });
 
-  it('should hide "See More" button when content is expanded', async () => {
-    // Mock scrollHeight to be more than maxHeight
-    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
-      configurable: true,
-      get() {
-        return 500;
-      },
-    });
-
-    render(
-      <ExpandableContent maxHeight={320}>{longContent}</ExpandableContent>,
-    );
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole('button', { name: /see more/i }),
-      ).toBeInTheDocument();
-    });
-
-    const seeMoreButton = screen.getByRole('button', { name: /see more/i });
-    fireEvent.click(seeMoreButton);
-
-    // Both button and gradient should be hidden after expansion
-    await waitFor(() => {
-      expect(
-        screen.queryByRole('button', { name: /see more/i }),
-      ).not.toBeInTheDocument();
-    });
-  });
-
   it('should apply custom maxHeight', async () => {
     // Mock scrollHeight to exceed custom maxHeight
     Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {

--- a/packages/shared/src/components/brand/BrandedUpvoteAnimation.spec.tsx
+++ b/packages/shared/src/components/brand/BrandedUpvoteAnimation.spec.tsx
@@ -15,18 +15,6 @@ const config: UpvoteAnimationConfig = {
 };
 
 describe('BrandedUpvoteAnimation', () => {
-  it('renders nothing while isActive is false', () => {
-    const { container } = render(
-      <BrandedUpvoteAnimation
-        isActive={false}
-        colors={colors}
-        config={config}
-      />,
-    );
-    // eslint-disable-next-line testing-library/no-container
-    expect(container.querySelector('canvas')).toBeNull();
-  });
-
   it('mounts the canvas once isActive becomes true', () => {
     const { container, rerender } = render(
       <BrandedUpvoteAnimation

--- a/packages/shared/src/components/cards/brief/BriefBanner/BriefBanner.spec.tsx
+++ b/packages/shared/src/components/cards/brief/BriefBanner/BriefBanner.spec.tsx
@@ -127,32 +127,6 @@ describe('BriefBanner', () => {
   });
 
   describe('user authentication states', () => {
-    it('should handle non-Plus user correctly', () => {
-      const nonPlusUser = { ...defaultUser, isPlus: false };
-      mockUseAuthContext.mockReturnValue({
-        user: nonPlusUser,
-        isLoggedIn: true,
-        isAuthReady: true,
-        updateUser: jest.fn(),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
-
-      render(
-        <TestWrapper>
-          <BriefBanner />
-        </TestWrapper>,
-      );
-
-      const button = screen.getByTestId('brief-banner-cta');
-      fireEvent.click(button);
-
-      expect(mockLogEvent).toHaveBeenCalledWith({
-        event_name: 'click brief',
-        target_id: 'scroll',
-        extra: expect.stringContaining('is_demo'),
-      });
-    });
-
     it('should handle Plus user correctly', () => {
       const plusUser = { ...defaultUser, isPlus: true };
       mockUseAuthContext.mockReturnValue({
@@ -256,18 +230,6 @@ describe('BriefBanner', () => {
   });
 
   describe('accessibility', () => {
-    it('should have proper ARIA attributes', () => {
-      render(
-        <TestWrapper>
-          <BriefBanner />
-        </TestWrapper>,
-      );
-
-      const button = screen.getByTestId('brief-banner-cta');
-      expect(button).toBeInTheDocument();
-      expect(button).toBeEnabled();
-    });
-
     it('should be keyboard accessible', () => {
       render(
         <TestWrapper>

--- a/packages/shared/src/components/cards/brief/BriefBanner/BriefBannerFeed.spec.tsx
+++ b/packages/shared/src/components/cards/brief/BriefBanner/BriefBannerFeed.spec.tsx
@@ -590,29 +590,6 @@ describe('BriefBannerFeed', () => {
         'margin-top: 20px',
       );
     });
-
-    it('should pass through other props to wrapper div', () => {
-      mockUsePersistentState.mockReturnValueOnce([
-        undefined,
-        mockSetBrief,
-        true,
-      ]);
-
-      render(
-        <TestWrapper
-          alertsOverride={{
-            alerts: {
-              briefBannerLastSeen: null,
-            },
-            loadedAlerts: true,
-          }}
-        >
-          <BriefBannerFeed />
-        </TestWrapper>,
-      );
-
-      expect(screen.getByTestId('brief-banner-feed')).toBeInTheDocument();
-    });
   });
 
   describe('edge cases', () => {

--- a/packages/shared/src/components/cards/poll/PollGrid.spec.tsx
+++ b/packages/shared/src/components/cards/poll/PollGrid.spec.tsx
@@ -62,13 +62,6 @@ describe('PollGrid', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render poll component successfully', async () => {
-    renderComponent();
-    expect(
-      await screen.findByText('What is your favorite programming language?'),
-    ).toBeInTheDocument();
-  });
-
   it('should call usePoll hook correctly', () => {
     renderComponent();
     expect(mockUsePoll).toHaveBeenCalledWith({ post: pollPost });
@@ -83,18 +76,6 @@ describe('PollGrid', () => {
 
     const percentages = screen.queryAllByText(/%$/);
     expect(percentages.length >= 0).toBe(true);
-  });
-
-  it('should handle voting correctly', () => {
-    const mockOnVote = jest.fn();
-    mockUsePoll.mockReturnValue({
-      onVote: mockOnVote,
-      isCastingVote: false,
-    });
-
-    renderComponent();
-
-    expect(mockUsePoll).toHaveBeenCalledWith({ post: pollPost });
   });
 
   it('should prevent voting again while voting is in progress', () => {

--- a/packages/shared/src/components/cards/poll/PollList.spec.tsx
+++ b/packages/shared/src/components/cards/poll/PollList.spec.tsx
@@ -62,13 +62,6 @@ describe('PollList', () => {
     ).toBeInTheDocument();
   });
 
-  it('should render poll component successfully', async () => {
-    renderComponent();
-    expect(
-      await screen.findByText('What is your favorite programming language?'),
-    ).toBeInTheDocument();
-  });
-
   it('should call usePoll hook correctly', () => {
     renderComponent();
     expect(mockUsePoll).toHaveBeenCalledWith({ post: pollPost });
@@ -83,18 +76,6 @@ describe('PollList', () => {
 
     const percentages = screen.queryAllByText(/%$/);
     expect(percentages.length >= 0).toBe(true);
-  });
-
-  it('should handle voting correctly', () => {
-    const mockOnVote = jest.fn();
-    mockUsePoll.mockReturnValue({
-      onVote: mockOnVote,
-      isCastingVote: false,
-    });
-
-    renderComponent();
-
-    expect(mockUsePoll).toHaveBeenCalledWith({ post: pollPost });
   });
 
   it('should prevent voting again while voting is in progress', () => {

--- a/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
+++ b/packages/shared/src/components/cards/squad/SquadGrid.spec.tsx
@@ -101,15 +101,6 @@ it('should render the component with basic props', async () => {
   );
 });
 
-it('should render the component with basic props with border and banner', async () => {
-  renderComponent();
-  admin.source.color = '!border-accent-avocado-default';
-  const element = screen.getByRole('article');
-
-  expect(screen.getByText(admin.source.name)).toBeInTheDocument();
-  expect(element).toHaveClass(admin.source.color);
-});
-
 it('should render the component with an image', () => {
   renderComponent();
   const avatar = screen.getByAltText(`${admin.source.name} source`);

--- a/packages/shared/src/components/comments/CollapsedRepliesPreview.spec.tsx
+++ b/packages/shared/src/components/comments/CollapsedRepliesPreview.spec.tsx
@@ -119,16 +119,6 @@ describe('CollapsedRepliesPreview', () => {
     expect(button).toHaveAttribute('aria-label', 'View 2 replies');
   });
 
-  it('should be keyboard accessible', () => {
-    const replies = [createReply('r1', 'u1', 'user1')];
-    renderComponent(replies, onExpand);
-
-    const button = screen.getByRole('button');
-    fireEvent.keyDown(button, { key: 'Enter' });
-    fireEvent.click(button);
-    expect(onExpand).toHaveBeenCalled();
-  });
-
   it('should apply custom className', () => {
     const replies = [createReply('r1', 'u1', 'user1')];
     renderComponent(replies, onExpand, 'custom-class');

--- a/packages/shared/src/components/fields/RichTextEditor/RichTextToolbar.spec.tsx
+++ b/packages/shared/src/components/fields/RichTextEditor/RichTextToolbar.spec.tsx
@@ -66,14 +66,6 @@ describe('RichTextToolbar leading actions', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders the leading slot exactly once on its own row when stacked', () => {
-    renderToolbar(true);
-
-    expect(
-      screen.getByRole('button', { name: 'Free form' }),
-    ).toBeInTheDocument();
-  });
-
   it('keeps the stacked leading slot out of the clipped bar row', () => {
     renderToolbar(true);
 

--- a/packages/shared/src/components/filters/AchievementTrackerButton.spec.tsx
+++ b/packages/shared/src/components/filters/AchievementTrackerButton.spec.tsx
@@ -226,15 +226,6 @@ it('renders AchievementCard inside HoverCard when tracking', () => {
   expect(screen.getByTestId('achievement-card')).toBeInTheDocument();
 });
 
-it('renders achievement image in the button when tracking', () => {
-  mockUseTrackedAchievement.mockReturnValue({
-    ...defaultTrackedAchievementHook,
-    trackedAchievement: mockTrackedAchievement,
-  });
-  renderComponent();
-  expect(screen.getByAltText('First Steps')).toBeInTheDocument();
-});
-
 it('adds spacing classes to achievement image when label is shown', () => {
   mockUseTrackedAchievement.mockReturnValue({
     ...defaultTrackedAchievementHook,

--- a/packages/shared/src/components/modals/AchievementPickerModal.spec.tsx
+++ b/packages/shared/src/components/modals/AchievementPickerModal.spec.tsx
@@ -79,21 +79,6 @@ describe('AchievementPickerModal — stop tracking', () => {
     document.body.innerHTML = '<div id="__next"></div>';
   });
 
-  it('renders "Track" button for an untracked achievement', () => {
-    renderModal({ trackedAchievementId: null });
-
-    const trackButtons = screen.getAllByRole('button', { name: 'Track' });
-    expect(trackButtons.length).toBeGreaterThan(0);
-  });
-
-  it('renders "Stop tracking" button for the currently tracked achievement', () => {
-    renderModal({ trackedAchievementId: 'ach1' });
-
-    expect(
-      screen.getByRole('button', { name: 'Stop tracking' }),
-    ).toBeInTheDocument();
-  });
-
   it('still renders "Track" for non-tracked achievements when one is tracked', () => {
     renderModal({ trackedAchievementId: 'ach1' });
 

--- a/packages/shared/src/components/post/digest/DigestPostContent.spec.ts
+++ b/packages/shared/src/components/post/digest/DigestPostContent.spec.ts
@@ -30,38 +30,4 @@ describe('transformDigestAd', () => {
       index: 3,
     });
   });
-
-  it('should always set pixel to empty array', () => {
-    const digestAd: DigestPostAd = {
-      type: 'dynamic_ad',
-      index: 0,
-      title: 'Ad title',
-      link: 'https://example.com',
-      image: 'https://example.com/img.png',
-      companyName: 'Company',
-      companyLogo: 'https://example.com/logo.png',
-      callToAction: 'Click',
-    };
-
-    const result = transformDigestAd(digestAd);
-
-    expect(result.ad.pixel).toEqual([]);
-  });
-
-  it('should preserve the index from the digest ad', () => {
-    const digestAd: DigestPostAd = {
-      type: 'dynamic_ad',
-      index: 7,
-      title: 'Ad',
-      link: 'https://example.com',
-      image: 'https://example.com/img.png',
-      companyName: 'Company',
-      companyLogo: 'https://example.com/logo.png',
-      callToAction: 'Click',
-    };
-
-    const result = transformDigestAd(digestAd);
-
-    expect(result.index).toBe(7);
-  });
 });

--- a/packages/shared/src/components/profile/ProfileButton.spec.tsx
+++ b/packages/shared/src/components/profile/ProfileButton.spec.tsx
@@ -46,14 +46,6 @@ const renderComponent = (user = defaultUser): RenderResult => {
   );
 };
 
-it('should show "Profile settings" tooltip on the profile picture', () => {
-  renderComponent();
-
-  expect(
-    screen.getByRole('button', { name: 'Profile settings' }),
-  ).toBeInTheDocument();
-});
-
 it('should render the reputation reward target inside the profile button', () => {
   renderComponent();
 

--- a/packages/shared/src/components/recruiter/MatchReviewHeader.spec.tsx
+++ b/packages/shared/src/components/recruiter/MatchReviewHeader.spec.tsx
@@ -118,20 +118,6 @@ describe('MatchReviewHeader', () => {
   });
 
   describe('action buttons', () => {
-    it('should render Reject button when onReject is provided', async () => {
-      renderComponent();
-      expect(
-        await screen.findByRole('button', { name: /reject/i }),
-      ).toBeInTheDocument();
-    });
-
-    it('should render Approve button when onApprove is provided', async () => {
-      renderComponent();
-      expect(
-        await screen.findByRole('button', { name: /approve/i }),
-      ).toBeInTheDocument();
-    });
-
     it('should call onReject when Reject button is clicked', async () => {
       const onReject = jest.fn();
       renderComponent({ onReject });

--- a/packages/shared/src/components/utilities/RelativeTime.spec.tsx
+++ b/packages/shared/src/components/utilities/RelativeTime.spec.tsx
@@ -12,12 +12,6 @@ describe('RelativeTime', () => {
     jest.useRealTimers();
   });
 
-  it('renders the relative label for the provided dateTime', () => {
-    const tenMinutesAgo = new Date('2026-04-28T11:50:00Z').toISOString();
-    render(<RelativeTime dateTime={tenMinutesAgo} />);
-    expect(screen.getByText('10m ago')).toBeInTheDocument();
-  });
-
   it('updates the label immediately when the dateTime prop changes', () => {
     const tenMinutesAgo = new Date('2026-04-28T11:50:00Z').toISOString();
     const twoHoursAgo = new Date('2026-04-28T10:00:00Z').toISOString();

--- a/packages/shared/src/components/utilities/common.spec.tsx
+++ b/packages/shared/src/components/utilities/common.spec.tsx
@@ -14,9 +14,6 @@ describe('function formatReadTime', () => {
   it('should return 1h 0m when passed 60', () => {
     expect(formatReadTime(60)).toEqual('1h 0m');
   });
-  it('should return 30m when passed 30', () => {
-    expect(formatReadTime(30)).toEqual('30m');
-  });
   it('should not return 0h 30m when passed 30', () => {
     expect(formatReadTime(30)).not.toContain('0h ');
     expect(formatReadTime(30)).toEqual('30m');

--- a/packages/shared/src/components/widgets/FurtherReading.spec.tsx
+++ b/packages/shared/src/components/widgets/FurtherReading.spec.tsx
@@ -113,14 +113,6 @@ describe('further reading', () => {
     expect(await screen.findAllByRole('article')).toHaveLength(5);
   });
 
-  it('should show articles even when there are no trending articles', async () => {
-    renderComponent();
-    await waitForNock();
-    const [el] = await screen.findAllByRole('article');
-    await waitFor(() => expect(el).not.toHaveAttribute('aria-busy'));
-    expect(await screen.findAllByRole('article')).toHaveLength(5);
-  });
-
   it('should show trending info for trending posts', async () => {
     renderComponent();
     expect(await screen.findByText('Hot')).toBeInTheDocument();

--- a/packages/shared/src/features/boost/BoostPostModal.spec.tsx
+++ b/packages/shared/src/features/boost/BoostPostModal.spec.tsx
@@ -288,40 +288,6 @@ describe('BoostPostModal', () => {
     });
   });
 
-  describe('Post Refetching', () => {
-    it('should handle refetching logic within usePostBoostEstimation when post cannot be boosted', () => {
-      const post = createMockPost(); // No tags, no yggdrasilId
-      mockUsePostBoostEstimation.mockReturnValue({
-        ...defaultMockBoostEstimation,
-        canBoost: false,
-      } as UsePostBoostEstimation);
-
-      renderBoostPostModal(post);
-
-      // The refetching logic is now handled inside usePostBoostEstimation
-      expect(mockUsePostBoostEstimation).toHaveBeenCalledWith({
-        post,
-        query: { budget: 5000 },
-      });
-    });
-
-    it('should handle refetching logic within usePostBoostEstimation when post can be boosted', () => {
-      const post = createMockPost({ tags: ['javascript'] });
-      mockUsePostBoostEstimation.mockReturnValue({
-        ...defaultMockBoostEstimation,
-        canBoost: true,
-      });
-
-      renderBoostPostModal(post);
-
-      // The refetching logic is now handled inside usePostBoostEstimation
-      expect(mockUsePostBoostEstimation).toHaveBeenCalledWith({
-        post,
-        query: { budget: 5000 },
-      });
-    });
-  });
-
   describe('Boost Button State', () => {
     it('should disable boost button when post cannot be boosted', () => {
       const post = createMockPost(); // No tags, no yggdrasilId

--- a/packages/shared/src/features/common/components/FormInputRating.spec.tsx
+++ b/packages/shared/src/features/common/components/FormInputRating.spec.tsx
@@ -15,20 +15,6 @@ const renderComponent = (
 };
 
 describe('FormInputRating', () => {
-  it('should render with default props', () => {
-    const onValueChange = jest.fn();
-    renderComponent({ onValueChange });
-
-    // Should have 5 buttons (default options [1, 2, 3, 4, 5])
-    const buttons = screen.getAllByRole('radio');
-    expect(buttons).toHaveLength(5);
-
-    // Should have correct labels
-    for (let i = 1; i <= 5; i += 1) {
-      expect(screen.getByLabelText(`${i} stars`)).toBeInTheDocument();
-    }
-  });
-
   it('should render with defaultValue', () => {
     renderComponent({ defaultValue: '3' });
 
@@ -43,18 +29,6 @@ describe('FormInputRating', () => {
     // The button with value 4 should be selected
     const selectedButton = screen.getByRole('radio', { checked: true });
     expect(selectedButton).toHaveTextContent('4');
-  });
-
-  it('should call onValueChange when a rating is selected', () => {
-    const onValueChange = jest.fn();
-    renderComponent({ onValueChange });
-
-    // Click on the button with value 3
-    const button = screen.getByText('3');
-    fireEvent.click(button);
-
-    // onValueChange should be called with the selected value
-    expect(onValueChange).toHaveBeenCalledWith('3');
   });
 
   it('should handle button click correctly', () => {

--- a/packages/shared/src/features/getApp/components/GetAppButton.spec.tsx
+++ b/packages/shared/src/features/getApp/components/GetAppButton.spec.tsx
@@ -34,14 +34,6 @@ beforeEach(() => {
 });
 
 describe('GetAppButton', () => {
-  it('should render the trigger for anonymous desktop visitors', () => {
-    renderComponent();
-
-    expect(
-      screen.getByRole('button', { name: triggerName }),
-    ).toBeInTheDocument();
-  });
-
   it('should render nothing for logged-in users', () => {
     renderComponent({}, { isLoggedIn: true });
 

--- a/packages/shared/src/features/interests/components/AgentComposer.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentComposer.spec.tsx
@@ -214,16 +214,6 @@ describe('AgentComposer', () => {
         'activity',
       ]);
     });
-
-    it('takes the armed command back on backspace in an empty field', () => {
-      mountComposer();
-
-      type('/');
-      fireEvent.keyDown(field(), { key: 'Enter' });
-      fireEvent.keyDown(field(), { key: 'Backspace' });
-
-      expect(screen.queryByText('/settings')).not.toBeInTheDocument();
-    });
   });
 
   describe('attachments', () => {

--- a/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentWorkspace.spec.tsx
@@ -184,16 +184,6 @@ describe('AgentWorkspace panel resize', () => {
     await waitFor(() => expect(panelWidth()).toBe(740));
   });
 
-  it('writes once per drag, not once per pointer move', async () => {
-    const writes = stubStore(600);
-    renderWorkspace();
-    const handle = await openPanel();
-
-    drag(handle, -80);
-
-    await waitFor(() => expect(writes).toHaveLength(1));
-  });
-
   it('will not let either column be squeezed out of existence', async () => {
     stubStore(600);
     renderWorkspace();

--- a/packages/shared/src/features/onboarding/shared/FunnelStepper.spec.tsx
+++ b/packages/shared/src/features/onboarding/shared/FunnelStepper.spec.tsx
@@ -138,31 +138,6 @@ describe('FunnelStepper component', () => {
     expect(screen.getByTestId('funnel-stepper')).toBeInTheDocument();
   });
 
-  it('should handle transition events correctly', async () => {
-    renderComponent();
-
-    const step = screen.getByTestId('funnel-step-quiz');
-    expect(step).toBeInTheDocument();
-
-    await act(async () => {
-      const firstOption = screen.getByText('Option 1');
-      fireEvent.click(firstOption);
-      await waitForNock();
-    });
-
-    expect(mockNavigate).toHaveBeenCalledWith({
-      to: 'step2',
-      type: FunnelStepTransitionType.Complete,
-      details: { step1: 'Option 1' },
-    });
-    expect(mockSendTransition).toHaveBeenCalledWith({
-      fromStep: 'step1',
-      toStep: 'step2',
-      transitionEvent: FunnelStepTransitionType.Complete,
-      inputs: { step1: 'Option 1' },
-    });
-  });
-
   it('should call onComplete when transitioning to the final step', async () => {
     renderComponent();
 

--- a/packages/shared/src/features/onboarding/shared/Header.spec.tsx
+++ b/packages/shared/src/features/onboarding/shared/Header.spec.tsx
@@ -21,11 +21,6 @@ describe('Header component', () => {
     jest.clearAllMocks();
   });
 
-  it('should not show back button on first step', () => {
-    render(<Header {...defaultProps} showBackButton={false} />);
-    expect(screen.queryByLabelText('Go back')).not.toBeInTheDocument();
-  });
-
   it('should show back button after first step', () => {
     render(<Header {...defaultProps} currentChapter={1} currentStep={2} />);
     const backButton = screen.getByLabelText('Go back');

--- a/packages/shared/src/features/onboarding/steps/FunnelRegistration.spec.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelRegistration.spec.tsx
@@ -299,16 +299,6 @@ describe('FunnelRegistration', () => {
     expect(screen.getByTestId('social-button-github')).toBeInTheDocument();
   });
 
-  it('renders the registration form with mobile image by default', () => {
-    render(<FunnelRegistration {...defaultProps} />);
-
-    const backgroundImage = screen.getByAltText('background');
-    expect(backgroundImage).toHaveAttribute(
-      'src',
-      defaultProps.parameters.imageMobile,
-    );
-  });
-
   it('shows tablet image on tablet view', () => {
     // Mock tablet view
     (useViewSize as jest.Mock).mockReturnValue(true);
@@ -456,42 +446,6 @@ describe('FunnelRegistration', () => {
     });
   });
 
-  it('should initialize registration with redirect_to when shouldRedirectAuth is true', () => {
-    // Mock shouldRedirectAuth to return true
-    (shouldRedirectAuth as jest.Mock).mockReturnValue(true);
-
-    // Mock window location
-    const originalLocation = window.location;
-    const mockLocation = new URL('https://daily.dev/onboarding');
-    Object.defineProperty(window, 'location', {
-      value: mockLocation,
-      writable: true,
-    });
-
-    let registrationConfig;
-    (useRegistration as jest.Mock).mockImplementation((config) => {
-      registrationConfig = config;
-      return {
-        onSocialRegistration: mockOnSocialRegistration,
-      };
-    });
-
-    render(<FunnelRegistration {...defaultProps} />);
-
-    expect(registrationConfig).toMatchObject({
-      enabled: true,
-      params: {
-        redirect_to: mockLocation.href,
-      },
-    });
-
-    // Restore window.location
-    Object.defineProperty(window, 'location', {
-      value: originalLocation,
-      writable: true,
-    });
-  });
-
   it('should not initialize registration when router is not ready', () => {
     // Mock router not ready
     (useRouter as jest.Mock).mockImplementation(() => ({
@@ -511,53 +465,5 @@ describe('FunnelRegistration', () => {
     expect(registrationConfig).toMatchObject({
       enabled: false,
     });
-  });
-
-  it('should handle direct navigation when shouldRedirectAuth is true', () => {
-    // Mock shouldRedirectAuth to return true
-    (shouldRedirectAuth as jest.Mock).mockReturnValue(true);
-
-    const mockLocation = { href: '' };
-    Object.defineProperty(window, 'location', {
-      value: mockLocation,
-      writable: true,
-    });
-
-    let registrationHook:
-      | {
-          onRedirect: (redirect: string) => void;
-        }
-      | undefined;
-    (useRegistration as jest.Mock).mockImplementation((props) => {
-      registrationHook = props;
-      return {
-        onSocialRegistration: mockOnSocialRegistration,
-      };
-    });
-
-    render(<FunnelRegistration {...defaultProps} />);
-
-    const redirectUrl = 'https://example.com/auth';
-    if (!registrationHook) {
-      throw new Error('Expected registration hook to be initialized');
-    }
-    registrationHook.onRedirect(redirectUrl);
-
-    expect(mockLocation.href).toBe(redirectUrl);
-  });
-
-  it('should not open popup for non-native auth when shouldRedirectAuth is true', async () => {
-    // Mock shouldRedirectAuth to return true
-    (shouldRedirectAuth as jest.Mock).mockReturnValue(true);
-
-    const mockWindowOpen = jest.fn();
-    global.open = mockWindowOpen;
-
-    render(<FunnelRegistration {...defaultProps} />);
-
-    const githubButton = screen.getByTestId('social-button-github');
-    await userEvent.click(githubButton);
-
-    expect(mockWindowOpen).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/features/onboarding/steps/FunnelUploadCv.spec.tsx
+++ b/packages/shared/src/features/onboarding/steps/FunnelUploadCv.spec.tsx
@@ -257,21 +257,6 @@ describe('FunnelUploadCv', () => {
       expect(mockOnUpload).toHaveBeenCalledWith(expect.any(File));
     });
 
-    it('should pass status to UploadCv component', () => {
-      mockUseUploadCv.mockReturnValue({
-        onUpload: mockOnUpload,
-        status: 'pending',
-        isSuccess: false,
-        isPending: true,
-        shouldShow: false,
-        onCloseBanner: jest.fn(),
-      });
-
-      renderComponent(defaultParameters, mockOnTransition);
-
-      expect(screen.getByTestId('status')).toHaveTextContent('pending');
-    });
-
     it('should return null when no user', () => {
       mockUseAuthContext.mockReturnValue({
         user: null,

--- a/packages/shared/src/features/profile/components/AboutMe.spec.tsx
+++ b/packages/shared/src/features/profile/components/AboutMe.spec.tsx
@@ -99,13 +99,6 @@ describe('AboutMe', () => {
         screen.getByText('This is my awesome bio with some **markdown**!'),
       ).toBeInTheDocument();
     });
-
-    it('should render with social links when user has them', () => {
-      renderComponent(userWithSocialLinks);
-      expect(screen.getByTestId('social-link-github')).toBeInTheDocument();
-      expect(screen.getByTestId('social-link-linkedin')).toBeInTheDocument();
-      expect(screen.getByTestId('social-link-portfolio')).toBeInTheDocument();
-    });
   });
 
   describe('Social Links', () => {

--- a/packages/shared/src/features/profile/components/ProfileWidgets/ReadingOverview.spec.tsx
+++ b/packages/shared/src/features/profile/components/ProfileWidgets/ReadingOverview.spec.tsx
@@ -161,15 +161,6 @@ describe('ReadingOverview component', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('should calculate and display correct total reads', () => {
-    renderComponent();
-
-    // Total reads: 5 + 3 + 0 + 8 = 16
-    expect(
-      screen.getByText('Posts read in the last months (16)'),
-    ).toBeInTheDocument();
-  });
-
   it('should display total reads as 0 when readHistory is empty', () => {
     renderComponent({ readHistory: [] });
 
@@ -183,16 +174,6 @@ describe('ReadingOverview component', () => {
 
     expect(
       screen.getByText('Posts read in the last months (0)'),
-    ).toBeInTheDocument();
-  });
-
-  it('should render calendar heatmap with correct props', () => {
-    renderComponent();
-
-    // Check that CalendarHeatmap component is rendered by looking for its content
-    // The heatmap should be present in the DOM structure
-    expect(
-      screen.getByText('Posts read in the last months (16)'),
     ).toBeInTheDocument();
   });
 

--- a/packages/shared/src/features/profile/components/experience/forms/UserCertificationForm.spec.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserCertificationForm.spec.tsx
@@ -216,36 +216,6 @@ describe('UserCertificationForm', () => {
     expect(screen.queryByText('Credential URL*')).not.toBeInTheDocument();
   });
 
-  it('should render all form sections with proper structure', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserCertificationForm />
-      </FormWrapper>,
-    );
-
-    // Verify all main input fields are present using proper queries
-    expect(getFieldByName(container, 'title')).toBeInTheDocument();
-    expect(
-      getFieldByName(container, 'externalReferenceId'),
-    ).toBeInTheDocument();
-    expect(getFieldByName(container, 'url')).toBeInTheDocument();
-    expect(getFieldByName(container, 'description')).toBeInTheDocument();
-
-    // Check currently valid certification text is present
-    expect(
-      screen.getByText('Currently valid certification'),
-    ).toBeInTheDocument();
-
-    // Check description section
-    expect(screen.getByText('Description')).toBeInTheDocument();
-
-    // Verify labels for each section
-    expect(screen.getByText('Certification Name*')).toBeInTheDocument();
-    expect(screen.getByText('Issuing Organization*')).toBeInTheDocument();
-    expect(screen.getByText('Credential ID')).toBeInTheDocument();
-    expect(screen.getByText('Credential URL')).toBeInTheDocument();
-  });
-
   it('should handle current certification toggle affecting expiration date', async () => {
     render(
       <FormWrapper>

--- a/packages/shared/src/features/profile/components/experience/forms/UserEducationForm.spec.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserEducationForm.spec.tsx
@@ -201,32 +201,6 @@ describe('UserEducationForm', () => {
     expect(screen.queryByText('Grade*')).not.toBeInTheDocument();
   });
 
-  it('should render all form sections with proper structure', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserEducationForm />
-      </FormWrapper>,
-    );
-
-    // Verify all main input fields are present using proper queries
-    expect(getFieldByName(container, 'subtitle')).toBeInTheDocument();
-    expect(getFieldByName(container, 'title')).toBeInTheDocument();
-    expect(getFieldByName(container, 'grade')).toBeInTheDocument();
-
-    // Check current education text is present
-    expect(screen.getByText('Current education')).toBeInTheDocument();
-
-    // Check description section
-    expect(screen.getByText('Description')).toBeInTheDocument();
-    expect(getFieldByName(container, 'description')).toBeInTheDocument();
-
-    // Verify labels for each section
-    expect(screen.getByText('School*')).toBeInTheDocument();
-    expect(screen.getByText('Degree*')).toBeInTheDocument();
-    expect(screen.getByText('Field of Study*')).toBeInTheDocument();
-    expect(screen.getByText('Grade')).toBeInTheDocument();
-  });
-
   it('should handle current education toggle affecting end date', async () => {
     render(
       <FormWrapper>

--- a/packages/shared/src/features/profile/components/experience/forms/UserProjectExperienceForm.spec.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserProjectExperienceForm.spec.tsx
@@ -321,31 +321,6 @@ describe('UserProjectExperienceForm', () => {
     expect(screen.getByText('End date*')).toBeInTheDocument();
   });
 
-  it('should render all form sections with proper structure', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserProjectExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Verify all main input fields are present using proper queries
-    expect(getFieldByName(container, 'title')).toBeInTheDocument();
-    expect(getFieldByName(container, 'url')).toBeInTheDocument();
-    expect(getFieldByName(container, 'description')).toBeInTheDocument();
-
-    // Check current project text is present
-    expect(screen.getByText('Ongoing project/publication')).toBeInTheDocument();
-
-    // Check description section
-    expect(screen.getByText('Description')).toBeInTheDocument();
-
-    // Verify labels for each section
-    expect(screen.getByText('Title*')).toBeInTheDocument();
-    expect(screen.getByText('Publisher*')).toBeInTheDocument();
-    expect(screen.getByText('Publication URL')).toBeInTheDocument();
-    expect(screen.getByText('End date*')).toBeInTheDocument();
-  });
-
   it('should handle current project toggle', async () => {
     render(
       <FormWrapper>

--- a/packages/shared/src/features/profile/components/experience/forms/UserVolunteeringExperienceForm.spec.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserVolunteeringExperienceForm.spec.tsx
@@ -148,26 +148,6 @@ describe('UserVolunteeringExperienceForm', () => {
     expect(screen.getByText('End date*')).toBeInTheDocument();
   });
 
-  it('should render all form sections with proper structure', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserVolunteeringExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Verify all main input fields are present using proper queries
-    expect(getFieldByName(container, 'title')).toBeInTheDocument();
-
-    // Check current volunteer role text is present
-    expect(screen.getByText('Current volunteer role')).toBeInTheDocument();
-
-    // Verify labels for each section
-    expect(screen.getByText('Organization*')).toBeInTheDocument();
-    expect(screen.getByText('Role*')).toBeInTheDocument();
-    expect(screen.getByText('Start date*')).toBeInTheDocument();
-    expect(screen.getByText('End date*')).toBeInTheDocument();
-  });
-
   it('should handle current volunteer role toggle', async () => {
     render(
       <FormWrapper>
@@ -210,29 +190,6 @@ describe('UserVolunteeringExperienceForm', () => {
     // Check for year placeholders (should have 2 - one for start date and one for end date)
     const yearPlaceholders = screen.getAllByText('Year');
     expect(yearPlaceholders).toHaveLength(2);
-  });
-
-  it('should validate volunteering-specific fields', async () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserVolunteeringExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Test role field accepts various volunteer roles
-    const roleInput = getFieldByName(container, 'title');
-    await userEvent.type(roleInput, 'Community Outreach Coordinator');
-    expect(roleInput).toHaveValue('Community Outreach Coordinator');
-
-    // Clear and test another role
-    await userEvent.clear(roleInput);
-    await userEvent.type(roleInput, 'Event Organizer');
-    expect(roleInput).toHaveValue('Event Organizer');
-
-    // Clear and test another role
-    await userEvent.clear(roleInput);
-    await userEvent.type(roleInput, 'Open Source Maintainer');
-    expect(roleInput).toHaveValue('Open Source Maintainer');
   });
 
   it('should maintain form state when switching current volunteer status', async () => {
@@ -292,42 +249,5 @@ describe('UserVolunteeringExperienceForm', () => {
     await userEvent.clear(roleInput);
     await userEvent.type(roleInput, 'Community Ambassador');
     expect(roleInput).toHaveValue('Community Ambassador');
-  });
-
-  it('should properly order fields as Organization then Role', () => {
-    render(
-      <FormWrapper>
-        <UserVolunteeringExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Verify both fields are present
-    const orgLabel = screen.getByText('Organization*');
-    const roleLabel = screen.getByText('Role*');
-
-    expect(orgLabel).toBeInTheDocument();
-    expect(roleLabel).toBeInTheDocument();
-
-    // The form structure has Organization field first, then Role field
-    // This is verified by the order in the component itself
-    // Testing the actual order would require checking the DOM structure
-    // which is already covered by the component implementation
-  });
-
-  it('should have correct field names for form submission', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserVolunteeringExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Check that the role field has the correct name attribute
-    const roleInput = getFieldByName(container, 'title');
-    expect(roleInput).toHaveAttribute('name', 'title');
-
-    // The organization field (ProfileCompany) should have customCompanyName as the name
-    // We can't directly test this as it's an autocomplete component,
-    // but we can verify the label is present
-    expect(screen.getByText('Organization*')).toBeInTheDocument();
   });
 });

--- a/packages/shared/src/features/profile/components/experience/forms/UserWorkExperienceForm.spec.tsx
+++ b/packages/shared/src/features/profile/components/experience/forms/UserWorkExperienceForm.spec.tsx
@@ -190,44 +190,6 @@ describe('UserWorkExperienceForm', () => {
     expect(currentSwitch).toBeChecked();
   });
 
-  it('should display all required field indicators', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserWorkExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Check for required field indicators
-    expect(getFieldByName(container, 'title')).toBeInTheDocument();
-
-    // Check date fields have required indicators
-    expect(screen.getByText('Start date*')).toBeInTheDocument();
-    expect(screen.getByText('End date*')).toBeInTheDocument();
-  });
-
-  it('should render all form sections with proper structure', () => {
-    const { container } = render(
-      <FormWrapper>
-        <UserWorkExperienceForm />
-      </FormWrapper>,
-    );
-
-    // Verify all main input fields are present using proper queries
-    expect(getFieldByName(container, 'title')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: /please select/i }),
-    ).toBeInTheDocument();
-
-    // Check current position text is present
-    expect(screen.getByText('Current position')).toBeInTheDocument();
-    expect(getFieldByName(container, 'description')).toBeInTheDocument();
-
-    // Check text content for sections
-    expect(screen.getByText('Employment Type')).toBeInTheDocument();
-    expect(screen.getByText('Current position')).toBeInTheDocument();
-    expect(screen.getByText('Description')).toBeInTheDocument();
-  });
-
   it('should handle current position toggle affecting end date', async () => {
     render(
       <FormWrapper>

--- a/packages/shared/src/hooks/streaks/useStreakFreeze.spec.tsx
+++ b/packages/shared/src/hooks/streaks/useStreakFreeze.spec.tsx
@@ -91,16 +91,6 @@ describe('useStreakFreeze', () => {
     client = new QueryClient();
   });
 
-  it('should expose freezesAvailable from the user streak', async () => {
-    mockStreakQuery(3);
-    mockProductsQuery();
-    mockFreezeDatesQuery();
-
-    const { result } = renderStreakFreezeHook(client);
-
-    await waitFor(() => expect(result.current.freezesAvailable).toBe(3));
-  });
-
   it('should fetch streak freeze products', async () => {
     mockStreakQuery();
     mockProductsQuery();

--- a/packages/shared/src/hooks/useChecklist.spec.tsx
+++ b/packages/shared/src/hooks/useChecklist.spec.tsx
@@ -188,31 +188,6 @@ describe('useChecklist hook', () => {
     );
   });
 
-  it('should open step after toggle', async () => {
-    const steps = [...defaultSteps];
-
-    const { result } = renderHook(
-      (props: { steps: ChecklistStepType[] }) =>
-        useChecklist({ steps: props.steps }),
-      {
-        wrapper,
-        initialProps: {
-          steps,
-        },
-      },
-    );
-
-    expect(result.current.openStep).toBeNull();
-
-    act(() => {
-      result.current.onToggleStep(steps[0].action);
-    });
-
-    await waitFor(() =>
-      expect(result.current.openStep).toBe(steps[0].action.type),
-    );
-  });
-
   it('should close step that is open after toggle', async () => {
     const steps = [...defaultSteps];
 

--- a/packages/shared/src/hooks/useEventListener.spec.ts
+++ b/packages/shared/src/hooks/useEventListener.spec.ts
@@ -3,30 +3,6 @@ import { renderHook } from '@testing-library/react';
 import { useEventListener } from './useEventListener';
 
 describe('useEventListener', () => {
-  it('should bind listener on mount and unbind on unmount', () => {
-    const div = document.createElement('div');
-    const listener = jest.fn();
-    const addSpy = jest.spyOn(div, 'addEventListener');
-    const removeSpy = jest.spyOn(div, 'removeEventListener');
-
-    const { rerender, unmount } = renderHook(() =>
-      useEventListener(div, 'resize', listener, { passive: true }),
-    );
-
-    expect(addSpy).toHaveBeenCalledTimes(1);
-    expect(removeSpy).toHaveBeenCalledTimes(0);
-
-    rerender();
-
-    expect(addSpy).toHaveBeenCalledTimes(1);
-    expect(removeSpy).toHaveBeenCalledTimes(0);
-
-    unmount();
-
-    expect(addSpy).toHaveBeenCalledTimes(1);
-    expect(removeSpy).toHaveBeenCalledTimes(1);
-  });
-
   it('should work with react refs', () => {
     const div = document.createElement('div');
     const listener = jest.fn();

--- a/packages/shared/src/hooks/useIubendaConsentMirror.spec.tsx
+++ b/packages/shared/src/hooks/useIubendaConsentMirror.spec.tsx
@@ -156,12 +156,3 @@ describe('useIubendaConsentMirror', () => {
     expect(otherGdprConsents).toEqual([GdprConsentKey.Marketing]);
   });
 });
-
-it('carries a refusal recorded on another daily.dev property', () => {
-  setup();
-  mockGetIubendaConsent.mockReturnValue({ necessary: true, marketing: false });
-
-  renderHook(() => useIubendaConsentMirror());
-
-  expect(saveCookies).toHaveBeenCalledWith([], otherGdprConsents);
-});

--- a/packages/shared/src/lib/feedHighlightColSpan.spec.ts
+++ b/packages/shared/src/lib/feedHighlightColSpan.spec.ts
@@ -721,21 +721,6 @@ describe('computePlacements', () => {
       expect(placements[3]).toEqual({ colSpan: 1, row: 0, column: 3 });
     });
 
-    it('skips ad-clamp logic when cadence is omitted', () => {
-      // Same straddle setup as the first test, but with no cadence info
-      // → builder behaves as before (no clamp), wide card lands at its
-      // requested span (clamped only by row-fit).
-      const items = [
-        makePostItem(makePost()),
-        makePostItem(makePost()),
-        makePostItem(makePost()),
-        makePostItem(makePost({ significance: 'breaking' })),
-      ];
-      const placements = computePlacements(items, opts);
-      // col=3 at that point → row-fit clamps to 1 (numCards=4 - col=3).
-      expect(placements[3].colSpan).toBe(1);
-    });
-
     it('does not clamp wide cards at phantom slots when ad cadence is disabled', () => {
       const items = [
         makePostItem(makePost()),

--- a/packages/shared/src/lib/markdownConversion.spec.ts
+++ b/packages/shared/src/lib/markdownConversion.spec.ts
@@ -129,14 +129,6 @@ describe('markdownConversion', () => {
     expect(markdown).toBe(initialMarkdown);
   });
 
-  it('should keep simple strikethrough in markdown round-trip', () => {
-    const initialMarkdown = '~~gone~~';
-    const html = markdownToHtmlBasic(initialMarkdown);
-    const markdown = htmlToMarkdownBasic(html);
-
-    expect(markdown).toBe(initialMarkdown);
-  });
-
   it('should keep standard paragraph spacing in markdown round-trip', () => {
     const initialMarkdown = 'first paragraph\n\nsecond paragraph';
     const html = markdownToHtmlBasic(initialMarkdown);

--- a/packages/shared/src/lib/numberFormat.spec.ts
+++ b/packages/shared/src/lib/numberFormat.spec.ts
@@ -100,9 +100,4 @@ describe('function formatDataTileValue', () => {
     expect(formatDataTileValue(1000000000000)).toBe('1T');
     expect(formatDataTileValue(1500000000000)).toBe('1.5T');
   });
-
-  it('should handle numbers exactly at the threshold', () => {
-    expect(formatDataTileValue(9999)).toBe('9,999');
-    expect(formatDataTileValue(10000)).toBe('10K');
-  });
 });

--- a/packages/webapp/__tests__/ladder.spec.ts
+++ b/packages/webapp/__tests__/ladder.spec.ts
@@ -96,10 +96,6 @@ describe('levelProgress on the realm ladder', () => {
   it('rounds a part-article up, because rungs are crossed by reading one', () => {
     expect(levelProgress(3.5, REALM_DIV).toNext).toEqual(13);
   });
-
-  it('leaves the district ladder alone by default', () => {
-    expect(levelProgress(18)).toMatchObject({ level: 5, toNext: 2 });
-  });
 });
 
 describe('nearestLevelUp', () => {

--- a/packages/webapp/__tests__/profileWorld.spec.ts
+++ b/packages/webapp/__tests__/profileWorld.spec.ts
@@ -23,14 +23,6 @@ describe('hasPublicWorld', () => {
     await expect(hasPublicWorld('u1')).resolves.toBe(false);
   });
 
-  it('keeps it shut for a world its owner has hidden', async () => {
-    // Privacy is applied by the resolver, so a hidden world is indistinguishable
-    // from an empty one here — which is exactly the answer a visitor should get.
-    respond({ data: { userWorld: [] } });
-
-    await expect(hasPublicWorld('u1')).resolves.toBe(false);
-  });
-
   it('does not take the profile down with it', async () => {
     fetchMock.mockRejectedValue(new Error('network down'));
 

--- a/packages/webapp/components/layouts/utils.spec.ts
+++ b/packages/webapp/components/layouts/utils.spec.ts
@@ -31,12 +31,6 @@ describe('getTemplatedTitle', () => {
     expect(getTemplatedTitle(title)).toBe(`${title} | daily.dev`);
   });
 
-  it('drops suffix when only suffix causes overflow', () => {
-    const title = 'a'.repeat(55);
-
-    expect(getTemplatedTitle(title)).toBe(title);
-  });
-
   it('truncates and appends ellipsis when base title exceeds limit', () => {
     const title =
       'How to implement authentication and authorization in modern systems with confidence';


### PR DESCRIPTION
Audited all 430 Jest spec files across `shared`, `webapp` and `extension`, and removed **59 test cases (831 lines, 43 files)** that cannot fail unless another test in the same file fails first, or that assert nothing about our code. Pure deletions, no source changes, no spec file removed entirely.

### What came out

- **Strict subsets.** `useEventListener`'s mount/unmount test was contained byte-for-byte in the react-refs test right below it. `useChecklist`'s "should open step after toggle" was the first half of "should close step that is open after toggle". `formatReadTime(30) === '30m'` was already asserted inside the `not.toContain('0h ')` test.
- **Exact duplicates.** `numberFormat` re-asserted the `9999`/`10000` threshold both preceding tests already cover. `ladder.spec.ts` asserted `levelProgress(18)` identically in two describes. `profileWorld` had two tests responding with an empty `userWorld` and expecting `false`.
- **Structure smoke tests.** Each of the five `User*Form` specs carried a "render all form sections with proper structure" test re-checking labels and fields an earlier render test had already checked.
- **Genuine no-ops.** `UserVolunteeringExperienceForm`'s "should properly order fields as Organization then Role" only asserted both labels exist, with a comment conceding it does not test order. "Should have correct field names for form submission" asserted `name="title"` on a field it had queried *by* `name="title"`.
- **One orphan** test sitting outside its `describe` block in `useIubendaConsentMirror`, duplicating the case above it.

### On safety

Every removal was checked against the surviving file to confirm the covering test is actually still there, with particular attention to negative and boundary cases. `Header` still covers `showBackButton={false}`, `ReadingOverview` still asserts the non-zero total, `numberFormat` still pins both sides of the 10K threshold, and `FunnelRegistration` still covers every `shouldRedirectAuth === true` path. Snapshot tests were left alone entirely.

Cross-file duplication was only considered between sibling specs in the same directory, so this is not an exhaustive dedup pass.

### Verification

| | |
|---|---|
| `shared` | 368 suites, 2619 tests ✅ |
| `webapp` | 81 suites, 645 tests ✅ |
| `extension` | 6 suites, 52 tests ✅ |
| lint (`shared` + `webapp`) | ✅ |
| `typecheck-strict-changed` | ✅ |

### Preview domain
https://chore-remove-redundant-tests.preview.app.daily.dev