### PR TITLE
feat(share): add Slack to the share surfaces

### DIFF
--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -13,6 +13,8 @@ import { LazyModal } from './modals/common/types';
 import { useLazyModal } from '../hooks/useLazyModal';
 import type { Squad } from '../graphql/sources';
 import { SocialShareButton } from './widgets/SocialShareButton';
+import { SlackShareButton } from './widgets/SlackShareButton';
+import { useSlackShareButton } from '../hooks/integrations/slack/useSlackShareButton';
 import { getShareableSquads, SquadsToShare } from './squads/SquadsToShare';
 import { Button } from './buttons/Button';
 import { ButtonSize, ButtonVariant } from './buttons/common';
@@ -27,9 +29,8 @@ interface ShareBarProps {
 
 const visibleRows = 2;
 const columns = 4;
-const fixedOptions = 4;
+const baseFixedOptions = 4;
 const maxVisibleOptions = visibleRows * columns;
-const maxVisibleSquadsWhenCollapsed = maxVisibleOptions - fixedOptions;
 
 export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -42,11 +43,18 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const { logOpts } = useContext(ActiveFeedContext);
   const { squads } = useAuthContext();
 
+  const { isEnabled: isSlackShareEnabled } = useSlackShareButton({
+    post,
+    origin: Origin.ShareBar,
+  });
+
   const shareableSquadsCount = useMemo(
     () => getShareableSquads(squads).length,
     [squads],
   );
   const squadOptionsCount = shareableSquadsCount || 1;
+  const fixedOptions = baseFixedOptions + (isSlackShareEnabled ? 1 : 0);
+  const maxVisibleSquadsWhenCollapsed = maxVisibleOptions - fixedOptions;
   const totalOptionsCount = fixedOptions + squadOptionsCount;
   const shouldShowToggle = totalOptionsCount > maxVisibleOptions;
 
@@ -107,6 +115,12 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
             />
           }
           label={copying ? 'Copied!' : 'Copy link'}
+        />
+        <SlackShareButton
+          post={post}
+          origin={Origin.ShareBar}
+          size={ButtonSize.Medium}
+          variant={ButtonVariant.Tertiary}
         />
         <SocialShareButton
           size={ButtonSize.Medium}

--- a/packages/shared/src/components/ShareBar.tsx
+++ b/packages/shared/src/components/ShareBar.tsx
@@ -14,7 +14,6 @@ import { useLazyModal } from '../hooks/useLazyModal';
 import type { Squad } from '../graphql/sources';
 import { SocialShareButton } from './widgets/SocialShareButton';
 import { SlackShareButton } from './widgets/SlackShareButton';
-import { useSlackShareButton } from '../hooks/integrations/slack/useSlackShareButton';
 import { getShareableSquads, SquadsToShare } from './squads/SquadsToShare';
 import { Button } from './buttons/Button';
 import { ButtonSize, ButtonVariant } from './buttons/common';
