### PR TITLE
Show community take in classic post layouts

### DIFF
--- a/packages/shared/src/components/post/SquadPostContent.spec.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.spec.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { TestBootProvider } from '../../../__tests__/helpers/boot';
+import {
+  postWithCommunitySentiment,
+  sharePost,
+} from '../../../__tests__/fixture/post';
+import type { Post } from '../../graphql/posts';
+import { Origin } from '../../lib/log';
+import { SquadPostContentRaw } from './SquadPostContent';
+
+jest.mock('./SquadPostWidgets', () => ({
+  SquadPostWidgets: () => <aside />,
+}));
+
+const sharedPostWithCommunitySentiment: Post = {
+  ...sharePost,
+  sharedPost: {
+    ...sharePost.sharedPost!,
+    communitySentiment: postWithCommunitySentiment.communitySentiment,
+  },
+};
+
+const renderContent = (post: Post) =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <SquadPostContentRaw post={post} origin={Origin.ArticleModal} />
+    </TestBootProvider>,
+  );
+
+describe('SquadPostContent community sentiment', () => {
+  it('renders in the classic share post layout when the shared post has a take', () => {
+    renderContent(sharedPostWithCommunitySentiment);
+
+    expect(
+      screen.getByRole('region', { name: 'What the community thinks' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Most agree it is worth reading.')).toBeVisible();
+  });
+
+  it('stays hidden in the classic share post layout when the shared post has no take', () => {
+    renderContent(sharePost);
+
+    expect(
+      screen.queryByRole('region', { name: 'What the community thinks' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/SquadPostContent.tsx
+++ b/packages/shared/src/components/post/SquadPostContent.tsx
@@ -26,6 +26,10 @@ import { useActions, useViewSize, ViewSize } from '../../hooks';
 import { ActionType } from '../../graphql/actions';
 import { useShowBoostButton } from '../../features/boost/useShowBoostButton';
 import type { Post } from '../../graphql/posts';
+import {
+  CommunitySentiment,
+  mapCommunitySentimentPost,
+} from './focus/CommunitySentiment';
 
 const ContentMap = {
   [PostType.Freeform]: MarkdownPostContent,
@@ -48,7 +52,7 @@ const getSquadContentComponent = (type: PostType) => {
 
 type SquadPostContentRawProps = Omit<PostContentProps, 'post'> & { post: Post };
 
-function SquadPostContentRaw({
+export function SquadPostContentRaw({
   post,
   isFallback,
   shouldOnboardAuthor,
@@ -110,6 +114,12 @@ function SquadPostContentRaw({
     ? PostType.VideoYouTube
     : socialTwitterType || post?.type;
   const Content = getSquadContentComponent(finalType);
+  const communitySentimentPost =
+    post.type === PostType.Share && post.sharedPost ? post.sharedPost : post;
+  const communitySentimentData = communitySentimentPost.communitySentiment
+    ? mapCommunitySentimentPost(communitySentimentPost.communitySentiment)
+    : undefined;
+  const showCommunitySentiment = !!communitySentimentData;
 
   return (
     <PostContentContainer
@@ -197,6 +207,12 @@ function SquadPostContentRaw({
             onReadArticle={onReadArticle}
             isCompactSpacing={isCompactModalSpacing}
           />
+          {showCommunitySentiment && (
+            <CommunitySentiment
+              data={communitySentimentData}
+              className={isCompactModalSpacing ? 'mb-4' : 'mb-6'}
+            />
+          )}
         </BasePostContent>
       </div>
       <SquadPostWidgets

--- a/packages/shared/src/components/post/collection/CollectionPostContent.spec.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.spec.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { QueryClient } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { TestBootProvider } from '../../../../__tests__/helpers/boot';
+import { postWithCommunitySentiment } from '../../../../__tests__/fixture/post';
+import type { Post } from '../../../graphql/posts';
+import { PostType } from '../../../graphql/posts';
+import { Origin } from '../../../lib/log';
+import { CollectionPostContentRaw } from './CollectionPostContent';
+
+jest.mock('./CollectionPostWidgets', () => ({
+  CollectionPostWidgets: () => <aside />,
+}));
+
+const collectionPostWithCommunitySentiment: Post = {
+  ...postWithCommunitySentiment,
+  id: 'collection-with-community-sentiment',
+  type: PostType.Collection,
+  title: 'Collection with a community take',
+  contentHtml: '<p>Collection body</p>',
+  numCollectionSources: 2,
+};
+
+const renderContent = (post: Post) =>
+  render(
+    <TestBootProvider client={new QueryClient()}>
+      <CollectionPostContentRaw post={post} origin={Origin.ArticleModal} />
+    </TestBootProvider>,
+  );
+
+describe('CollectionPostContent community sentiment', () => {
+  it('renders in the classic collection layout when the post has a take', () => {
+    renderContent(collectionPostWithCommunitySentiment);
+
+    expect(
+      screen.getByRole('region', { name: 'What the community thinks' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Most agree it is worth reading.')).toBeVisible();
+  });
+
+  it('stays hidden in the classic collection layout when the post has no take', () => {
+    renderContent({
+      ...collectionPostWithCommunitySentiment,
+      communitySentiment: null,
+    });
+
+    expect(
+      screen.queryByRole('region', { name: 'What the community thinks' }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/shared/src/components/post/collection/CollectionPostContent.tsx
+++ b/packages/shared/src/components/post/collection/CollectionPostContent.tsx
@@ -25,13 +25,17 @@ import { CollectionPostHeaderActions } from './CollectionPostHeaderActions';
 import { isPostUpdated, type Post } from '../../../graphql/posts';
 import { pluralize } from '../../../lib/strings';
 import { TRENDS_SOURCE_ID } from '../../../lib/utils';
+import {
+  CommunitySentiment,
+  mapCommunitySentimentPost,
+} from '../focus/CommunitySentiment';
 import { getCollectionPillLabel, isTrendsPost } from './common';
 
 type CollectionPostContentRawProps = Omit<PostContentProps, 'post'> & {
   post: Post;
 };
 
-const CollectionPostContentRaw = ({
+export const CollectionPostContentRaw = ({
   post,
   className = {},
   shouldOnboardAuthor,
@@ -61,6 +65,10 @@ const CollectionPostContentRaw = ({
   const hasSources = !!numCollectionSources && numCollectionSources > 0;
   const sourceId = isTrendsPost(post) ? TRENDS_SOURCE_ID : 'collections';
   const { onCopyPostLink, onReadArticle } = engagementActions;
+  const communitySentimentData = post.communitySentiment
+    ? mapCommunitySentimentPost(post.communitySentiment)
+    : undefined;
+  const showCommunitySentiment = !!communitySentimentData;
 
   const hasNavigation = !!onPreviousPost || !!onNextPost;
   const containerClass = classNames(
@@ -186,6 +194,9 @@ const CollectionPostContentRaw = ({
               </div>
             )}
             <Markdown content={contentHtml ?? ''} />
+            {showCommunitySentiment && (
+              <CommunitySentiment data={communitySentimentData} />
+            )}
           </div>
         </BasePostContent>
       </PostContainer>


### PR DESCRIPTION
Summary: render community take in classic squad/share and collection post layouts, and add regression specs for both. Tests: focused shared Jest specs, strict changed-file typecheck, and full webapp test.

### Preview domain
https://codex-community-take-from-main.preview.app.daily.dev