### PR TITLE
chore: take storybook out of Vercel and the PR checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,8 @@
 Dockerfile  eol=lf
 *.sh        eol=lf
+
+# Storybook is designer-facing and not part of any build or check. Mark it
+# generated so GitHub collapses it in pull request diffs.
+packages/storybook/** linguist-generated=true
+*.stories.tsx          linguist-generated=true
+*.mdx                  linguist-generated=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ pnpm monorepo for the daily.dev app suite:
 - `packages/extension`: Chrome/Edge/Opera extension.
 - `packages/shared`: components, hooks, GraphQL, design system. Code used by both surfaces lives here.
 - `packages/storybook`, `packages/playwright`, eslint/prettier config packages.
+- Storybook is designer territory: no Vercel deploy, no CI job, no strict typecheck, and `.gitattributes` collapses its diffs on GitHub. Don't add checks for it.
 
 ## Verification
 

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -19,10 +19,6 @@ const packageConfigs = [
     dir: 'packages/extension',
     tsconfig: 'tsconfig.strict.json',
   },
-  {
-    dir: 'packages/storybook',
-    tsconfig: 'tsconfig.json',
-  },
 ];
 
 // Files temporarily excluded from strict type checking.

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,9 @@
 {
-  "installCommand": "if [ -f pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 install; elif [ -f ../../pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 --dir ../.. install; else corepack pnpm@10.33.4 install; fi"
+  "installCommand": "if [ -f pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 install; elif [ -f ../../pnpm-workspace.yaml ]; then corepack pnpm@10.33.4 --dir ../.. install; else corepack pnpm@10.33.4 install; fi",
+  "git": {
+    "deploymentEnabled": false
+  },
+  "github": {
+    "silent": true
+  }
 }


### PR DESCRIPTION
## Changes

Storybook is designer territory and nothing in the app builds from it, so its Vercel deployments and PR checks were noise on every PR. This takes it out of both, and hides its diffs from review.

- **`vercel.json`** (root, the storybook Vercel project, see f0b4af41a): `git.deploymentEnabled: false` so no deployment is created on push, plus `github.silent: true` so no check or bot comment lands on a PR.
- **`scripts/typecheck-strict-changed.js`**: dropped the `packages/storybook` entry. A storybook-only change now selects no packages and the `typecheck_strict_changed` job exits clean.
- **`.gitattributes`**: marks `packages/storybook/**` (plus stray `*.stories.tsx` / `*.mdx` elsewhere, today just `Buttons.mdx` in shared) as `linguist-generated`, so GitHub collapses them in the Files-changed view. GitHub-only attribute, local `git diff` is unaffected.
- **`AGENTS.md`**: one line so nobody re-adds checks for it later.

CircleCI never had a storybook build or lint job, and no GitHub workflow touches it, so there was nothing else to remove.

### Follow-up in the Vercel dashboard

Not doable from the repo:

1. Delete the storybook project (Settings → Advanced → Delete Project), or just disconnect its Git repo under Settings → Git if you want the last build to stay reachable.
2. Once deleted, the root `vercel.json` is dead config and can go. It stays for now because a project without that file would fall back to defaults and start *failing* builds instead of skipping them.

> [!WARNING]
> If any other Vercel project also uses the repo root as its Root Directory, `deploymentEnabled: false` disables that one too. Worth a glance at the project list before merging.

Designers lose the hosted storybook URL once the project is deleted. If a link matters more than `pnpm --filter @dailydotdev/storybook dev`, we'd need Chromatic or a manual `vercel deploy`.

## Events

No.

## Experiment

No.

## Manual Testing

No app code touched. Verified locally:

- `node ./scripts/typecheck-strict-changed.js` → passes.
- `git check-attr linguist-generated` → `true` for `packages/storybook/stories/*.stories.tsx` and `packages/shared/src/components/buttons/Buttons.mdx`, `unspecified` for `Button.tsx`.
- `vercel.json` parses.


### Preview domain
https://chore-remove-storybook-from-ci.preview.app.daily.dev