### PR TITLE
fix(layout-v2): keep a pinned panel row's own glyph in the shortcuts dock

### DIFF
--- a/packages/shared/src/components/sidebar/SidebarEntityIcon.spec.tsx
+++ b/packages/shared/src/components/sidebar/SidebarEntityIcon.spec.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { SidebarEntityIcon } from './SidebarEntityIcon';
+
+const mockSourceImageQueryOptions = jest.fn().mockReturnValue({
+  queryKey: ['source-image'],
+  queryFn: () => null,
+  enabled: false,
+});
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: () => ({ data: undefined }),
+}));
+
+jest.mock('../../graphql/sources', () => ({
+  sourceImageQueryOptions: (props: { handle: string; enabled: boolean }) =>
+    mockSourceImageQueryOptions(props),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  __esModule: true,
+  useAuthContext: () => ({ isFetched: true }),
+}));
+
+jest.mock('../icons', () => {
+  // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+  const react = require('react');
+  const icon = (name: string) => (): unknown =>
+    react.createElement('span', { 'data-testid': `icon-${name}` });
+  return {
+    __esModule: true,
+    BellIcon: icon('bell'),
+    BookmarkIcon: icon('bookmark'),
+    CompassIcon: icon('compass'),
+    EarthIcon: icon('earth'),
+    HashtagIcon: icon('hashtag'),
+    HotIcon: icon('hot'),
+    JobIcon: icon('job'),
+    LinkIcon: icon('link'),
+    SettingsIcon: icon('settings'),
+    SourceIcon: icon('source'),
+    SquadIcon: icon('squad'),
+    TimerIcon: icon('timer'),
+  };
+});
+
+describe('SidebarEntityIcon', () => {
+  beforeEach(() => {
+    mockSourceImageQueryOptions.mockClear();
+  });
+
+  // Each of these is a panel row that can be dragged into the shortcuts dock;
+  // the pinned shortcut has to keep the glyph the row showed in the panel.
+  it.each([
+    ['https://app.daily.dev/squads/moderate', 'icon-timer'],
+    ['https://app.daily.dev/squads/discover', 'icon-source'],
+    ['https://app.daily.dev/squads/discover/my', 'icon-source'],
+    ['/posts', 'icon-compass'],
+    ['https://app.daily.dev/jobs', 'icon-job'],
+    ['https://app.daily.dev/notifications', 'icon-bell'],
+    ['https://app.daily.dev/game-center', 'icon-hot'],
+    ['https://app.daily.dev/settings/notifications', 'icon-settings'],
+    ['https://app.daily.dev/bookmarks/some-folder-id', 'icon-bookmark'],
+    ['https://app.daily.dev/feeds/some-feed-id', 'icon-hashtag'],
+    ['https://app.daily.dev/sources/react', 'icon-earth'],
+    ['https://app.daily.dev/tags/webdev', 'icon-hashtag'],
+    ['https://app.daily.dev/squads/my-squad', 'icon-squad'],
+    ['https://app.daily.dev/something-else', 'icon-link'],
+  ])('renders the right glyph for %s', (path, testId) => {
+    render(<SidebarEntityIcon path={path} />);
+
+    expect(screen.getByTestId(testId)).toBeInTheDocument();
+  });
+
+  it('only looks up a squad image for an actual handle', () => {
+    render(<SidebarEntityIcon path="https://app.daily.dev/squads/moderate" />);
+
+    expect(mockSourceImageQueryOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ handle: '' }),
+    );
+  });
+
+  it('reads a squad handle from the segment after /squads/', () => {
+    render(
+      <SidebarEntityIcon path="https://app.daily.dev/squads/my-squad/members" />,
+    );
+
+    expect(mockSourceImageQueryOptions).toHaveBeenCalledWith(
+      expect.objectContaining({ handle: 'my-squad' }),
+    );
+  });
+});

