### PR TITLE
chore(sidebar): hardcode tour eligibility

### DIFF
--- a/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
+++ b/packages/shared/src/components/sidebar/SidebarDesktopV2.tsx
@@ -976,8 +976,8 @@ export const SidebarDesktopV2 = ({
     [isAnyDragging, setSidebarDragging],
   );
 
-  // Every tour and coach hook below is inert unless the `sidebar_tour` flag is
-  // on, so the control arm keeps the rail's unmodified markup and behaviour.
+  // The tour and coach hooks below stay inert until the v2 rail, auth and
+  // persisted state are ready.
   const tour = useSidebarTourState();
   const dotsCoach = useDotsCoach(tour.dotsCoach);
   const {
@@ -2662,7 +2662,7 @@ export const SidebarDesktopV2 = ({
         the aside rather than a child: these portal to the body, and React
         portals still bubble their events up the React tree, which would feed
         the rail's own mousemove/mouseleave prediction machinery. Each is null
-        unless the `sidebar_tour` flag put it there. */}
+        unless the sidebar tour has something to show. */}
       <SidebarTourOverlay tour={tour} />
       <PinCoach
         coach={tour.pinCoach}

--- a/packages/shared/src/features/sidebarTour/SidebarTourOverlay.spec.tsx
+++ b/packages/shared/src/features/sidebarTour/SidebarTourOverlay.spec.tsx
@@ -8,13 +8,11 @@ import {
 } from '@testing-library/react';
 import React from 'react';
 import { QueryClient } from '@tanstack/react-query';
-import { GrowthBook } from '@growthbook/growthbook-react';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import defaultUser from '../../../__tests__/fixture/loggedUser';
 import type { LoggedUser } from '../../lib/user';
-import { featureSidebarTour } from '../../lib/featureManagement';
 import { LogEvent } from '../../lib/log';
 import { SpotlightProvider } from '../../components/spotlight/SpotlightContext';
 import { SidebarDesktopV2 } from '../../components/sidebar/SidebarDesktopV2';
@@ -54,14 +52,7 @@ const openModal = () =>
     client.setQueryData(MODAL_KEY, { type: LazyModal.ReportPost });
   });
 
