### PR TITLE
fix(read): keep the phone header hidden below 320px, threshold in px

### DIFF
--- a/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
@@ -48,11 +48,10 @@ export function ReadTopLeaderboard({
       className={classNames(
         'bg-background-default pb-2 pt-4',
         // Bleeds into the column's phone padding like GoBackHeaderMobile
-        // below it, so the 320px card has its full width on a 320px screen.
-        // Narrower than that, nothing standard fits: the wrapper hides, and a
-        // hidden wrapper never intersects, so the twin never requests. A raw
-        // media query because the screens config rules out max-* variants.
-        '-mx-4 tablet:mx-0 [@media(max-width:19.9375rem)]:hidden',
+        // below it, so the 320x50 card has its full width on a 320px screen —
+        // the body's min-width, so the card never gets less. Given less,
+        // AdSense drops the fixed size and serves whatever fits the space.
+        '-mx-4 tablet:mx-0',
         className,
         // --sticky-header-offset is published by MainLayout and matches the
         // fixed chrome this layout actually has: 4rem for the v1 header, 0 on
@@ -76,11 +75,7 @@ export function ReadTopLeaderboard({
     >
       {/* Two breakpoint twins of one unit: the phone requests a fixed
           320x50 (see READ_SLOT.topLeaderboardPhone), tablet+ keeps the
-          responsive 728x90. The fixed size only holds while the card is at
-          least 320px wide — given less, AdSense drops the size and serves
-          whatever fits the space, which is why the wrapper above bleeds
-          into the padding rather than leaving the column's 288px on a
-          320px phone.
+          responsive 728x90.
           Neither is eager: an eager push from a display:none twin would
           initialise the visible one out of order, and both sit at the top of
           the page where the intersection observer fires on first paint

--- a/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
+++ b/packages/shared/src/components/post/read/ReadTopLeaderboard.tsx
@@ -48,10 +48,14 @@ export function ReadTopLeaderboard({
       className={classNames(
         'bg-background-default pb-2 pt-4',
         // Bleeds into the column's phone padding like GoBackHeaderMobile
-        // below it, so the 320x50 card has its full width on a 320px screen —
-        // the body's min-width, so the card never gets less. Given less,
-        // AdSense drops the fixed size and serves whatever fits the space.
-        '-mx-4 tablet:mx-0',
+        // below it, so the 320x50 card has its full width on a 320px screen.
+        // Hidden on narrower screens: AdSense sizes a fixed unit against the
+        // document's client width, not its container, so even with the card
+        // held at 320px by the body's min-width a 312px screen gets a 312x250
+        // in place of the banner. A hidden wrapper never intersects, so the
+        // twin never requests. In px, like the creative and the screens
+        // config, so the threshold does not drift with the browser font size.
+        '-mx-4 tablet:mx-0 [@media(max-width:319px)]:hidden',
         className,
         // --sticky-header-offset is published by MainLayout and matches the
         // fixed chrome this layout actually has: 4rem for the v1 header, 0 on


### PR DESCRIPTION
## Summary

Follow-up to #6629. Its code review argued the sub-320px guard on the phone header wrapper was redundant, and this PR originally removed it. Testing the removal on the preview showed the guard is needed, so this PR now keeps it and fixes its threshold instead.

**Why the guard is needed.** `body { min-width: 20rem }` does hold the bled card at 320px on narrower screens, but AdSense sizes a fixed unit against the document's client width, not its container. With the guard removed, a 300px screen got a 300x250 in place of the banner and a 312px screen got a 312x250, each inside a 320px card. Galaxy Z Fold 3 and 4 cover screens sit around 317 CSS px, so this is a real, if small, population. Hiding the wrapper means the twin never intersects and never requests, which is the only way to keep AdSense from substituting a size.

**What changes.**

- The threshold moves from `19.9375rem` to `319px`. `rem` in a media query resolves against the browser's default font size, so a desktop user with a large font setting had the header hidden on 360 to 478px layouts where the banner fits. The creative and the Tailwind screens are both in px, so the guard is too. This is a deliberate exception to the rem-for-arbitrary-values convention, noted in the comment.
- The class-site comment states the actual mechanism, and the duplicated explanation on the twin comment is trimmed back to what was on main.

## Verification

- `ReadTopLeaderboard` spec, prettier, eslint and the strict typecheck guard pass. Tailwind CLI emits the `@media(max-width:319px)` rule.
- Preview with the guard removed (this PR's first revision), Chrome DevTools device emulation: 300px screen gave a 300x250 header element, 312px gave 312x250, both in a 320px card, with the wrapper at x=0 and 320px wide.
- Preview with the px guard, same emulation on this head: 300px screen hides the wrapper (`display: none`, no `<ins>` mounted, no request); 320px screen renders the wrapper at x=0, 320px wide, 93px tall with a 320x50 `<ins>`. Widths above 320 are untouched by this change and were verified on #6629.



### Preview domain
https://fix-read-phone-header-drop-narro.preview.app.daily.dev
