### PR TITLE
fix(read): keep phone ads inside their cards, 320x50 header on phones

### DIFF
--- a/packages/shared/src/components/post/read/ReadAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/read/ReadAdSlot.spec.tsx
@@ -234,6 +234,7 @@ describe('ReadAdSlot', () => {
     );
     expect(ins).toHaveStyle({ width: '300px', height: '250px' });
     expect(ins).not.toHaveAttribute('data-ad-format');
+    expect(ins).toHaveAttribute('data-full-width-responsive', 'false');
   });
 
   it('never renders for logged-in users', () => {

--- a/packages/shared/src/components/post/read/ReadAdSlot.spec.tsx
+++ b/packages/shared/src/components/post/read/ReadAdSlot.spec.tsx
@@ -117,10 +117,12 @@ describe('ReadAdSlot', () => {
     setSlots({ '3': { id: '1234567890', type: 'display' } });
     render(<ReadAdSlot slot={3} format={ReadAdFormat.MediumRectangle} eager />);
 
-    // Left on `auto`, a 300px-wide slot is free to answer with a 300x600.
+    // Left on `auto`, a 300px-wide slot is free to answer with a 300x600;
+    // left on the phone default, the ins stretches to the screen width and
+    // overflows the card.
     const ins = screen.getByTestId('adsense-slot-3');
     expect(ins).toHaveAttribute('data-ad-format', 'rectangle');
-    expect(ins).not.toHaveAttribute('data-full-width-responsive');
+    expect(ins).toHaveAttribute('data-full-width-responsive', 'false');
   });
 
   it('keeps banners horizontal so a rectangle cannot fill them', () => {

--- a/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
@@ -14,9 +14,9 @@ export interface ReadTopLeaderboardProps {
   released?: boolean;
   slot?: number;
   /**
-   * The twin the phone requests instead of `slot`, so phone and desktop fill
-   * report under their own slot numbers. Must come from the same surface's
-   * map as `slot`, or the twin would ride the other surface's flag gating.
+   * The fixed 320x50 twin the phone requests instead of the responsive
+   * unit. Must come from the same surface's map as `slot`, or the twin
+   * would ride the other surface's flag gating.
    */
   phoneSlot?: number;
   surface?: 'read' | 'organic';
@@ -27,7 +27,7 @@ export interface ReadTopLeaderboardProps {
  * Top leaderboard (slot 2), first thing in the article column. The column is
  * 745px wide inside its padding at the layout's full width, so a 728px
  * leaderboard renders at its booked size within the page rather than spanning
- * it; narrower viewports get a 320x50 or 320x100 mobile banner instead.
+ * it; narrower viewports get the 320x50 mobile banner instead.
  *
  * Stays pinned for the first ten seconds of scrolling, then releases and
  * scrolls away with the page. Sticky rather than fixed so it only pins within
@@ -68,10 +68,9 @@ export function ReadTopLeaderboard({
           'z-2 laptop:sticky laptop:top-[var(--sticky-header-offset)]',
       )}
     >
-      {/* Two breakpoint twins of one unit, both horizontal responsive: the
-          phone's 320px cap leaves room for the mobile banners only, tablet+
-          gets the 728x90. Expandable and video creatives are blocked on the
-          unit account-side, not here — see READ_SLOT.topLeaderboardPhone.
+      {/* Two breakpoint twins of one unit: the phone requests a fixed
+          320x50 (see READ_SLOT.topLeaderboardPhone), tablet+ keeps the
+          responsive 728x90.
           Neither is eager: an eager push from a display:none twin would
           initialise the visible one out of order, and both sit at the top of
           the page where the intersection observer fires on first paint
@@ -79,7 +78,7 @@ export function ReadTopLeaderboard({
       <ReadAdSlot
         slot={phoneSlot}
         surface={surface}
-        format={ReadAdFormat.Leaderboard}
+        format={ReadAdFormat.MobileBanner}
         className="tablet:hidden"
         refreshes
       />

--- a/packages/shared/src/components/post/read/slots.ts
+++ b/packages/shared/src/components/post/read/slots.ts
@@ -23,15 +23,14 @@ export const READ_SLOT = {
   /** Half page closing the rail — the page's only sticky unit. */
   railBottomSticky: 19,
   /**
-   * The top leaderboard's phone twin: the same AdSense unit, requested
-   * separately so phone and desktop fill split by slot number in our events.
-   * It was a fixed 320x100 after a responsive request came back as expandable
-   * video and pinned half the screen inside the phone-sticky header block,
-   * but 320x100 alone has too little inventory and the header sat empty on
-   * most phones. It is a horizontal responsive request again (320x50 and
-   * 320x100 both serve) with expandable and video creatives blocked on the
-   * unit in the AdSense account, which is the only place that can rule them
-   * out: the <ins> can shape a request, not filter formats.
+   * The top leaderboard's phone twin: the same AdSense unit requested at a
+   * fixed 320x50, the smallest standard banner. Fixed rather than responsive
+   * because a responsive request can come back as expandable video, which
+   * inside the phone-sticky header block once pinned half the screen, and
+   * because on a phone user agent AdSense stretches a responsive ins to the
+   * full screen width regardless of the wrapper. 320x50 over the earlier
+   * 320x100: it is the best-filled mobile size and takes the least of the
+   * pinned header.
    */
   topLeaderboardPhone: 20,
 } as const;
@@ -105,13 +104,12 @@ export const MAX_CONTENT_ADS_PER_SECTION = 4;
  */
 export const READ_ADSENSE_SLOTS: AdsenseSlots = {
   [READ_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  // Same responsive request as the desktop twin: FORMAT_SPEC caps the phone
-  // at 320px and `horizontal` keeps rectangles out, so only the mobile
-  // banners fit. See READ_SLOT.topLeaderboardPhone for why this is not fixed.
-  // TODO(vas): in AdSense, block "Expandable" and "Video" under Blocking
-  // controls > Ad serving for unit 9942870945 before shipping — the fixed
-  // size was the only thing keeping expandables out of the pinned header.
-  [READ_SLOT.topLeaderboardPhone]: { id: '9942870945', type: 'display' },
+  [READ_SLOT.topLeaderboardPhone]: {
+    id: '9942870945',
+    type: 'display',
+    width: 320,
+    height: 50,
+  },
   // The three MPU placements below share existing Display units while the
   // dedicated ones don't exist: Google's per-unit reporting blends them, but
   // our first-party events split by slot number, so per-placement RPM stays
@@ -154,7 +152,7 @@ export const ORGANIC_SLOT = {
   topLeaderboard: 15,
   /** Rail unit below the direct-sold ad widget. */
   railAfterDirectAd: 16,
-  /** The organic leaderboard's responsive phone twin — see slot 20. */
+  /** The organic leaderboard's fixed 320x50 phone twin — see slot 20. */
   topLeaderboardPhone: 21,
   /** MPU repeated through the TLDR, same cadence as the articles page. */
   inContentMpu: 22,
@@ -170,7 +168,12 @@ export const ORGANIC_SLOT = {
 // (Display 300x250) in AdSense and swap the ids for per-placement RPM.
 export const ORGANIC_ADSENSE_SLOTS: AdsenseSlots = {
   [ORGANIC_SLOT.topLeaderboard]: { id: '9942870945', type: 'display' },
-  [ORGANIC_SLOT.topLeaderboardPhone]: { id: '9942870945', type: 'display' },
+  [ORGANIC_SLOT.topLeaderboardPhone]: {
+    id: '9942870945',
+    type: 'display',
+    width: 320,
+    height: 50,
+  },
   [ORGANIC_SLOT.railAfterDirectAd]: { id: '6921226982', type: 'display' },
   // Shared units, same trade as the articles map: Google's per-unit rows
   // blend, first-party events split by slot number.

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -172,12 +172,17 @@ function getInsAttributes(
   }
 
   if (config.width && config.height) {
+    // The opt-out applies here too: the units are responsive on the AdSense
+    // side, and without it a phone user agent had the tag rewrite a fixed
+    // 320x50 into a 390x390 with a negative margin, the same full-width
+    // expansion as below.
     return {
       style: {
         display: 'inline-block',
         width: config.width,
         height: config.height,
       },
+      'data-full-width-responsive': 'false',
     };
   }
 

--- a/packages/shared/src/features/monetization/ProgrammaticAd.tsx
+++ b/packages/shared/src/features/monetization/ProgrammaticAd.tsx
@@ -21,6 +21,7 @@ export enum ProgrammaticAdFormat {
   MediumRectangle = 'mediumRectangle',
   Rectangle = 'rectangle',
   HalfPage = 'halfPage',
+  MobileBanner = 'mobileBanner',
   Native = 'native',
 }
 
@@ -58,10 +59,12 @@ type FormatSpec = {
 };
 
 export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
-  // Leaderboard on desktop, large mobile banner on a phone.
+  // Leaderboard on desktop; the phone header is the MobileBanner twin below.
+  // The phone cap stays so a Leaderboard left visible on a phone still comes
+  // back as a banner rather than whatever else fits the column.
   [ProgrammaticAdFormat.Leaderboard]: {
     label: 'Leaderboard',
-    size: '728x90 · 320x50 / 320x100 mobile',
+    size: '728x90 · 320x100 mobile',
     minHeight: 'min-h-[136px] tablet:min-h-[126px]',
     maxWidth: 'max-w-[320px] tablet:max-w-[728px]',
     shape: 'horizontal',
@@ -91,6 +94,17 @@ export const FORMAT_SPEC: Record<ProgrammaticAdFormat, FormatSpec> = {
     minHeight: 'min-h-[356px]',
     maxWidth: 'max-w-[300px]',
     shape: 'vertical',
+  },
+  // The phone header unit, booked at the fixed 320x50: the smallest standard
+  // size, so the pinned header block takes the least of a phone screen, and a
+  // fixed request can only return its exact size — no expandable or video
+  // creative can answer it, which a responsive request could not rule out.
+  [ProgrammaticAdFormat.MobileBanner]: {
+    label: 'Mobile banner',
+    size: '320x50',
+    minHeight: 'min-h-[86px]',
+    maxWidth: 'max-w-[320px]',
+    shape: 'horizontal',
   },
   [ProgrammaticAdFormat.Native]: {
     label: 'Native',
@@ -168,7 +182,16 @@ function getInsAttributes(
   }
 
   if (shape) {
-    return { style: { display: 'block' }, 'data-ad-format': shape };
+    // Off explicitly: for a phone user agent AdSense defaults full-width
+    // responsive ON and stretches the ins to the screen width, past the
+    // wrapper's IAB cap — a 390px ins overflowing a 300px card, and a 390x390
+    // request for a horizontal unit that nothing fills. Off, the ins takes
+    // the wrapper's width and the shape decides the height.
+    return {
+      style: { display: 'block' },
+      'data-ad-format': shape,
+      'data-full-width-responsive': 'false',
+    };
   }
 
   return {


### PR DESCRIPTION
## Summary

Mobile AdSense units on `/articles/*` and anonymous `/posts/*` rendered outside their cards and mostly unfilled on real phones. Follow-up to #6626.

**Root cause.** On a phone user agent AdSense defaults `data-full-width-responsive` to on, so every responsive `<ins>` stretched to the screen width regardless of the wrapper. On an iPhone 12 Pro (390px) the rectangle units became a 390px `<ins>` overflowing the 300px card, and the horizontal header requested a 390x390 that nothing fills, leaving a 426px tall empty white card pinned at the top of the screen. In a desktop browser this never showed because the default only applies to mobile user agents.

**Changes**

- Shaped responsive units (`horizontal`, `rectangle`, `vertical`) now send `data-full-width-responsive="false"`, so the `<ins>` takes the wrapper's width and the shape decides the height. Rectangles come back as 300x250 inside the 300px card again.
- Fixed-size units send the same opt-out. The units are responsive on the AdSense side, and without it the tag rewrote the fixed 320x50 header into a 390x390 with a negative margin on the first preview build.
- The phone header twin (slots 20 and 21) is a fixed 320x50 with a new `MobileBanner` format that reserves exactly 86px, so the pinned header block takes the least screen possible and the card hugs the creative. A fixed request also cannot come back as expandable video, which is what the earlier fixed size existed to prevent, so the AdSense-side blocking TODO from #6626 is no longer needed.
- Comments in the slot map, `ReadTopLeaderboard` and the format spec describe the phone behaviour.

## Verification

- Reproduced on production with Chrome DevTools device emulation (iPhone 12 Pro, 390x844, mobile UA): header request `390x390` unfilled, rectangles `unfill-optimized` with a 390px `<ins>` in a 300px wrapper.
- Read and monetization specs pass (9 suites, 82 tests). Prettier and the strict typecheck guard pass on the changed files.
- Verified on the preview with the same emulation: header `<ins>` 320x50 in a 320px card (93px tall), rectangle `<ins>` 300x250 in a 300px card, both with `data-full-width-responsive="false"`. Preview serves blank test creatives, so creative rendering is a production check after deploy.

## After deploy

Compare request vs fill for slots 20/21 and the rectangle slots in ClickHouse, split by device. Fill on phones should jump now that the requests are for standard sizes.


### Preview domain
https://fix-read-phone-ads-full-width.preview.app.daily.dev