-const renderRail = (
-  isFeatureEnabled: boolean,
-  isModalOpen = false,
-): RenderResult => {
-  const gb = new GrowthBook();
-  gb.setFeatures({
-    [featureSidebarTour.id]: { defaultValue: isFeatureEnabled },
-  });
+const renderRail = (isModalOpen = false): RenderResult => {
   client = new QueryClient();
   // The tour waits for the seen-flag to have loaded, and that now rides
   // `useActions`. Seeded rather than mocked so the real hook is exercised.
@@ -77,7 +68,6 @@ const renderRail = (
   return render(
     <TestBootProvider
       client={client}
-      gb={gb}
       auth={{ user: existingUser, isLoggedIn: true }}
       settings={{ updateFlag }}
       log={{ logEvent }}
@@ -112,33 +102,9 @@ describe('sidebar tour wiring', () => {
     } as unknown as NextRouter);
   });
 
-  describe('with the feature flag off', () => {
-    it('leaves the rail exactly as it is today', async () => {
-      renderRail(false);
-
-      const aside = await screen.findByTestId('sidebar-aside');
-      expect(aside).not.toHaveClass(RAIL_TOUR_LIFT_CLASS);
-
-      // Give the auto-start timer more than its grace period to misfire.
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1200);
-      });
-
-      expect(
-        screen.queryByTestId('sidebar-tour-scrim'),
-      ).not.toBeInTheDocument();
-      expect(screen.queryByText('Skip tour')).not.toBeInTheDocument();
-
-      fireEvent.click(screen.getByLabelText('Support'));
-
-      expect(screen.queryByText('Sidebar tutorial')).not.toBeInTheDocument();
-      expect(screen.getByText('Docs')).toBeInTheDocument();
-    });
-  });
-
-  describe('with the feature flag on', () => {
+  describe('when the user is eligible for the tour', () => {
     it('spotlights the rail and teaches compact mode on step one', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -161,7 +127,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('ends the tour on skip and does not bring it back', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -185,7 +151,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('ends the tour on Escape and logs the step it left from', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -208,7 +174,7 @@ describe('sidebar tour wiring', () => {
 
     it('swallows a compact write that the settings mutation rejects', async () => {
       updateFlag.mockRejectedValueOnce(new Error('settings unavailable'));
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -221,7 +187,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('drops a step whose target stops existing rather than stranding the scrim', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -244,7 +210,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('leaves the tour alone when a modal already consumed Escape', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -263,7 +229,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('ends the tour when the rail navigates out from under it', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -288,7 +254,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('ignores a rewrite of the URL the user is already on', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -307,7 +273,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('never starts on top of a modal that already owns the screen', async () => {
-      renderRail(true, true);
+      renderRail(true);
 
       await screen.findByTestId('sidebar-aside');
       await new Promise((resolve) => {
@@ -320,7 +286,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('steps aside when a modal opens over a running tour', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -345,7 +311,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('announces the card as a labelled dialog and lands focus on the primary action', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -359,7 +325,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('drops the compact switch once the tour leaves the rail step', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -375,7 +341,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('finishes on the last step behind a "Got it" button', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -398,7 +364,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('makes the rail inert so nothing opens or navigates under the card', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -423,7 +389,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('keeps focus inside the card when Tab reaches its last control', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -446,7 +412,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('renames the support entry and files it under Changelog', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -471,7 +437,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('shows the drag demo on the dock step only', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -488,7 +454,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('teaches the dock gesture rather than inviting it mid-run', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,
@@ -512,7 +478,7 @@ describe('sidebar tour wiring', () => {
     });
 
     it('offers the tour again from the support menu', async () => {
-      renderRail(true);
+      renderRail();
 
       await screen.findByTestId('sidebar-tour-scrim', undefined, {
         timeout: TOUR_TIMEOUT,

--- a/packages/shared/src/features/sidebarTour/useSidebarTourState.spec.tsx
+++ b/packages/shared/src/features/sidebarTour/useSidebarTourState.spec.tsx
@@ -2,20 +2,16 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
-import { GrowthBook } from '@growthbook/growthbook-react';
 import type { NextRouter } from 'next/router';
 import { useRouter } from 'next/router';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import defaultUser from '../../../__tests__/fixture/loggedUser';
 import type { LoggedUser } from '../../lib/user';
-import {
-  featureSidebarTour,
-  featureSidebarTourExistingBefore,
-} from '../../lib/featureManagement';
 import { LogEvent } from '../../lib/log';
 import { ActionType } from '../../graphql/actions';
 import {
   COACH_MAX_EXPOSURES,
+  SIDEBAR_TOUR_EXISTING_USER_CUTOFF,
   SIDEBAR_PIN_COACH_KEY,
   useSidebarTourState,
 } from './useSidebarTourState';
@@ -79,21 +75,20 @@ const keysWrittenFor = (key: string): string[] =>
     .filter(([written]) => written.startsWith(`${key}:`))
     .map(([written]) => written);
 
-// A rollout day, and an account either side of it.
-const ROLLOUT_DAY = '2026-09-01T00:00:00.000Z';
-const dayFromRollout = (days: number): string =>
+// The hardcoded sidebar tour cutoff, and an account either side of it.
+const dayFromCutoff = (days: number): string =>
   new Date(
-    new Date(ROLLOUT_DAY).getTime() + days * 24 * 60 * 60 * 1000,
+    SIDEBAR_TOUR_EXISTING_USER_CUTOFF + days * 24 * 60 * 60 * 1000,
   ).toISOString();
 
 const existingUser: LoggedUser = {
   ...defaultUser,
-  createdAt: dayFromRollout(-1),
+  createdAt: dayFromCutoff(-1),
 };
 
 const newUser: LoggedUser = {
   ...defaultUser,
-  createdAt: dayFromRollout(1),
+  createdAt: dayFromCutoff(1),
 };
 
 const logEvent = jest.fn();
@@ -116,25 +111,12 @@ const mountRail = () => {
 
 interface RenderOptions {
   user?: LoggedUser | null;
-  isFeatureEnabled?: boolean;
-  existingBefore?: string;
 }
 
-const renderTour = ({
-  user = existingUser,
-  isFeatureEnabled = true,
-  existingBefore = ROLLOUT_DAY,
-}: RenderOptions = {}) => {
-  const gb = new GrowthBook();
-  gb.setFeatures({
-    [featureSidebarTour.id]: { defaultValue: isFeatureEnabled },
-    [featureSidebarTourExistingBefore.id]: { defaultValue: existingBefore },
-  });
-
+const renderTour = ({ user = existingUser }: RenderOptions = {}) => {
   const wrapper = ({ children }: { children: ReactNode }) => (
     <TestBootProvider
       client={new QueryClient()}
-      gb={gb}
       log={{ logEvent }}
       auth={{ user: user ?? undefined, isLoggedIn: !!user }}
     >
@@ -172,18 +154,6 @@ describe('useSidebarTourState', () => {
 
   afterEach(() => {
     unmountRail();
-  });
-
-  it('treats everyone as an existing user until the rollout sets a cutoff', async () => {
-    // v2 has never shipped, so on a first rollout nobody has landed on the new
-    // rail before today: an unset cutoff must not withhold the tour from the
-    // accounts that signed up most recently.
-    const { result } = await renderEnabledTour({
-      user: newUser,
-      existingBefore: '',
-    });
-
-    expect(result.current.canAutoStart).toBe(true);
   });
 
   it('offers the tour to an existing user who has not seen it', async () => {
@@ -240,18 +210,6 @@ describe('useSidebarTourState', () => {
 
     await waitFor(() => expect(result.current.isEnabled).toBe(false));
     expect(result.current.canAutoStart).toBe(false);
-  });
-
-  it('shows nothing while the feature flag is off', async () => {
-    const { result } = renderTour({ isFeatureEnabled: false });
-
-    await waitFor(() => expect(result.current.isEnabled).toBe(false));
-    expect(result.current.canAutoStart).toBe(false);
-
-    act(() => result.current.start('auto'));
-
-    expect(result.current.isRunning).toBe(false);
-    expect(result.current.step).toBeNull();
   });
 
   it('runs every step whose target is on the rail', async () => {
@@ -476,16 +434,10 @@ describe('useSidebarTourState', () => {
 
   it('drops a parked run when the user stops being eligible mid-tour', async () => {
     let user: LoggedUser | null = existingUser;
-    const gb = new GrowthBook();
-    gb.setFeatures({
-      [featureSidebarTour.id]: { defaultValue: true },
-      [featureSidebarTourExistingBefore.id]: { defaultValue: ROLLOUT_DAY },
-    });
     const client = new QueryClient();
     const wrapper = ({ children }: { children: ReactNode }) => (
       <TestBootProvider
         client={client}
-        gb={gb}
         log={{ logEvent }}
         auth={{ user: user ?? undefined, isLoggedIn: !!user }}
       >

--- a/packages/shared/src/features/sidebarTour/useSidebarTourState.ts
+++ b/packages/shared/src/features/sidebarTour/useSidebarTourState.ts
@@ -2,15 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import { useAuthContext } from '../../contexts/AuthContext';
 import { useLogContext } from '../../contexts/LogContext';
-import { useConditionalFeature } from '../../hooks/useConditionalFeature';
 import { useLayoutVariant } from '../../hooks/layout/useLayoutVariant';
 import usePersistentContext from '../../hooks/usePersistentContext';
 import { useActions } from '../../hooks/useActions';
 import { ActionType } from '../../graphql/actions';
-import {
-  featureSidebarTour,
-  featureSidebarTourExistingBefore,
-} from '../../lib/featureManagement';
 import { LogEvent } from '../../lib/log';
 import { resolveSidebarTourSteps } from './steps';
 import type {
@@ -65,6 +60,8 @@ export const COACH_MAX_EXPOSURES = 3;
 // so both ambient coaches only charge an exposure once one has sat there.
 export const COACH_EXPOSURE_DWELL_MS = 700;
 
+export const SIDEBAR_TOUR_EXISTING_USER_CUTOFF = Date.UTC(2026, 8, 8);
+
 export interface SidebarCoachState {
   isActive: boolean;
   onShown: () => void;
@@ -112,7 +109,7 @@ const useCoachCounter = (key: string): CoachCounter => {
 };
 
 export interface SidebarTourState {
-  // Flag on, v2 rail, signed in, and the persisted flags have loaded.
+  // v2 rail, signed in, and the persisted flags have loaded.
   isEnabled: boolean;
   isRunning: boolean;
   step: SidebarTourStep | null;
@@ -140,15 +137,7 @@ export const useSidebarTourState = (): SidebarTourState => {
   const { logEvent } = useLogContext();
   const router = useRouter();
 
-  const shouldEvaluate = isV2 && isAuthReady && !!user;
-  const { value: isFeatureEnabled } = useConditionalFeature({
-    feature: featureSidebarTour,
-    shouldEvaluate,
-  });
-  const { value: existingUserBefore } = useConditionalFeature({
-    feature: featureSidebarTourExistingBefore,
-    shouldEvaluate,
-  });
+  const isEligible = isV2 && isAuthReady && !!user;
 
   const { checkHasCompleted, completeAction, isActionsFetched } = useActions();
   const isTourSeen = checkHasCompleted(ActionType.SidebarTourSeen);
@@ -161,12 +150,12 @@ export const useSidebarTourState = (): SidebarTourState => {
   // was already seen never flashes on the way to being read.
   const isFetched =
     isActionsFetched && pinCounter.isFetched && dotsCounter.isFetched;
-  const isEnabled = shouldEvaluate && isFeatureEnabled && isFetched;
+  const isEnabled = isEligible && isFetched;
 
   const [steps, setSteps] = useState<SidebarTourStep[] | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
 
-  // Logging out or losing the flag mid-tour must not leave a run parked and
+  // Logging out or losing eligibility mid-tour must not leave a run parked and
   // ready to resume the moment eligibility comes back. The seen flag stays
   // untouched: the user never acted on it.
   useEffect(() => {
@@ -179,13 +168,10 @@ export const useSidebarTourState = (): SidebarTourState => {
   }, [isEnabled, steps]);
 
   // Only people whose muscle memory the rail broke get the tour on their own.
-  // With no cutoff set that is everyone, which is true of a first rollout: the
-  // v2 rail has not shipped, so nobody has landed on it before today.
-  const existingBefore = new Date(existingUserBefore);
+  // Everyone who signed up before September 8, 2026 came from the old sidebar.
   const isExistingUser =
-    !existingUserBefore ||
-    Number.isNaN(existingBefore.getTime()) ||
-    (!!user?.createdAt && new Date(user.createdAt) < existingBefore);
+    !!user?.createdAt &&
+    new Date(user.createdAt).getTime() < SIDEBAR_TOUR_EXISTING_USER_CUTOFF;
 
   const step = steps?.[stepIndex] ?? null;
   const isRunning = isEnabled && !!step;

--- a/packages/shared/src/hooks/layout/useLayoutVariant.ts
+++ b/packages/shared/src/hooks/layout/useLayoutVariant.ts
@@ -37,7 +37,7 @@ export const useLayoutVariant = (): UseLayoutVariant => {
   const { isV2, isLoading } = useLayoutVariantFlag();
 
   // The shell the mirrored route painted stands only until the flag can
-  // contradict it, so turning `layout_v2` off takes effect on this render
+  // contradict it, so turning `layout_v2_2` off takes effect on this render
   // rather than the next hard navigation. `isLaptop` is client-only and would
   // contradict what the server painted, so it applies from the second render
   // on: `isAuthReady` is false on the server and on the first client render,

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -247,7 +247,7 @@ export const featureOnboardingChrome = new Feature<OnboardingChromeVariant>(
   OnboardingChromeVariant.Control,
 );
 
-export const featureLayoutV2 = new Feature('layout_v2', false);
+export const featureLayoutV2 = new Feature('layout_v2_2', false);
 
 export const featureEngagementBarV2 = new Feature('engagement_bar_v2', false);
 
@@ -335,22 +335,3 @@ export const featureCommentFirstAction = new Feature(
 // Kill switch for the batched GraphQL transport (`graphql/batch.ts`). Off is
 // the control: the API only accepts batched bodies once its own change ships.
 export const featureGqlBatching = new Feature('gql_batching', false);
-
-// Sidebar v2 onboarding: a three-step spotlight tour for users whose muscle
-// memory the rail broke, plus the ambient pin/••• coaching for everyone else.
-// Control shows nothing at all. Keep the default false so GrowthBook ramps it.
-export const featureSidebarTour = new Feature('sidebar_tour', false);
-
-// ISO date splitting the tour's two audiences: accounts created before it came
-// from the old sidebar and get the guided tour, accounts created after land on
-// the v2 rail first and get the ambient coaches instead.
-//
-// Empty means "everyone here now came from the old sidebar", which is what a
-// first rollout looks like: v2 has never shipped, so no account has seen it.
-// Set this to the day the rollout starts and the split becomes exact again --
-// it lives in GrowthBook precisely because a build-time date cannot know when
-// the ramp actually reached people.
-export const featureSidebarTourExistingBefore = new Feature(
-  'sidebar_tour_existing_before',
-  '',
-);


### PR DESCRIPTION
## Summary
- remove the sidebar_tour and sidebar_tour_existing_before GrowthBook gates
- make the sidebar tour available from hardcoded app/auth/layout readiness
- start the guided sidebar tutorial only for users created before 2026-09-08T00:00:00.000Z
- restart the layout_v2 experiment with the fresh layout_v2_2 key

## Tests
- node ./scripts/typecheck-strict-changed.js
- pnpm --filter @dailydotdev/shared test -- useSidebarTourState SidebarTourOverlay layoutVariant.spec --runInBand
- pnpm --filter webapp test -- MainLayoutServerVariant --runInBand

### Preview domain
https://codex-restart-layout-and-hardcod.preview.app.daily.dev