### PR TITLE
fix(feed): take the gutter back off the phone feed

### DIFF
--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -261,11 +261,14 @@ export const FeedContainer = ({
           // From tablet up the container above carries `feedGutter`, so
           // any horizontal padding here stacks on top of it and leaves
           // the banner narrower than the cards underneath. Below tablet
-          // there is no gutter and the banner — unlike a post card — has
-          // no inset of its own, so it keeps the one it always had.
+          // there is no gutter, and the banner needs one of its own: a
+          // post card runs full-bleed on purpose, but this is a rounded,
+          // bordered box, and without the inset it paints its border and
+          // clipped corners on the screen edge. Not the card's `px-4` —
+          // the banner has that already for its text; this is the box.
           className={classNames(
-            'laptop:pt-0',
-            hasFirstSlotCard ? 'px-4 tablet:px-0' : 'tablet:pt-1',
+            'px-4 tablet:px-0 laptop:pt-0',
+            !hasFirstSlotCard && 'tablet:pt-1',
           )}
         >
           <ProfileUploadBanner

--- a/packages/shared/src/components/feeds/FeedContainer.tsx
+++ b/packages/shared/src/components/feeds/FeedContainer.tsx
@@ -258,14 +258,14 @@ export const FeedContainer = ({
     >
       {shouldShowBanner && (
         <div
-          // Vertical only. The horizontal inset used to live here
-          // because the container above had none below laptop; it now
-          // carries `feedGutter` at every width, so any padding here
-          // stacks on top of it and leaves the banner narrower than
-          // the cards underneath.
+          // From tablet up the container above carries `feedGutter`, so
+          // any horizontal padding here stacks on top of it and leaves
+          // the banner narrower than the cards underneath. Below tablet
+          // there is no gutter and the banner — unlike a post card — has
+          // no inset of its own, so it keeps the one it always had.
           className={classNames(
             'laptop:pt-0',
-            !hasFirstSlotCard && 'tablet:pt-1',
+            hasFirstSlotCard ? 'px-4 tablet:px-0' : 'tablet:pt-1',
           )}
         >
           <ProfileUploadBanner

--- a/packages/shared/src/components/utilities/common.tsx
+++ b/packages/shared/src/components/utilities/common.tsx
@@ -119,7 +119,14 @@ export const BaseFeedPage = classed(
  * asking for the same number of columns in a narrower space.
  *
  * Below laptop the card does not exist and neither does this class, so the
- * small-width gutter this constant exists for applies in both layouts.
+ * tablet gutter this constant exists for applies in both layouts.
+ *
+ * Below tablet there is no gutter either, which is what every layout has
+ * always shipped on phones. The feed is a single full-bleed column there:
+ * cards run edge to edge and carry their own `px-4`, so a gutter here is
+ * that inset charged twice and leaves the post text 32px off the screen.
+ * The chrome that uses this constant to line up with the cards — the tab
+ * strip — has to go full-bleed on phones for the same reason.
  *
  * Keyed to the frame's own class rather than to `isV2` on purpose. The flag
  * resolves after mount, so a React-side gate let the gutter and the frame
@@ -127,7 +134,7 @@ export const BaseFeedPage = classed(
  * exactly when the frame that replaces it is on screen.
  */
 export const feedGutter =
-  'px-4 tablet:px-6 laptop:px-10 laptop:[.layout-frame_&]:px-0';
+  'tablet:px-6 laptop:px-10 laptop:[.layout-frame_&]:px-0';
 
 // Vertical padding only. The horizontal inset moved to FeedContainer
 // (see `feedGutter`) because this component is not in the tree on


### PR DESCRIPTION
## What

[#6516](https://github.com/dailydotdev/apps/pull/6516) gave the feed a single horizontal inset so the old layout stopped losing its side padding on desktop. It set that inset from the base breakpoint up:

```
feedGutter = 'px-4 tablet:px-6 laptop:px-10 laptop:[.layout-frame_&]:px-0'
```

The leading `px-4` has no breakpoint prefix, so it also applied to phones — where no layout had ever shipped a feed gutter. Before #6516, `pageMainClassNames` was `tablet:p-4 laptop:p-10` (nothing below 656px) and the mobile list layout forced `!px-0`.

## Why it reads as doubled padding

On a phone the feed is one full-bleed column and the post card carries its own `px-4`, so the gutter charges that inset a second time. Measured live at 375px:

| | before #6516 | on `main` | this PR |
|---|---|---|---|
| `FeedContainer` padding | 0px | **16px** | 0px |
| Sticky tab strip padding | 0px | **16px** | 0px |
| First card | left 0, width 375 | **left 16, width 343** | left 0, width 375 |
| Post text off screen edge | 16px | **32px** | 16px |

## The change

`feedGutter` starts at tablet instead of at base. The tablet and laptop values and the v2 frame override are untouched, so the desktop fix #6516 shipped is unchanged — measured after this change: **375px → 0px, 800px → 24px, 1200px → 40px**.

The CV upload banner keeps a horizontal inset below tablet. Not because it lacks one — `ProfileUploadBanner` carries `px-4` for its text — but because it is a rounded, bordered box: a post card runs full-bleed on purpose, and the banner would otherwise paint its border and clipped corners on the screen edge. It applies whether or not the feed has a first-slot card, since that has no bearing on whether a bordered box should touch the viewport.

## Testing

- Measured computed padding and card geometry in the browser at 375 / 800 / 1200px against the local webapp. Also confirmed the Explore tab strip's labels stay aligned with card content at phone width (each `Tab` has ~20px of its own padding, so the first label lands at 20px against the card's 16px content edge).
- `node ./scripts/typecheck-strict-changed.js` — clean
- `eslint` on both changed files — clean
- `packages/shared` — 379 suites / 2708 tests pass
- `packages/webapp` — 86 suites / 683 tests pass

Verified at phone viewport width in the dev server, not in the iOS simulator; the iOS app is a webview over the same CSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)