### PR TITLE
fix(read): give the phone header banner its full width on 320px screens

### DIFF
--- a/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
@@ -47,6 +47,12 @@ export function ReadTopLeaderboard({
     <div
       className={classNames(
         'bg-background-default pb-2 pt-4',
+        // Bleeds into the column's phone padding like GoBackHeaderMobile
+        // below it, so the 320px card has its full width on a 320px screen.
+        // Narrower than that, nothing standard fits: the wrapper hides, and a
+        // hidden wrapper never intersects, so the twin never requests. A raw
+        // media query because the screens config rules out max-* variants.
+        '-mx-4 tablet:mx-0 [@media(max-width:19.9375rem)]:hidden',
         className,
         // --sticky-header-offset is published by MainLayout and matches the
         // fixed chrome this layout actually has: 4rem for the v1 header, 0 on
@@ -70,7 +76,11 @@ export function ReadTopLeaderboard({
     >
       {/* Two breakpoint twins of one unit: the phone requests a fixed
           320x50 (see READ_SLOT.topLeaderboardPhone), tablet+ keeps the
-          responsive 728x90.
+          responsive 728x90. The fixed size only holds while the card is at
+          least 320px wide — given less, AdSense drops the size and serves
+          whatever fits the space, which is why the wrapper above bleeds
+          into the padding rather than leaving the column's 288px on a
+          320px phone.
           Neither is eager: an eager push from a display:none twin would
           initialise the visible one out of order, and both sit at the top of
           the page where the intersection observer fires on first paint


### PR DESCRIPTION
## Summary

Follow-up to #6628. On the first-generation iPhone SE (320px) the phone header ad still rendered as a half-screen square overflowing its card.

**Root cause.** The post column keeps 16px of padding on phones, leaving 288px at a 320px viewport. The header twin is a fixed 320x50, and when a fixed `<ins>` is wider than its container AdSense abandons the size and serves whatever fits the measured space, here a 304x250.

**Change.** `ReadTopLeaderboard`'s wrapper bleeds into the column padding below tablet (`-mx-4 tablet:mx-0`), the same thing `GoBackHeaderMobile` directly beneath it already does, so the card has 320px on a 320px screen and the fixed size holds. As merged, the wrapper also hides below 320px via `[@media(max-width:19.9375rem)]:hidden`. The code review showed that guard is unnecessary and harmful (`body { min-width: 20rem }` floors the layout at 320px, so the bled card always fits); it is removed in #6630.

Wider phones are unaffected: the card is capped at 320px and centered, so the extra room shows up as the same margins as before.

## Verification

- `ReadTopLeaderboard` spec, prettier, eslint and the strict typecheck guard pass on the changed file.
- Preview checked with Chrome DevTools device emulation (mobile UA, fresh isolated context, measured ~9s after load):

| Viewport | Surface | Header card | Header `<ins>` | Result |
|---|---|---|---|---|
| 320x568 | `/posts/*` | 320 wide at x=0, 93 tall | 320x50 | fixed, was 288 wide with a 304x250 |
| 320x568 | `/articles/*` | 320 wide at x=0, 93 tall | 320x50 | fixed |
| 300 wide | `/posts/*` | wrapper hidden by the guard | not mounted | fixed in #6630 |
| 360x800 | `/posts/*` | 320 wide, centered | 320x50 | unchanged |
| 390x844 | `/posts/*` | 320 wide, centered | 320x50 | unchanged |

The in-content rectangle is untouched by this change and still sits inside its card at every width.


### Preview domain
https://fix-read-phone-leaderboard-narro.preview.app.daily.dev


