### PR TITLE
perf(graphql): merge shell queries, batch secondary queries, gate widget queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ pnpm monorepo for the daily.dev app suite:
 - Import from source files, never through barrel `index.ts` files, and don't add new barrels.
 - Queries are options-creator functions spread into `useQuery` (see `packages/shared/src/hooks/AGENTS.md`). Page or feature scoped state uses `createContextProvider` from `@kickass-coderz/react` (see `contexts/ActivePostContext.tsx`).
 - GraphQL has no codegen. Types in `packages/shared/src/graphql/types.ts` and the domain files are hand-written; update them with the query you edit.
+- Every GraphQL query is its own round trip unless it opts into `gqlBatchRequest` (`graphql/batch.ts`), which coalesces the queries fired in the same tick into one POST behind the `gql_batching` flag. Paint-blocking queries (boot, feeds, the post query) stay on `gqlClient.request`, and mutations never batch.
+- Data the shell needs on every page load for a logged-in user (actions, streak, feed list) comes from one `SHELL_STATE_QUERY` (`graphql/shellState.ts`) that `ShellStateProvider` fans out into the per-hook cache keys, so add a root field there instead of a new standalone shell query and gate the hook on `useShellState().isSettled` so it only fetches on its own as the fallback. Never merge boot, the feed, or the post query with anything slower, and gate widget queries on the surface that renders them.
 - Payment providers are per platform (`contexts/payment/index.tsx`): Paddle on web, StoreKit on iOS, a Chrome extension variant. Don't assume Paddle.
 - Native iOS/Android wrappers run the webapp shell, so `isExtension`/`BootApp` can't tell them apart. Platform comes from `getDailyClientPlatform(version)` in `packages/shared/src/lib/func.ts`, never from an extension/webapp boolean.
 

--- a/packages/extension/src/newtab/App.tsx
+++ b/packages/extension/src/newtab/App.tsx
@@ -44,6 +44,7 @@ import { version } from '../../package.json';
 import MainFeedPage from './MainFeedPage';
 import HijackingLoginStrip from './HijackingLoginStrip';
 import { BootDataProvider } from '../../../shared/src/contexts/BootProvider';
+import { ShellStateProvider } from '../../../shared/src/contexts/ShellStateProvider';
 import { getContentScriptPermissionAndRegister } from '../lib/extensionScripts';
 import { useContentScriptStatus } from '../../../shared/src/hooks';
 
