### PR TITLE
feat: attach clipboard images to feedback

### DIFF
--- a/packages/shared/src/components/modals/FeedbackModal.spec.tsx
+++ b/packages/shared/src/components/modals/FeedbackModal.spec.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import FeedbackModal from './FeedbackModal';
 
@@ -44,6 +50,18 @@ const renderComponent = () => {
       <FeedbackModal isOpen onRequestClose={jest.fn()} ariaHideApp={false} />
     </QueryClientProvider>,
   );
+};
+
+const pasteFiles = (files: File[]): Event => {
+  const event = new Event('paste', { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'clipboardData', {
+    value: { files, items: [] },
+  });
+  act(() => {
+    document.dispatchEvent(event);
+  });
+
+  return event;
 };
 
 describe('FeedbackModal', () => {
@@ -178,6 +196,42 @@ describe('FeedbackModal', () => {
     // The original attachment and its preview URL must survive the rejection
     expect(screen.getByAltText('Screenshot preview')).toBeInTheDocument();
     expect(mockRevokePreviewUrl).not.toHaveBeenCalled();
+  });
+
+  it('attaches an image pasted from the clipboard', async () => {
+    renderComponent();
+
+    const file = new File(['pasted'], 'image.png', { type: 'image/png' });
+    const event = pasteFiles([file]);
+
+    expect(
+      await screen.findByAltText('Screenshot preview'),
+    ).toBeInTheDocument();
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('rejects a pasted image that fails validation', async () => {
+    renderComponent();
+
+    const tooLarge = new File(['x'], 'image.png', { type: 'image/png' });
+    Object.defineProperty(tooLarge, 'size', { value: 6 * 1024 * 1024 });
+    pasteFiles([tooLarge]);
+
+    await waitFor(() =>
+      expect(mockDisplayToast).toHaveBeenCalledWith(
+        'File too large. Maximum size is 5MB.',
+      ),
+    );
+    expect(screen.queryByAltText('Screenshot preview')).not.toBeInTheDocument();
+  });
+
+  it('leaves a text-only paste to the focused field', async () => {
+    renderComponent();
+
+    const event = pasteFiles([]);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.queryByAltText('Screenshot preview')).not.toBeInTheDocument();
   });
 
   it('renders all categories and submits content quality with updated enum value', async () => {

--- a/packages/shared/src/components/modals/FeedbackModal.tsx
+++ b/packages/shared/src/components/modals/FeedbackModal.tsx
@@ -27,10 +27,12 @@ import {
   revokePreviewUrl,
   isValidImageType,
   isValidFileSize,
+  getImageFileFromClipboard,
   MAX_SCREENSHOT_SIZE,
 } from '../../lib/screenshot';
 import { ScreenshotCropper } from '../feedback/ScreenshotCropper';
 import { useSettingsContext } from '../../contexts/SettingsContext';
+import { useEventListener } from '../../hooks/useEventListener';
 
 const FEEDBACK_MAX_LENGTH = 2000;
 type FeedbackModalProps = Omit<ModalProps, 'onRequestClose'> & {
@@ -251,6 +253,23 @@ const FeedbackModal = ({
   const isSubmitDisabled =
     !description.trim() || isOperationInProgress || isCropping;
 
+  // The modal owns the whole overlay while it is mounted, so listening on the
+  // document catches the paste wherever focus sits, textarea included. Only
+  // image pastes are swallowed; text still lands in the field it was aimed at.
+  useEventListener(globalThis?.document, 'paste', (event: ClipboardEvent) => {
+    if (isOperationInProgress || isCropping) {
+      return;
+    }
+
+    const file = getImageFileFromClipboard(event.clipboardData);
+    if (!file) {
+      return;
+    }
+
+    event.preventDefault();
+    handleScreenshotChange(file);
+  });
+
   return (
     <Modal
       {...props}
@@ -362,6 +381,15 @@ const FeedbackModal = ({
               aria-label="Upload screenshot"
             />
           </div>
+
+          {!isCropping && (
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              You can also paste an image straight from your clipboard.
+            </Typography>
+          )}
 
           {/* Screenshot preview */}
           {screenshotPreview && isCropping && (

--- a/packages/shared/src/lib/screenshot.spec.ts
+++ b/packages/shared/src/lib/screenshot.spec.ts
@@ -1,4 +1,4 @@
-import { toNaturalRect } from './screenshot';
+import { getImageFileFromClipboard, toNaturalRect } from './screenshot';
 
 describe('toNaturalRect', () => {
   const display = { width: 400, height: 300 };
@@ -28,5 +28,68 @@ describe('toNaturalRect', () => {
         natural,
       ),
     ).toEqual({ x: 1560, y: 1160, width: 40, height: 40 });
+  });
+});
+
+describe('getImageFileFromClipboard', () => {
+  const image = new File(['image'], 'image.png', { type: 'image/png' });
+
+  const clipboard = (
+    data: Partial<Pick<DataTransfer, 'files' | 'items'>>,
+  ): DataTransfer => data as unknown as DataTransfer;
+
+  it('returns the first image among the pasted files', () => {
+    const text = new File(['notes'], 'notes.txt', { type: 'text/plain' });
+
+    expect(
+      getImageFileFromClipboard(
+        clipboard({ files: [text, image] as unknown as FileList }),
+      ),
+    ).toBe(image);
+  });
+
+  it('falls back to the clipboard items when files is empty', () => {
+    const items = [
+      { kind: 'string', type: 'text/plain', getAsFile: () => null },
+      { kind: 'file', type: 'image/png', getAsFile: () => image },
+    ];
+
+    expect(
+      getImageFileFromClipboard(
+        clipboard({
+          files: [] as unknown as FileList,
+          items: items as unknown as DataTransferItemList,
+        }),
+      ),
+    ).toBe(image);
+  });
+
+  it('returns null for a text-only clipboard', () => {
+    expect(
+      getImageFileFromClipboard(
+        clipboard({
+          files: [] as unknown as FileList,
+          items: [
+            { kind: 'string', type: 'text/plain', getAsFile: () => null },
+          ] as unknown as DataTransferItemList,
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns null without clipboard data', () => {
+    expect(getImageFileFromClipboard(null)).toBeNull();
+  });
+
+  // An unsupported image type must still come through so the caller's
+  // isValidImageType() check is what reports it to the user.
+  it('returns an unsupported image type for the caller to reject', () => {
+    const bitmap = new File(['bmp'], 'image.bmp', { type: 'image/bmp' });
+
+    expect(
+      getImageFileFromClipboard(
+        clipboard({ files: [bitmap] as unknown as FileList }),
+      ),
+    ).toBe(bitmap);
   });
 });

--- a/packages/shared/src/lib/screenshot.ts
+++ b/packages/shared/src/lib/screenshot.ts
@@ -220,3 +220,31 @@ export const MAX_SCREENSHOT_SIZE = 5 * 1024 * 1024;
  */
 export const isValidFileSize = (file: File): boolean =>
   file.size <= MAX_SCREENSHOT_SIZE;
+
+/**
+ * Pull the first image out of a paste event's clipboard payload.
+ * Chrome exposes pasted images on `files`; `items` covers the browsers that
+ * only populate the item list. The image type itself is not filtered here so
+ * an unsupported one still reaches isValidImageType() and gets a toast.
+ */
+export const getImageFileFromClipboard = (
+  clipboardData: DataTransfer | null,
+): File | null => {
+  if (!clipboardData) {
+    return null;
+  }
+
+  const file = Array.from(clipboardData.files ?? []).find((item) =>
+    item.type.startsWith('image/'),
+  );
+
+  if (file) {
+    return file;
+  }
+
+  const item = Array.from(clipboardData.items ?? []).find(
+    (entry) => entry.kind === 'file' && entry.type.startsWith('image/'),
+  );
+
+  return item?.getAsFile() ?? null;
+};


### PR DESCRIPTION
## Summary

- attach images pasted while the feedback modal is open
- reuse the existing type and size validation path
- preserve normal text paste behavior
- make clipboard image support discoverable in the modal

## Verification

- 17 focused shared tests passed
- 683 webapp tests passed
- changed-file strict typecheck passed
- ESLint passed for all changed files
- package-wide shared and webapp typechecks still report only unrelated pre-existing test typing backlog; no changed file is reported

Linear: https://linear.app/dailydev/issue/ENG-2056

### Preview domain
https://eng-2056-feedback-feature-reques.preview.app.daily.dev