### PR TITLE
fix(interests): carry post references in vote and explain feedback

### DIFF
--- a/packages/shared/src/features/interests/attachments.spec.ts
+++ b/packages/shared/src/features/interests/attachments.spec.ts
@@ -148,12 +148,26 @@ describe('messagePostAttachments', () => {
         { type: 'text', html: '<p>Two things.</p>' },
         { type: 'posts', posts: [makePost('a')] },
         { type: 'picks', posts: [makePost('b')] },
-        { type: 'feedLink', label: 'All', posts: [makePost('c')] },
       ],
     });
 
-    expect(chips.map(({ id }) => id)).toEqual(['post:a', 'post:b', 'post:c']);
+    expect(chips.map(({ id }) => id)).toEqual(['post:a', 'post:b']);
     expect(chips.every(({ kind }) => kind === 'post')).toBe(true);
+  });
+
+  it('leaves feed links out, so a whole feed cannot claim the feedback', () => {
+    const chips = messagePostAttachments({
+      blocks: [
+        {
+          type: 'feedLink',
+          label: 'All',
+          posts: [makePost('x'), makePost('y')],
+        },
+        { type: 'picks', posts: [makePost('a')] },
+      ],
+    });
+
+    expect(chips.map(({ id }) => id)).toEqual(['post:a']);
   });
 
   it('names a post once even when several blocks carry it', () => {

--- a/packages/shared/src/features/interests/attachments.spec.ts
+++ b/packages/shared/src/features/interests/attachments.spec.ts
@@ -3,7 +3,9 @@ import {
   activityAttachment,
   agentAttachments,
   feedAttachment,
+  FEEDBACK_POST_LIMIT,
   mentionCandidates,
+  messagePostAttachments,
   postAttachment,
   quoteAttachment,
   targetAttachment,
@@ -136,6 +138,63 @@ describe('targetAttachment', () => {
 
   it('has nothing to offer for the debug tab', () => {
     expect(targetAttachment({ type: 'debug' })).toBeUndefined();
+  });
+});
+
+describe('messagePostAttachments', () => {
+  it('turns every post the reply cited into a chip, in order', () => {
+    const chips = messagePostAttachments({
+      blocks: [
+        { type: 'text', html: '<p>Two things.</p>' },
+        { type: 'posts', posts: [makePost('a')] },
+        { type: 'picks', posts: [makePost('b')] },
+        { type: 'feedLink', label: 'All', posts: [makePost('c')] },
+      ],
+    });
+
+    expect(chips.map(({ id }) => id)).toEqual(['post:a', 'post:b', 'post:c']);
+    expect(chips.every(({ kind }) => kind === 'post')).toBe(true);
+  });
+
+  it('names a post once even when several blocks carry it', () => {
+    const chips = messagePostAttachments({
+      blocks: [
+        { type: 'posts', posts: [makePost('a')] },
+        { type: 'picks', posts: [makePost('a'), makePost('b')] },
+      ],
+    });
+
+    expect(chips.map(({ id }) => id)).toEqual(['post:a', 'post:b']);
+  });
+
+  it('stops at the limit so one vote does not reference a whole feed', () => {
+    const posts = Array.from({ length: FEEDBACK_POST_LIMIT + 3 }, (_, i) =>
+      makePost(`p${i}`),
+    );
+
+    expect(
+      messagePostAttachments({ blocks: [{ type: 'posts', posts }] }),
+    ).toHaveLength(FEEDBACK_POST_LIMIT);
+    expect(
+      messagePostAttachments({ blocks: [{ type: 'posts', posts }] }, 2),
+    ).toHaveLength(2);
+  });
+
+  it('has nothing for a text-only reply or one without blocks', () => {
+    expect(
+      messagePostAttachments({ blocks: [{ type: 'text', html: '<p>Hi</p>' }] }),
+    ).toEqual([]);
+    expect(messagePostAttachments({})).toEqual([]);
+  });
+
+  it('flattens into the marker form the API sweeps for', () => {
+    const chips = messagePostAttachments({
+      blocks: [{ type: 'posts', posts: [makePost('a'), makePost('b')] }],
+    });
+
+    expect(promptWithContext('Fewer like this', chips)).toBe(
+      'Fewer like this\n\nIn the context of: @dailydev:post:a, @dailydev:post:b',
+    );
   });
 });
 

--- a/packages/shared/src/features/interests/attachments.ts
+++ b/packages/shared/src/features/interests/attachments.ts
@@ -70,6 +70,34 @@ export const targetAttachment = (
   return agentAttachments.find(({ id }) => id === `agent:${target.type}`);
 };
 
+// Most posts one piece of feedback can point at. The API sweeps every marker
+// into a relationship, so a reply that lists a whole feed would drown the
+// finding the vote was actually about.
+export const FEEDBACK_POST_LIMIT = 5;
+
+// The posts a reply cited, as chips, so feedback about that reply can name
+// them with the `@dailydev:post:` markers the API resolves.
+export const messagePostAttachments = (
+  message: Pick<AgentMessage, 'blocks'>,
+  limit = FEEDBACK_POST_LIMIT,
+): AgentAttachment[] => {
+  const seen = new Set<string>();
+
+  return (message.blocks ?? [])
+    .flatMap((block) => (isPostsBlock(block) ? block.posts : []))
+    .filter(({ id }) => {
+      if (seen.has(id)) {
+        return false;
+      }
+
+      seen.add(id);
+
+      return true;
+    })
+    .slice(0, limit)
+    .map(postAttachment);
+};
+
 const transcriptPosts = (messages: AgentMessage[]): Post[] =>
   messages
     // Newest first, so deduping downstream keeps the most recent copy.

--- a/packages/shared/src/features/interests/attachments.ts
+++ b/packages/shared/src/features/interests/attachments.ts
@@ -76,7 +76,9 @@ export const targetAttachment = (
 export const FEEDBACK_POST_LIMIT = 5;
 
 // The posts a reply cited, as chips, so feedback about that reply can name
-// them with the `@dailydev:post:` markers the API resolves.
+// them with the `@dailydev:post:` markers the API resolves. Feed links are
+// left out: a hydrated feed link can carry the whole feed, so its posts would
+// misattribute the feedback to posts the reply never singled out.
 export const messagePostAttachments = (
   message: Pick<AgentMessage, 'blocks'>,
   limit = FEEDBACK_POST_LIMIT,
@@ -84,7 +86,9 @@ export const messagePostAttachments = (
   const seen = new Set<string>();
 
   return (message.blocks ?? [])
-    .flatMap((block) => (isPostsBlock(block) ? block.posts : []))
+    .flatMap((block) =>
+      block.type === 'posts' || block.type === 'picks' ? block.posts : [],
+    )
     .filter(({ id }) => {
       if (seen.has(id)) {
         return false;

--- a/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.spec.tsx
@@ -1,15 +1,25 @@
 import React from 'react';
-import { fireEvent, render, screen, within } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import { QueryClient } from '@tanstack/react-query';
 import { TestBootProvider } from '../../../../__tests__/helpers/boot';
 import { mockDesktop } from '../../../../__tests__/helpers/media';
 import basePost from '../../../../__tests__/fixture/post';
+import defaultUser from '../../../../__tests__/fixture/loggedUser';
 import type { Post } from '../../../graphql/posts';
 import * as copy from '../../../hooks/useCopy';
 import * as lazyModal from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../../components/modals/common/types';
 import { Origin } from '../../../lib/log';
+import type { InterestTurn } from '../../../graphql/interests';
 import type { AgentMessage } from '../chat';
+import * as command from '../hooks/useSendInterestCommand';
+import * as queries from '../queries';
 import { AgentProvider, useAgent } from '../AgentContext';
 import { AgentChatSection } from './AgentChatSection';
 
@@ -210,6 +220,136 @@ describe('the reply actions', () => {
     );
 
     expect(labels[labels.length - 1]).toBe('Share reply');
+  });
+});
+
+describe('voting on a reply', () => {
+  // Feedback is a no-op in the demo, so the vote goes through the live
+  // provider with the transport and the transcript query stubbed.
+  const mountLive = (turn: InterestTurn) => {
+    const send = jest.fn().mockResolvedValue(undefined);
+
+    jest
+      .spyOn(command, 'useSendInterestCommand')
+      .mockReturnValue({ isSending: false, sendCommand: send } as never);
+    jest.spyOn(queries, 'interestHistoryQueryOptions').mockReturnValue({
+      queryKey: ['history', 'a1', turn.id],
+      queryFn: async () => ({
+        edges: [{ node: turn, cursor: turn.id }],
+        pageInfo: { hasNextPage: false, hasPreviousPage: false },
+      }),
+    } as never);
+    jest.spyOn(queries, 'interestRunQueryOptions').mockReturnValue({
+      queryKey: ['run', 'a1', turn.id],
+      queryFn: async () => {
+        throw new Error('run not found');
+      },
+      retry: false,
+    } as never);
+
+    render(
+      <TestBootProvider client={new QueryClient()} auth={{ user: defaultUser }}>
+        <AgentProvider
+          id="a1"
+          interest={{ id: 'a1', query: 'zig' } as never}
+          isDemo={false}
+          findings={[
+            {
+              id: 'f1',
+              post: post('p1', 'Zig 0.15'),
+              score: 0.9,
+              rationale: '',
+              createdAt: new Date(0).toISOString(),
+            },
+            {
+              id: 'f2',
+              post: post('p2', 'Ghostty is open source'),
+              score: 0.8,
+              rationale: '',
+              createdAt: new Date(0).toISOString(),
+            },
+          ]}
+        >
+          <AgentChatSection />
+        </AgentProvider>
+      </TestBootProvider>,
+    );
+
+    return send;
+  };
+
+  const run = (blocks: InterestTurn['blocks']): InterestTurn =>
+    ({
+      id: 'run-1',
+      role: 'agent',
+      createdAt: '2026-01-01T00:01:00Z',
+      status: 'completed',
+      trigger: 'spawn',
+      blocks,
+    } as InterestTurn);
+
+  it('names the posts the reply cited, so the agent knows which finding it is about', async () => {
+    const send = mountLive(
+      run([
+        { type: 'text', html: '<p>Kept two.</p>' },
+        { type: 'picks', postIds: ['p1', 'p2'] },
+      ]),
+    );
+
+    fireEvent.click(await screen.findByLabelText('Bad reply'));
+
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    const [{ text, reply: wantsReply }] = send.mock.calls[0];
+
+    expect(wantsReply).toBe(false);
+    expect(text).toContain('Fewer replies like this one: "Kept two.');
+    expect(text).toContain(
+      'In the context of: @dailydev:post:p1, @dailydev:post:p2',
+    );
+  });
+
+  it('sends the bare excerpt when the reply cited nothing', async () => {
+    const send = mountLive(run([{ type: 'text', html: '<p>Kept two.</p>' }]));
+
+    fireEvent.click(await screen.findByLabelText('Good reply'));
+
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    const [{ text }] = send.mock.calls[0];
+
+    expect(text).toBe('More replies like this one: "Kept two."');
+    expect(text).not.toContain('@dailydev:post:');
+  });
+});
+
+describe('explaining a vote', () => {
+  const AttachmentsProbe = () => {
+    const { attachments } = useAgent();
+    return (
+      <div data-testid="attachments">
+        {attachments.map(({ id }) => id).join(',')}
+      </div>
+    );
+  };
+
+  it('attaches the posts the reply cited alongside the quoted text', () => {
+    render(
+      <TestBootProvider client={new QueryClient()}>
+        <AgentProvider id="a1" isDemo initialMessages={[reply]}>
+          <AgentChatSection />
+          <AttachmentsProbe />
+        </AgentProvider>
+      </TestBootProvider>,
+    );
+
+    fireEvent.click(screen.getByLabelText('Bad reply'));
+    fireEvent.click(screen.getByText('Tell it why'));
+
+    const ids = screen.getByTestId('attachments').textContent?.split(',') ?? [];
+
+    expect(ids.some((id) => id.startsWith('quote:'))).toBe(true);
+    expect(ids).toContain('post:p1');
+    expect(ids).toContain('post:p2');
+    expect(new Set(ids).size).toBe(ids.length);
   });
 });
 

--- a/packages/shared/src/features/interests/components/AgentChatSection.tsx
+++ b/packages/shared/src/features/interests/components/AgentChatSection.tsx
@@ -32,13 +32,17 @@ import { DateFormat } from '../../../components/utilities/DateFormat';
 import { TimeFormatType } from '../../../lib/dateFormat';
 import type { Post } from '../../../graphql/posts';
 import type { AgentBlock, AgentMessage } from '../chat';
-import { FEEDBACK_MARKER_REGEX } from '../chat';
+import { FEEDBACK_MARKER_REGEX, promptWithContext } from '../chat';
 import { webappUrl } from '../../../lib/constants';
 import { useAgent } from '../AgentContext';
 import { transcriptProse } from '../prose';
 import { messageAsMarkdown, messageAsText } from '../replyText';
 import { AgentShareReplyModal } from './AgentShareReplyModal';
-import { feedAttachment, quoteAttachment } from '../attachments';
+import {
+  feedAttachment,
+  messagePostAttachments,
+  quoteAttachment,
+} from '../attachments';
 import { AgentPickList } from './AgentPickList';
 import { AgentAttachmentChip } from './AgentAttachmentChip';
 import { addToChatFloat, AgentAddToChatButton } from './AgentAddToChatButton';
@@ -195,11 +199,14 @@ const MessageActions = ({
 
     setVote(next);
     const text = messageAsText(message);
+    const excerpt = `${
+      next === 'up' ? 'More' : 'Fewer'
+    } replies like this one: "${text.slice(0, 140)}"`;
+
+    // The excerpt alone gives the agent nothing to act on: the posts the reply
+    // cited go along as markers, the same way attached chips are flattened.
     sendFeedback(
-      `${next === 'up' ? 'More' : 'Fewer'} replies like this one: "${text.slice(
-        0,
-        140,
-      )}"`,
+      promptWithContext(excerpt, messagePostAttachments(message)),
     ).catch(() => setVote(undefined));
   };
 
@@ -219,6 +226,9 @@ const MessageActions = ({
     if (text) {
       attachContext(quoteAttachment(text));
     }
+
+    // The quote is for the reader; the posts are what the API can resolve.
+    messagePostAttachments(message).forEach(attachContext);
 
     writeDraft(
       vote === 'down'


### PR DESCRIPTION
## Problem

The interest agent's thumbs up/down quick-action and the "Tell it why" explain flow sent feedback as a bare text excerpt of the reply. The text carried no post reference, so the API's `@dailydev:post:<id>` marker sweep had nothing to resolve and the agent could not tie the feedback to the finding it was actually about.

## What changed

- `attachments.ts`: new `messagePostAttachments(message, limit)` that collects the posts a reply cited across its posts / picks blocks (feedLink blocks are excluded: a hydrated feed link can carry the whole feed and would misattribute the feedback), dedupes them, caps at `FEEDBACK_POST_LIMIT` (5), and returns them as post chips.
- `AgentChatSection.tsx`:
  - Vote quick-action now builds the excerpt and passes it through `promptWithContext` with the reply's post chips, so the feedback text ends with `In the context of: @dailydev:post:<id>, ...` — the same flattening attached chips already use.
  - Explain flow attaches the reply's post chips alongside the quote chip, so the follow-up message carries resolvable markers too.
- Specs added for the helper (ordering, dedupe, limit, empty, marker form) and for the vote and explain flows in `AgentChatSection.spec.tsx`.

Out of scope / not included: auto-attaching the currently active post when voting; this PR only references posts the reply itself cited.

## Test status

- `jest src/features/interests`: 21 suites, 279 tests pass (52 in the four touched spec files).
- ESLint clean on the touched files; `tsc --noEmit` reports no errors in the interests feature.

## Disclosure

This change was implemented and tested with the help of an AI coding assistant (Claude); a human reviewed the diff before opening the PR.


### Preview domain
https://fix-interest-feedback-post-marke.preview.app.daily.dev
