### PR TITLE
fix(read): request the phone header leaderboard responsively

### DIFF
--- a/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
@@ -14,9 +14,9 @@ export interface ReadTopLeaderboardProps {
   released?: boolean;
   slot?: number;
   /**
-   * The fixed 320x100 twin the phone requests instead of the responsive
-   * unit. Must come from the same surface's map as `slot`, or the twin
-   * would ride the other surface's flag gating.
+   * The twin the phone requests instead of `slot`, so phone and desktop fill
+   * report under their own slot numbers. Must come from the same surface's
+   * map as `slot`, or the twin would ride the other surface's flag gating.
    */
   phoneSlot?: number;
   surface?: 'read' | 'organic';
@@ -27,7 +27,7 @@ export interface ReadTopLeaderboardProps {
  * Top leaderboard (slot 2), first thing in the article column. The column is
  * 745px wide inside its padding at the layout's full width, so a 728px
  * leaderboard renders at its booked size within the page rather than spanning
- * it; narrower viewports get the 320x100 large mobile banner instead.
+ * it; narrower viewports get a 320x50 or 320x100 mobile banner instead.
  *
  * Stays pinned for the first ten seconds of scrolling, then releases and
  * scrolls away with the page. Sticky rather than fixed so it only pins within
@@ -68,9 +68,10 @@ export function ReadTopLeaderboard({
           'z-2 laptop:sticky laptop:top-[var(--sticky-header-offset)]',
       )}
     >
-      {/* Two breakpoint twins of one unit: the phone requests a fixed
-          320x100 (a responsive request can answer with expandable video —
-          half a pinned phone screen), tablet+ keeps the responsive 728x90.
+      {/* Two breakpoint twins of one unit, both horizontal responsive: the
+          phone's 320px cap leaves room for the mobile banners only, tablet+
+          gets the 728x90. Expandable and video creatives are blocked on the
+          unit account-side, not here — see READ_SLOT.topLeaderboardPhone.
           Neither is eager: an eager push from a display:none twin would
           initialise the visible one out of order, and both sit at the top of
           the page where the intersection observer fires on first paint

--- a/packages/shared/src/components/post/read/slots.ts
+++ b/packages/shared/src/components/post/read/slots.ts
@@ -23,10 +23,15 @@ export const READ_SLOT = {
   /** Half page closing the rail — the page's only sticky unit. */
   railBottomSticky: 19,
   /**
-   * The top leaderboard's phone twin: the same AdSense unit requested at a
-   * fixed 320x100. A responsive request can come back as expandable video,
-   * which inside the phone-sticky header block pinned half the screen; a
-   * fixed-size request can only return its exact size.
+   * The top leaderboard's phone twin: the same AdSense unit, requested
+   * separately so phone and desktop fill split by slot number in our events.
+   * It was a fixed 320x100 after a responsive request came back as expandable
+   * video and pinned half the screen inside the phone-sticky header block,
+   * but 320x100 alone has too little inventory and the header sat empty on
+   * most phones. It is a horizontal responsive request again (320x50 and
+   * 320x100 both serve) with expandable and video creatives blocked on the
+   * unit in the AdSense account, which is the only place that can rule them
+   * out: the <ins> can shape a request, not filter formats.
    */
   topLeaderboardPhone: 20,
 } as const;
@@ -100,12 +105,13 @@ export const MAX_CONTENT_ADS_PER_SECTION = 4;
  */
 export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   [READ_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  [READ_SLOT.topLeaderboardPhone]: {
-    id: '9942870945',
-    type: 'display',
-    width: 320,
-    height: 100,
-  },
+  // Same responsive request as the desktop twin: FORMAT_SPEC caps the phone
+  // at 320px and `horizontal` keeps rectangles out, so only the mobile
+  // banners fit. See READ_SLOT.topLeaderboardPhone for why this is not fixed.
+  // TODO(vas): in AdSense, block "Expandable" and "Video" under Blocking
+  // controls > Ad serving for unit 9942870945 before shipping — the fixed
+  // size was the only thing keeping expandables out of the pinned header.
+  [READ_SLOT.topLeaderboardPhone]: { id: '9942870945', type: 'display' },
   // The three MPU placements below share existing Display units while the
   // dedicated ones don't exist: Google's per-unit reporting blends them, but
   // our first-party events split by slot number, so per-placement RPM stays
@@ -148,7 +154,7 @@ export const ORGANIC_SLOT = {
   topLeaderboard: 15,
   /** Rail unit below the direct-sold ad widget. */
   railAfterDirectAd: 16,
-  /** The organic leaderboard's fixed 320x100 phone twin — see slot 20. */
+  /** The organic leaderboard's responsive phone twin — see slot 20. */
   topLeaderboardPhone: 21,
   /** MPU repeated through the TLDR, same cadence as the articles page. */
   inContentMpu: 22,
@@ -164,12 +170,7 @@ export const ORGANIC_SLOT = {
 // (Display 300x250) in AdSense and swap the ids for per-placement RPM.
 export const ORGANIC_ADSENSE_SLOTS: AdsenseSlots = {
   [ORGANIC_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  [ORGANIC_SLOT.topLeaderboardPhone]: {
-    id: '9942870945',
-    type: 'display',
-    width: 320,
-    height: 100,
-  },
+  [ORGANIC_SLOT.topLeaderboardPhone]: { id: '9942870945', type: 'display' },
   [ORGANIC_SLOT.railAfterDirectAd]: { id: '6921226982', type: 'display' },
   // Shared units, same trade as the articles map: Google's per-unit rows
   // blend, first-party events split by slot number.

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -61,7 +61,7 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
   // Leaderboard on desktop, large mobile banner on a phone.
   [ProgrammaticAdFormat.Leaderboard]: {
     label: 'Leaderboard',
-    size: '728x90 · 320x100 mobile',
+    size: '728x90 · 320x50 / 320x100 mobile',
     minHeight: 'min-h-[136px] tablet:min-h-[126px]',
     maxWidth: 'max-w-[320px] tablet:max-w-[728px]',
     shape: 'horizontal',


### PR DESCRIPTION
## Summary

The mobile header ad on `/articles/*` and on `/posts/*` for anonymous visitors was a fixed 320x100 AdSense request. AdSense has little inventory at that exact size, so the slot often stayed empty on phones.

- Slots 20 and 21 (the phone twins of the top leaderboard) drop their fixed `width`/`height`, so the `<ins>` sends `data-ad-format="horizontal"` like the desktop twin. The Leaderboard format spec still caps the phone at 320px, so only 320x50 and 320x100 banners can fill it.
- Comments in the slot map, `ReadTopLeaderboard` and the format spec label now describe the responsive request and why the fixed size was dropped.

## Before merging

The fixed size was the only thing keeping expandable video out of the pinned phone header. Block **Expandable** and **Video** for unit `9942870945` in AdSense (Blocking controls → Ad serving) before this deploys. A TODO next to slot 20 tracks this.

## Verification

- `ReadAdSlot`, `ReadTopLeaderboard` and monetization specs pass (9 suites, 82 tests).
- Prettier and the strict typecheck guard pass on the changed files.
- Webapp tsc shows only pre-existing test-file backlog and stale `.next` generated types, none related to this change.
- Fill improvement is not verifiable locally: compare request vs fill counts for slots 20 and 21 in ClickHouse a few days after deploy.