@@ -29,8 +28,9 @@ interface ShareBarProps {
 
 const visibleRows = 2;
 const columns = 4;
-const baseFixedOptions = 4;
+const fixedOptions = 5;
 const maxVisibleOptions = visibleRows * columns;
+const maxVisibleSquadsWhenCollapsed = maxVisibleOptions - fixedOptions;
 
 export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const [isExpanded, setIsExpanded] = useState(false);
@@ -43,18 +43,11 @@ export default function ShareBar({ post }: ShareBarProps): ReactElement {
   const { logOpts } = useContext(ActiveFeedContext);
   const { squads } = useAuthContext();
 
-  const { isEnabled: isSlackShareEnabled } = useSlackShareButton({
-    post,
-    origin: Origin.ShareBar,
-  });
-
   const shareableSquadsCount = useMemo(
     () => getShareableSquads(squads).length,
     [squads],
   );
   const squadOptionsCount = shareableSquadsCount || 1;
-  const fixedOptions = baseFixedOptions + (isSlackShareEnabled ? 1 : 0);
-  const maxVisibleSquadsWhenCollapsed = maxVisibleOptions - fixedOptions;
   const totalOptionsCount = fixedOptions + squadOptionsCount;
   const shouldShowToggle = totalOptionsCount > maxVisibleOptions;
 

--- a/packages/shared/src/components/fields/Autocomplete.tsx
+++ b/packages/shared/src/components/fields/Autocomplete.tsx
@@ -120,6 +120,8 @@ const Autocomplete = ({
           side="bottom"
           align="start"
           avoidCollisions
+          // without padding the list runs flush into the viewport edge
+          collisionPadding={16}
           sameWidthAsAnchor
           onOpenAutoFocus={(e) => e.preventDefault()} // keep focus in input
           onCloseAutoFocus={(e) => e.preventDefault()} // avoid refocus jumps

--- a/packages/shared/src/components/fields/Autocomplete.tsx
+++ b/packages/shared/src/components/fields/Autocomplete.tsx
@@ -39,7 +39,9 @@ const Autocomplete = ({
   const [input, setInput] = useState(defaultValue || '');
   const [isFocused, setIsFocused] = useState(false);
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [selectedOption, setSelectedOption] = useState(undefined);
+  const [selectedOption, setSelectedOption] = useState<
+    AutocompleteOption | undefined
+  >(undefined);
 
   /* 
    To prevent flickering of the selected option image as the user types.
@@ -112,7 +114,9 @@ const Autocomplete = ({
           />
         </PopoverAnchor>
         <PopoverContent
-          className="rounded-16 border border-border-subtlest-tertiary bg-background-popover data-[side=bottom]:mt-1 data-[side=top]:mb-1"
+          // sameWidthAsAnchor caps the height but nothing scrolls, so a long
+          // list renders past the popover and over the page behind it
+          className="overflow-y-auto rounded-16 border border-border-subtlest-tertiary bg-background-popover data-[side=bottom]:mt-1 data-[side=top]:mb-1"
           side="bottom"
           align="start"
           avoidCollisions

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -16,7 +16,7 @@ import {
   TypographyType,
 } from '../typography/Typography';
 import type { Post } from '../../graphql/posts';
-import { slackRecentChannelsQueryOptions } from '../../graphql/integrations';
+import { integrationRecentChannelsQueryOptions } from '../../graphql/integrations';
 import { useSlackShare } from '../../hooks/integrations/slack/useSlackShare';
 import { useSlackChannelsQuery } from '../../hooks/integrations/slack/useSlackChannelsQuery';
 import { useToastNotification } from '../../hooks/useToastNotification';
@@ -45,7 +45,10 @@ const SlackShareModal = ({
   const { user } = useAuthContext();
   const { integration, isLoading, share, isSharing } = useSlackShare();
   const { data: recentChannels = [] } = useQuery(
-    slackRecentChannelsQueryOptions({ integrationId: integration?.id, user }),
+    integrationRecentChannelsQueryOptions({
+      integrationId: integration?.id,
+      user,
+    }),
   );
   const {
     channels,

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -43,7 +43,8 @@ const SlackShareModal = ({
   const { displayToast } = useToastNotification();
   const { logEvent } = useLogContext();
   const { user } = useAuthContext();
-  const { integration, isLoading, share, isSharing } = useSlackShare();
+  const { integration, canPostAsUser, isLoading, share, isSharing, connect } =
+    useSlackShare();
   const { data: recentChannels = [] } = useQuery(
     integrationRecentChannelsQueryOptions({
       integrationId: integration?.id,
@@ -106,6 +107,22 @@ const SlackShareModal = ({
           >
             Share to Slack
           </Typography>
+          {!canPostAsUser && (
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              This posts as the daily.dev app.{' '}
+              <button
+                type="button"
+                className="underline"
+                onClick={() => connect(window.location.pathname)}
+              >
+                Reconnect Slack
+              </button>{' '}
+              to post under your own name.
+            </Typography>
+          )}
           {!!recentChannels.length && (
             <div className="flex flex-col gap-2">
               <Typography

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -9,6 +9,7 @@ import { Button } from '../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../buttons/common';
 import { SlackIcon } from '../icons';
 import { Loader } from '../Loader';
+import Alert, { AlertType } from '../widgets/Alert';
 import {
   Typography,
   TypographyColor,
@@ -16,7 +17,10 @@ import {
   TypographyType,
 } from '../typography/Typography';
 import type { Post } from '../../graphql/posts';
-import { integrationRecentChannelsQueryOptions } from '../../graphql/integrations';
+import {
+  integrationRecentChannelsQueryOptions,
+  UserIntegrationType,
+} from '../../graphql/integrations';
 import { useSlackShare } from '../../hooks/integrations/slack/useSlackShare';
 import { useSlackChannelsQuery } from '../../hooks/integrations/slack/useSlackChannelsQuery';
 import { useToastNotification } from '../../hooks/useToastNotification';
@@ -63,21 +67,52 @@ const SlackShareModal = ({
   });
   const [selectedIndex, setSelectedIndex] = useState(-1);
 
-  const onShare = async (channelId: string, event: React.MouseEvent) => {
+  const onShare = async (
+    channelId: string,
+    channelSource: 'recent' | 'list',
+    event: React.MouseEvent,
+  ) => {
+    const attribution = {
+      origin,
+      channel_source: channelSource,
+      posted_as: canPostAsUser ? 'user' : 'app',
+    };
+
     try {
       await share({ channelId, postId: post.id });
 
       logEvent(
         postLogEvent(LogEvent.SharePost, post, {
-          extra: { provider: ShareProvider.Slack, origin },
+          extra: { provider: ShareProvider.Slack, ...attribution },
         }),
       );
 
       displayToast('Shared to Slack');
       props.onRequestClose?.(event);
-    } catch {
+    } catch (error) {
+      // the bot path fails on private channels by design, so the reason matters
+      // as much as the count
+      logEvent(
+        postLogEvent(LogEvent.ShareToSlackError, post, {
+          extra: {
+            ...attribution,
+            error: (error as Error)?.message,
+          },
+        }),
+      );
+
       displayToast('Could not share to Slack, please try again');
     }
+  };
+
+  const onReconnect = () => {
+    logEvent({
+      event_name: LogEvent.StartAddingWorkspace,
+      target_id: UserIntegrationType.Slack,
+      extra: JSON.stringify({ origin, reason: 'upgrade' }),
+    });
+
+    connect(window.location.pathname);
   };
 
   return (
@@ -107,22 +142,6 @@ const SlackShareModal = ({
           >
             Share to Slack
           </Typography>
-          {!canPostAsUser && (
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Tertiary}
-            >
-              This posts as the daily.dev app.{' '}
-              <button
-                type="button"
-                className="underline"
-                onClick={() => connect(window.location.pathname)}
-              >
-                Reconnect Slack
-              </button>{' '}
-              to post under your own name.
-            </Typography>
-          )}
           {!!recentChannels.length && (
             <div className="flex flex-col gap-2">
               <Typography
@@ -140,7 +159,9 @@ const SlackShareModal = ({
                     size={ButtonSize.Small}
                     icon={<SlackIcon />}
                     disabled={isSharing}
-                    onClick={(event: React.MouseEvent) => onShare(id, event)}
+                    onClick={(event: React.MouseEvent) =>
+                      onShare(id, 'recent', event)
+                    }
                   >
                     {channelLabel(name)}
                   </Button>
@@ -178,11 +199,29 @@ const SlackShareModal = ({
             disabled={selectedIndex < 0}
             loading={isSharing}
             onClick={(event: React.MouseEvent) =>
-              onShare(channels[selectedIndex].id, event)
+              onShare(channels[selectedIndex].id, 'list', event)
             }
           >
             Share
           </Button>
+          {!canPostAsUser && (
+            <Alert
+              type={AlertType.Warning}
+              title={
+                <span>
+                  This posts as the daily.dev app.{' '}
+                  <button
+                    type="button"
+                    className="underline"
+                    onClick={onReconnect}
+                  >
+                    Reconnect Slack
+                  </button>{' '}
+                  to post under your own name.
+                </span>
+              }
+            />
+          )}
         </Modal.Body>
       )}
     </Modal>

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -1,0 +1,172 @@
+import type { ReactElement } from 'react';
+import React, { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { ModalProps } from './common/Modal';
+import { Modal } from './common/Modal';
+import { ModalClose } from './common/ModalClose';
+import { Dropdown } from '../fields/Dropdown';
+import { Button } from '../buttons/Button';
+import { ButtonSize, ButtonVariant } from '../buttons/common';
+import { SlackIcon } from '../icons';
+import { Loader } from '../Loader';
+import {
+  Typography,
+  TypographyColor,
+  TypographyTag,
+  TypographyType,
+} from '../typography/Typography';
+import type { Post } from '../../graphql/posts';
+import { slackRecentChannelsQueryOptions } from '../../graphql/integrations';
+import { useSlackShare } from '../../hooks/integrations/slack/useSlackShare';
+import { useSlackChannelsQuery } from '../../hooks/integrations/slack/useSlackChannelsQuery';
+import { useToastNotification } from '../../hooks/useToastNotification';
+import { useAuthContext } from '../../contexts/AuthContext';
+import { useLogContext } from '../../contexts/LogContext';
+import { postLogEvent } from '../../lib/feed';
+import type { Origin } from '../../lib/log';
+import { LogEvent } from '../../lib/log';
+import { ShareProvider } from '../../lib/share';
+
+export type SlackShareModalProps = Omit<ModalProps, 'children'> & {
+  post: Post;
+  origin?: Origin;
+};
+
+const channelLabel = (name: string) =>
+  name.startsWith('#') ? name : `#${name}`;
+
+const SlackShareModal = ({
+  post,
+  origin,
+  ...props
+}: SlackShareModalProps): ReactElement => {
+  const { displayToast } = useToastNotification();
+  const { logEvent } = useLogContext();
+  const { user } = useAuthContext();
+  const { integration, isLoading, share, isSharing } = useSlackShare();
+  const { data: recentChannels = [] } = useQuery(
+    slackRecentChannelsQueryOptions({ integrationId: integration?.id, user }),
+  );
+  const {
+    channels,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading: isLoadingChannels,
+  } = useSlackChannelsQuery({
+    integrationId: integration?.id ?? '',
+    queryOptions: { enabled: !!integration?.id },
+  });
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+
+  const onShare = async (channelId: string, event: React.MouseEvent) => {
+    try {
+      await share({ channelId, postId: post.id });
+
+      logEvent(
+        postLogEvent(LogEvent.SharePost, post, {
+          extra: { provider: ShareProvider.Slack, origin },
+        }),
+      );
+
+      displayToast('Shared to Slack');
+      props.onRequestClose?.(event);
+    } catch {
+      displayToast('Could not share to Slack, please try again');
+    }
+  };
+
+  return (
+    <Modal
+      kind={Modal.Kind.FlexibleCenter}
+      size={Modal.Size.XSmall}
+      isDrawerOnMobile
+      {...props}
+    >
+      <ModalClose
+        className="right-4 top-4"
+        onClick={props.onRequestClose}
+        variant={ButtonVariant.Tertiary}
+      />
+      {isLoading && (
+        <Modal.Body className="flex items-center justify-center">
+          <Loader />
+        </Modal.Body>
+      )}
+      {!isLoading && (
+        <Modal.Body className="flex flex-col gap-4">
+          <Typography
+            tag={TypographyTag.H3}
+            type={TypographyType.Title3}
+            color={TypographyColor.Primary}
+            bold
+          >
+            Share to Slack
+          </Typography>
+          {!!recentChannels.length && (
+            <div className="flex flex-col gap-2">
+              <Typography
+                type={TypographyType.Footnote}
+                color={TypographyColor.Tertiary}
+              >
+                Recent
+              </Typography>
+              <div className="flex flex-wrap gap-2">
+                {recentChannels.map(({ id, name }) => (
+                  <Button
+                    key={id}
+                    type="button"
+                    variant={ButtonVariant.Float}
+                    size={ButtonSize.Small}
+                    icon={<SlackIcon />}
+                    disabled={isSharing}
+                    onClick={(event: React.MouseEvent) => onShare(id, event)}
+                  >
+                    {channelLabel(name)}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="flex flex-col gap-2">
+            <Typography
+              type={TypographyType.Footnote}
+              color={TypographyColor.Tertiary}
+            >
+              All channels
+            </Typography>
+            <Dropdown
+              placeholder={
+                isLoadingChannels ? 'Loading channels' : 'Select channel'
+              }
+              shouldIndicateSelected
+              buttonSize={ButtonSize.Medium}
+              iconOnly={false}
+              selectedIndex={selectedIndex}
+              options={channels.map(({ name }) => channelLabel(name))}
+              onChange={(_, index) => setSelectedIndex(index)}
+              scrollable
+              fetchNextPage={fetchNextPage}
+              canFetchMore={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+            />
+          </div>
+          <Button
+            type="button"
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Large}
+            disabled={selectedIndex < 0}
+            loading={isSharing}
+            onClick={(event: React.MouseEvent) =>
+              onShare(channels[selectedIndex].id, event)
+            }
+          >
+            Share
+          </Button>
+        </Modal.Body>
+      )}
+    </Modal>
+  );
+};
+
+export default SlackShareModal;

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -22,6 +22,7 @@ import {
   UserIntegrationType,
 } from '../../graphql/integrations';
 import { useSlackShare } from '../../hooks/integrations/slack/useSlackShare';
+import { getSlackShareRedirectPath } from '../../hooks/integrations/slack/useSlackShareButton';
 import { useSlackChannelsQuery } from '../../hooks/integrations/slack/useSlackChannelsQuery';
 import { useToastNotification } from '../../hooks/useToastNotification';
 import { useAuthContext } from '../../contexts/AuthContext';
@@ -112,7 +113,7 @@ const SlackShareModal = ({
       extra: JSON.stringify({ origin, reason: 'upgrade' }),
     });
 
-    connect(window.location.pathname);
+    connect(getSlackShareRedirectPath(post));
   };
 
   return (

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -184,6 +184,9 @@ const SlackShareModal = ({
           )}
           <Autocomplete
             name="slack-channel"
+            // secondary drops Autocomplete's own heading, which would otherwise
+            // repeat the label the field already floats above the input
+            fieldType="secondary"
             label="All channels"
             placeholder={
               isFetchingAll ? 'Loading channels' : 'Search for a channel'

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -1,10 +1,10 @@
 import type { ReactElement } from 'react';
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import type { ModalProps } from './common/Modal';
 import { Modal } from './common/Modal';
 import { ModalClose } from './common/ModalClose';
-import { Dropdown } from '../fields/Dropdown';
+import Autocomplete from '../fields/Autocomplete';
 import { Button } from '../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../buttons/common';
 import { SlackIcon } from '../icons';
@@ -40,6 +40,8 @@ export type SlackShareModalProps = Omit<ModalProps, 'children'> & {
 const channelLabel = (name: string) =>
   name.startsWith('#') ? name : `#${name}`;
 
+const maxVisibleChannels = 50;
+
 const SlackShareModal = ({
   post,
   origin,
@@ -56,17 +58,27 @@ const SlackShareModal = ({
       user,
     }),
   );
-  const {
-    channels,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    isLoading: isLoadingChannels,
-  } = useSlackChannelsQuery({
+  const { channels, isFetchingAll } = useSlackChannelsQuery({
     integrationId: integration?.id ?? '',
     queryOptions: { enabled: !!integration?.id },
+    fetchAll: true,
   });
-  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [channelQuery, setChannelQuery] = useState('');
+  const [selectedChannelId, setSelectedChannelId] = useState<string>();
+
+  const channelOptions = useMemo(() => {
+    const query = channelQuery.trim().toLowerCase().replace(/^#/, '');
+    const matches = query
+      ? channels.filter(({ name }) => name.toLowerCase().includes(query))
+      : channels;
+
+    // the popover renders one button per option, and a large workspace has
+    // thousands; the search is how you reach the rest
+    return matches.slice(0, maxVisibleChannels).map(({ id, name }) => ({
+      value: id,
+      label: channelLabel(name),
+    }));
+  }, [channels, channelQuery]);
 
   const onShare = async (
     channelId: string,
@@ -170,38 +182,29 @@ const SlackShareModal = ({
               </div>
             </div>
           )}
-          <div className="flex flex-col gap-2">
-            <Typography
-              type={TypographyType.Footnote}
-              color={TypographyColor.Tertiary}
-            >
-              All channels
-            </Typography>
-            <Dropdown
-              placeholder={
-                isLoadingChannels ? 'Loading channels' : 'Select channel'
-              }
-              shouldIndicateSelected
-              buttonSize={ButtonSize.Medium}
-              iconOnly={false}
-              selectedIndex={selectedIndex}
-              options={channels.map(({ name }) => channelLabel(name))}
-              onChange={(_, index) => setSelectedIndex(index)}
-              scrollable
-              fetchNextPage={fetchNextPage}
-              canFetchMore={hasNextPage}
-              isFetchingNextPage={isFetchingNextPage}
-            />
-          </div>
+          <Autocomplete
+            name="slack-channel"
+            label="All channels"
+            placeholder={
+              isFetchingAll ? 'Loading channels' : 'Search for a channel'
+            }
+            options={channelOptions}
+            isLoading={isFetchingAll}
+            selectedValue={selectedChannelId}
+            onChange={setChannelQuery}
+            onSelect={setSelectedChannelId}
+          />
           <Button
             type="button"
             variant={ButtonVariant.Primary}
             size={ButtonSize.Large}
-            disabled={selectedIndex < 0}
+            disabled={!selectedChannelId}
             loading={isSharing}
-            onClick={(event: React.MouseEvent) =>
-              onShare(channels[selectedIndex].id, 'list', event)
-            }
+            onClick={(event: React.MouseEvent) => {
+              if (selectedChannelId) {
+                onShare(selectedChannelId, 'list', event);
+              }
+            }}
           >
             Share
           </Button>

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -40,7 +40,7 @@ export type SlackShareModalProps = Omit<ModalProps, 'children'> & {
 const channelLabel = (name: string) =>
   name.startsWith('#') ? name : `#${name}`;
 
-const maxVisibleChannels = 50;
+const maxVisibleChannels = 20;
 
 const SlackShareModal = ({
   post,

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -208,7 +208,10 @@ const SlackShareModal = ({
             <Alert
               type={AlertType.Warning}
               title={
-                <span>
+                // Alert lays its title out as a flex row, so multi-line copy
+                // needs to be a shrinkable item or it renders on one line and
+                // overflows the panel
+                <span className="flex-1">
                   This posts as the daily.dev app.{' '}
                   <button
                     type="button"

--- a/packages/shared/src/components/modals/SlackShareModal.tsx
+++ b/packages/shared/src/components/modals/SlackShareModal.tsx
@@ -7,7 +7,6 @@ import { ModalClose } from './common/ModalClose';
 import Autocomplete from '../fields/Autocomplete';
 import { Button } from '../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../buttons/common';
-import { SlackIcon } from '../icons';
 import { Loader } from '../Loader';
 import Alert, { AlertType } from '../widgets/Alert';
 import {
@@ -156,10 +155,13 @@ const SlackShareModal = ({
             Share to Slack
           </Typography>
           {!!recentChannels.length && (
-            <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1">
+              {/* matches the label the channel field renders below it */}
               <Typography
-                type={TypographyType.Footnote}
-                color={TypographyColor.Tertiary}
+                className="px-2"
+                type={TypographyType.Caption1}
+                color={TypographyColor.Primary}
+                bold
               >
                 Recent
               </Typography>
@@ -170,7 +172,6 @@ const SlackShareModal = ({
                     type="button"
                     variant={ButtonVariant.Float}
                     size={ButtonSize.Small}
-                    icon={<SlackIcon />}
                     disabled={isSharing}
                     onClick={(event: React.MouseEvent) =>
                       onShare(id, 'recent', event)
@@ -184,12 +185,12 @@ const SlackShareModal = ({
           )}
           <Autocomplete
             name="slack-channel"
-            // secondary drops Autocomplete's own heading, which would otherwise
-            // repeat the label the field already floats above the input
+            // secondary keeps Autocomplete from rendering a second heading of
+            // its own above the one the field already draws
             fieldType="secondary"
             label="All channels"
             placeholder={
-              isFetchingAll ? 'Loading channels' : 'Search for a channel'
+              isFetchingAll ? 'Loading channels' : 'Select a channel'
             }
             options={channelOptions}
             isLoading={isFetchingAll}

--- a/packages/shared/src/components/modals/common.tsx
+++ b/packages/shared/src/components/modals/common.tsx
@@ -166,6 +166,10 @@ const SlackIntegrationModal = dynamic(
     ),
 );
 
+const SlackShareModal = dynamic(
+  () => import(/* webpackChunkName: "slackShareModal" */ './SlackShareModal'),
+);
+
 const ReportSourceModal = dynamic(
   () =>
     import(
@@ -553,6 +557,7 @@ export const modals = {
   [LazyModal.RecoverStreak]: StreakRecoverModal,
   [LazyModal.StreakFreezePurchase]: StreakFreezePurchaseModal,
   [LazyModal.SlackIntegration]: SlackIntegrationModal,
+  [LazyModal.SlackShare]: SlackShareModal,
   [LazyModal.ReportSource]: ReportSourceModal,
   [LazyModal.UserFollowersModal]: UserFollowersModal,
   [LazyModal.UserFollowingModal]: UserFollowingModal,

--- a/packages/shared/src/components/modals/common/types.ts
+++ b/packages/shared/src/components/modals/common/types.ts
@@ -52,6 +52,7 @@ export enum LazyModal {
   TopMembers = 'topMembers',
   BookmarkReminder = 'bookmarkReminder',
   SlackIntegration = 'slackIntegration',
+  SlackShare = 'slackShare',
   ReportSource = 'reportSource',
   UserFollowersModal = 'userFollowersModal',
   UserFollowingModal = 'userFollowingModal',

--- a/packages/shared/src/components/popover/Popover.tsx
+++ b/packages/shared/src/components/popover/Popover.tsx
@@ -20,7 +20,9 @@ export const PopoverContent = forwardRef<HTMLDivElement, PopoverContentProps>(
           {...props}
           className={classNames(
             sameWidthAsAnchor &&
-              'max-h-[var(--radix-popover-content-available-height)] w-[var(--radix-popover-trigger-width)]',
+              // the available height runs to the viewport edge, so a list long
+              // enough to hit the cap would sit flush against it
+              'max-h-[calc(var(--radix-popover-content-available-height)-1rem)] w-[var(--radix-popover-trigger-width)]',
             props.className,
           )}
         >

--- a/packages/shared/src/components/post/focus/DiscussionShareRow.tsx
+++ b/packages/shared/src/components/post/focus/DiscussionShareRow.tsx
@@ -6,7 +6,13 @@ import type { Squad } from '../../../graphql/sources';
 import { Button } from '../../buttons/Button';
 import { ButtonSize, ButtonVariant } from '../../buttons/common';
 import { Tooltip } from '../../tooltip/Tooltip';
-import { CopyIcon, ShareIcon, TwitterIcon, WhatsappIcon } from '../../icons';
+import {
+  CopyIcon,
+  ShareIcon,
+  SlackIcon,
+  TwitterIcon,
+  WhatsappIcon,
+} from '../../icons';
 import { useCopyPostLink } from '../../../hooks/useCopyPostLink';
 import { useGetShortUrl } from '../../../hooks';
 import { getShareLink, ShareProvider } from '../../../lib/share';
@@ -18,6 +24,7 @@ import { useLazyModal } from '../../../hooks/useLazyModal';
 import { LazyModal } from '../../modals/common/types';
 import { ReferralCampaignKey } from '../../../lib';
 import { getShareableSquads } from '../../squads/SquadsToShare';
+import { useSlackShareButton } from '../../../hooks/integrations/slack/useSlackShareButton';
 import SourceProfilePicture from '../../profile/SourceProfilePicture';
 import { ProfileImageSize } from '../../ProfilePicture';
 
@@ -37,7 +44,7 @@ const mobileInlineSquads = 2;
 
 /**
  * Compact share row for the discussion panel. Surfaces the most-used quick
- * actions (copy, X, WhatsApp) inline and defers the long tail (Facebook,
+ * actions (copy, Slack, X, WhatsApp) inline and defers the long tail (Facebook,
  * squads, native share) to the full Share modal behind a single "more" action.
  */
 export const DiscussionShareRow = ({
@@ -52,6 +59,10 @@ export const DiscussionShareRow = ({
   const { logEvent } = useLogContext();
   const { openModal } = useLazyModal();
   const { squads } = useAuthContext();
+  const { onClick: onShareToSlack } = useSlackShareButton({
+    post,
+    origin: Origin.ShareBar,
+  });
   const inlineSquads = withSquads
     ? getShareableSquads(squads).slice(0, maxInlineSquads)
     : [];
@@ -118,6 +129,16 @@ export const DiscussionShareRow = ({
               />
             }
             onClick={onCopy}
+            size={ButtonSize.Small}
+            type="button"
+            variant={ButtonVariant.Tertiary}
+          />
+        </Tooltip>
+        <Tooltip content="Share on Slack">
+          <Button
+            aria-label="Share on Slack"
+            icon={<SlackIcon />}
+            onClick={onShareToSlack}
             size={ButtonSize.Small}
             type="button"
             variant={ButtonVariant.Tertiary}

--- a/packages/shared/src/components/post/focus/DiscussionShareRow.tsx
+++ b/packages/shared/src/components/post/focus/DiscussionShareRow.tsx
@@ -61,7 +61,7 @@ export const DiscussionShareRow = ({
   const { squads } = useAuthContext();
   const { onClick: onShareToSlack } = useSlackShareButton({
     post,
-    origin: Origin.ShareBar,
+    origin: Origin.DiscussionPanel,
   });
   const inlineSquads = withSquads
     ? getShareableSquads(squads).slice(0, maxInlineSquads)

--- a/packages/shared/src/components/widgets/Alert.tsx
+++ b/packages/shared/src/components/widgets/Alert.tsx
@@ -9,24 +9,28 @@ type AlertPropObject<T> = Record<AlertType, T>;
 
 export enum AlertType {
   Info = 'info',
+  Warning = 'warning',
   Error = 'error',
   Success = 'success',
 }
 
 const fontColor: AlertPropObject<string> = {
   info: 'text-accent-bun-default',
+  warning: 'text-status-warning',
   error: 'text-status-error',
   success: 'text-status-success',
 };
 
 const borderColor: AlertPropObject<string> = {
   info: 'border-l-accent-bun-default',
+  warning: 'border-l-status-warning',
   error: 'border-l-status-error',
   success: 'border-l-status-success',
 };
 
 const iconType: AlertPropObject<typeof FeedbackIcon> = {
   info: FeedbackIcon,
+  warning: AlertIcon,
   error: AlertIcon,
   success: CheckIcon,
 };

--- a/packages/shared/src/components/widgets/SlackShareButton.tsx
+++ b/packages/shared/src/components/widgets/SlackShareButton.tsx
@@ -1,0 +1,39 @@
+import type { ReactElement } from 'react';
+import React from 'react';
+import { SocialShareButton } from './SocialShareButton';
+import { SlackIcon } from '../icons';
+import type { ButtonSize } from '../buttons/common';
+import { ButtonVariant } from '../buttons/common';
+import type { Post } from '../../graphql/posts';
+import type { Origin } from '../../lib/log';
+import { useSlackShareButton } from '../../hooks/integrations/slack/useSlackShareButton';
+
+export type SlackShareButtonProps = {
+  post: Post;
+  origin?: Origin;
+  size?: ButtonSize;
+  variant?: ButtonVariant;
+};
+
+export const SlackShareButton = ({
+  post,
+  origin,
+  size,
+  variant = ButtonVariant.Primary,
+}: SlackShareButtonProps): ReactElement | null => {
+  const { isEnabled, onClick } = useSlackShareButton({ post, origin });
+
+  if (!isEnabled) {
+    return null;
+  }
+
+  return (
+    <SocialShareButton
+      icon={<SlackIcon />}
+      size={size}
+      variant={variant}
+      onClick={onClick}
+      label="Slack"
+    />
+  );
+};

--- a/packages/shared/src/components/widgets/SlackShareButton.tsx
+++ b/packages/shared/src/components/widgets/SlackShareButton.tsx
@@ -20,12 +20,8 @@ export const SlackShareButton = ({
   origin,
   size,
   variant = ButtonVariant.Primary,
-}: SlackShareButtonProps): ReactElement | null => {
-  const { isEnabled, onClick } = useSlackShareButton({ post, origin });
-
-  if (!isEnabled) {
-    return null;
-  }
+}: SlackShareButtonProps): ReactElement => {
+  const { onClick } = useSlackShareButton({ post, origin });
 
   return (
     <SocialShareButton

--- a/packages/shared/src/components/widgets/SocialShare.tsx
+++ b/packages/shared/src/components/widgets/SocialShare.tsx
@@ -104,6 +104,8 @@ export const SocialShare = ({
       <SocialShareContainer title="Share externally">
         <SocialShareList
           link={link}
+          post={isComment ? undefined : post}
+          origin={origin}
           description={post?.title ?? ''}
           emailSummary={post?.summary}
           isCopying={copying}

--- a/packages/shared/src/components/widgets/SocialShareList.tsx
+++ b/packages/shared/src/components/widgets/SocialShareList.tsx
@@ -16,10 +16,15 @@ import {
 import { IconSize } from '../Icon';
 import { ButtonColor, ButtonVariant } from '../buttons/Button';
 import { useGetShortUrl } from '../../hooks';
+import { SlackShareButton } from './SlackShareButton';
+import type { Post } from '../../graphql/posts';
+import type { Origin } from '../../lib/log';
 
 interface SocialShareListProps {
   link: string;
   description: string;
+  post?: Post;
+  origin?: Origin;
   emailTitle?: string;
   emailSummary?: string;
   isCopying?: boolean;
@@ -31,6 +36,8 @@ interface SocialShareListProps {
 
 export function SocialShareList({
   link,
+  post,
+  origin,
   emailTitle,
   emailSummary,
   description,
@@ -66,6 +73,7 @@ export function SocialShareList({
           label={isCopying ? 'Copied!' : 'Copy link'}
         />
       )}
+      {!!post && <SlackShareButton post={post} origin={origin} />}
       <SocialShareButton
         icon={<TwitterIcon />}
         variant={ButtonVariant.Primary}

--- a/packages/shared/src/graphql/integrations.ts
+++ b/packages/shared/src/graphql/integrations.ts
@@ -1,5 +1,8 @@
 import { gql } from 'graphql-request';
 import type { Source } from './sources';
+import { gqlClient } from './common';
+import { generateQueryKey, RequestKey, StaleTime } from '../lib/query';
+import type { LoggedUser } from '../lib/user';
 
 export enum UserIntegrationType {
   Slack = 'slack',
@@ -12,6 +15,7 @@ export type UserIntegration = {
   updatedAt: Date;
   name: string;
   userId: string;
+  canPostAsUser?: boolean;
 };
 
 export type SlackChannel = {
@@ -36,6 +40,52 @@ export const SLACK_CHANNELS_QUERY = gql`
         name
       }
       cursor
+    }
+  }
+`;
+
+export const SLACK_RECENT_CHANNELS_QUERY = gql`
+  query SlackRecentChannels($integrationId: ID!) {
+    slackRecentChannels(integrationId: $integrationId) {
+      id
+      name
+    }
+  }
+`;
+
+export const slackRecentChannelsQueryOptions = ({
+  integrationId,
+  user,
+}: {
+  integrationId?: string;
+  user?: LoggedUser;
+}) => ({
+  queryKey: generateQueryKey(RequestKey.SlackRecentChannels, user, {
+    integrationId,
+  }),
+  queryFn: async (): Promise<SlackChannel[]> => {
+    const { slackRecentChannels } = await gqlClient.request<{
+      slackRecentChannels: SlackChannel[];
+    }>(SLACK_RECENT_CHANNELS_QUERY, { integrationId });
+
+    return slackRecentChannels;
+  },
+  staleTime: StaleTime.Default,
+  enabled: !!integrationId && !!user,
+});
+
+export const SLACK_POST_MESSAGE_MUTATION = gql`
+  mutation SlackPostMessage(
+    $integrationId: ID!
+    $channelId: ID!
+    $postId: ID!
+  ) {
+    slackPostMessage(
+      integrationId: $integrationId
+      channelId: $channelId
+      postId: $postId
+    ) {
+      _
     }
   }
 `;

--- a/packages/shared/src/graphql/integrations.ts
+++ b/packages/shared/src/graphql/integrations.ts
@@ -74,13 +74,13 @@ export const integrationRecentChannelsQueryOptions = ({
   enabled: !!integrationId && !!user,
 });
 
-export const SLACK_POST_MESSAGE_MUTATION = gql`
-  mutation SlackPostMessage(
+export const INTEGRATION_SHARE_POST_MUTATION = gql`
+  mutation IntegrationSharePost(
     $integrationId: ID!
     $channelId: ID!
     $postId: ID!
   ) {
-    slackPostMessage(
+    integrationSharePost(
       integrationId: $integrationId
       channelId: $channelId
       postId: $postId

--- a/packages/shared/src/graphql/integrations.ts
+++ b/packages/shared/src/graphql/integrations.ts
@@ -44,31 +44,31 @@ export const SLACK_CHANNELS_QUERY = gql`
   }
 `;
 
-export const SLACK_RECENT_CHANNELS_QUERY = gql`
-  query SlackRecentChannels($integrationId: ID!) {
-    slackRecentChannels(integrationId: $integrationId) {
+export const INTEGRATION_RECENT_CHANNELS_QUERY = gql`
+  query IntegrationRecentChannels($integrationId: ID!) {
+    integrationRecentChannels(integrationId: $integrationId) {
       id
       name
     }
   }
 `;
 
-export const slackRecentChannelsQueryOptions = ({
+export const integrationRecentChannelsQueryOptions = ({
   integrationId,
   user,
 }: {
   integrationId?: string;
   user?: LoggedUser;
 }) => ({
-  queryKey: generateQueryKey(RequestKey.SlackRecentChannels, user, {
+  queryKey: generateQueryKey(RequestKey.IntegrationRecentChannels, user, {
     integrationId,
   }),
   queryFn: async (): Promise<SlackChannel[]> => {
-    const { slackRecentChannels } = await gqlClient.request<{
-      slackRecentChannels: SlackChannel[];
-    }>(SLACK_RECENT_CHANNELS_QUERY, { integrationId });
+    const { integrationRecentChannels } = await gqlClient.request<{
+      integrationRecentChannels: SlackChannel[];
+    }>(INTEGRATION_RECENT_CHANNELS_QUERY, { integrationId });
 
-    return slackRecentChannels;
+    return integrationRecentChannels;
   },
   staleTime: StaleTime.Default,
   enabled: !!integrationId && !!user,

--- a/packages/shared/src/graphql/integrations.ts
+++ b/packages/shared/src/graphql/integrations.ts
@@ -34,7 +34,7 @@ export type UserSourceIntegration = {
 
 export const SLACK_CHANNELS_QUERY = gql`
   query SlackChannels($integrationId: ID!, $cursor: String) {
-    slackChannels(integrationId: $integrationId, limit: 100, cursor: $cursor) {
+    slackChannels(integrationId: $integrationId, limit: 200, cursor: $cursor) {
       data {
         id
         name

--- a/packages/shared/src/graphql/users.ts
+++ b/packages/shared/src/graphql/users.ts
@@ -800,6 +800,7 @@ export const USER_INTEGRATIONS = gql`
           id
           type
           name
+          canPostAsUser
         }
       }
     }

--- a/packages/shared/src/hooks/integrations/slack/useSlack.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlack.ts
@@ -25,6 +25,9 @@ export type UseSlack = {
 };
 
 const scopes = ['channels:read', 'chat:write', 'channels:join', 'groups:read'];
+// requested alongside the bot scopes on every entry point, so a workspace
+// connected from any flow can post as the user without a second consent screen
+const userScopes = ['channels:read', 'chat:write', 'groups:read'];
 
 export const useSlack = (): UseSlack => {
   const { user } = useAuthContext();
@@ -39,6 +42,7 @@ export const useSlack = (): UseSlack => {
 
       url.searchParams.append('state', user!.id);
       url.searchParams.append('scope', scopes.join(','));
+      url.searchParams.append('user_scope', userScopes.join(','));
       url.searchParams.append(
         'client_id',
         process.env.NEXT_PUBLIC_SLACK_CLIENT_ID!,

--- a/packages/shared/src/hooks/integrations/slack/useSlackChannelsQuery.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackChannelsQuery.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import type { SlackChannel } from '../../../graphql/integrations';
 import { SLACK_CHANNELS_QUERY } from '../../../graphql/integrations';
@@ -17,20 +17,32 @@ export type UseSlackChannelsQueryProps = {
   integrationId: string;
   queryOptions?: { enabled?: boolean };
   selectedChannelId?: string;
+  /**
+   * Pull the remaining pages in the background. Slack has no channel search
+   * endpoint, so filtering can only ever happen over what has been fetched, and
+   * a search box that quietly ignores unfetched channels is worse than none.
+   */
+  fetchAll?: boolean;
 };
 
 export type UseSlackChannelsQuery = {
   channels: SlackChannel[];
+  isFetchingAll: boolean;
   fetchNextPage: () => Promise<unknown>;
   hasNextPage: boolean;
   isFetchingNextPage: boolean;
   isLoading: boolean;
 };
 
+// a bound so a very large workspace cannot turn the picker into a request storm
+// against Slack's per-minute limit; the filter then covers the first pages only
+const maxAutoFetchedPages = 10;
+
 export const useSlackChannelsQuery = ({
   integrationId,
   queryOptions,
   selectedChannelId,
+  fetchAll = false,
 }: UseSlackChannelsQueryProps): UseSlackChannelsQuery => {
   const { user } = useAuthContext();
   const enabled = !!integrationId;
@@ -86,8 +98,24 @@ export const useSlackChannelsQuery = ({
     ];
   }, [queryResult.data?.pages, selectedChannelId]);
 
+  const loadedPages = queryResult.data?.pages?.length ?? 0;
+  const canFetchMore =
+    fetchAll &&
+    queryResult.hasNextPage &&
+    !queryResult.isFetchingNextPage &&
+    loadedPages < maxAutoFetchedPages;
+
+  useEffect(() => {
+    if (!canFetchMore) {
+      return;
+    }
+
+    queryResult.fetchNextPage();
+  }, [canFetchMore, queryResult]);
+
   return {
     channels,
+    isFetchingAll: queryResult.isLoading || canFetchMore,
     fetchNextPage: queryResult.fetchNextPage,
     hasNextPage: queryResult.hasNextPage,
     isFetchingNextPage: queryResult.isFetchingNextPage,

--- a/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { gqlClient } from '../../../graphql/common';
 import {
   SLACK_POST_MESSAGE_MUTATION,
-  slackRecentChannelsQueryOptions,
+  integrationRecentChannelsQueryOptions,
   UserIntegrationType,
 } from '../../../graphql/integrations';
 import type { UserIntegration } from '../../../graphql/integrations';
@@ -52,7 +52,7 @@ export const useSlackShare = (): UseSlackShare => {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: slackRecentChannelsQueryOptions({
+        queryKey: integrationRecentChannelsQueryOptions({
           integrationId: integration!.id,
           user,
         }).queryKey,

--- a/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
@@ -13,10 +13,15 @@ import { useSlack } from './useSlack';
 
 export type UseSlackShare = {
   /**
-   * The workspace a share posts to. Absent while loading, when the user has no
-   * Slack workspace, or when the connected one predates user-token scopes.
+   * The workspace a share posts to. Absent while loading, or when the user has
+   * no Slack workspace connected.
    */
   integration?: UserIntegration;
+  /**
+   * Whether a share is attributed to the person. False means it posts as the
+   * daily.dev app, which is what happens until the workspace grants user scopes.
+   */
+  canPostAsUser: boolean;
   isLoading: boolean;
   connect: (redirectPath: string) => void;
   share: (params: { channelId: string; postId: string }) => Promise<void>;
@@ -29,12 +34,14 @@ export const useSlackShare = (): UseSlackShare => {
   const { connect } = useSlack();
   const { data: integrations, isLoading } = useIntegrationsQuery();
 
-  // an integration connected before user scopes were requested holds no user
-  // token, so it cannot post as the person and has to go back through OAuth
-  const integration = integrations?.find(
-    ({ type, canPostAsUser }) =>
-      type === UserIntegrationType.Slack && canPostAsUser,
+  // prefer a workspace that can post as the person, but fall back to any
+  // connected one: sharing as the app beats not sharing at all
+  const slackIntegrations = integrations?.filter(
+    ({ type }) => type === UserIntegrationType.Slack,
   );
+  const integration =
+    slackIntegrations?.find(({ canPostAsUser }) => canPostAsUser) ??
+    slackIntegrations?.[0];
 
   const { mutateAsync: share, isPending: isSharing } = useMutation({
     mutationFn: async ({
@@ -62,6 +69,7 @@ export const useSlackShare = (): UseSlackShare => {
 
   return {
     integration,
+    canPostAsUser: !!integration?.canPostAsUser,
     isLoading,
     connect: useCallback(
       (redirectPath: string) => connect({ redirectPath }),

--- a/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { gqlClient } from '../../../graphql/common';
 import {
-  SLACK_POST_MESSAGE_MUTATION,
+  INTEGRATION_SHARE_POST_MUTATION,
   integrationRecentChannelsQueryOptions,
   UserIntegrationType,
 } from '../../../graphql/integrations';
@@ -51,7 +51,7 @@ export const useSlackShare = (): UseSlackShare => {
       channelId: string;
       postId: string;
     }) => {
-      await gqlClient.request(SLACK_POST_MESSAGE_MUTATION, {
+      await gqlClient.request(INTEGRATION_SHARE_POST_MUTATION, {
         integrationId: integration!.id,
         channelId,
         postId,

--- a/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
@@ -1,0 +1,78 @@
+import { useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { gqlClient } from '../../../graphql/common';
+import {
+  SLACK_POST_MESSAGE_MUTATION,
+  slackRecentChannelsQueryOptions,
+  UserIntegrationType,
+} from '../../../graphql/integrations';
+import type { UserIntegration } from '../../../graphql/integrations';
+import { useAuthContext } from '../../../contexts/AuthContext';
+import { useIntegrationsQuery } from '../useIntegrationsQuery';
+import { useSlack } from './useSlack';
+
+export type UseSlackShare = {
+  /**
+   * The workspace a share posts to. Absent while loading, when the user has no
+   * Slack workspace, or when the connected one predates user-token scopes.
+   */
+  integration?: UserIntegration;
+  isLoading: boolean;
+  connect: (redirectPath: string) => void;
+  share: (params: { channelId: string; postId: string }) => Promise<void>;
+  isSharing: boolean;
+};
+
+export const useSlackShare = (): UseSlackShare => {
+  const { user } = useAuthContext();
+  const queryClient = useQueryClient();
+  const { connect } = useSlack();
+  const { data: integrations, isLoading } = useIntegrationsQuery();
+
+  // an integration connected before user scopes were requested holds no user
+  // token, so it cannot post as the person and has to go back through OAuth
+  const integration = integrations?.find(
+    ({ type, canPostAsUser }) =>
+      type === UserIntegrationType.Slack && canPostAsUser,
+  );
+
+  const { mutateAsync: share, isPending: isSharing } = useMutation({
+    mutationFn: async ({
+      channelId,
+      postId,
+    }: {
+      channelId: string;
+      postId: string;
+    }) => {
+      await gqlClient.request(SLACK_POST_MESSAGE_MUTATION, {
+        integrationId: integration!.id,
+        channelId,
+        postId,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: slackRecentChannelsQueryOptions({
+          integrationId: integration!.id,
+          user,
+        }).queryKey,
+      });
+    },
+  });
+
+  return {
+    integration,
+    isLoading,
+    connect: useCallback(
+      (redirectPath: string) => connect({ redirectPath }),
+      [connect],
+    ),
+    share: useCallback(
+      async (params) => {
+        await share(params);
+      },
+      [share],
+    ),
+    isSharing,
+  };
+};

--- a/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShare.ts
@@ -28,11 +28,15 @@ export type UseSlackShare = {
   isSharing: boolean;
 };
 
-export const useSlackShare = (): UseSlackShare => {
+export const useSlackShare = ({
+  enabled = true,
+}: { enabled?: boolean } = {}): UseSlackShare => {
   const { user } = useAuthContext();
   const queryClient = useQueryClient();
   const { connect } = useSlack();
-  const { data: integrations, isLoading } = useIntegrationsQuery();
+  const { data: integrations, isLoading } = useIntegrationsQuery({
+    queryOptions: { enabled },
+  });
 
   // prefer a workspace that can post as the person, but fall back to any
   // connected one: sharing as the app beats not sharing at all

--- a/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
@@ -77,17 +77,16 @@ export const useSlackShareButton = ({
   return { onClick };
 };
 
-const hasSlackShareReturnParams = (postId?: string): boolean => {
-  if (!postId || typeof window === 'undefined') {
-    return false;
+const readSlackShareReturnPostId = (): string | undefined => {
+  if (typeof window === 'undefined') {
+    return undefined;
   }
 
   const params = new URLSearchParams(window.location.search);
 
-  return (
-    params.get('lzym') === LazyModal.SlackShare &&
-    params.get(postIdParam) === postId
-  );
+  return params.get('lzym') === LazyModal.SlackShare
+    ? params.get(postIdParam) ?? undefined
+    : undefined;
 };
 
 /**
@@ -98,17 +97,20 @@ const hasSlackShareReturnParams = (postId?: string): boolean => {
  */
 export const useSlackShareReturn = ({ post }: { post?: Post }): void => {
   const { openModal } = useLazyModal();
-  const [isReturning] = useState(() => hasSlackShareReturnParams(post?.id));
-  const { integration, isLoading } = useSlackShare({ enabled: isReturning });
+  // read once from the location, and deliberately not keyed on the post: the
+  // post arrives a render later than the URL does, so a latch that consulted it
+  // would conclude there was nothing to return to
+  const [returnPostId] = useState(readSlackShareReturnPostId);
+  const { integration, isLoading } = useSlackShare({ enabled: !!returnPostId });
   const reopened = useRef(false);
 
   useEffect(() => {
     if (
-      !isReturning ||
+      !returnPostId ||
       reopened.current ||
       isLoading ||
       !integration ||
-      !post
+      post?.id !== returnPostId
     ) {
       return;
     }
@@ -126,5 +128,5 @@ export const useSlackShareReturn = ({ post }: { post?: Post }): void => {
     );
 
     openModal({ type: LazyModal.SlackShare, props: { post } });
-  }, [isReturning, isLoading, integration, post, openModal]);
+  }, [returnPostId, isLoading, integration, post, openModal]);
 };

--- a/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
@@ -7,6 +7,7 @@ import { LazyModal } from '../../../components/modals/common/types';
 import { useLogContext } from '../../../contexts/LogContext';
 import type { Origin } from '../../../lib/log';
 import { LogEvent } from '../../../lib/log';
+import { postLogEvent } from '../../../lib/feed';
 import { getPathnameWithQuery } from '../../../lib/links';
 
 export type UseSlackShareButton = {
@@ -24,13 +25,25 @@ export const useSlackShareButton = ({
 }): UseSlackShareButton => {
   const { logEvent } = useLogContext();
   const { openModal } = useLazyModal();
-  const { integration, isLoading, connect } = useSlackShare();
+  const { integration, canPostAsUser, isLoading, connect } = useSlackShare();
 
   const openPicker = useCallback(() => {
     openModal({ type: LazyModal.SlackShare, props: { post, origin } });
   }, [openModal, post, origin]);
 
   const onClick = useCallback(() => {
+    // logged on both branches: counting only the ones that go to OAuth would
+    // hide every share attempt by someone already connected
+    logEvent(
+      postLogEvent(LogEvent.StartShareToSlack, post, {
+        extra: {
+          origin,
+          has_integration: !!integration,
+          can_post_as_user: canPostAsUser,
+        },
+      }),
+    );
+
     if (integration) {
       openPicker();
 
@@ -40,7 +53,7 @@ export const useSlackShareButton = ({
     logEvent({
       event_name: LogEvent.StartAddingWorkspace,
       target_id: UserIntegrationType.Slack,
-      extra: JSON.stringify({ origin }),
+      extra: JSON.stringify({ origin, reason: 'share' }),
     });
 
     connect(
@@ -52,7 +65,7 @@ export const useSlackShareButton = ({
         }),
       ),
     );
-  }, [integration, openPicker, logEvent, origin, connect, post.id]);
+  }, [integration, canPostAsUser, openPicker, logEvent, origin, connect, post]);
 
   // returning from OAuth reopens the picker on whichever surface started the
   // share, so the round trip costs the user nothing beyond the consent screen.

--- a/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
@@ -4,15 +4,12 @@ import { UserIntegrationType } from '../../../graphql/integrations';
 import { useSlackShare } from './useSlackShare';
 import { useLazyModal } from '../../useLazyModal';
 import { LazyModal } from '../../../components/modals/common/types';
-import { useConditionalFeature } from '../../useConditionalFeature';
-import { featureSlackShare } from '../../../lib/featureManagement';
 import { useLogContext } from '../../../contexts/LogContext';
 import type { Origin } from '../../../lib/log';
 import { LogEvent } from '../../../lib/log';
 import { getPathnameWithQuery } from '../../../lib/links';
 
 export type UseSlackShareButton = {
-  isEnabled: boolean;
   onClick: () => void;
 };
 
@@ -28,10 +25,6 @@ export const useSlackShareButton = ({
   const { logEvent } = useLogContext();
   const { openModal } = useLazyModal();
   const { integration, isLoading, connect } = useSlackShare();
-  const { value: isEnabled } = useConditionalFeature({
-    feature: featureSlackShare,
-    shouldEvaluate: !!post,
-  });
 
   const openPicker = useCallback(() => {
     openModal({ type: LazyModal.SlackShare, props: { post, origin } });
@@ -94,5 +87,5 @@ export const useSlackShareButton = ({
     openPicker();
   }, [isLoading, integration, post.id, openPicker]);
 
-  return { isEnabled, onClick };
+  return { onClick };
 };

--- a/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Post } from '../../../graphql/posts';
 import { UserIntegrationType } from '../../../graphql/integrations';
 import { useSlackShare } from './useSlackShare';
@@ -16,6 +16,21 @@ export type UseSlackShareButton = {
 
 const postIdParam = 'slackPostId';
 
+/**
+ * Where Slack sends the user back. It has to be the post's own page: the share
+ * can start from a post modal over the feed or from the extension, and neither
+ * is an address the API callback can return to, since it only ever redirects to
+ * a path on the webapp.
+ */
+export const getSlackShareRedirectPath = (post: Post): string =>
+  getPathnameWithQuery(
+    `/posts/${post.slug ?? post.id}`,
+    new URLSearchParams({
+      lzym: LazyModal.SlackShare,
+      [postIdParam]: post.id,
+    }),
+  );
+
 export const useSlackShareButton = ({
   post,
   origin,
@@ -25,7 +40,7 @@ export const useSlackShareButton = ({
 }): UseSlackShareButton => {
   const { logEvent } = useLogContext();
   const { openModal } = useLazyModal();
-  const { integration, canPostAsUser, isLoading, connect } = useSlackShare();
+  const { integration, canPostAsUser, connect } = useSlackShare();
 
   const openPicker = useCallback(() => {
     openModal({ type: LazyModal.SlackShare, props: { post, origin } });
@@ -56,38 +71,51 @@ export const useSlackShareButton = ({
       extra: JSON.stringify({ origin, reason: 'share' }),
     });
 
-    connect(
-      getPathnameWithQuery(
-        window.location.pathname,
-        new URLSearchParams({
-          lzym: LazyModal.SlackShare,
-          [postIdParam]: post.id,
-        }),
-      ),
-    );
+    connect(getSlackShareRedirectPath(post));
   }, [integration, canPostAsUser, openPicker, logEvent, origin, connect, post]);
 
-  // returning from OAuth reopens the picker on whichever surface started the
-  // share, so the round trip costs the user nothing beyond the consent screen.
-  // read straight from the location rather than the router: this runs on every
-  // surface that renders a share list, including the extension
+  return { onClick };
+};
+
+const hasSlackShareReturnParams = (postId?: string): boolean => {
+  if (!postId || typeof window === 'undefined') {
+    return false;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+
+  return (
+    params.get('lzym') === LazyModal.SlackShare &&
+    params.get(postIdParam) === postId
+  );
+};
+
+/**
+ * Reopens the picker after the OAuth round trip. It lives on the post page
+ * rather than on the share button because the button that started the flow may
+ * not exist at the destination: the share can begin in a post modal or on the
+ * extension, and the share bar itself is desktop only.
+ */
+export const useSlackShareReturn = ({ post }: { post?: Post }): void => {
+  const { openModal } = useLazyModal();
+  const [isReturning] = useState(() => hasSlackShareReturnParams(post?.id));
+  const { integration, isLoading } = useSlackShare({ enabled: isReturning });
   const reopened = useRef(false);
+
   useEffect(() => {
-    if (reopened.current || isLoading || !integration) {
-      return;
-    }
-
-    const params = new URLSearchParams(window.location.search);
-
     if (
-      params.get('lzym') !== LazyModal.SlackShare ||
-      params.get(postIdParam) !== post.id
+      !isReturning ||
+      reopened.current ||
+      isLoading ||
+      !integration ||
+      !post
     ) {
       return;
     }
 
     reopened.current = true;
 
+    const params = new URLSearchParams(window.location.search);
     params.delete('lzym');
     params.delete(postIdParam);
 
@@ -97,8 +125,6 @@ export const useSlackShareButton = ({
       getPathnameWithQuery(window.location.pathname, params),
     );
 
-    openPicker();
-  }, [isLoading, integration, post.id, openPicker]);
-
-  return { onClick };
+    openModal({ type: LazyModal.SlackShare, props: { post } });
+  }, [isReturning, isLoading, integration, post, openModal]);
 };

--- a/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlackShareButton.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef } from 'react';
+import type { Post } from '../../../graphql/posts';
+import { UserIntegrationType } from '../../../graphql/integrations';
+import { useSlackShare } from './useSlackShare';
+import { useLazyModal } from '../../useLazyModal';
+import { LazyModal } from '../../../components/modals/common/types';
+import { useConditionalFeature } from '../../useConditionalFeature';
+import { featureSlackShare } from '../../../lib/featureManagement';
+import { useLogContext } from '../../../contexts/LogContext';
+import type { Origin } from '../../../lib/log';
+import { LogEvent } from '../../../lib/log';
+import { getPathnameWithQuery } from '../../../lib/links';
+
+export type UseSlackShareButton = {
+  isEnabled: boolean;
+  onClick: () => void;
+};
+
+const postIdParam = 'slackPostId';
+
+export const useSlackShareButton = ({
+  post,
+  origin,
+}: {
+  post: Post;
+  origin?: Origin;
+}): UseSlackShareButton => {
+  const { logEvent } = useLogContext();
+  const { openModal } = useLazyModal();
+  const { integration, isLoading, connect } = useSlackShare();
+  const { value: isEnabled } = useConditionalFeature({
+    feature: featureSlackShare,
+    shouldEvaluate: !!post,
+  });
+
+  const openPicker = useCallback(() => {
+    openModal({ type: LazyModal.SlackShare, props: { post, origin } });
+  }, [openModal, post, origin]);
+
+  const onClick = useCallback(() => {
+    if (integration) {
+      openPicker();
+
+      return;
+    }
+
+    logEvent({
+      event_name: LogEvent.StartAddingWorkspace,
+      target_id: UserIntegrationType.Slack,
+      extra: JSON.stringify({ origin }),
+    });
+
+    connect(
+      getPathnameWithQuery(
+        window.location.pathname,
+        new URLSearchParams({
+          lzym: LazyModal.SlackShare,
+          [postIdParam]: post.id,
+        }),
+      ),
+    );
+  }, [integration, openPicker, logEvent, origin, connect, post.id]);
+
+  // returning from OAuth reopens the picker on whichever surface started the
+  // share, so the round trip costs the user nothing beyond the consent screen.
+  // read straight from the location rather than the router: this runs on every
+  // surface that renders a share list, including the extension
+  const reopened = useRef(false);
+  useEffect(() => {
+    if (reopened.current || isLoading || !integration) {
+      return;
+    }
+
+    const params = new URLSearchParams(window.location.search);
+
+    if (
+      params.get('lzym') !== LazyModal.SlackShare ||
+      params.get(postIdParam) !== post.id
+    ) {
+      return;
+    }
+
+    reopened.current = true;
+
+    params.delete('lzym');
+    params.delete(postIdParam);
+
+    window.history.replaceState(
+      window.history.state,
+      '',
+      getPathnameWithQuery(window.location.pathname, params),
+    );
+
+    openPicker();
+  }, [isLoading, integration, post.id, openPicker]);
+
+  return { isEnabled, onClick };
+};

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -332,6 +332,11 @@ export const featureCommentFirstAction = new Feature(
   false,
 );
 
+// Slack in the share surfaces. Off is the control, and the experiment is judged
+// on total share events and unique sharers, not on Slack clicks: a Slack button
+// that only redistributes the existing provider tail has not moved anything.
+export const featureSlackShare = new Feature('slack_share', false);
+
 // Kill switch for the batched GraphQL transport (`graphql/batch.ts`). Off is
 // the control: the API only accepts batched bodies once its own change ships.
 export const featureGqlBatching = new Feature('gql_batching', false);

--- a/packages/shared/src/lib/featureManagement.ts
+++ b/packages/shared/src/lib/featureManagement.ts
@@ -332,11 +332,6 @@ export const featureCommentFirstAction = new Feature(
   false,
 );
 
-// Slack in the share surfaces. Off is the control, and the experiment is judged
-// on total share events and unique sharers, not on Slack clicks: a Slack button
-// that only redistributes the existing provider tail has not moved anything.
-export const featureSlackShare = new Feature('slack_share', false);
-
 // Kill switch for the batched GraphQL transport (`graphql/batch.ts`). Off is
 // the control: the API only accepts batched bodies once its own change ships.
 export const featureGqlBatching = new Feature('gql_batching', false);

--- a/packages/shared/src/lib/log.ts
+++ b/packages/shared/src/lib/log.ts
@@ -2,6 +2,7 @@ import type { PurchaseType } from '../graphql/paddle';
 
 export enum Origin {
   ShareBar = 'share bar',
+  DiscussionPanel = 'discussion panel',
   ReadingHistoryContextMenu = 'reading history context menu',
   ArticlePage = 'article page',
   ArticleModal = 'article modal',
@@ -174,6 +175,8 @@ export enum LogEvent {
   CompleteSquadCreation = 'complete squad creation',
   StartShareToSquad = 'start share to squad',
   ShareToSquad = 'share to squad',
+  StartShareToSlack = 'start share to slack',
+  ShareToSlackError = 'share to slack error',
   ChecklistClose = 'checklist close',
   DeletePost = 'delete post',
   DeleteComment = 'delete comment',

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -190,7 +190,7 @@ export enum RequestKey {
   Ads = 'ads',
   FeedByIds = 'feedByIds',
   SlackChannels = 'slack_channels',
-  SlackRecentChannels = 'slack_recent_channels',
+  IntegrationRecentChannels = 'integration_recent_channels',
   UserIntegrations = 'user_integrations',
   UserSourceIntegrations = 'user_source_integrations',
   SourceFeed = 'sourceFeed',

--- a/packages/shared/src/lib/query.ts
+++ b/packages/shared/src/lib/query.ts
@@ -190,6 +190,7 @@ export enum RequestKey {
   Ads = 'ads',
   FeedByIds = 'feedByIds',
   SlackChannels = 'slack_channels',
+  SlackRecentChannels = 'slack_recent_channels',
   UserIntegrations = 'user_integrations',
   UserSourceIntegrations = 'user_source_integrations',
   SourceFeed = 'sourceFeed',

--- a/packages/shared/src/lib/referral.ts
+++ b/packages/shared/src/lib/referral.ts
@@ -7,4 +7,5 @@ export enum ReferralCampaignKey {
   ShareSource = 'share_source',
   ShareTag = 'share_tag',
   ShareAgent = 'share_agent',
+  ShareSlack = 'share_slack',
 }

--- a/packages/shared/src/lib/share.ts
+++ b/packages/shared/src/lib/share.ts
@@ -10,6 +10,7 @@ export enum ShareProvider {
   LinkedIn = 'linkedin',
   Telegram = 'telegram',
   Email = 'email',
+  Slack = 'slack',
 }
 
 export const getWhatsappShareLink = (link: string): string =>

--- a/packages/webapp/pages/join/index.tsx
+++ b/packages/webapp/pages/join/index.tsx
@@ -28,6 +28,7 @@ const componentsMap: ReferralRecord<FunctionComponent<JoinPageProps>> = {
   [ReferralCampaignKey.ShareSource]: Referral,
   [ReferralCampaignKey.ShareTag]: Referral,
   [ReferralCampaignKey.ShareAgent]: Referral,
+  [ReferralCampaignKey.ShareSlack]: Referral,
 };
 
 const referralCampaignValues = new Set<string>(

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -79,6 +79,7 @@ import { useConditionalFeature } from '@dailydotdev/shared/src/hooks/useConditio
 import { isPostRedesignEligible } from '@dailydotdev/shared/src/hooks/post/usePostRedesign';
 import { featurePostRedesign } from '@dailydotdev/shared/src/lib/featureManagement';
 import { PostFocusCard } from '@dailydotdev/shared/src/components/post/focus/PostFocusCard';
+import { useSlackShareReturn } from '@dailydotdev/shared/src/hooks/integrations/slack/useSlackShareButton';
 import { AdsenseHeadHints } from '../../../components/AdsenseHeadHints';
 import { getShareImageUrl, noindexSeoProps } from '../../../next-seo';
 import { isPostDetailPath } from '../../../lib/postRoutes';
@@ -218,6 +219,7 @@ export const PostPage = ({
       retry: false,
     },
   });
+  useSlackShareReturn({ post });
   const queryClient = useQueryClient();
   const postError = (isError
     ? queryClient.getQueryState(getPostByIdKey(id))?.error


### PR DESCRIPTION
Puts Slack in the share row, posting as the user. Not behind a flag: this is a feature, not an experiment, so there is no control to measure against.

API PR: https://github.com/dailydotdev/daily-api/pull/4248 (merge first, this depends on its schema)

## Why

Slack is reachable today only from squad admin settings and the brief page, all of which ask for a recurring subscription before the user has felt any value. Cohorted, the entry points split hard:

| Origin | Starters (12mo) | To a working channel |
|---|---|---|
| New Squad modal | 499 | 2.4% |
| Settings | 276 | 1.4% |
| Squad page | 101 | **30.7%** |

The squad page converts because intent and target are both unambiguous. Sharing a post has exactly that shape: you are on the post, you want to send it, the target is in front of you.

## What

- Slack button in `SocialShareList`, which covers the share modal, mobile floating bar, engagement rail and collection widgets in one change. `ShareBar` builds its own row so it is wired separately, and its collapse math now accounts for the extra option.
- No integration goes **straight to OAuth**, no intro modal. Returning from OAuth reopens the picker on whichever surface started the share.
- Picker paints recents instantly from our own API, full channel list loads behind it. One tap on a recent posts and closes.
- User scopes are requested on **every** entry point including the squad flow, so a workspace connected anywhere can post as the user with no second consent screen.
- An integration connected before user scopes reports `canPostAsUser: false` and is treated as absent, routing those users back through OAuth rather than failing the share.

## Measurement

Watch **total share events and unique sharers**, not Slack clicks. Slack clicks will look good either way; if they are matched by copy-link falling, the button only redistributed the existing 14.5% provider tail and nothing moved. Share destination logging ships here too, which also closes the blind spot where the Slack desktop client strips referrers.

## Safe to merge before Slack approves the scopes

The production app now has the three user scopes with request reasons, but they are pending Marketplace approval. Rather than block the merge, the share falls back to the bot token, which needs nothing new from Slack: `chat:write`, `channels:join` and `channels:read` are already approved and already carry the squad broadcast.

So on merge the share works, attributed to the daily.dev app, and the picker offers a reconnect to upgrade to posting as the person. Once Slack approves, the next authorization flips a user to their own name automatically.

Two consequences worth knowing:

- **Private channels do not work on the bot path.** `conversations.join` cannot join one, so those shares return a message saying they need permission to post as you. Public channels are fine.
- **Early numbers will understate the feature.** An APP-badged message is exactly the thing that gets muted, so the interim period is the weaker version of this flow. With no flag there is no clean control, so do not read the first weeks as a verdict.

## Note for reviewers

`useSlackShareButton` reads `window.location` rather than `useRouter`. `ShareModal.spec` asserts against the last `useRouter()` mock result, and since the global mock returns a fresh `push` per call, an extra call in a shared widget silently breaks it. Reading the location directly avoids that and works on every surface this renders on, including the extension.

## Testing

shared 2,871 passed (394 suites); webapp 685 passed (86 suites); lint clean both packages; strict-changed guard passed; full webapp `tsc` shows no new failures. That last one caught `/join` requiring a component per `ReferralCampaignKey`, which CI would have missed.

Not verified in a browser: the flag defaults off and the local webapp points at the production API, which does not yet have the new schema.

### Preview domain
https://slack-share-to-channel.preview.app.daily.dev