@@ -218,12 +219,14 @@ export default function App({
               getPage={() => currentPage}
               deviceId={deviceId}
             >
-              <SubscriptionContextProvider>
-                <ShortcutsProvider>
-                  <LazyModalElement />
-                  <InternalAppWithFeaturesBoundary />
-                </ShortcutsProvider>
-              </SubscriptionContextProvider>
+              <ShellStateProvider>
+                <SubscriptionContextProvider>
+                  <ShortcutsProvider>
+                    <LazyModalElement />
+                    <InternalAppWithFeaturesBoundary />
+                  </ShortcutsProvider>
+                </SubscriptionContextProvider>
+              </ShellStateProvider>
             </BootDataProvider>
           </ExtensionContextProvider>
           <ReactQueryDevtools />

--- a/packages/shared/src/components/MainLayout.tsx
+++ b/packages/shared/src/components/MainLayout.tsx
@@ -217,12 +217,6 @@ function MainLayoutComponent({
   const isLayoutChromeResolved =
     !isHoldingChrome && (!isLaptop || !isLayoutVariantLoading);
 
-  // Extension new tab mounts its own `ExtensionTopBanners` strip, so
-  // the webapp strip is suppressed there to avoid duplicate cards.
-  const { hasAny: hasTopBannersRaw } = useHomepageTopBannersVisibility();
-  const showHomepageTopBanners = !isExtension;
-  const hasTopBanners = showHomepageTopBanners && hasTopBannersRaw;
-
   // The dual-sidebar layout takes ownership of the global header chrome
   // (logo + search + user actions) on laptop+ for authenticated users
   // (and for extension new tab regardless of auth state). When that's
@@ -240,6 +234,15 @@ function MainLayoutComponent({
     ownsHeaderAudience &&
     showSidebar &&
     (isAuthReady ? sidebarRendered : hasServerShell);
+
+  // Extension new tab mounts its own `ExtensionTopBanners` strip, so
+  // the webapp strip is suppressed there to avoid duplicate cards. The strip
+  // only renders inside the sidebar-owned header, so the visibility hook is
+  // evaluated there too instead of on every shell mount.
+  const showHomepageTopBanners = !isExtension;
+  const { hasAny: hasTopBanners } = useHomepageTopBannersVisibility({
+    enabled: showHomepageTopBanners && sidebarOwnsHeader,
+  });
 
   let stickyHeaderOffset = 'laptop:[--sticky-header-offset:4rem]';
   if (sidebarOwnsHeader) {

--- a/packages/shared/src/components/brand/MentionedToolsWidget.tsx
+++ b/packages/shared/src/components/brand/MentionedToolsWidget.tsx
@@ -54,22 +54,6 @@ export const MentionedToolsWidget = ({
   const { displayToast } = useToastNotification();
   const { logEvent } = useLogContext();
 
-  const { stackItems, add, remove } = useUserStack(user as PublicProfile);
-
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedToolName, setSelectedToolName] = useState<string | null>(null);
-
-  const isToolInStack = useCallback(
-    (toolName: string): boolean => {
-      return stackItems.some(
-        (item) =>
-          item.tool.title.toLowerCase() === toolName.toLowerCase() ||
-          item.title?.toLowerCase() === toolName.toLowerCase(),
-      );
-    },
-    [stackItems],
-  );
-
   // Extract tools from the matching creative
   const mentionedTools = useMemo(() => {
     const creative = getCreativeForTags(postTags);
@@ -87,6 +71,26 @@ export const MentionedToolsWidget = ({
       }),
     );
   }, [postTags, getCreativeForTags]);
+
+  // The widget renders nothing without a matching creative, so the showcase
+  // request only goes out for the posts that actually show tools.
+  const { stackItems, add, remove } = useUserStack(user as PublicProfile, {
+    enabled: mentionedTools.length > 0,
+  });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedToolName, setSelectedToolName] = useState<string | null>(null);
+
+  const isToolInStack = useCallback(
+    (toolName: string): boolean => {
+      return stackItems.some(
+        (item) =>
+          item.tool.title.toLowerCase() === toolName.toLowerCase() ||
+          item.title?.toLowerCase() === toolName.toLowerCase(),
+      );
+    },
+    [stackItems],
+  );
 
   const handleToolClick = useCallback(
     (tool: Tool) => {

--- a/packages/shared/src/components/cards/entity/UserEntityCard.tsx
+++ b/packages/shared/src/components/cards/entity/UserEntityCard.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import Link from '../../utilities/Link';
 import type { UserShortProfile } from '../../../lib/user';
 import { fallbackImages } from '../../../lib/config';
@@ -23,19 +24,34 @@ import { Button, ButtonSize, ButtonVariant } from '../../buttons/Button';
 import EntityDescription from './EntityDescription';
 import useShowFollowAction from '../../../hooks/useShowFollowAction';
 import { webappUrl } from '../../../lib/constants';
+import { getPostByIdKey } from '../../../lib/query';
 
 type Props = {
   user?: UserShortProfile;
+  // The post query already selects `author.contentPreference`, so cards
+  // rendered from a post seed the follow status from it instead of asking for
+  // it again. Follow/unfollow mutations keep writing to the same key.
+  postId?: string;
   className?: {
     container?: string;
   };
 };
 
-const UserEntityCard = ({ user, className }: Props) => {
+const UserEntityCard = ({ user, postId, className }: Props) => {
   const { user: loggedUser } = useContext(AuthContext);
+  const queryClient = useQueryClient();
+  const postUpdatedAt = postId
+    ? queryClient.getQueryState(getPostByIdKey(postId))?.dataUpdatedAt
+    : undefined;
   const { data: contentPreference } = useContentPreferenceStatusQuery({
     id: user?.id,
     entity: ContentPreferenceType.User,
+    queryOptions: postUpdatedAt
+      ? {
+          initialData: user?.contentPreference ?? null,
+          initialDataUpdatedAt: postUpdatedAt,
+        }
+      : undefined,
   });
   const { isLoading } = useShowFollowAction({
     entityId: user?.id,

--- a/packages/shared/src/components/filters/AchievementTrackerButton.spec.tsx
+++ b/packages/shared/src/components/filters/AchievementTrackerButton.spec.tsx
@@ -32,6 +32,10 @@ jest.mock('../../hooks/profile/useTrackedAchievement', () => ({
   useTrackedAchievement: () => mockUseTrackedAchievement(),
 }));
 
+jest.mock('../../hooks/profile/useAchievementTracker', () => ({
+  useAchievementTracker: () => ({ isSettled: true }),
+}));
+
 jest.mock('../../hooks', () => ({
   useViewSize: (...args: unknown[]) => mockUseViewSize(...args),
   ViewSize: { Laptop: 'laptop' },

--- a/packages/shared/src/components/filters/AchievementTrackerButton.tsx
+++ b/packages/shared/src/components/filters/AchievementTrackerButton.tsx
@@ -10,6 +10,7 @@ import { useSettingsContext } from '../../contexts/SettingsContext';
 import { useConditionalFeature } from '../../hooks/useConditionalFeature';
 import { useProfileAchievements } from '../../hooks/profile/useProfileAchievements';
 import { useTrackedAchievement } from '../../hooks/profile/useTrackedAchievement';
+import { useAchievementTracker } from '../../hooks/profile/useAchievementTracker';
 import { getTargetCount } from '../../graphql/user/achievements';
 import { useViewSize, ViewSize } from '../../hooks';
 import { useLayoutVariant } from '../../hooks/layout/useLayoutVariant';
@@ -84,22 +85,27 @@ export function AchievementTrackerButton(): ReactElement | null {
     feature: achievementTrackingWidgetFeature,
     shouldEvaluate: !!user,
   });
+  const isExperimentEnabled = isAchievementTrackingWidgetEnabled === true;
+  const { isSettled } = useAchievementTracker(
+    isExperimentEnabled && !isAchievementTrackingWidgetLoading,
+  );
   const {
     achievements,
     unlockedCount,
     totalCount,
     isPending: isAchievementsPending,
-  } = useProfileAchievements(user, isAchievementTrackingWidgetEnabled === true);
+  } = useProfileAchievements(user, isExperimentEnabled && isSettled);
 
   const shouldRender = shouldShowAchievementTracker({
-    isExperimentEnabled: isAchievementTrackingWidgetEnabled === true,
+    isExperimentEnabled,
     unlockedCount,
     totalCount,
   });
   const shouldQueryTrackedAchievement =
     !!user &&
+    isSettled &&
     !isAchievementTrackingWidgetLoading &&
-    (isAchievementTrackingWidgetEnabled !== true || !isAchievementsPending) &&
+    (!isExperimentEnabled || !isAchievementsPending) &&
     shouldRender;
   const {
     trackedAchievement,
@@ -165,7 +171,7 @@ export function AchievementTrackerButton(): ReactElement | null {
     return null;
   }
 
-  if (isAchievementTrackingWidgetEnabled !== true) {
+  if (!isExperimentEnabled) {
     return null;
   }
 

--- a/packages/shared/src/components/marketing/banners/HomepageTopBanners.tsx
+++ b/packages/shared/src/components/marketing/banners/HomepageTopBanners.tsx
@@ -39,15 +39,20 @@ const CompactReminderCat = (): ReactElement => (
   <ReadingReminderCatLaptop className="!m-0 h-24 w-28 shrink-0 self-center rounded-12 object-contain tablet:h-28 tablet:w-32" />
 );
 
-export const useHomepageTopBannersVisibility = (): {
+export const useHomepageTopBannersVisibility = ({
+  enabled: isEnabled = true,
+}: { enabled?: boolean } = {}): {
   showReminder: boolean;
   showCv: boolean;
   hasAny: boolean;
 } => {
   const { isLoggedIn, isAuthReady } = useAuthContext();
-  const reminder = useReadingReminderHero({ requireMobile: false });
+  const reminder = useReadingReminderHero({
+    requireMobile: false,
+    enabled: isEnabled,
+  });
   const { shouldShow: shouldShowCv } = useUploadCv();
-  const enabled = isAuthReady && isLoggedIn;
+  const enabled = isEnabled && isAuthReady && isLoggedIn;
   const showReminder = enabled && reminder.shouldShow;
   const showCv = enabled && shouldShowCv;
   return { showReminder, showCv, hasAny: showReminder || showCv };

--- a/packages/shared/src/components/post/PostWidgets.tsx
+++ b/packages/shared/src/components/post/PostWidgets.tsx
@@ -173,6 +173,7 @@ export function PostWidgets({
               container: cardClasses,
             }}
             user={creator as UserShortProfile}
+            postId={post.id}
           />
         ),
       )}

--- a/packages/shared/src/components/post/SquadPostWidgets.tsx
+++ b/packages/shared/src/components/post/SquadPostWidgets.tsx
@@ -60,6 +60,7 @@ export function SquadPostWidgets({
             container: cardClasses,
           }}
           user={post.author as UserShortProfile}
+          postId={post.id}
         />
       )}
       <PostSidebarAdWidget

--- a/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
@@ -746,7 +746,7 @@ export const SidebarDesktopV2 = ({
     : 'Daily Quests';
   const { logEvent } = useLogContext();
   const { isAvailable: isBannerAvailable } = useBanner();
-  const { open: openSpotlight } = useSpotlight();
+  const { open: openSpotlight, prefetch: prefetchSpotlight } = useSpotlight();
   const { openModal, modal } = useLazyModal();
   const { isLoggedIn, user } = useAuthContext();
   const { isCustomDefaultFeed } = useCustomDefaultFeed();
@@ -2160,6 +2160,8 @@ export const SidebarDesktopV2 = ({
                 type="button"
                 aria-label="Search"
                 onClick={openSpotlight}
+                onMouseEnter={prefetchSpotlight}
+                onFocus={prefetchSpotlight}
                 className="focus-outline flex size-10 items-center justify-center rounded-12 text-text-tertiary transition-[background-color,color,transform] duration-150 ease-out hover:bg-surface-hover hover:text-text-primary active:scale-90 motion-reduce:transition-none"
               >
                 <SearchIcon size={RAIL_ICON_SIZE} aria-hidden />

--- a/packages/shared/src/components/sidebar/SidebarEntityIcon.tsx
+++ b/packages/shared/src/components/sidebar/SidebarEntityIcon.tsx
@@ -1,9 +1,11 @@
 import type { ReactElement } from 'react';
 import React from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Image, ImageType } from '../image/Image';
 import { EarthIcon, HashtagIcon, LinkIcon, SquadIcon } from '../icons';
 import { RAIL_ICON_SIZE } from './common';
-import { useSquad } from '../../hooks/squads/useSquad';
+import { sourceImageQueryOptions } from '../../graphql/sources';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 const handleFromPath = (path: string): string =>
   path.split('?')[0].split('#')[0].split('/').filter(Boolean).pop() ?? '';
@@ -13,10 +15,9 @@ const stripOrigin = (path: string): string =>
 
 // Resolves the right glyph/image for a pinned page shortcut from its path — a
 // squad shows its actual logo, sources/tags get their icon — so a pinned page
-// never falls back to a generic link icon when we can do better. The squad
-// lookup self-disables for non-squad paths, so only squad shortcuts fetch.
-// When `image` is provided (captured at drag time) it renders immediately and
-// the fetch is skipped entirely, so there's no placeholder flash.
+// never falls back to a generic link icon when we can do better. Entries store
+// the logo they were pinned with, so `image` renders immediately and nothing is
+// fetched; the lookup only covers squad shortcuts pinned before that.
 export const SidebarEntityIcon = ({
   path,
   image,
@@ -28,10 +29,13 @@ export const SidebarEntityIcon = ({
   const isSquad = normalized.startsWith('/squads/');
   const isSource = normalized.startsWith('/sources/');
   const isTag = normalized.startsWith('/tags/');
-  // Only fetch when we don't already have the image in hand.
-  const { squad } = useSquad({
-    handle: isSquad && !image ? handleFromPath(path) : '',
-  });
+  const { isFetched: isBootFetched } = useAuthContext();
+  const { data: source } = useQuery(
+    sourceImageQueryOptions({
+      handle: isSquad ? handleFromPath(path) : '',
+      enabled: !!isBootFetched && !image,
+    }),
+  );
 
   if (image) {
     return (
@@ -50,9 +54,9 @@ export const SidebarEntityIcon = ({
   }
 
   if (isSquad) {
-    return squad?.image ? (
+    return source?.image ? (
       <Image
-        src={squad.image}
+        src={source.image}
         type={ImageType.Squad}
         alt=""
         aria-hidden

--- a/packages/shared/src/components/sidebar/sections/RecentSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/RecentSection.tsx
@@ -22,13 +22,12 @@ import {
 import { Image, ImageType } from '../../image/Image';
 import { Section } from '../Section';
 import { SidebarSettingsFlags } from '../../../graphql/settings';
-import { sourceQueryOptions } from '../../../graphql/sources';
+import { sourceImageQueryOptions } from '../../../graphql/sources';
 import type { SidebarSectionProps } from './common';
 import type { RecentPage, RecentPageType } from '../../../lib/recentPages';
 import { toWebappHref } from '../../../lib/links';
 import { useRecentPages } from '../../../hooks/useRecentPages';
 import { useAuthContext } from '../../../contexts/AuthContext';
-import { useSquad } from '../../../hooks/squads/useSquad';
 import { useUserShortByIdQuery } from '../../../hooks/user/useUserShortByIdQuery';
 import { useJobsFeature } from '../../../hooks/useJobsFeature';
 
@@ -93,35 +92,39 @@ const iconForType = (page: RecentPage, type: RecentPageType): ReactElement => {
 const handleFromPath = (path: string): string =>
   path.split('?')[0].split('#')[0].split('/').filter(Boolean).pop() ?? '';
 
-// Renders the real entity avatar (squad logo / profile picture) when we can
-// resolve it — the entity is usually already cached from the visit — and falls
-// back to the typed vector icon while loading or when it can't be resolved.
+// Renders the real entity avatar (squad logo / profile picture). Entries record
+// the avatar with the visit, so only rows written before that fall back to a
+// lookup, and the typed vector icon covers whatever still can't be resolved.
 const RecentItemIcon = ({ page }: { page: RecentPage }): ReactElement => {
   const type = resolveType(page);
   const handle = handleFromPath(page.path);
   const { user } = useAuthContext();
   const isOwnProfile =
     type === 'user' && !!user?.username && handle === user.username;
+  const isSourceLike = type === 'squad' || type === 'source';
+  const needsLookup = !page.image && !isOwnProfile;
 
   // Each query self-disables when handed an empty id/handle, so only the row's
   // matching entity is fetched.
-  const { squad } = useSquad({ handle: type === 'squad' ? handle : '' });
   const { data: otherUser } = useUserShortByIdQuery({
-    id: type === 'user' && !isOwnProfile ? handle : '',
+    id: needsLookup && type === 'user' ? handle : '',
   });
   const { data: source } = useQuery(
-    sourceQueryOptions({ sourceId: type === 'source' ? handle : '' }),
+    sourceImageQueryOptions({
+      handle: isSourceLike ? handle : '',
+      enabled: needsLookup,
+    }),
   );
 
-  let image: string | undefined;
-  if (isOwnProfile) {
-    image = user?.image;
-  } else if (type === 'user') {
-    image = otherUser?.image;
-  } else if (type === 'squad') {
-    image = squad?.image;
-  } else if (type === 'source') {
-    image = source?.image;
+  let { image } = page;
+  if (!image) {
+    if (isOwnProfile) {
+      image = user?.image;
+    } else if (type === 'user') {
+      image = otherUser?.image;
+    } else if (isSourceLike) {
+      image = source?.image;
+    }
   }
 
   if (image) {

--- a/packages/shared/src/components/spotlight/SpotlightContext.tsx
+++ b/packages/shared/src/components/spotlight/SpotlightContext.tsx
@@ -7,7 +7,7 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { gqlClient } from '../../graphql/common';
 import { isExtension } from '../../lib/func';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -22,6 +22,20 @@ import { registerSpotlightShortcutBlocker } from './shortcuts';
 type SpotlightActionsResponse = { spotlightActions: SpotlightAction[] };
 
 export const SPOTLIGHT_ACTIONS_QUERY_KEY = ['spotlight', 'actions'];
+
+const getSpotlightActions = async (): Promise<SpotlightAction[]> => {
+  const result = await gqlClient.request<SpotlightActionsResponse>(
+    SPOTLIGHT_ACTIONS_QUERY,
+  );
+
+  return result.spotlightActions;
+};
+
+const spotlightActionsQueryOptions = {
+  queryKey: SPOTLIGHT_ACTIONS_QUERY_KEY,
+  queryFn: getSpotlightActions,
+  staleTime: Infinity,
+};
 
 const platformId = isExtension ? 'extension' : 'webapp';
 
@@ -72,22 +86,36 @@ export const SpotlightProvider = ({
   const [pendingConfirmId, setPendingConfirmId] = useState<string | null>(null);
   const [pages, setPages] = useState<SpotlightScope[]>([]);
 
-  const { isLoggedIn } = useAuthContext();
+  const queryClient = useQueryClient();
+  const { isLoggedIn, isFetched: isBootFetched } = useAuthContext();
   const { isPlus } = usePlusSubscription();
   const { data: rawActions, isPending: isActionsLoading } = useQuery({
-    queryKey: SPOTLIGHT_ACTIONS_QUERY_KEY,
-    queryFn: async () => {
-      const result = await gqlClient.request<SpotlightActionsResponse>(
-        SPOTLIGHT_ACTIONS_QUERY,
-      );
-      return result.spotlightActions;
-    },
-    staleTime: Infinity,
+    ...spotlightActionsQueryOptions,
+    enabled: isOpen,
     gcTime: Infinity,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   });
+
+  useEffect(() => {
+    if (!isBootFetched) {
+      return undefined;
+    }
+
+    const prefetch = () =>
+      queryClient.prefetchQuery(spotlightActionsQueryOptions);
+
+    if (!globalThis.requestIdleCallback) {
+      const timeout = globalThis.setTimeout(prefetch, 0);
+
+      return () => globalThis.clearTimeout(timeout);
+    }
+
+    const handle = globalThis.requestIdleCallback(prefetch);
+
+    return () => globalThis.cancelIdleCallback(handle);
+  }, [isBootFetched, queryClient]);
 
   const actions = useMemo<SpotlightAction[]>(() => {
     return (rawActions ?? []).filter((action) => {

--- a/packages/shared/src/components/spotlight/SpotlightContext.tsx
+++ b/packages/shared/src/components/spotlight/SpotlightContext.tsx
@@ -65,6 +65,12 @@ export interface SpotlightContextValue {
   popScope: () => void;
   /** Reset the stack to `All`. */
   clearScope: () => void;
+  /**
+   * Warm the action catalog before the modal opens. Call it from hover/focus
+   * on anything that opens Spotlight so the list is there on click; the query
+   * never goes stale, so repeat calls are free.
+   */
+  prefetch: () => void;
   /** Action catalog from the API, filtered by current user's auth/plus/platform. */
   actions: SpotlightAction[];
   isActionsLoading: boolean;
@@ -87,7 +93,7 @@ export const SpotlightProvider = ({
   const [pages, setPages] = useState<SpotlightScope[]>([]);
 
   const queryClient = useQueryClient();
-  const { isLoggedIn, isFetched: isBootFetched } = useAuthContext();
+  const { isLoggedIn } = useAuthContext();
   const { isPlus } = usePlusSubscription();
   const { data: rawActions, isPending: isActionsLoading } = useQuery({
     ...spotlightActionsQueryOptions,
@@ -98,24 +104,9 @@ export const SpotlightProvider = ({
     refetchOnReconnect: false,
   });
 
-  useEffect(() => {
-    if (!isBootFetched) {
-      return undefined;
-    }
-
-    const prefetch = () =>
-      queryClient.prefetchQuery(spotlightActionsQueryOptions);
-
-    if (!globalThis.requestIdleCallback) {
-      const timeout = globalThis.setTimeout(prefetch, 0);
-
-      return () => globalThis.clearTimeout(timeout);
-    }
-
-    const handle = globalThis.requestIdleCallback(prefetch);
-
-    return () => globalThis.cancelIdleCallback(handle);
-  }, [isBootFetched, queryClient]);
+  const prefetch = useCallback(() => {
+    queryClient.prefetchQuery(spotlightActionsQueryOptions);
+  }, [queryClient]);
 
   const actions = useMemo<SpotlightAction[]>(() => {
     return (rawActions ?? []).filter((action) => {
@@ -217,6 +208,7 @@ export const SpotlightProvider = ({
       pushScope,
       popScope,
       clearScope,
+      prefetch,
       actions,
       isActionsLoading,
     }),
@@ -236,6 +228,7 @@ export const SpotlightProvider = ({
       pushScope,
       popScope,
       clearScope,
+      prefetch,
       actions,
       isActionsLoading,
     ],

--- a/packages/shared/src/components/spotlight/SpotlightTrigger.tsx
+++ b/packages/shared/src/components/spotlight/SpotlightTrigger.tsx
@@ -25,7 +25,7 @@ const shortcutKeys = [isAppleDevice() ? '⌘' : 'Ctrl', 'K'];
 export const SpotlightTrigger = ({
   className,
 }: SpotlightTriggerProps): ReactElement => {
-  const { open } = useSpotlight();
+  const { open, prefetch } = useSpotlight();
   const { logEvent } = useLogContext();
   const isLaptop = useViewSize(ViewSize.Laptop);
 
@@ -45,6 +45,8 @@ export const SpotlightTrigger = ({
       aria-label="Open search"
       aria-keyshortcuts={isLaptop ? shortcutKeys.join('+') : undefined}
       onClick={onOpen}
+      onMouseEnter={prefetch}
+      onFocus={prefetch}
       className={classNames(
         // Sizing, color, and shape match the production SearchPanel field.
         'relative flex h-12 w-full items-center overflow-hidden rounded-12 border border-transparent bg-background-subtle px-3 text-left transition-colors',

--- a/packages/shared/src/components/widgets/FeaturedArchives.tsx
+++ b/packages/shared/src/components/widgets/FeaturedArchives.tsx
@@ -14,13 +14,14 @@ import {
   getArchiveUrlFromArchive,
   getArchiveIndexUrl,
 } from '../../lib/archive';
-import { gqlClient } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 import { RequestKey, StaleTime } from '../../lib/query';
 import Link from '../utilities/Link';
 import { ArrowIcon } from '../icons';
 import { MedalIcon } from '../icons/Medal';
 import { IconSize } from '../Icon';
 import { WidgetContainer } from './common';
+import { useAuthContext } from '../../contexts/AuthContext';
 
 interface FeaturedArchivesProps {
   postId: string;
@@ -85,14 +86,16 @@ export function FeaturedArchives({
   postId,
   className,
 }: FeaturedArchivesProps): ReactElement | null {
+  const { isFetched: isBootFetched } = useAuthContext();
   const { data } = useQuery({
     queryKey: [RequestKey.FeaturedArchives, postId],
     queryFn: () =>
-      gqlClient.request<FeaturedArchivesData>(FEATURED_ARCHIVES_QUERY, {
+      gqlBatchRequest<FeaturedArchivesData>(FEATURED_ARCHIVES_QUERY, {
         subjectType: ArchiveSubjectType.Post,
         subjectId: postId,
       }),
     staleTime: StaleTime.OneHour,
+    enabled: !!postId && isBootFetched,
   });
 
   const archives = data?.featuredArchives;

--- a/packages/shared/src/contexts/ShellStateContext.tsx
+++ b/packages/shared/src/contexts/ShellStateContext.tsx
@@ -1,0 +1,29 @@
+import { createContextProvider } from '@kickass-coderz/react';
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+import { safeContextHookExport } from '../lib/func';
+
+export type ShellStateContextProps = {
+  isSettled: boolean;
+  children?: ReactNode;
+};
+
+export type ShellState = {
+  isSettled: boolean;
+};
+
+const [ShellStateContextProvider, useShellStateHook] = createContextProvider(
+  ({ isSettled }: ShellStateContextProps): ShellState =>
+    useMemo(() => ({ isSettled }), [isSettled]),
+  {
+    errorMessage: 'ShellStateContextNotFound',
+  },
+);
+
+const useShellState = safeContextHookExport(
+  useShellStateHook,
+  'ShellStateContextNotFound',
+  { isSettled: true },
+);
+
+export { ShellStateContextProvider, useShellState };

--- a/packages/shared/src/contexts/ShellStateProvider.spec.tsx
+++ b/packages/shared/src/contexts/ShellStateProvider.spec.tsx
@@ -1,0 +1,189 @@
+import React from 'react';
+import type { ReactNode } from 'react';
+import nock from 'nock';
+import { QueryClient } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { TestBootProvider } from '../../__tests__/helpers/boot';
+import { mockGraphQL } from '../../__tests__/helpers/graphql';
+import loggedUser from '../../__tests__/fixture/loggedUser';
+import { ActionType, COMPLETED_USER_ACTIONS } from '../graphql/actions';
+import { FEED_LIST_QUERY } from '../graphql/feed';
+import { SHELL_STATE_QUERY } from '../graphql/shellState';
+import { generateQueryKey, RequestKey, StaleTime } from '../lib/query';
+import { useActions } from '../hooks/useActions';
+import { useFeeds } from '../hooks/feed/useFeeds';
+import { ShellStateProvider } from './ShellStateProvider';
+
+let queryClient: QueryClient;
+
+const feedListVariables = { includeTagChipFeeds: false };
+
+const shellStateData = {
+  actions: [{ type: 'my_feed', completedAt: '2024-01-01T00:00:00.000Z' }],
+  userStreak: {
+    max: 5,
+    total: 10,
+    current: 3,
+    lastViewAt: '2024-01-01T00:00:00.000Z',
+    weekStart: 1,
+    freezesAvailable: 0,
+  },
+  feedList: {
+    pageInfo: { endCursor: null, hasNextPage: false },
+    edges: [{ node: { id: 'f1', userId: loggedUser.id } }],
+  },
+};
+
+beforeEach(() => {
+  nock.cleanAll();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: StaleTime.Base } },
+  });
+});
+
+const Wrapper = ({ children }: { children: ReactNode }) => (
+  <TestBootProvider client={queryClient} auth={{ user: loggedUser }}>
+    <ShellStateProvider>{children}</ShellStateProvider>
+  </TestBootProvider>
+);
+
+describe('ShellStateProvider', () => {
+  it('seeds the actions, streak and feed list caches from a single request', async () => {
+    let actionsRequests = 0;
+
+    mockGraphQL({
+      request: { query: SHELL_STATE_QUERY, variables: feedListVariables },
+      result: () => ({ data: shellStateData }),
+    });
+    mockGraphQL({
+      request: { query: COMPLETED_USER_ACTIONS },
+      result: () => {
+        actionsRequests += 1;
+        return { data: { actions: [] } };
+      },
+    });
+
+    renderHook(() => useActions(), { wrapper: Wrapper });
+
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData(
+          generateQueryKey(RequestKey.Actions, loggedUser),
+        ),
+      ).toEqual({ actions: shellStateData.actions, serverLoaded: true }),
+    );
+
+    expect(
+      queryClient.getQueryData(
+        generateQueryKey(RequestKey.UserStreak, loggedUser),
+      ),
+    ).toEqual(shellStateData.userStreak);
+    expect(
+      queryClient.getQueryData(
+        generateQueryKey(RequestKey.Feeds, loggedUser, feedListVariables),
+      ),
+    ).toEqual(shellStateData.feedList);
+    expect(actionsRequests).toEqual(0);
+  });
+
+  it('lets the individual queries run when the merged request fails', async () => {
+    mockGraphQL({
+      request: { query: SHELL_STATE_QUERY, variables: feedListVariables },
+      result: () => ({ errors: [{ message: 'Forbidden' }] }),
+    });
+    mockGraphQL({
+      request: { query: COMPLETED_USER_ACTIONS },
+      result: () => ({ data: { actions: shellStateData.actions } }),
+    });
+
+    const { result } = renderHook(() => useActions(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.isActionsFetched).toEqual(true));
+
+    expect(result.current.actions).toEqual(shellStateData.actions);
+  });
+
+  it('skips seeding the feed list when the returned actions change the variables', async () => {
+    let feedListRequests = 0;
+    const settledFeedList = {
+      pageInfo: { endCursor: null, hasNextPage: false },
+      edges: [{ node: { id: 'f2', userId: loggedUser.id } }],
+    };
+
+    mockGraphQL({
+      request: { query: SHELL_STATE_QUERY, variables: feedListVariables },
+      result: () => ({
+        data: {
+          ...shellStateData,
+          actions: [
+            {
+              type: ActionType.CompletedOnboarding,
+              completedAt: '2024-01-01T00:00:00.000Z',
+            },
+          ],
+        },
+      }),
+    });
+    mockGraphQL({
+      request: {
+        query: FEED_LIST_QUERY,
+        variables: { includeTagChipFeeds: true },
+      },
+      result: () => {
+        feedListRequests += 1;
+        return { data: { feedList: settledFeedList } };
+      },
+    });
+
+    const { result } = renderHook(() => useFeeds(), { wrapper: Wrapper });
+
+    await waitFor(() => expect(result.current.feeds).toEqual(settledFeedList));
+
+    expect(
+      queryClient.getQueryData(
+        generateQueryKey(RequestKey.Feeds, loggedUser, feedListVariables),
+      ),
+    ).toBeUndefined();
+    expect(feedListRequests).toEqual(1);
+  });
+
+  it('asks for the chip feeds up front when boot says the user is seeded', async () => {
+    const seededUser = {
+      ...loggedUser,
+      flags: { tagChipFeedsSeededAt: '2026-01-01T00:00:00.000Z' },
+    };
+    const seededVariables = { includeTagChipFeeds: true };
+    let feedListRequests = 0;
+
+    mockGraphQL({
+      request: { query: SHELL_STATE_QUERY, variables: seededVariables },
+      result: () => ({ data: shellStateData }),
+    });
+    mockGraphQL({
+      request: { query: FEED_LIST_QUERY, variables: seededVariables },
+      result: () => {
+        feedListRequests += 1;
+        return { data: { feedList: shellStateData.feedList } };
+      },
+    });
+
+    const { result } = renderHook(() => useFeeds(), {
+      wrapper: ({ children }) => (
+        <TestBootProvider client={queryClient} auth={{ user: seededUser }}>
+          <ShellStateProvider>{children}</ShellStateProvider>
+        </TestBootProvider>
+      ),
+    });
+
+    await waitFor(() =>
+      expect(result.current.feeds).toEqual(shellStateData.feedList),
+    );
+
+    expect(
+      queryClient.getQueryData(
+        generateQueryKey(RequestKey.Feeds, seededUser, seededVariables),
+      ),
+    ).toEqual(shellStateData.feedList);
+    expect(feedListRequests).toEqual(0);
+  });
+});

--- a/packages/shared/src/contexts/ShellStateProvider.tsx
+++ b/packages/shared/src/contexts/ShellStateProvider.tsx
@@ -1,0 +1,147 @@
+import type { ReactElement, ReactNode } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Action } from '../graphql/actions';
+import type {
+  ShellStateData,
+  ShellStateVariables,
+} from '../graphql/shellState';
+import { SHELL_STATE_QUERY } from '../graphql/shellState';
+import type { LoggedUser } from '../lib/user';
+import { generateQueryKey, RequestKey } from '../lib/query';
+import { disabledRefetch } from '../lib/func';
+import { featureFeedChips } from '../lib/featureManagement';
+import {
+  getFeedListQueryKey,
+  getFeedListVariables,
+  useFeedListVariables,
+} from '../hooks/feed/useFeeds';
+import {
+  DATE_SINCE_ACTIONS_REQUIRED,
+  onboardingCompletedActions,
+} from '../hooks/auth/useOnboardingActions';
+import { useConditionalFeature } from '../hooks/useConditionalFeature';
+import { useGqlBatchingFlag } from '../hooks/useGqlBatchingFlag';
+import { useRequestProtocol } from '../hooks/useRequestProtocol';
+import { useAuthContext } from './AuthContext';
+import { ShellStateContextProvider } from './ShellStateContext';
+
+export type ShellStateProviderProps = {
+  children?: ReactNode;
+};
+
+type ShellStateRequestProps = {
+  onSettled: (userId: string) => void;
+};
+
+const isOnboardingCompleteFromActions = (
+  user: LoggedUser | undefined,
+  actions: Action[],
+): boolean => {
+  if (
+    user?.createdAt &&
+    new Date(user.createdAt) < DATE_SINCE_ACTIONS_REQUIRED
+  ) {
+    return true;
+  }
+
+  const completed = new Set(actions.map(({ type }) => type));
+
+  return Object.values(onboardingCompletedActions).some((required) =>
+    required.every((action) => completed.has(action)),
+  );
+};
+
+const isSameFeedListVariables = (
+  left: ShellStateVariables,
+  right: ShellStateVariables,
+): boolean =>
+  left.includeTagChipFeeds === right.includeTagChipFeeds &&
+  left.tagChipSeedStrategy === right.tagChipSeedStrategy;
+
+const ShellStateRequest = ({ onSettled }: ShellStateRequestProps): null => {
+  const client = useQueryClient();
+  const { user } = useAuthContext();
+  const { requestMethod } = useRequestProtocol();
+  const variables = useFeedListVariables();
+  const variablesRef = useRef(variables);
+  variablesRef.current = variables;
+  const { value: feedChipsVariant } = useConditionalFeature({
+    feature: featureFeedChips,
+    shouldEvaluate: !!user,
+  });
+  const feedChipsVariantRef = useRef(feedChipsVariant);
+  feedChipsVariantRef.current = feedChipsVariant;
+
+  const { isFetched } = useQuery({
+    queryKey: generateQueryKey(RequestKey.ShellState, user),
+    queryFn: async () => {
+      const feedListVariables = variablesRef.current;
+      const data = await requestMethod<ShellStateData>(
+        SHELL_STATE_QUERY,
+        feedListVariables,
+      );
+
+      client.setQueryData(generateQueryKey(RequestKey.Actions, user), {
+        actions: data.actions,
+        serverLoaded: true,
+      });
+      client.setQueryData(
+        generateQueryKey(RequestKey.UserStreak, user),
+        data.userStreak,
+      );
+
+      // The request goes out before the actions are known, so only seed the
+      // feed list key `useFeeds` ends up reading.
+      const settledVariables = getFeedListVariables({
+        feedChipsVariant: feedChipsVariantRef.current,
+        isOnboardingComplete: isOnboardingCompleteFromActions(
+          user,
+          data.actions,
+        ),
+        isTagChipFeedsSeeded: !!user?.flags?.tagChipFeedsSeededAt,
+      });
+
+      if (isSameFeedListVariables(feedListVariables, settledVariables)) {
+        client.setQueryData(getFeedListQueryKey(user, feedListVariables), {
+          edges: data.feedList.edges,
+          pageInfo: data.feedList.pageInfo,
+        });
+      }
+
+      return data;
+    },
+    enabled: !!user,
+    staleTime: Infinity,
+    retry: false,
+    ...disabledRefetch,
+  });
+
+  const userId = user?.id;
+
+  useEffect(() => {
+    if (isFetched && userId) {
+      onSettled(userId);
+    }
+  }, [isFetched, onSettled, userId]);
+
+  return null;
+};
+
+export const ShellStateProvider = ({
+  children,
+}: ShellStateProviderProps): ReactElement => {
+  const { user } = useAuthContext();
+  useGqlBatchingFlag();
+  const [settledUserId, setSettledUserId] = useState<string>();
+  const isSettled = !user || settledUserId === user.id;
+
+  return (
+    <ShellStateContextProvider isSettled={isSettled}>
+      {!!user && (
+        <ShellStateRequest key={user.id} onSettled={setSettledUserId} />
+      )}
+      {children}
+    </ShellStateContextProvider>
+  );
+};

--- a/packages/shared/src/features/hackathon/queries.ts
+++ b/packages/shared/src/features/hackathon/queries.ts
@@ -1,5 +1,5 @@
 import { queryOptions } from '@tanstack/react-query';
-import { gqlClient } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 import {
   HACKATHON_PARTICIPATION_QUERY,
   type HackathonParticipationData,
@@ -13,7 +13,7 @@ export const hackathonParticipationQueryOptions = (
   queryOptions({
     queryKey: generateQueryKey(RequestKey.HackathonParticipation, user),
     queryFn: () =>
-      gqlClient.request<HackathonParticipationData>(
+      gqlBatchRequest<HackathonParticipationData>(
         HACKATHON_PARTICIPATION_QUERY,
       ),
     enabled: !!user?.id,

--- a/packages/shared/src/features/profile/hooks/useProfileShowcase.ts
+++ b/packages/shared/src/features/profile/hooks/useProfileShowcase.ts
@@ -33,6 +33,7 @@ export type UseProfileShowcase<Slice extends keyof ProfileShowcase> =
 export function useProfileShowcase<Slice extends keyof ProfileShowcase>(
   user: ShowcaseUser,
   slice: Slice,
+  { enabled = true }: { enabled?: boolean } = {},
 ): UseProfileShowcase<Slice> {
   const queryClient = useQueryClient();
   const userId = user?.id;
@@ -52,7 +53,7 @@ export function useProfileShowcase<Slice extends keyof ProfileShowcase>(
     queryKey,
     queryFn: () => getProfileShowcase(userId as string),
     select,
-    enabled: !!userId,
+    enabled: !!userId && enabled,
     staleTime: StaleTime.Default,
   });
 

--- a/packages/shared/src/features/profile/hooks/useUserStack.ts
+++ b/packages/shared/src/features/profile/hooks/useUserStack.ts
@@ -19,7 +19,10 @@ import { useProfilePreview } from '../../../hooks/profile/useProfilePreview';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
 
-export function useUserStack(user: PublicProfile | null) {
+export function useUserStack(
+  user: PublicProfile | null,
+  { enabled = true }: { enabled?: boolean } = {},
+) {
   const { isOwner } = useProfilePreview(user);
   const { logEvent } = useLogContext();
 
@@ -27,7 +30,7 @@ export function useUserStack(user: PublicProfile | null) {
     queryKey,
     invalidate: invalidateQuery,
     ...query
-  } = useProfileShowcase(user, 'userStack');
+  } = useProfileShowcase(user, 'userStack', { enabled });
 
   const stackItems = useMemo(
     () => query.data?.edges?.map(({ node }) => node) ?? [],

--- a/packages/shared/src/graphql/actions.ts
+++ b/packages/shared/src/graphql/actions.ts
@@ -80,13 +80,20 @@ export interface Action {
   completedAt: Date;
 }
 
+export const USER_ACTION_FRAGMENT = gql`
+  fragment UserAction on UserAction {
+    type
+    completedAt
+  }
+`;
+
 export const COMPLETED_USER_ACTIONS = gql`
   query CompletedUserActions {
     actions {
-      type
-      completedAt
+      ...UserAction
     }
   }
+  ${USER_ACTION_FRAGMENT}
 `;
 
 export const getUserActions = async (): Promise<Action[]> => {

--- a/packages/shared/src/graphql/batch.spec.ts
+++ b/packages/shared/src/graphql/batch.spec.ts
@@ -1,0 +1,154 @@
+import nock from 'nock';
+import type { ApiErrorResult } from './common';
+import { ApiError, getApiError } from './common';
+import { gqlBatchRequest, setGqlBatchingEnabled } from './batch';
+
+const QUERY_A = `query A {
+  a
+}`;
+const QUERY_B = `query B {
+  b
+}`;
+
+const apiUrl = 'http://localhost:3000';
+
+let bodies: unknown[] = [];
+
+const recordBody = (body: unknown): boolean => {
+  bodies.push(body);
+
+  return true;
+};
+
+beforeEach(() => {
+  nock.cleanAll();
+  bodies = [];
+  setGqlBatchingEnabled(false);
+});
+
+afterEach(() => {
+  setGqlBatchingEnabled(false);
+});
+
+describe('gqlBatchRequest', () => {
+  it('sends one request for calls made in the same window', async () => {
+    setGqlBatchingEnabled(true);
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, [{ data: { a: 1 } }, { data: { b: 2 } }]);
+
+    const [first, second] = await Promise.all([
+      gqlBatchRequest<{ a: number }>(QUERY_A),
+      gqlBatchRequest<{ b: number }>(QUERY_B),
+    ]);
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]).toEqual([
+      { query: QUERY_A, operationName: 'A' },
+      { query: QUERY_B, operationName: 'B' },
+    ]);
+    expect(first).toEqual({ a: 1 });
+    expect(second).toEqual({ b: 2 });
+  });
+
+  it('rejects only the item that returned errors', async () => {
+    setGqlBatchingEnabled(true);
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, [
+        { data: { a: 1 } },
+        {
+          errors: [
+            { message: 'Not found', extensions: { code: ApiError.NotFound } },
+          ],
+        },
+      ]);
+
+    const results = await Promise.allSettled([
+      gqlBatchRequest<{ a: number }>(QUERY_A),
+      gqlBatchRequest<{ b: number }>(QUERY_B),
+    ]);
+
+    expect(results[0]).toMatchObject({ status: 'fulfilled', value: { a: 1 } });
+    expect(results[1].status).toEqual('rejected');
+
+    const { reason } = results[1] as PromiseRejectedResult;
+
+    expect(
+      getApiError(reason as ApiErrorResult, ApiError.NotFound)?.message,
+    ).toEqual('Not found');
+  });
+
+  it('sends a request per call while batching is off', async () => {
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { data: { a: 1 } });
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { data: { b: 2 } });
+
+    await Promise.all([
+      gqlBatchRequest<{ a: number }>(QUERY_A),
+      gqlBatchRequest<{ b: number }>(QUERY_B),
+    ]);
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies.every((body) => !Array.isArray(body))).toBe(true);
+  });
+
+  it('falls back to single requests when the server rejects the array body', async () => {
+    setGqlBatchingEnabled(true);
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { errors: [{ message: 'body must be object' }] });
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { data: { a: 1 } });
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { data: { b: 2 } });
+
+    const [first, second] = await Promise.all([
+      gqlBatchRequest<{ a: number }>(QUERY_A),
+      gqlBatchRequest<{ b: number }>(QUERY_B),
+    ]);
+
+    expect(first).toEqual({ a: 1 });
+    expect(second).toEqual({ b: 2 });
+    expect(bodies).toHaveLength(3);
+    expect(Array.isArray(bodies[0])).toBe(true);
+    expect(bodies.slice(1).every((body) => !Array.isArray(body))).toBe(true);
+
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { data: { a: 3 } });
+
+    const third = await gqlBatchRequest<{ a: number }>(QUERY_A);
+
+    expect(third).toEqual({ a: 3 });
+    expect(bodies).toHaveLength(4);
+    expect(Array.isArray(bodies[3])).toBe(false);
+  });
+
+  it('splits a queue longer than the batch limit', async () => {
+    setGqlBatchingEnabled(true);
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(
+        200,
+        Array.from({ length: 10 }, (_, index) => ({ data: { a: index } })),
+      );
+    nock(apiUrl)
+      .post('/graphql', recordBody)
+      .reply(200, { data: { a: 10 } });
+
+    const results = await Promise.all(
+      Array.from({ length: 11 }, () => gqlBatchRequest<{ a: number }>(QUERY_A)),
+    );
+
+    expect(bodies).toHaveLength(2);
+    expect(bodies[0]).toHaveLength(10);
+    expect(Array.isArray(bodies[1])).toBe(false);
+    expect(results[10]).toEqual({ a: 10 });
+  });
+});

--- a/packages/shared/src/graphql/batch.ts
+++ b/packages/shared/src/graphql/batch.ts
@@ -1,0 +1,241 @@
+import { ClientError } from 'graphql-request';
+import type { GraphQLError } from 'graphql-request/dist/types';
+import { graphqlUrl } from '../lib/config';
+import { gqlClient } from './common';
+
+// The API rejects a longer array with a 400.
+export const GQL_MAX_BATCH_SIZE = 10;
+
+const BATCH_WINDOW = 10;
+const BATCHING_STORAGE_KEY = 'dailydev:gqlBatching';
+
+type BatchItem = {
+  document: string;
+  variables?: Record<string, unknown>;
+  resolve: (data: unknown) => void;
+  reject: (error: unknown) => void;
+};
+
+type BatchResponseItem = {
+  data?: Record<string, unknown> | null;
+  errors?: GraphQLError[];
+};
+
+let batchingEnabled = false;
+let queue: BatchItem[] = [];
+let flushHandle: ReturnType<typeof setTimeout> | undefined;
+
+export const setGqlBatchingEnabled = (enabled: boolean): void => {
+  batchingEnabled = enabled;
+};
+
+const getStorageOverride = (): boolean | undefined => {
+  if (process.env.NODE_ENV === 'production') {
+    return undefined;
+  }
+
+  try {
+    const value = globalThis.localStorage?.getItem(BATCHING_STORAGE_KEY);
+
+    if (value === '1') {
+      return true;
+    }
+
+    if (value === '0') {
+      return false;
+    }
+  } catch {
+    // storage can throw in private mode
+  }
+
+  return undefined;
+};
+
+const isBatchingEnabled = (): boolean =>
+  getStorageOverride() ?? batchingEnabled;
+
+// Mirrors how the `unsetHeader` patch in `common.ts` reaches the client's own
+// headers, so a batch carries the same auth/client headers a single request has.
+const getClientHeaders = (): Record<string, string> => {
+  const options = Reflect.get(gqlClient, 'options');
+  const headers =
+    options && typeof options === 'object'
+      ? Reflect.get(options, 'headers')
+      : undefined;
+
+  if (!headers) {
+    return {};
+  }
+
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    const plain: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      plain[key] = value;
+    });
+
+    return plain;
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers as Array<[string, string]>);
+  }
+
+  if (typeof headers === 'object') {
+    return { ...(headers as Record<string, string>) };
+  }
+
+  return {};
+};
+
+const operationNamePattern = /(?:query|mutation|subscription)\s+(\w+)/;
+
+const getOperationName = (document: string): string | undefined =>
+  document.match(operationNamePattern)?.[1];
+
+const toClientError = (
+  item: BatchItem,
+  response: BatchResponseItem,
+  status: number,
+): ClientError =>
+  new ClientError(
+    { ...response, status },
+    { query: item.document, variables: item.variables },
+  );
+
+const rejectBatch = (items: BatchItem[], status: number, message: string) => {
+  items.forEach((item) => {
+    item.reject(toClientError(item, { errors: [{ message }] }, status));
+  });
+};
+
+const requestSingle = async (item: BatchItem): Promise<void> => {
+  try {
+    item.resolve(await gqlClient.request(item.document, item.variables));
+  } catch (error) {
+    item.reject(error);
+  }
+};
+
+// A server without batching answers the array body with a plain object, so the
+// items are retried one by one and the session stops sending arrays.
+const fallbackToSingleRequests = async (items: BatchItem[]): Promise<void> => {
+  setGqlBatchingEnabled(false);
+
+  await Promise.all(items.map(requestSingle));
+};
+
+const flush = async (): Promise<void> => {
+  flushHandle = undefined;
+
+  const items = queue.slice(0, GQL_MAX_BATCH_SIZE);
+  queue = queue.slice(GQL_MAX_BATCH_SIZE);
+
+  // Anything over the API's cap waits for the next window.
+  if (queue.length) {
+    flushHandle = setTimeout(flush, BATCH_WINDOW);
+  }
+
+  if (!items.length) {
+    return;
+  }
+
+  if (items.length === 1) {
+    await requestSingle(items[0]);
+
+    return;
+  }
+
+  const body = items.map(({ document, variables }) => {
+    const operationName = getOperationName(document);
+
+    return {
+      query: document,
+      variables,
+      ...(operationName && { operationName }),
+    };
+  });
+
+  let response: Response;
+
+  try {
+    response = await globalThis.fetch(graphqlUrl, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { ...getClientHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    rejectBatch(items, 0, (error as Error)?.message ?? 'Network error');
+
+    return;
+  }
+
+  if (!response.ok) {
+    rejectBatch(items, response.status, 'GraphQL batch request failed');
+
+    return;
+  }
+
+  let payload: unknown;
+
+  try {
+    payload = await response.json();
+  } catch {
+    payload = undefined;
+  }
+
+  if (!Array.isArray(payload)) {
+    await fallbackToSingleRequests(items);
+
+    return;
+  }
+
+  if (payload.length !== items.length) {
+    rejectBatch(items, response.status, 'Malformed GraphQL batch response');
+
+    return;
+  }
+
+  const results = payload as BatchResponseItem[];
+
+  items.forEach((item, index) => {
+    const result = results[index];
+
+    if (result?.data && !result.errors?.length) {
+      item.resolve(result.data);
+
+      return;
+    }
+
+    item.reject(toClientError(item, result ?? {}, response.status));
+  });
+};
+
+const scheduleFlush = () => {
+  if (flushHandle) {
+    return;
+  }
+
+  flushHandle = setTimeout(flush, BATCH_WINDOW);
+};
+
+// Queries opt into this instead of `gqlClient.request` so several secondary
+// requests fired in the same tick leave as one POST. Mutations never do.
+export const gqlBatchRequest = <T>(
+  document: string,
+  variables?: Record<string, unknown>,
+): Promise<T> => {
+  if (typeof window === 'undefined' || !isBatchingEnabled()) {
+    return gqlClient.request<T>(document, variables);
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    queue.push({
+      document,
+      variables,
+      resolve: resolve as (data: unknown) => void,
+      reject,
+    });
+    scheduleFlush();
+  });
+};

--- a/packages/shared/src/graphql/bookmarks.ts
+++ b/packages/shared/src/graphql/bookmarks.ts
@@ -1,6 +1,7 @@
 import { gql } from 'graphql-request';
 import type { EmptyResponse } from './emptyResponse';
 import { gqlClient } from './common';
+import { gqlBatchRequest } from './batch';
 
 export const SET_BOOKMARK_REMINDER = gql`
   mutation SetBookmarkReminder($postId: ID!, $remindAt: DateTime) {
@@ -72,11 +73,9 @@ export const GET_BOOKMARK_FOLDERS = gql`
 `;
 
 export const getBookmarkFolders = async (): Promise<BookmarkFolder[]> => {
-  return gqlClient
-    .request<{
-      bookmarkLists: Array<BookmarkFolder>;
-    }>(GET_BOOKMARK_FOLDERS)
-    .then((data) => data.bookmarkLists);
+  return gqlBatchRequest<{
+    bookmarkLists: Array<BookmarkFolder>;
+  }>(GET_BOOKMARK_FOLDERS).then((data) => data.bookmarkLists);
 };
 
 export const CREATE_BOOKMARK_FOLDER = gql`

--- a/packages/shared/src/graphql/feed.ts
+++ b/packages/shared/src/graphql/feed.ts
@@ -806,6 +806,21 @@ export const PREVIEW_FEED_QUERY = gql`
   ${FEED_POST_CONNECTION_FRAGMENT}
 `;
 
+export const FEED_LIST_CONNECTION_FRAGMENT = gql`
+  fragment FeedListConnection on FeedConnection {
+    pageInfo {
+      endCursor
+      hasNextPage
+    }
+    edges {
+      node {
+        ...CustomFeed
+      }
+    }
+  }
+  ${CUSTOM_FEED_FRAGMENT}
+`;
+
 export const FEED_LIST_QUERY = gql`
   query FeedList(
     $includeTagChipFeeds: Boolean
@@ -815,18 +830,10 @@ export const FEED_LIST_QUERY = gql`
       includeTagChipFeeds: $includeTagChipFeeds
       tagChipSeedStrategy: $tagChipSeedStrategy
     ) {
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      edges {
-        node {
-          ...CustomFeed
-        }
-      }
+      ...FeedListConnection
     }
   }
-  ${CUSTOM_FEED_FRAGMENT}
+  ${FEED_LIST_CONNECTION_FRAGMENT}
 `;
 
 export const CUSTOM_FEED_QUERY = gql`

--- a/packages/shared/src/graphql/notifications.ts
+++ b/packages/shared/src/graphql/notifications.ts
@@ -3,6 +3,7 @@ import type { NotificationIconType } from '../components/notifications/utils';
 import { NotificationType } from '../components/notifications/utils';
 import type { Connection } from './common';
 import { gqlClient } from './common';
+import { gqlBatchRequest } from './batch';
 import type { EmptyResponse } from './emptyResponse';
 import type { WithClassNameProps } from '../components/utilities';
 
@@ -247,9 +248,9 @@ type FetchParams = Pick<
 export const getNotificationPreferences = async (
   params: FetchParams[],
 ): Promise<NotificationPreference[]> => {
-  const res = await gqlClient.request(NOTIFICATION_PREFERENCES_QUERY, {
-    data: params,
-  });
+  const res = await gqlBatchRequest<{
+    notificationPreferences: NotificationPreference[];
+  }>(NOTIFICATION_PREFERENCES_QUERY, { data: params });
 
   return res.notificationPreferences;
 };

--- a/packages/shared/src/graphql/shellState.ts
+++ b/packages/shared/src/graphql/shellState.ts
@@ -1,0 +1,42 @@
+import { gql } from 'graphql-request';
+import type { Action } from './actions';
+import { USER_ACTION_FRAGMENT } from './actions';
+import type { Connection } from './common';
+import type { Feed, TagChipSeedStrategy } from './feed';
+import { FEED_LIST_CONNECTION_FRAGMENT } from './feed';
+import { USER_STREAK_FRAGMENT } from './fragments';
+import type { UserStreak } from './users';
+
+export type ShellStateVariables = {
+  includeTagChipFeeds: boolean;
+  tagChipSeedStrategy?: TagChipSeedStrategy;
+};
+
+export type ShellStateData = {
+  actions: Action[];
+  userStreak: UserStreak;
+  feedList: Connection<Feed>;
+};
+
+export const SHELL_STATE_QUERY = gql`
+  query ShellState(
+    $includeTagChipFeeds: Boolean
+    $tagChipSeedStrategy: TagChipSeedStrategy
+  ) {
+    actions {
+      ...UserAction
+    }
+    userStreak {
+      ...UserStreakFragment
+    }
+    feedList(
+      includeTagChipFeeds: $includeTagChipFeeds
+      tagChipSeedStrategy: $tagChipSeedStrategy
+    ) {
+      ...FeedListConnection
+    }
+  }
+  ${USER_ACTION_FRAGMENT}
+  ${USER_STREAK_FRAGMENT}
+  ${FEED_LIST_CONNECTION_FRAGMENT}
+`;

--- a/packages/shared/src/graphql/sources.ts
+++ b/packages/shared/src/graphql/sources.ts
@@ -2,6 +2,7 @@ import { gql } from 'graphql-request';
 import type { UserShortProfile } from '../lib/user';
 import type { Connection } from './common';
 import { gqlClient } from './common';
+import { gqlBatchRequest } from './batch';
 import {
   SOURCE_CATEGORY_FRAGMENT,
   SOURCE_DIRECTORY_INFO_FRAGMENT,
@@ -252,11 +253,44 @@ export interface SourceCategoryData {
   categories: Connection<SourceCategory>;
 }
 
+// Dock shortcuts and sidebar Recent rows persist the entity image with their
+// entry, so this only backfills the ones written before it was recorded.
+export const SOURCE_IMAGE_QUERY = gql`
+  query SourceImage($id: ID!) {
+    source(id: $id) {
+      id
+      handle
+      image
+    }
+  }
+`;
+
+export const sourceImageQueryOptions = ({
+  handle,
+  enabled,
+}: {
+  handle: string;
+  enabled: boolean;
+}) => {
+  return {
+    queryKey: [RequestKey.Source, null, handle, 'image'],
+    queryFn: async () => {
+      const res = await gqlBatchRequest<{
+        source: Pick<Source, 'id' | 'handle' | 'image'>;
+      }>(SOURCE_IMAGE_QUERY, { id: handle });
+
+      return res.source;
+    },
+    staleTime: StaleTime.OneHour,
+    enabled: enabled && !!handle,
+  };
+};
+
 export const sourceQueryOptions = ({ sourceId }: { sourceId: string }) => {
   return {
     queryKey: [RequestKey.Source, null, sourceId],
     queryFn: async () => {
-      const res = await gqlClient.request<SourceData>(SOURCE_QUERY, {
+      const res = await gqlBatchRequest<SourceData>(SOURCE_QUERY, {
         id: sourceId,
       });
 

--- a/packages/shared/src/graphql/user/achievements.ts
+++ b/packages/shared/src/graphql/user/achievements.ts
@@ -1,5 +1,6 @@
 import { gql } from 'graphql-request';
 import { gqlClient } from '../common';
+import { gqlBatchRequest } from '../batch';
 
 export enum AchievementType {
   Instant = 'instant',
@@ -109,34 +110,47 @@ export const ACHIEVEMENTS_QUERY = gql`
   ${ACHIEVEMENT_FRAGMENT}
 `;
 
+export const USER_ACHIEVEMENT_FRAGMENT = gql`
+  fragment UserAchievementFragment on UserAchievement {
+    achievement {
+      ...AchievementFragment
+    }
+    progress
+    unlockedAt
+    createdAt
+    updatedAt
+  }
+  ${ACHIEVEMENT_FRAGMENT}
+`;
+
 export const USER_ACHIEVEMENTS_QUERY = gql`
   query UserAchievements($userId: ID!) {
     userAchievements(userId: $userId) {
-      achievement {
-        ...AchievementFragment
-      }
-      progress
-      unlockedAt
-      createdAt
-      updatedAt
+      ...UserAchievementFragment
     }
   }
-  ${ACHIEVEMENT_FRAGMENT}
+  ${USER_ACHIEVEMENT_FRAGMENT}
 `;
 
 export const TRACKED_ACHIEVEMENT_QUERY = gql`
   query TrackedAchievement {
     trackedAchievement {
-      achievement {
-        ...AchievementFragment
-      }
-      progress
-      unlockedAt
-      createdAt
-      updatedAt
+      ...UserAchievementFragment
     }
   }
-  ${ACHIEVEMENT_FRAGMENT}
+  ${USER_ACHIEVEMENT_FRAGMENT}
+`;
+
+export const ACHIEVEMENT_TRACKER_QUERY = gql`
+  query AchievementTracker($userId: ID!) {
+    userAchievements(userId: $userId) {
+      ...UserAchievementFragment
+    }
+    trackedAchievement {
+      ...UserAchievementFragment
+    }
+  }
+  ${USER_ACHIEVEMENT_FRAGMENT}
 `;
 
 export const TRACK_ACHIEVEMENT_MUTATION = gql`
@@ -243,16 +257,28 @@ export const getAchievements = async (): Promise<Achievement[]> => {
 export const getUserAchievements = async (
   userId: string,
 ): Promise<UserAchievement[]> => {
-  const result = await gqlClient.request<UserAchievementsData>(
+  const result = await gqlBatchRequest<UserAchievementsData>(
     USER_ACHIEVEMENTS_QUERY,
     { userId },
   );
   return result.userAchievements;
 };
 
+export type AchievementTrackerData = {
+  userAchievements: UserAchievement[];
+  trackedAchievement: UserAchievement | null;
+};
+
+export const getAchievementTracker = async (
+  userId: string,
+): Promise<AchievementTrackerData> =>
+  gqlBatchRequest<AchievementTrackerData>(ACHIEVEMENT_TRACKER_QUERY, {
+    userId,
+  });
+
 export const getTrackedAchievement =
   async (): Promise<UserAchievement | null> => {
-    const result = await gqlClient.request<TrackedAchievementData>(
+    const result = await gqlBatchRequest<TrackedAchievementData>(
       TRACKED_ACHIEVEMENT_QUERY,
     );
 

--- a/packages/shared/src/graphql/user/profileShowcase.ts
+++ b/packages/shared/src/graphql/user/profileShowcase.ts
@@ -1,6 +1,6 @@
 import { gql } from 'graphql-request';
 import type { Connection } from '../common';
-import { gqlClient } from '../common';
+import { gqlBatchRequest } from '../batch';
 import type { UserStack } from './userStack';
 import { MAX_STACK_ITEMS, USER_STACK_FRAGMENT } from './userStack';
 import type { HotTake } from './userHotTake';
@@ -79,7 +79,7 @@ const PROFILE_SHOWCASE_QUERY = gql`
 `;
 
 export const getProfileShowcase = (userId: string): Promise<ProfileShowcase> =>
-  gqlClient.request<ProfileShowcase>(PROFILE_SHOWCASE_QUERY, {
+  gqlBatchRequest<ProfileShowcase>(PROFILE_SHOWCASE_QUERY, {
     userId,
     stackFirst: MAX_STACK_ITEMS,
     first: 50,

--- a/packages/shared/src/hooks/contentPreference/useContentPreferenceStatusQuery.ts
+++ b/packages/shared/src/hooks/contentPreference/useContentPreferenceStatusQuery.ts
@@ -8,7 +8,8 @@ import { CONTENT_PREFERENCE_STATUS_QUERY } from '../../graphql/contentPreference
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { useAuthContext } from '../../contexts/AuthContext';
 import type { ApiErrorResult } from '../../graphql/common';
-import { ApiError, gqlClient } from '../../graphql/common';
+import { ApiError } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 import { useMutationSubscription } from '../mutationSubscription/useMutationSubscription';
 import type { ContentPreferenceMutation } from './types';
 import {
@@ -50,7 +51,7 @@ export const useContentPreferenceStatusQuery = ({
       ];
 
       try {
-        const result = await gqlClient.request<{
+        const result = await gqlBatchRequest<{
           contentPreferenceStatus: ContentPreference;
         }>(CONTENT_PREFERENCE_STATUS_QUERY, queryVariables);
 

--- a/packages/shared/src/hooks/feed/useFeeds.ts
+++ b/packages/shared/src/hooks/feed/useFeeds.ts
@@ -8,6 +8,8 @@ import {
   DELETE_FEED_MUTATION,
   TagChipSeedStrategy,
 } from '../../graphql/feed';
+import type { ShellStateVariables } from '../../graphql/shellState';
+import type { LoggedUser } from '../../lib/user';
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { labels } from '../../lib';
@@ -19,6 +21,7 @@ import {
   FeedChipsVariant,
   featureFeedChips,
 } from '../../lib/featureManagement';
+import { useShellState } from '../../contexts/ShellStateContext';
 
 export type CreateFeedProps = {
   name: string;
@@ -36,27 +39,65 @@ export type UseFeeds = {
   deleteFeed: (props: DeleteFeedProps) => Promise<Pick<Feed, 'id'>>;
 };
 
-export const useFeeds = (): UseFeeds => {
-  const queryClient = useQueryClient();
-  const { displayToast } = useToastNotification();
-  const { user, feeds: bootFeeds } = useAuthContext();
+export type FeedListVariablesProps = {
+  feedChipsVariant: string;
+  isOnboardingComplete: boolean;
+  isTagChipFeedsSeeded?: boolean;
+};
+
+export const getFeedListVariables = ({
+  feedChipsVariant,
+  isOnboardingComplete,
+  isTagChipFeedsSeeded,
+}: FeedListVariablesProps): ShellStateVariables => {
+  const includeTagChipFeeds =
+    feedChipsVariant !== FeedChipsVariant.None &&
+    (isOnboardingComplete || !!isTagChipFeedsSeeded);
+  const tagChipSeedStrategy =
+    includeTagChipFeeds && feedChipsVariant === FeedChipsVariant.V3
+      ? TagChipSeedStrategy.V3
+      : undefined;
+
+  return {
+    includeTagChipFeeds,
+    ...(tagChipSeedStrategy && { tagChipSeedStrategy }),
+  };
+};
+
+export const useFeedListVariables = (): ShellStateVariables => {
+  const { user } = useAuthContext();
   const { isOnboardingComplete } = useOnboardingActions();
 
   const { value: feedChipsVariant } = useConditionalFeature({
     feature: featureFeedChips,
     shouldEvaluate: !!user,
   });
-  const includeTagChipFeeds =
-    feedChipsVariant !== FeedChipsVariant.None && isOnboardingComplete;
-  const tagChipSeedStrategy =
-    includeTagChipFeeds && feedChipsVariant === FeedChipsVariant.V3
-      ? TagChipSeedStrategy.V3
-      : undefined;
 
-  const queryKey = generateQueryKey(RequestKey.Feeds, user, {
-    includeTagChipFeeds,
-    ...(tagChipSeedStrategy && { tagChipSeedStrategy }),
-  });
+  const isTagChipFeedsSeeded = !!user?.flags?.tagChipFeedsSeededAt;
+
+  return useMemo(
+    () =>
+      getFeedListVariables({
+        feedChipsVariant,
+        isOnboardingComplete,
+        isTagChipFeedsSeeded,
+      }),
+    [feedChipsVariant, isOnboardingComplete, isTagChipFeedsSeeded],
+  );
+};
+
+export const getFeedListQueryKey = (
+  user: Pick<LoggedUser, 'id'> | undefined,
+  variables: ShellStateVariables,
+): unknown[] => generateQueryKey(RequestKey.Feeds, user, variables);
+
+export const useFeeds = (): UseFeeds => {
+  const queryClient = useQueryClient();
+  const { displayToast } = useToastNotification();
+  const { user, feeds: bootFeeds } = useAuthContext();
+  const { isSettled } = useShellState();
+  const variables = useFeedListVariables();
+  const queryKey = getFeedListQueryKey(user, variables);
 
   const initialData: FeedList['feedList'] | undefined = useMemo(() => {
     if (!bootFeeds) {
@@ -73,14 +114,14 @@ export const useFeeds = (): UseFeeds => {
     queryKey,
 
     queryFn: async () => {
-      const result = await gqlClient.request<FeedList>(FEED_LIST_QUERY, {
-        includeTagChipFeeds,
-        ...(tagChipSeedStrategy && { tagChipSeedStrategy }),
-      });
+      const result = await gqlClient.request<FeedList>(
+        FEED_LIST_QUERY,
+        variables,
+      );
 
       return result.feedList;
     },
-    enabled: !!user,
+    enabled: !!user && isSettled,
     initialData,
     initialDataUpdatedAt: 0, // to interim force re-fetch until we sunset boot feeds data
     staleTime: StaleTime.OneHour,

--- a/packages/shared/src/hooks/notifications/useReadingReminderHero.ts
+++ b/packages/shared/src/hooks/notifications/useReadingReminderHero.ts
@@ -24,6 +24,7 @@ interface UseReadingReminderHero {
 
 interface UseReadingReminderHeroProps {
   requireMobile?: boolean;
+  enabled?: boolean;
 }
 
 const DEFAULT_READING_REMINDER_HOUR = 9;
@@ -50,6 +51,7 @@ const getIsRegisteredToday = (createdAt?: string | Date): boolean => {
 
 export const useReadingReminderHero = ({
   requireMobile = true,
+  enabled = true,
 }: UseReadingReminderHeroProps = {}): UseReadingReminderHero => {
   const { isLoggedIn, user } = useAuthContext();
   const { logEvent } = useLogContext();
@@ -58,7 +60,7 @@ export const useReadingReminderHero = ({
     getPersonalizedDigest,
     isLoading: isDigestLoading,
     subscribePersonalizedDigest,
-  } = usePersonalizedDigest();
+  } = usePersonalizedDigest({ enabled });
   const [lastSeen, setLastSeen, isFetched] = usePersistentContext<
     string | null
   >(PersistentContextKeys.ReadingReminderLastSeen, null);
@@ -74,6 +76,7 @@ export const useReadingReminderHero = ({
   const isMobile = useViewSize(ViewSize.MobileL);
   const isEligibleViewSize = !requireMobile || isMobile;
   const shouldEvaluate =
+    enabled &&
     isEligibleViewSize &&
     isLoggedIn &&
     !isDigestLoading &&

--- a/packages/shared/src/hooks/post/usePostCodeSnippets.ts
+++ b/packages/shared/src/hooks/post/usePostCodeSnippets.ts
@@ -17,7 +17,7 @@ import {
   StaleTime,
 } from '../../lib/query';
 import type { Connection } from '../../graphql/common';
-import { gqlClient } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 
 type UsePostCodeSnippetsData = Connection<PostCodeSnippet>;
 
@@ -46,7 +46,7 @@ export const usePostCodeSnippetsQuery = ({
       id: postId,
     }),
     queryFn: async ({ pageParam }) => {
-      const result = await gqlClient.request<{
+      const result = await gqlBatchRequest<{
         postCodeSnippets: UsePostCodeSnippetsData;
       }>(POST_CODE_SNIPPETS_QUERY, {
         id: postId,

--- a/packages/shared/src/hooks/post/useRelatedPosts.ts
+++ b/packages/shared/src/hooks/post/useRelatedPosts.ts
@@ -18,6 +18,7 @@ import {
   RequestKey,
   StaleTime,
 } from '../../lib/query';
+import { gqlBatchRequest } from '../../graphql/batch';
 import { useRequestProtocol } from '../useRequestProtocol';
 
 export type UseRelatedPostsProps = {
@@ -41,7 +42,7 @@ export const useRelatedPosts = ({
   relationType,
   perPage = RELATED_POSTS_PER_PAGE_DEFAULT,
 }: UseRelatedPostsProps): UseRelatedPosts => {
-  const { requestMethod } = useRequestProtocol();
+  const { requestMethod, isCompanion } = useRequestProtocol();
   const queryClient = useQueryClient();
 
   const {
@@ -56,14 +57,23 @@ export const useRelatedPosts = ({
       type: relationType,
     }),
     queryFn: async ({ pageParam }) => {
-      const result = await requestMethod<{
-        relatedPosts: RelatedPostsQueryData;
-      }>(RELATED_POSTS_QUERY, {
+      const variables = {
         id: postId,
         relationType,
         first: perPage,
         after: pageParam,
-      });
+      };
+      // The companion runs its own request protocol; everywhere else this is a
+      // secondary widget query, so it rides the batch.
+      const result = await (isCompanion
+        ? requestMethod<{ relatedPosts: RelatedPostsQueryData }>(
+            RELATED_POSTS_QUERY,
+            variables,
+          )
+        : gqlBatchRequest<{ relatedPosts: RelatedPostsQueryData }>(
+            RELATED_POSTS_QUERY,
+            variables,
+          ));
 
       return result.relatedPosts;
     },

--- a/packages/shared/src/hooks/profile/useAchievementTracker.ts
+++ b/packages/shared/src/hooks/profile/useAchievementTracker.ts
@@ -1,0 +1,41 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { getAchievementTracker } from '../../graphql/user/achievements';
+import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
+import { disabledRefetch } from '../../lib/func';
+import { useAuthContext } from '../../contexts/AuthContext';
+
+interface UseAchievementTracker {
+  isSettled: boolean;
+}
+
+export const useAchievementTracker = (
+  shouldQuery: boolean,
+): UseAchievementTracker => {
+  const queryClient = useQueryClient();
+  const { user } = useAuthContext();
+  const enabled = !!user?.id && shouldQuery;
+
+  const { isFetched } = useQuery({
+    queryKey: generateQueryKey(RequestKey.AchievementTracker, user),
+    queryFn: async () => {
+      const data = await getAchievementTracker(user!.id);
+
+      queryClient.setQueryData(
+        generateQueryKey(RequestKey.UserAchievements, user, 'profile'),
+        data.userAchievements,
+      );
+      queryClient.setQueryData(
+        generateQueryKey(RequestKey.TrackedAchievement, user, 'profile'),
+        data.trackedAchievement,
+      );
+
+      return data;
+    },
+    staleTime: StaleTime.Default,
+    retry: false,
+    enabled,
+    ...disabledRefetch,
+  });
+
+  return { isSettled: !enabled || isFetched };
+};

--- a/packages/shared/src/hooks/squads/useSquadPendingPosts.ts
+++ b/packages/shared/src/hooks/squads/useSquadPendingPosts.ts
@@ -17,7 +17,7 @@ import {
 } from '../../lib/query';
 import { useAuthContext } from '../../contexts/AuthContext';
 import type { Connection } from '../../graphql/common';
-import { gqlClient } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 import { SourcePermissions } from '../../graphql/sources';
 
 type UseSquadPendingPosts = UseInfiniteQueryResult<
@@ -53,15 +53,13 @@ export const useSquadPendingPosts = ({
       status,
     ),
     queryFn: async ({ pageParam }) => {
-      return gqlClient
-        .request<{
-          sourcePostModerations: Connection<SourcePostModeration[]>;
-        }>(SQUAD_PENDING_POSTS_QUERY, {
-          sourceId: squadId,
-          status,
-          after: pageParam,
-        })
-        .then((res) => res.sourcePostModerations);
+      return gqlBatchRequest<{
+        sourcePostModerations: Connection<SourcePostModeration[]>;
+      }>(SQUAD_PENDING_POSTS_QUERY, {
+        sourceId: squadId,
+        status,
+        after: pageParam,
+      }).then((res) => res.sourcePostModerations);
     },
     initialPageParam: '',
     getNextPageParam: (lastPage) => getNextPageParam(lastPage?.pageInfo),

--- a/packages/shared/src/hooks/streaks/useReadingStreak.ts
+++ b/packages/shared/src/hooks/streaks/useReadingStreak.ts
@@ -14,6 +14,7 @@ import type { ResponseError } from '../../graphql/common';
 import { gqlClient } from '../../graphql/common';
 import type { DayOfWeek } from '../../lib/date';
 import { isSameDayInTimezone } from '../../lib/timezones';
+import { useShellState } from '../../contexts/ShellStateContext';
 
 type UpdateReadingStreakConfig = {
   weekStart: DayOfWeek;
@@ -34,6 +35,7 @@ interface UserReadingStreak {
 
 export const useReadingStreak = (): UserReadingStreak => {
   const { user, isLoggedIn } = useAuthContext();
+  const { isSettled } = useShellState();
   const { optOutReadingStreak, loadedSettings } = useContext(SettingsContext);
   const queryClient = useQueryClient();
   const queryKey = generateQueryKey(RequestKey.UserStreak, user);
@@ -42,7 +44,7 @@ export const useReadingStreak = (): UserReadingStreak => {
     queryKey,
     queryFn: getReadingStreak,
     staleTime: StaleTime.Default,
-    enabled: isLoggedIn,
+    enabled: isLoggedIn && isSettled,
     refetchIntervalInBackground: true,
   });
 

--- a/packages/shared/src/hooks/useActions.ts
+++ b/packages/shared/src/hooks/useActions.ts
@@ -5,6 +5,7 @@ import type { Action, ActionType } from '../graphql/actions';
 import { completeUserAction, getUserActions } from '../graphql/actions';
 import { generateQueryKey, RequestKey } from '../lib/query';
 import { disabledRefetch } from '../lib/func';
+import { useShellState } from '../contexts/ShellStateContext';
 
 interface UseActions {
   actions: Action[];
@@ -21,6 +22,7 @@ interface ActionQueryData {
 export const useActions = (): UseActions => {
   const client = useQueryClient();
   const { user } = useAuthContext();
+  const { isSettled } = useShellState();
   const actionsKey = generateQueryKey(RequestKey.Actions, user);
 
   const { data, isPending } = useQuery({
@@ -39,7 +41,7 @@ export const useActions = (): UseActions => {
 
       return { actions: [...current, ...filtered], serverLoaded: true };
     },
-    enabled: !!user,
+    enabled: !!user && isSettled,
     ...disabledRefetch,
   });
 

--- a/packages/shared/src/hooks/useBanner.ts
+++ b/packages/shared/src/hooks/useBanner.ts
@@ -4,7 +4,7 @@ import AlertContext from '../contexts/AlertContext';
 import { generateQueryKey, RequestKey } from '../lib/query';
 import type { Banner } from '../graphql/banner';
 import { BANNER_QUERY } from '../graphql/banner';
-import { gqlClient } from '../graphql/common';
+import { gqlBatchRequest } from '../graphql/batch';
 import { hackathonParticipationQueryOptions } from '../features/hackathon/queries';
 import { useAuthContext } from '../contexts/AuthContext';
 
@@ -21,7 +21,9 @@ export function useBanner(): UseBanner {
   const { data: latestBanner } = useQuery({
     queryKey: generateQueryKey(RequestKey.Banner, null),
     queryFn: () =>
-      gqlClient.request(BANNER_QUERY, { lastSeen: alerts.lastBanner }),
+      gqlBatchRequest<{ banner?: Banner }>(BANNER_QUERY, {
+        lastSeen: alerts.lastBanner,
+      }),
     enabled: !!alerts.banner,
   });
 
@@ -42,7 +44,7 @@ export function useBanner(): UseBanner {
     }
 
     const lastSeenBannerDate = Date.parse(alerts?.lastBanner);
-    const latestBannerDate = Date.parse(latestBanner?.banner?.timestamp);
+    const latestBannerDate = Date.parse(latestBanner?.banner?.timestamp ?? '');
 
     if (Number.isNaN(latestBannerDate) || Number.isNaN(lastSeenBannerDate)) {
       return false;

--- a/packages/shared/src/hooks/useFeedSettings.ts
+++ b/packages/shared/src/hooks/useFeedSettings.ts
@@ -11,7 +11,7 @@ import AuthContext from '../contexts/AuthContext';
 import type { LoggedUser } from '../lib/user';
 import { disabledRefetch } from '../lib/func';
 import { RequestKey, StaleTime } from '../lib/query';
-import { gqlClient } from '../graphql/common';
+import { gqlBatchRequest } from '../graphql/batch';
 
 export const getFeedSettingsQueryKey = (
   user?: LoggedUser,
@@ -47,13 +47,9 @@ export default function useFeedSettings({
   const { data: feedQuery = {}, isPending } = useQuery<AllTagCategoriesData>({
     queryKey: filtersKey,
     queryFn: () =>
-      gqlClient.request(
+      gqlBatchRequest<AllTagCategoriesData>(
         FEED_SETTINGS_QUERY,
-        feedId
-          ? {
-              feedId,
-            }
-          : undefined,
+        feedId ? { feedId } : undefined,
       ),
     ...disabledRefetch,
     enabled: enabled && !!user,

--- a/packages/shared/src/hooks/useGqlBatchingFlag.ts
+++ b/packages/shared/src/hooks/useGqlBatchingFlag.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { useFeature } from '../components/GrowthBookProvider';
+import { featureGqlBatching } from '../lib/featureManagement';
+import { setGqlBatchingEnabled } from '../graphql/batch';
+
+// The transport is module state, so one mount in the shell drives it for every
+// query. The companion content script keeps its own request protocol and never
+// goes through here.
+export const useGqlBatchingFlag = (): void => {
+  const isEnabled = useFeature(featureGqlBatching);
+
+  useEffect(() => {
+    setGqlBatchingEnabled(!!isEnabled);
+  }, [isEnabled]);
+};

--- a/packages/shared/src/hooks/useMarketingCtas.ts
+++ b/packages/shared/src/hooks/useMarketingCtas.ts
@@ -8,6 +8,7 @@ import {
   type MarketingCtaVariant,
 } from '../components/marketing/cta/common';
 import { gqlClient } from '../graphql/common';
+import { gqlBatchRequest } from '../graphql/batch';
 import { MARKETING_CTAS_BY_VARIANT_QUERY } from '../graphql/marketingCta';
 import { CLEAR_MARKETING_CTA_MUTATION } from '../graphql/users';
 import type { Boot } from '../lib/boot';
@@ -43,7 +44,7 @@ export function useMarketingCtas(
   const { data, isLoading } = useQuery({
     queryKey,
     queryFn: async () => {
-      const res = await gqlClient.request<MarketingCtasResponse>(
+      const res = await gqlBatchRequest<MarketingCtasResponse>(
         MARKETING_CTAS_BY_VARIANT_QUERY,
         { variant },
       );

--- a/packages/shared/src/hooks/usePersonalizedDigest.ts
+++ b/packages/shared/src/hooks/usePersonalizedDigest.ts
@@ -13,6 +13,7 @@ import {
 import { RequestKey, StaleTime, generateQueryKey } from '../lib/query';
 import { useAuthContext } from '../contexts/AuthContext';
 import { ApiError, getApiError, gqlClient } from '../graphql/common';
+import { gqlBatchRequest } from '../graphql/batch';
 import type { ApiErrorResult } from '../graphql/common';
 
 export enum SendType {
@@ -51,7 +52,13 @@ type UnsubscribePersonalizedDigestParams =
     }
   | undefined;
 
-export const usePersonalizedDigest = (): UsePersonalizedDigest => {
+interface UsePersonalizedDigestProps {
+  enabled?: boolean;
+}
+
+export const usePersonalizedDigest = ({
+  enabled = true,
+}: UsePersonalizedDigestProps = {}): UsePersonalizedDigest => {
   const { isLoggedIn, user } = useAuthContext();
   const queryClient = useQueryClient();
   const queryKey = generateQueryKey(RequestKey.PersonalizedDigest, user);
@@ -60,7 +67,7 @@ export const usePersonalizedDigest = (): UsePersonalizedDigest => {
     queryKey,
     queryFn: async () => {
       try {
-        const result = await gqlClient.request<{
+        const result = await gqlBatchRequest<{
           personalizedDigest: UserPersonalizedDigest[];
         }>(GET_PERSONALIZED_DIGEST_SETTINGS, {});
 
@@ -80,7 +87,7 @@ export const usePersonalizedDigest = (): UsePersonalizedDigest => {
         throw error;
       }
     },
-    enabled: isLoggedIn,
+    enabled: isLoggedIn && enabled,
     staleTime: StaleTime.Default,
   });
 

--- a/packages/shared/src/hooks/useQuestDashboard.ts
+++ b/packages/shared/src/hooks/useQuestDashboard.ts
@@ -26,7 +26,7 @@ export const useQuestDashboard = ({
       return result.questDashboard;
     },
     enabled: isLoggedIn && enabled,
-    staleTime: StaleTime.OneMinute,
+    staleTime: StaleTime.Default,
     retry: false,
   });
 };

--- a/packages/shared/src/hooks/useRecentPages.ts
+++ b/packages/shared/src/hooks/useRecentPages.ts
@@ -1,11 +1,16 @@
 import { useEffect, useSyncExternalStore } from 'react';
 import { useRouter } from 'next/router';
-import type { RecentPage, RecentPageType } from '../lib/recentPages';
+import type {
+  RecentPage,
+  RecentPageMeta,
+  RecentPageType,
+} from '../lib/recentPages';
 import { withoutLayoutVariantPrefix } from '../lib/layoutVariant';
 import {
   getRecentPages,
   recordRecentPage,
   subscribeRecentPages,
+  updateRecentPageMeta,
 } from '../lib/recentPages';
 
 const EMPTY: RecentPage[] = [];
@@ -13,6 +18,22 @@ const getServerSnapshot = (): RecentPage[] => EMPTY;
 
 export const useRecentPages = (): RecentPage[] =>
   useSyncExternalStore(subscribeRecentPages, getRecentPages, getServerSnapshot);
+
+// Entity pages (squad, source, profile) already hold the avatar the sidebar
+// row wants, so they hand it to the store instead of leaving the row to fetch.
+export const useRecentPageMeta = (meta: RecentPageMeta): void => {
+  const router = useRouter();
+  const path = router?.asPath?.split('?')[0].split('#')[0];
+  const { image } = meta;
+
+  useEffect(() => {
+    if (!path || !image) {
+      return;
+    }
+
+    updateRecentPageMeta(path, { image });
+  }, [path, image]);
+};
 
 const brandSuffix = /\s*[|·\-–—]\s*daily\.dev\s*$/i;
 const cleanTitle = (title: string): string =>

--- a/packages/shared/src/hooks/user/useUserShortByIdQuery.ts
+++ b/packages/shared/src/hooks/user/useUserShortByIdQuery.ts
@@ -2,7 +2,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
 import { useQuery } from '@tanstack/react-query';
 import { USER_SHORT_BY_ID } from '../../graphql/users';
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
-import { gqlClient } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 import type { PublicProfile } from '../../lib/user';
 
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -21,7 +21,10 @@ export const useUserShortByIdQuery = ({
   const queryResult = useQuery({
     queryKey,
     queryFn: async (): Promise<PublicProfile> => {
-      const res = await gqlClient.request(USER_SHORT_BY_ID, { id });
+      const res = await gqlBatchRequest<{ user: PublicProfile }>(
+        USER_SHORT_BY_ID,
+        { id },
+      );
       return res.user;
     },
     staleTime: StaleTime.Default,

--- a/packages/shared/src/hooks/userCompany/useUserCompaniesQuery.tsx
+++ b/packages/shared/src/hooks/userCompany/useUserCompaniesQuery.tsx
@@ -3,7 +3,7 @@ import type { UserCompany } from '../../lib/userCompany';
 import { GET_USER_COMPANIES } from '../../graphql/users';
 import { generateQueryKey, RequestKey, StaleTime } from '../../lib/query';
 import { useAuthContext } from '../../contexts/AuthContext';
-import { gqlClient } from '../../graphql/common';
+import { gqlBatchRequest } from '../../graphql/batch';
 
 interface UseUserCompaniesQuery {
   userCompanies: UserCompany[];
@@ -17,7 +17,9 @@ export const useUserCompaniesQuery = (): UseUserCompaniesQuery => {
   const { data, isPending } = useQuery({
     queryKey,
     queryFn: async (): Promise<UserCompany[]> => {
-      const res = await gqlClient.request(GET_USER_COMPANIES);
+      const res = await gqlBatchRequest<{ companies: UserCompany[] }>(
+        GET_USER_COMPANIES,
+      );
 
       return res.companies;
     },

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -342,3 +342,7 @@ export const featureCommentFirstAction = new Feature(
   'comment_first_action',
   false,
 );
+
+// Kill switch for the batched GraphQL transport (`graphql/batch.ts`). Off is
+// the control: the API only accepts batched bodies once its own change ships.
+export const featureGqlBatching = new Feature('gql_batching', false);

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -299,6 +299,8 @@ export enum RequestKey {
   WorldDomainRanking = 'world_domain_ranking',
   WorldRecentLevelUps = 'world_recent_level_ups',
   FollowedWorlds = 'followed_worlds',
+  ShellState = 'shell_state',
+  AchievementTracker = 'achievement_tracker',
 }
 
 export const getPostByIdKey = (id: string): QueryKey => [RequestKey.Post, id];

--- a/packages/shared/src/lib/recentPages.ts
+++ b/packages/shared/src/lib/recentPages.ts
@@ -7,7 +7,12 @@ export type RecentPage = {
   path: string;
   title: string;
   type?: RecentPageType;
+  // Avatar/logo captured by the page that already loaded the entity, so the
+  // sidebar row renders it without a lookup of its own.
+  image?: string;
 };
+
+export type RecentPageMeta = Pick<RecentPage, 'image'>;
 
 const STORAGE_KEY = 'dailydev:recentPages';
 const MAX_RECENT = 5;
@@ -16,6 +21,9 @@ const MAX_RECENT = 5;
 // layout and the reader in the sidebar share one reactive list.
 let cache: RecentPage[] | null = null;
 const listeners = new Set<() => void>();
+// The entity page has its metadata on mount, but the recorder only writes the
+// entry once the document title settles, so meta arrives first and waits here.
+const pendingMeta = new Map<string, RecentPageMeta>();
 
 const readStorage = (): RecentPage[] => {
   if (typeof window === 'undefined') {
@@ -52,14 +60,50 @@ export const subscribeRecentPages = (listener: () => void): (() => void) => {
   };
 };
 
+const persist = (next: RecentPage[]): void => {
+  cache = next;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore storage quota / privacy-mode failures
+  }
+  listeners.forEach((listener) => listener());
+};
+
+export const updateRecentPageMeta = (
+  path: string,
+  meta: RecentPageMeta,
+): void => {
+  if (typeof window === 'undefined' || !path || !meta.image) {
+    return;
+  }
+
+  const current = getRecentPages();
+  const index = current.findIndex((page) => page.path === path);
+  if (index === -1) {
+    pendingMeta.set(path, meta);
+    return;
+  }
+
+  if (current[index].image === meta.image) {
+    return;
+  }
+
+  const next = [...current];
+  next[index] = { ...next[index], ...meta };
+  persist(next);
+};
+
 export const recordRecentPage = (entry: RecentPage): void => {
   if (typeof window === 'undefined' || !entry.path || !entry.title) {
     return;
   }
 
   const current = getRecentPages();
+  const head = { ...entry, ...pendingMeta.get(entry.path) };
+  pendingMeta.delete(entry.path);
   const next = [
-    entry,
+    head,
     ...current.filter((page) => page.path !== entry.path),
   ].slice(0, MAX_RECENT);
 
@@ -68,16 +112,11 @@ export const recordRecentPage = (entry: RecentPage): void => {
   const isNoop =
     current.length === next.length &&
     current.every((page, index) => page.path === next[index].path) &&
-    current[0]?.title === next[0]?.title;
+    current[0]?.title === next[0]?.title &&
+    current[0]?.image === next[0]?.image;
   if (isNoop) {
     return;
   }
 
-  cache = next;
-  try {
-    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-  } catch {
-    // ignore storage quota / privacy-mode failures
-  }
-  listeners.forEach((listener) => listener());
+  persist(next);
 };

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -159,6 +159,9 @@ export type UserFlagsPublic = Partial<{
   showPlusGift: boolean;
   cvUploadedAt: Date;
   lastExtensionUse: string | null;
+  // Set once the API has seeded the user's tag chip feeds, so asking for them
+  // is side-effect free even before the onboarding actions land.
+  tagChipFeedsSeededAt: string | null;
 }>;
 
 export type UserSubscriptionFlags = Partial<{

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -28,6 +28,7 @@ import { LogEvent, TargetType } from '@dailydotdev/shared/src/lib/log';
 import { usePostReferrerContext } from '@dailydotdev/shared/src/contexts/PostReferrerContext';
 import { PageHeader } from '@dailydotdev/shared/src/components/layout/PageHeader';
 import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayoutVariant';
+import { useRecentPageMeta } from '@dailydotdev/shared/src/hooks/useRecentPages';
 import { getLayout as getFooterNavBarLayout } from '../FooterNavBarLayout';
 import { getLayout as getMainLayout } from '../MainLayout';
 import { getPageSeoTitles } from '../utils';
@@ -117,6 +118,7 @@ export default function ProfileLayout({
 
   // Auto-collapse sidebar on small screens
   useProfileSidebarCollapse();
+  useRecentPageMeta({ image: user?.image });
 
   useEffect(() => {
     if (trackedView || !user) {

--- a/packages/webapp/pages/_app.tsx
+++ b/packages/webapp/pages/_app.tsx
@@ -22,6 +22,7 @@ import '@dailydotdev/shared/src/styles/globals.css';
 import '../styles/iubenda.css';
 import useLogPageView from '@dailydotdev/shared/src/hooks/log/useLogPageView';
 import { BootDataProvider } from '@dailydotdev/shared/src/contexts/BootProvider';
+import { ShellStateProvider } from '@dailydotdev/shared/src/contexts/ShellStateProvider';
 import { PostReferrerContextProvider } from '@dailydotdev/shared/src/contexts/PostReferrerContext';
 import useDeviceId from '@dailydotdev/shared/src/hooks/log/useDeviceId';
 import { useError } from '@dailydotdev/shared/src/hooks/useError';
@@ -453,17 +454,19 @@ export default function App(
             version={version}
             deviceId={deviceId}
           >
-            <PixelsProvider>
-              <PushNotificationContextProvider>
-                <SubscriptionContextProvider>
-                  <PostReferrerContextProvider>
-                    <ShortcutsProvider>
-                      <InternalApp {...props} />
-                    </ShortcutsProvider>
-                  </PostReferrerContextProvider>
-                </SubscriptionContextProvider>
-              </PushNotificationContextProvider>
-            </PixelsProvider>
+            <ShellStateProvider>
+              <PixelsProvider>
+                <PushNotificationContextProvider>
+                  <SubscriptionContextProvider>
+                    <PostReferrerContextProvider>
+                      <ShortcutsProvider>
+                        <InternalApp {...props} />
+                      </ShortcutsProvider>
+                    </PostReferrerContextProvider>
+                  </SubscriptionContextProvider>
+                </PushNotificationContextProvider>
+              </PixelsProvider>
+            </ShellStateProvider>
           </BootDataProvider>
           <ReactQueryDevtools />
         </HydrationBoundary>

--- a/packages/webapp/pages/sources/[source].tsx
+++ b/packages/webapp/pages/sources/[source].tsx
@@ -70,6 +70,7 @@ import { useLayoutVariant } from '@dailydotdev/shared/src/hooks/layout/useLayout
 import { ArchiveScopeType } from '@dailydotdev/shared/src/graphql/archive';
 import { EntitySectionHeading } from '@dailydotdev/shared/src/components/entity/EntitySectionHeading';
 import { EntityRailWithFade } from '@dailydotdev/shared/src/components/entity/EntityRailWithFade';
+import { useRecentPageMeta } from '@dailydotdev/shared/src/hooks/useRecentPages';
 import Custom404 from '../404';
 import { defaultOpenGraph, defaultSeo, getShareImageUrl } from '../../next-seo';
 import { mainFeedLayoutProps } from '../../components/layouts/MainFeedPage';
@@ -234,6 +235,7 @@ const SourcePage = ({
   const isV2Laptop = isV2;
   const { shouldShowAuthBanner } = useOnboardingActions();
   const { user } = useContext(AuthContext);
+  useRecentPageMeta({ image: source?.image });
   const mostUpvotedQueryVariables = useMemo(
     () => ({
       source: source?.id,

--- a/packages/webapp/pages/squads/[handle]/index.tsx
+++ b/packages/webapp/pages/squads/[handle]/index.tsx
@@ -83,6 +83,7 @@ import {
   useToastNotification,
 } from '@dailydotdev/shared/src/hooks/useToastNotification';
 import { useEnableNotification } from '@dailydotdev/shared/src/hooks/notifications/useEnableNotification';
+import { useRecentPageMeta } from '@dailydotdev/shared/src/hooks/useRecentPages';
 import {
   ButtonColor,
   ButtonIconPosition,
@@ -290,6 +291,7 @@ const SquadPage = ({
   const [loggedImpression, setLoggedImpression] = useState(false);
   const { squad, isLoading, isFetched, isForbidden } = useSquad({ handle });
   const squadId = squad?.id;
+  useRecentPageMeta({ image: squad?.image });
   const shownToastForSquadInSession = useRef<Record<string, boolean>>({});
   const squadNotificationToastState = useMemo(
     () => createSquadNotificationToastStateStore(user?.id),

--- a/scripts/typecheck-strict-changed.js
+++ b/scripts/typecheck-strict-changed.js
@@ -209,6 +209,10 @@ const strictSkipList = new Set([
   'packages/shared/src/components/post/common/SharedPostLink.tsx',
   'packages/shared/src/components/widgets/PostToc.tsx',
   'packages/shared/src/features/profile/components/experience/UserExperienceItem.tsx',
+  // Touched only to move their query onto the batched transport; the strict
+  // errors on other lines predate that change.
+  'packages/shared/src/hooks/useBanner.ts',
+  'packages/shared/src/hooks/useFeedSettings.ts',
 ]);
 
 const changedFiles = getChangedTypescriptFiles().filter(


### PR DESCRIPTION
## Why

Every GraphQL query is its own POST. A logged-in home feed load issued boot plus 11 GraphQL requests, a post page boot plus 17, arriving in five or six dependent waves. Any request to the API costs about 200 ms from the browser regardless of size (a no-op query and `/health` cost the same), while parallel requests overlap almost entirely. So the cost is the waves and the redundant requests, not the payloads.

## What

**Tier 1, shell state.** `SHELL_STATE_QUERY` (`graphql/shellState.ts`) requests `actions`, `userStreak` and `feedList` in one document. `ShellStateProvider` runs it once per user, in parallel with boot like `useActions` already did, and fans the result into the existing cache keys with `setQueryData`. `useActions`, `useReadingStreak` and `useFeeds` are gated on `useShellState().isSettled` and keep their own `queryFn`, so invalidation, refetch-on-focus and mutations are unchanged, and if the merged request fails they fetch as today. The context default is settled, so any tree without the provider (companion, tests) behaves exactly as before.

`includeTagChipFeeds` depends on the actions for accounts created after 2025-01-20, so the provider derives the settled variables from the response and only seeds the feeds key `useFeeds` will actually read. Sending `true` up front is not safe until boot exposes `user.flags.tagChipFeedsSeededAt` (dailydotdev/daily-api#4229): the API consumes a one-shot seed slot before checking topics. With the flag present the predicate sends `true`, without it behaviour is identical to today.

**Tier 2, batched transport.** `gqlBatchRequest` (`graphql/batch.ts`) coalesces secondary queries fired within 10 ms into one array POST (max 10, the API cap), behind the `gql_batching` GrowthBook flag, default off. Each item resolves or rejects on its own with a `ClientError`, so `getApiError` keeps working. If the server answers the array with a plain object, batching switches off for the session and the items are replayed as single requests, so an API rollback degrades to today. Opted in: content preference status, featured archives, personalized digest, feed settings, user companies, profile showcase, source lookups, bookmark folders, banner and hackathon, marketing CTAs, related posts, achievements, user short profile, code snippets, notification preferences, squad pending posts. Kept on the direct path: boot, every feed query, the post query, comments, quest dashboard, smart titles, the two check queries, spotlight, all mutations, the REST ad calls.

**Tier 3, gates and deferrals.** Spotlight actions are fetched only when the palette opens, with a prefetch on hover or focus of the two elements that open it, so nothing is requested on load. The personalized digest only evaluates where the top banner strip can render (`sidebarOwnsHeader`). The sidebar dock and Recent rows store the entity image with the entry (entity pages hand it over through `useRecentPageMeta`) and fall back to a three-field `source` query only for entries written before that. The achievement tracker button uses one merged query instead of two sequential ones. The author follow status on a post is seeded from the post query's own `contentPreference`. Featured archives waits for boot, and the mentioned tools widget only fetches when the post has a matching creative.

`AGENTS.md` gets two conventions: shell data goes into the merged document, and secondary queries opt into `gqlBatchRequest` while paint-blocking ones never do.

## Measured

Real Chrome, logged in, dev server against the production API, layout v2 desktop.

| Page | Before | After |
| --- | --- | --- |
| Home feed | boot + 11 GraphQL | boot + 6 GraphQL (shell merged, achievements merged, spotlight only on open) |
| Post page | boot + 17 GraphQL | boot + 13 GraphQL |

The remaining shell requests on the home feed are the merged shell state, the feed itself, the quest dashboard, the personalized digest (banner strip renders on this layout), the achievement tracker and a dock icon lookup for a pin that predates storing the image. The quest dashboard also moved from a one-minute to the default five-minute stale time: the questUpdate and questRotationUpdate subscriptions already invalidate it on change, so the minute cadence only added refetches on route changes and window focus. Batching is not counted here because it is off until the API change deploys.

## Rollout

1. dailydotdev/daily-api#4229 is merged; wait for its deploy.
2. Merge this. Nothing changes on the wire for batching until `gql_batching` is turned on in GrowthBook; the shell merge and the gates ship immediately.
3. Turn on `gql_batching`. The transport self-disables per session if the API ever rejects the array body again.

## Follow-ups

- `QuestDashboard` is still the slowest request on every page (about 550 ms). A lighter summary field was evaluated and rejected: the cost is the milestone reconciliation in `syncMilestoneQuestProgress`, which runs sequential aggregate counts over views, upvotes and comments and also writes progress, so a summary could not skip it. The real fix is moving that reconciliation off the read path on the API.
- `PostComments` polls 500 rows every 60 s while a post is open.
- `useCheckLocation` types the response as `{ location }` while the document returns `checkLocation`, and treats the server's `{ _: false }` reply as "set".
- CDN caching of user-independent GET queries is a separate track.

## Verification

- `node ./scripts/typecheck-strict-changed.js`: pass
- `pnpm --filter shared test`: 381 suites / 2716 tests pass (plus the new batch and shell state specs)
- `pnpm --filter webapp test`: 86 suites / 683 tests pass
- `pnpm --filter webapp typecheck`: the 15 pre-existing errors in `packages/webapp/__tests__/` fixtures only
- `pnpm --filter shared lint`, `webapp lint`, `extension lint`: pass


### Preview domain
https://perf-graphql-shell-state.preview.app.daily.dev