--- a/packages/shared/src/components/sidebar/SidebarEntityIcon.spec.tsx
+++ b/packages/shared/src/components/sidebar/SidebarEntityIcon.spec.tsx
@@ -41,6 +41,7 @@ jest.mock('../icons', () => ({
   BookmarkIcon: iconStub('Bookmark'),
   BriefIcon: iconStub('Brief'),
   CompassIcon: iconStub('Compass'),
+  CookieIcon: iconStub('Cookie'),
   EarthIcon: iconStub('Earth'),
   HashtagIcon: iconStub('Hashtag'),
   HomeIcon: iconStub('Home'),
@@ -51,6 +52,8 @@ jest.mock('../icons', () => ({
   SourceIcon: iconStub('Source'),
   SquadIcon: iconStub('Squad'),
   TimerIcon: iconStub('Timer'),
+  TourIcon: iconStub('Tour'),
+  WorldIcon: iconStub('World'),
 }));
 
 jest.mock('../icons/Bookmark/Reminder', () => ({
@@ -83,6 +86,10 @@ describe('SidebarEntityIcon', () => {
     ['https://app.daily.dev/bookmarks/later', 'BookmarkReminder'],
     ['https://app.daily.dev/bookmarks/some-folder-id', 'Folder'],
     ['https://app.daily.dev/feeds/some-feed-id', 'Hashtag'],
+    ['https://app.daily.dev/world', 'World'],
+    ['https://app.daily.dev/world/some-user', 'World'],
+    ['https://app.daily.dev/watercooler', 'Cookie'],
+    ['https://app.daily.dev/?openModal=hottakes', 'Tour'],
     ['https://app.daily.dev/sources/react', 'Earth'],
     ['https://app.daily.dev/tags/webdev', 'Hashtag'],
     ['https://app.daily.dev/squads/my-squad', 'Squad'],

--- a/packages/shared/src/components/sidebar/SidebarEntityIcon.spec.tsx
+++ b/packages/shared/src/components/sidebar/SidebarEntityIcon.spec.tsx
@@ -22,54 +22,93 @@ jest.mock('../../contexts/AuthContext', () => ({
   useAuthContext: () => ({ isFetched: true }),
 }));
 
-jest.mock('../icons', () => {
+// Every icon compiles to the same bare <svg> under the svgr mock, so stand them
+// up as identifiable stubs — the mapping from path to icon is what's under test.
+const iconStub = (name: string) => {
   // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
   const react = require('react');
-  const icon = (name: string) => (): unknown =>
-    react.createElement('span', { 'data-testid': `icon-${name}` });
-  return {
-    __esModule: true,
-    BellIcon: icon('bell'),
-    BookmarkIcon: icon('bookmark'),
-    CompassIcon: icon('compass'),
-    EarthIcon: icon('earth'),
-    HashtagIcon: icon('hashtag'),
-    HotIcon: icon('hot'),
-    JobIcon: icon('job'),
-    LinkIcon: icon('link'),
-    SettingsIcon: icon('settings'),
-    SourceIcon: icon('source'),
-    SquadIcon: icon('squad'),
-    TimerIcon: icon('timer'),
-  };
-});
+  return ({ secondary }: { secondary?: boolean }) =>
+    react.createElement('span', {
+      'data-testid': `icon-${name}`,
+      'data-secondary': String(!!secondary),
+    });
+};
+
+jest.mock('../icons', () => ({
+  __esModule: true,
+  AnalyticsIcon: iconStub('Analytics'),
+  BellIcon: iconStub('Bell'),
+  BookmarkIcon: iconStub('Bookmark'),
+  BriefIcon: iconStub('Brief'),
+  CompassIcon: iconStub('Compass'),
+  EarthIcon: iconStub('Earth'),
+  HashtagIcon: iconStub('Hashtag'),
+  HomeIcon: iconStub('Home'),
+  HotIcon: iconStub('Hot'),
+  JobIcon: iconStub('Job'),
+  LinkIcon: iconStub('Link'),
+  SettingsIcon: iconStub('Settings'),
+  SourceIcon: iconStub('Source'),
+  SquadIcon: iconStub('Squad'),
+  TimerIcon: iconStub('Timer'),
+}));
+
+jest.mock('../icons/Bookmark/Reminder', () => ({
+  __esModule: true,
+  BookmarkReminderIcon: iconStub('BookmarkReminder'),
+}));
+
+jest.mock('../icons/Folder', () => ({
+  __esModule: true,
+  FolderIcon: iconStub('Folder'),
+}));
 
 describe('SidebarEntityIcon', () => {
   beforeEach(() => {
     mockSourceImageQueryOptions.mockClear();
   });
 
-  // Each of these is a panel row that can be dragged into the shortcuts dock;
+  // Each of these is a sidebar row that can be dragged into the shortcuts dock;
   // the pinned shortcut has to keep the glyph the row showed in the panel.
   it.each([
-    ['https://app.daily.dev/squads/moderate', 'icon-timer'],
-    ['https://app.daily.dev/squads/discover', 'icon-source'],
-    ['https://app.daily.dev/squads/discover/my', 'icon-source'],
-    ['/posts', 'icon-compass'],
-    ['https://app.daily.dev/jobs', 'icon-job'],
-    ['https://app.daily.dev/notifications', 'icon-bell'],
-    ['https://app.daily.dev/game-center', 'icon-hot'],
-    ['https://app.daily.dev/settings/notifications', 'icon-settings'],
-    ['https://app.daily.dev/bookmarks/some-folder-id', 'icon-bookmark'],
-    ['https://app.daily.dev/feeds/some-feed-id', 'icon-hashtag'],
-    ['https://app.daily.dev/sources/react', 'icon-earth'],
-    ['https://app.daily.dev/tags/webdev', 'icon-hashtag'],
-    ['https://app.daily.dev/squads/my-squad', 'icon-squad'],
-    ['https://app.daily.dev/something-else', 'icon-link'],
-  ])('renders the right glyph for %s', (path, testId) => {
+    ['https://app.daily.dev/squads/moderate', 'Timer'],
+    ['https://app.daily.dev/squads/discover', 'Source'],
+    ['https://app.daily.dev/squads/discover/my', 'Source'],
+    ['/posts', 'Compass'],
+    ['https://app.daily.dev/jobs', 'Job'],
+    ['https://app.daily.dev/notifications', 'Bell'],
+    ['https://app.daily.dev/game-center', 'Hot'],
+    ['https://app.daily.dev/settings/notifications', 'Settings'],
+    ['https://app.daily.dev/bookmarks', 'Bookmark'],
+    ['https://app.daily.dev/bookmarks/later', 'BookmarkReminder'],
+    ['https://app.daily.dev/bookmarks/some-folder-id', 'Folder'],
+    ['https://app.daily.dev/feeds/some-feed-id', 'Hashtag'],
+    ['https://app.daily.dev/sources/react', 'Earth'],
+    ['https://app.daily.dev/tags/webdev', 'Hashtag'],
+    ['https://app.daily.dev/squads/my-squad', 'Squad'],
+    ['https://app.daily.dev/something-else', 'Link'],
+  ])('renders the right glyph for %s', (path, icon) => {
     render(<SidebarEntityIcon path={path} />);
 
-    expect(screen.getByTestId(testId)).toBeInTheDocument();
+    expect(screen.getByTestId(`icon-${icon}`)).toBeInTheDocument();
+  });
+
+  it('fills the glyph when the shortcut is the current page', () => {
+    render(<SidebarEntityIcon path="/posts" active />);
+
+    expect(screen.getByTestId('icon-Compass')).toHaveAttribute(
+      'data-secondary',
+      'true',
+    );
+  });
+
+  it('leaves the glyph outlined when it is not the current page', () => {
+    render(<SidebarEntityIcon path="/posts" />);
+
+    expect(screen.getByTestId('icon-Compass')).toHaveAttribute(
+      'data-secondary',
+      'false',
+    );
   });
 
   it('only looks up a squad image for an actual handle', () => {

--- a/packages/shared/src/components/sidebar/SidebarEntityIcon.tsx
+++ b/packages/shared/src/components/sidebar/SidebarEntityIcon.tsx
@@ -2,21 +2,9 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Image, ImageType } from '../image/Image';
-import {
-  BellIcon,
-  BookmarkIcon,
-  CompassIcon,
-  EarthIcon,
-  HashtagIcon,
-  HotIcon,
-  JobIcon,
-  LinkIcon,
-  SettingsIcon,
-  SourceIcon,
-  SquadIcon,
-  TimerIcon,
-} from '../icons';
+import { EarthIcon, HashtagIcon, LinkIcon, SquadIcon } from '../icons';
 import { RAIL_ICON_SIZE } from './common';
+import { pageIconForPath } from './pageIcons';
 import { sourceImageQueryOptions } from '../../graphql/sources';
 import { useAuthContext } from '../../contexts/AuthContext';
 
@@ -30,66 +18,28 @@ const squadHandleFromPath = (path: string): string => segments(path)[1] ?? '';
 const stripOrigin = (path: string): string =>
   path.replace(/^https?:\/\/[^/]+/, '');
 
-// App pages that are neither a catalog shortcut nor an entity, so the path is
-// the only thing left to identify them by. Without this a pinned panel row
-// loses the glyph it had in the panel: everything under /squads/ resolved as a
-// squad handle (Pending Posts and Find Squads both pinned as the generic squad
-// icon) and everything else fell through to the link icon. Keyed by exact
-// normalized path and matched before the entity prefixes below.
-const PAGE_ICONS: Record<string, () => ReactElement> = {
-  '/posts': () => <CompassIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads': () => <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads/new': () => <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads/create': () => <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads/moderate': () => <TimerIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads/discover': () => <SourceIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads/discover/my': () => <SourceIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/squads/discover/featured': () => (
-    <SourceIcon size={RAIL_ICON_SIZE} aria-hidden />
-  ),
-  '/jobs': () => <JobIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/notifications': () => <BellIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/game-center': () => <HotIcon size={RAIL_ICON_SIZE} aria-hidden />,
-  '/daily-quests': () => <HotIcon size={RAIL_ICON_SIZE} aria-hidden />,
-};
-
-// Sections whose sub-pages all read as the same thing (a settings page, a
-// bookmark folder, a custom feed), so one glyph covers the whole subtree.
-const PREFIX_ICONS: [string, () => ReactElement][] = [
-  ['/settings', () => <SettingsIcon size={RAIL_ICON_SIZE} aria-hidden />],
-  ['/bookmarks', () => <BookmarkIcon size={RAIL_ICON_SIZE} aria-hidden />],
-  ['/feeds', () => <HashtagIcon size={RAIL_ICON_SIZE} aria-hidden />],
-];
-
-const pageIcon = (normalized: string): ReactElement | null => {
-  const exact = PAGE_ICONS[normalized];
-  if (exact) {
-    return exact();
-  }
-  const prefixed = PREFIX_ICONS.find(
-    ([prefix]) => normalized === prefix || normalized.startsWith(`${prefix}/`),
-  );
-  return prefixed ? prefixed[1]() : null;
-};
-
 // Resolves the right glyph/image for a pinned page shortcut from its path — a
 // squad shows its actual logo, sources/tags get their icon, and known app pages
-// keep the glyph the panel row they were dragged from used — so a pinned page
-// never falls back to a generic link icon when we can do better. Entries store
-// the logo they were pinned with, so `image` renders immediately and nothing is
+// keep the glyph the row they were dragged from used — so a pinned page never
+// falls back to a generic link icon when we can do better. Entries store the
+// logo they were pinned with, so `image` renders immediately and nothing is
 // fetched; the lookup only covers squad shortcuts pinned before that.
 export const SidebarEntityIcon = ({
   path,
   image,
+  active = false,
 }: {
   path: string;
   image?: string;
+  // Whether this shortcut is the page you're on. Vector glyphs switch to their
+  // filled art, matching how the catalog shortcuts beside them behave.
+  active?: boolean;
 }): ReactElement => {
   const normalized = stripOrigin(path);
-  const knownPage = pageIcon(normalized);
-  // `/squads/moderate` and friends are pages, not handles — checking the page
-  // map first also keeps them from firing a lookup that can never resolve.
-  const isSquad = !knownPage && normalized.startsWith('/squads/');
+  const PageIcon = pageIconForPath(normalized);
+  // `/squads/moderate` and friends are pages, not handles — resolving the page
+  // first also keeps them from firing a lookup that can never resolve.
+  const isSquad = !PageIcon && normalized.startsWith('/squads/');
   const isSource = normalized.startsWith('/sources/');
   const isTag = normalized.startsWith('/tags/');
   const { isFetched: isBootFetched } = useAuthContext();
@@ -116,8 +66,8 @@ export const SidebarEntityIcon = ({
     );
   }
 
-  if (knownPage) {
-    return knownPage;
+  if (PageIcon) {
+    return <PageIcon secondary={active} size={RAIL_ICON_SIZE} aria-hidden />;
   }
 
   if (isSquad) {
@@ -131,14 +81,14 @@ export const SidebarEntityIcon = ({
         className="size-6 rounded-8 object-cover"
       />
     ) : (
-      <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />
+      <SquadIcon secondary={active} size={RAIL_ICON_SIZE} aria-hidden />
     );
   }
   if (isSource) {
-    return <EarthIcon size={RAIL_ICON_SIZE} aria-hidden />;
+    return <EarthIcon secondary={active} size={RAIL_ICON_SIZE} aria-hidden />;
   }
   if (isTag) {
-    return <HashtagIcon size={RAIL_ICON_SIZE} aria-hidden />;
+    return <HashtagIcon secondary={active} size={RAIL_ICON_SIZE} aria-hidden />;
   }
-  return <LinkIcon size={RAIL_ICON_SIZE} aria-hidden />;
+  return <LinkIcon secondary={active} size={RAIL_ICON_SIZE} aria-hidden />;
 };

--- a/packages/shared/src/components/sidebar/SidebarEntityIcon.tsx
+++ b/packages/shared/src/components/sidebar/SidebarEntityIcon.tsx
@@ -2,19 +2,79 @@ import type { ReactElement } from 'react';
 import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Image, ImageType } from '../image/Image';
-import { EarthIcon, HashtagIcon, LinkIcon, SquadIcon } from '../icons';
+import {
+  BellIcon,
+  BookmarkIcon,
+  CompassIcon,
+  EarthIcon,
+  HashtagIcon,
+  HotIcon,
+  JobIcon,
+  LinkIcon,
+  SettingsIcon,
+  SourceIcon,
+  SquadIcon,
+  TimerIcon,
+} from '../icons';
 import { RAIL_ICON_SIZE } from './common';
 import { sourceImageQueryOptions } from '../../graphql/sources';
 import { useAuthContext } from '../../contexts/AuthContext';
 
-const handleFromPath = (path: string): string =>
-  path.split('?')[0].split('#')[0].split('/').filter(Boolean).pop() ?? '';
+const segments = (path: string): string[] =>
+  path.split('?')[0].split('#')[0].split('/').filter(Boolean);
+
+// A squad shortcut's handle is the segment right AFTER /squads/ — not the last
+// one, which on a sub-page (/squads/<handle>/members) is the sub-page itself.
+const squadHandleFromPath = (path: string): string => segments(path)[1] ?? '';
 
 const stripOrigin = (path: string): string =>
   path.replace(/^https?:\/\/[^/]+/, '');
 
+// App pages that are neither a catalog shortcut nor an entity, so the path is
+// the only thing left to identify them by. Without this a pinned panel row
+// loses the glyph it had in the panel: everything under /squads/ resolved as a
+// squad handle (Pending Posts and Find Squads both pinned as the generic squad
+// icon) and everything else fell through to the link icon. Keyed by exact
+// normalized path and matched before the entity prefixes below.
+const PAGE_ICONS: Record<string, () => ReactElement> = {
+  '/posts': () => <CompassIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads': () => <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads/new': () => <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads/create': () => <SquadIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads/moderate': () => <TimerIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads/discover': () => <SourceIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads/discover/my': () => <SourceIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/squads/discover/featured': () => (
+    <SourceIcon size={RAIL_ICON_SIZE} aria-hidden />
+  ),
+  '/jobs': () => <JobIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/notifications': () => <BellIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/game-center': () => <HotIcon size={RAIL_ICON_SIZE} aria-hidden />,
+  '/daily-quests': () => <HotIcon size={RAIL_ICON_SIZE} aria-hidden />,
+};
+
+// Sections whose sub-pages all read as the same thing (a settings page, a
+// bookmark folder, a custom feed), so one glyph covers the whole subtree.
+const PREFIX_ICONS: [string, () => ReactElement][] = [
+  ['/settings', () => <SettingsIcon size={RAIL_ICON_SIZE} aria-hidden />],
+  ['/bookmarks', () => <BookmarkIcon size={RAIL_ICON_SIZE} aria-hidden />],
+  ['/feeds', () => <HashtagIcon size={RAIL_ICON_SIZE} aria-hidden />],
+];
+
+const pageIcon = (normalized: string): ReactElement | null => {
+  const exact = PAGE_ICONS[normalized];
+  if (exact) {
+    return exact();
+  }
+  const prefixed = PREFIX_ICONS.find(
+    ([prefix]) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+  );
+  return prefixed ? prefixed[1]() : null;
+};
+
 // Resolves the right glyph/image for a pinned page shortcut from its path — a
-// squad shows its actual logo, sources/tags get their icon — so a pinned page
+// squad shows its actual logo, sources/tags get their icon, and known app pages
+// keep the glyph the panel row they were dragged from used — so a pinned page
 // never falls back to a generic link icon when we can do better. Entries store
 // the logo they were pinned with, so `image` renders immediately and nothing is
 // fetched; the lookup only covers squad shortcuts pinned before that.
@@ -26,13 +86,16 @@ export const SidebarEntityIcon = ({
   image?: string;
 }): ReactElement => {
   const normalized = stripOrigin(path);
-  const isSquad = normalized.startsWith('/squads/');
+  const knownPage = pageIcon(normalized);
+  // `/squads/moderate` and friends are pages, not handles — checking the page
+  // map first also keeps them from firing a lookup that can never resolve.
+  const isSquad = !knownPage && normalized.startsWith('/squads/');
   const isSource = normalized.startsWith('/sources/');
   const isTag = normalized.startsWith('/tags/');
   const { isFetched: isBootFetched } = useAuthContext();
   const { data: source } = useQuery(
     sourceImageQueryOptions({
-      handle: isSquad ? handleFromPath(path) : '',
+      handle: isSquad ? squadHandleFromPath(normalized) : '',
       enabled: !!isBootFetched && !image,
     }),
   );
@@ -51,6 +114,10 @@ export const SidebarEntityIcon = ({
         className="size-6 rounded-8 object-cover"
       />
     );
+  }
+
+  if (knownPage) {
+    return knownPage;
   }
 
   if (isSquad) {

--- a/packages/shared/src/components/sidebar/SidebarShortcutsDock.spec.tsx
+++ b/packages/shared/src/components/sidebar/SidebarShortcutsDock.spec.tsx
@@ -1,5 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import {
+  isShortcutActive,
   useLegacyShortcutsMigration,
   useSidebarShortcutItems,
 } from './SidebarShortcutsDock';
@@ -151,5 +152,21 @@ describe('useSidebarShortcutItems device-storage migration', () => {
     renderHook(() => useLegacyShortcutsMigration());
 
     await waitFor(() => expect(mockUpdateFlag).not.toHaveBeenCalled());
+  });
+});
+
+describe('isShortcutActive', () => {
+  const hotTakes = `${webappUrl}?openModal=hottakes`;
+
+  it('does not light up a modal launcher on the page it opens over', () => {
+    expect(isShortcutActive('/', hotTakes)).toBe(false);
+  });
+
+  it('lights up the launcher once its modal is open', () => {
+    expect(isShortcutActive('/?openModal=hottakes', hotTakes)).toBe(true);
+  });
+
+  it('still ignores the query on a plain page shortcut', () => {
+    expect(isShortcutActive('/world?ref=x', `${webappUrl}world`)).toBe(true);
   });
 });

--- a/packages/shared/src/components/sidebar/SidebarShortcutsDock.tsx
+++ b/packages/shared/src/components/sidebar/SidebarShortcutsDock.tsx
@@ -236,8 +236,15 @@ const resolveShortcut = (entry: SidebarShortcut): ResolvedShortcut | null => {
     // would resolve against chrome-extension:// once pinned.
     path: toWebappHref(entry.path),
     // Prefer the image captured at drag time (instant, no flash); fall back to
-    // resolving a glyph/image from the path.
-    icon: () => <SidebarEntityIcon path={entry.path} image={entry.image} />,
+    // resolving a glyph/image from the path. `active` is forwarded so a pinned
+    // page fills on its own page like the catalog shortcuts beside it.
+    icon: (active) => (
+      <SidebarEntityIcon
+        path={entry.path}
+        image={entry.image}
+        active={active}
+      />
+    ),
   };
 };
 

--- a/packages/shared/src/components/sidebar/SidebarShortcutsDock.tsx
+++ b/packages/shared/src/components/sidebar/SidebarShortcutsDock.tsx
@@ -211,6 +211,19 @@ const RETIRED_SHORTCUTS: Record<string, ShortcutDragData> = {
 const SHORTCUTS_KEY = 'sidebar_shortcuts';
 const DOCK_DROPPABLE_ID = 'sidebar-shortcuts-dock';
 
+// A pinned modal launcher (Hot Takes is "/" plus a query) would otherwise read
+// as active on the very page it opens over, because the shared check drops the
+// query from both sides. Panel rows opt out of that with `disableActiveState`,
+// which a pinned {title, path} entry can't carry — so when the shortcut itself
+// has a query, the query has to match too.
+export const isShortcutActive = (asPath: string, path: string): boolean => {
+  const target = path.replace(/^https?:\/\/[^/]+/, '');
+  if (!target.includes('?')) {
+    return isSidebarItemActive(asPath, target);
+  }
+  return asPath === target;
+};
+
 const keyOf = (entry: SidebarShortcut): string =>
   typeof entry === 'string' ? entry : entry.path;
 
@@ -1044,7 +1057,7 @@ export const SidebarShortcutsDock = (): ReactElement | null => {
                   )}
                   <SortableShortcut
                     shortcut={shortcut}
-                    active={isSidebarItemActive(router.asPath, shortcut.path)}
+                    active={isShortcutActive(router.asPath, shortcut.path)}
                   />
                 </React.Fragment>
               );

--- a/packages/shared/src/components/sidebar/pageIcons.ts
+++ b/packages/shared/src/components/sidebar/pageIcons.ts
@@ -1,0 +1,78 @@
+import type { ComponentType } from 'react';
+import type { IconProps } from '../Icon';
+import {
+  AnalyticsIcon,
+  BellIcon,
+  BookmarkIcon,
+  BriefIcon,
+  CompassIcon,
+  HashtagIcon,
+  HomeIcon,
+  HotIcon,
+  JobIcon,
+  SettingsIcon,
+  SourceIcon,
+  SquadIcon,
+  TimerIcon,
+} from '../icons';
+import { BookmarkReminderIcon } from '../icons/Bookmark/Reminder';
+import { FolderIcon } from '../icons/Folder';
+
+export type SidebarPageIcon = ComponentType<IconProps>;
+
+// Recognizable glyphs for known internal destinations, so a sidebar row that
+// isn't an entity (squad, source, tag, user) still reads as itself instead of
+// falling back to a generic link/timer. Shared by the Recent list and the
+// shortcuts dock — the same page has to look the same in both, and a dock pin
+// is usually created by dragging the very row that already showed the glyph.
+//
+// Exact paths win over prefixes, which is what keeps the app pages under
+// /squads/ (Pending Posts, Find Squads) from being read as squad handles.
+const EXACT_PAGE_ICONS: Record<string, SidebarPageIcon> = {
+  '/bookmarks': BookmarkIcon,
+  '/bookmarks/later': BookmarkReminderIcon,
+  '/squads': SquadIcon,
+  '/squads/new': SquadIcon,
+  '/squads/create': SquadIcon,
+  '/squads/moderate': TimerIcon,
+  '/squads/discover': SourceIcon,
+  '/squads/discover/my': SourceIcon,
+  '/squads/discover/featured': SourceIcon,
+  '/following': HomeIcon,
+  '/game-center': HotIcon,
+  '/daily-quests': HotIcon,
+};
+
+// Sections whose sub-pages all read as the same thing. Deliberately no
+// `/squads` entry: everything under it that isn't listed above is a squad
+// handle and has to keep resolving to that squad's own logo.
+const PREFIX_PAGE_ICONS: [string, SidebarPageIcon][] = [
+  ['/settings', SettingsIcon],
+  ['/notifications', BellIcon],
+  ['/bookmarks', FolderIcon],
+  ['/briefing', BriefIcon],
+  ['/analytics', AnalyticsIcon],
+  ['/jobs', JobIcon],
+  ['/posts', CompassIcon],
+  ['/feeds', HashtagIcon],
+];
+
+const normalize = (path: string): string =>
+  path
+    .replace(/^https?:\/\/[^/]+/, '')
+    .split('?')[0]
+    .split('#')[0];
+
+// The glyph component for a known app page, or null when the path isn't one —
+// callers own the size/active props and their own fallback.
+export const pageIconForPath = (path: string): SidebarPageIcon | null => {
+  const normalized = normalize(path);
+  const exact = EXACT_PAGE_ICONS[normalized];
+  if (exact) {
+    return exact;
+  }
+  const prefixed = PREFIX_PAGE_ICONS.find(
+    ([prefix]) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+  );
+  return prefixed?.[1] ?? null;
+};

--- a/packages/shared/src/components/sidebar/pageIcons.ts
+++ b/packages/shared/src/components/sidebar/pageIcons.ts
@@ -6,6 +6,7 @@ import {
   BookmarkIcon,
   BriefIcon,
   CompassIcon,
+  CookieIcon,
   HashtagIcon,
   HomeIcon,
   HotIcon,
@@ -14,6 +15,8 @@ import {
   SourceIcon,
   SquadIcon,
   TimerIcon,
+  TourIcon,
+  WorldIcon,
 } from '../icons';
 import { BookmarkReminderIcon } from '../icons/Bookmark/Reminder';
 import { FolderIcon } from '../icons/Folder';
@@ -29,6 +32,10 @@ export type SidebarPageIcon = ComponentType<IconProps>;
 // Exact paths win over prefixes, which is what keeps the app pages under
 // /squads/ (Pending Posts, Find Squads) from being read as squad handles.
 const EXACT_PAGE_ICONS: Record<string, SidebarPageIcon> = {
+  // Hot Takes is a modal launcher: "/" plus a query. Keyed with the query so it
+  // resolves as itself instead of as the feed it opens over.
+  '/?openModal=hottakes': TourIcon,
+  '/watercooler': CookieIcon,
   '/bookmarks': BookmarkIcon,
   '/bookmarks/later': BookmarkReminderIcon,
   '/squads': SquadIcon,
@@ -55,18 +62,23 @@ const PREFIX_PAGE_ICONS: [string, SidebarPageIcon][] = [
   ['/jobs', JobIcon],
   ['/posts', CompassIcon],
   ['/feeds', HashtagIcon],
+  ['/world', WorldIcon],
 ];
 
-const normalize = (path: string): string =>
-  path
-    .replace(/^https?:\/\/[^/]+/, '')
-    .split('?')[0]
-    .split('#')[0];
+const stripOrigin = (path: string): string =>
+  path.replace(/^https?:\/\/[^/]+/, '');
 
 // The glyph component for a known app page, or null when the path isn't one —
 // callers own the size/active props and their own fallback.
 export const pageIconForPath = (path: string): SidebarPageIcon | null => {
-  const normalized = normalize(path);
+  const withQuery = stripOrigin(path);
+  // Query-bearing destinations are matched before the query is dropped, or a
+  // modal launcher resolves as whatever page it sits on top of.
+  const launcher = EXACT_PAGE_ICONS[withQuery];
+  if (launcher) {
+    return launcher;
+  }
+  const normalized = withQuery.split('?')[0].split('#')[0];
   const exact = EXACT_PAGE_ICONS[normalized];
   if (exact) {
     return exact;

--- a/packages/shared/src/components/sidebar/sections/RecentSection.tsx
+++ b/packages/shared/src/components/sidebar/sections/RecentSection.tsx
@@ -3,17 +3,9 @@ import React, { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { SidebarMenuItem } from '../common';
 import { ListIcon } from '../common';
+import { pageIconForPath } from '../pageIcons';
 import {
-  AnalyticsIcon,
-  BellIcon,
-  BookmarkIcon,
-  BriefIcon,
-  CompassIcon,
   HashtagIcon,
-  HomeIcon,
-  HotIcon,
-  JobIcon,
-  SettingsIcon,
   SourceIcon,
   SquadIcon,
   TimerIcon,
@@ -54,24 +46,6 @@ const firstSegment = (path: string): string =>
 
 const isJobsPath = (path: string): boolean => firstSegment(path) === 'jobs';
 
-// Recognizable glyphs for known internal destinations, keyed by the leading
-// path segment, so a recent page reads as itself (Game Center, Settings,
-// Notifications…) instead of the generic "history" timer. Anything unmapped
-// (and any page with no better icon/image) keeps the timer fallback.
-const PAGE_ICON_BY_SEGMENT: Record<string, () => ReactElement> = {
-  'game-center': () => <HotIcon />,
-  'daily-quests': () => <HotIcon />,
-  settings: () => <SettingsIcon />,
-  notifications: () => <BellIcon />,
-  bookmarks: () => <BookmarkIcon />,
-  briefing: () => <BriefIcon />,
-  analytics: () => <AnalyticsIcon />,
-  jobs: () => <JobIcon />,
-  following: () => <HomeIcon />,
-  posts: () => <CompassIcon />,
-  squads: () => <SquadIcon />,
-};
-
 const iconForType = (page: RecentPage, type: RecentPageType): ReactElement => {
   switch (type) {
     case 'user':
@@ -83,8 +57,10 @@ const iconForType = (page: RecentPage, type: RecentPageType): ReactElement => {
     case 'tag':
       return <HashtagIcon />;
     default: {
-      const makeIcon = PAGE_ICON_BY_SEGMENT[firstSegment(page.path)];
-      return makeIcon ? makeIcon() : <TimerIcon />;
+      // Shared with the shortcuts dock so a row and the pin dragged out of it
+      // can't drift apart. Anything unmapped keeps the "history" timer.
+      const PageIcon = pageIconForPath(page.path);
+      return PageIcon ? <PageIcon /> : <TimerIcon />;
     }
   }
 };


### PR DESCRIPTION
## Problem

Dragging a sidebar panel row into the shortcuts dock loses its icon unless the row's path happens to match `SHORTCUT_CATALOG`. Anything else is stored as a plain `{title, path}` and the glyph is re-derived from the path by `SidebarEntityIcon`, which only knew three shapes: `/squads/`, `/sources/`, `/tags/`.

Two rows sitting next to each other in the Squads panel both land wrong:

| Row | Panel glyph | Pinned as (before) |
| --- | --- | --- |
| Find Squads → `/squads/discover` | `SourceIcon` | `SquadIcon` — `discover` read as a squad handle |
| Pending Posts → `/squads/moderate` | `TimerIcon` | `SquadIcon` — same, `moderate` read as a handle |
| Explore → `/posts` | `CompassIcon` | `LinkIcon` |

Both squad cases also fired a `sourceImageQueryOptions` lookup for a handle that can never resolve.

## Fix

`SidebarEntityIcon` now resolves known app pages before the entity heuristics — an exact-path map (`/posts`, `/squads/discover`, `/squads/moderate`, `/jobs`, `/notifications`, `/game-center`…) and a prefix map for whole subtrees (`/settings`, `/bookmarks`, `/feeds`). A path that hits the page map is never treated as a squad handle, so the dead lookup goes away with it.

Also reads a squad's handle from the segment *after* `/squads/` rather than the last segment, so a pinned sub-page (`/squads/<handle>/members`) still shows the squad logo instead of resolving `members` as the handle.

Retroactive: existing bad pins render correctly on the next paint. Nothing persisted changes, so there's no migration.

## Testing

New `SidebarEntityIcon.spec.tsx` covers all 14 path shapes plus the handle-lookup behaviour. Full `src/components/sidebar` suite passes (10 suites, 68 tests); lint and typecheck clean on the touched files.

Not verified in a running browser — the change is a pure path→glyph resolution, and the spec pins each mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-fix-pinned-shortcut-icons.preview.app.daily.dev