### PR TITLE
fix(slack): start the OAuth flow from the API so state is single-use

### DIFF
--- a/packages/shared/src/hooks/integrations/slack/useSlack.spec.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlack.spec.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react';
+import { useSlack } from './useSlack';
+import { apiUrl } from '../../../lib/config';
+
+describe('useSlack', () => {
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: { origin: 'https://app.daily.dev', href: '' },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+    });
+  });
+
+  it('should send the browser to the API authorize endpoint with the redirect path', () => {
+    const { result } = renderHook(() => useSlack());
+
+    result.current.connect({ redirectPath: '/squads/daily?param=a b' });
+
+    const url = new URL(window.location.href);
+    expect(url.origin + url.pathname).toBe(
+      `${apiUrl}/integrations/slack/auth/authorize`,
+    );
+    expect(url.searchParams.get('redirectPath')).toBe(
+      '/squads/daily?param=a b',
+    );
+  });
+});

--- a/packages/shared/src/hooks/integrations/slack/useSlack.ts
+++ b/packages/shared/src/hooks/integrations/slack/useSlack.ts
@@ -1,11 +1,8 @@
 import { useCallback } from 'react';
-import { useAuthContext } from '../../../contexts/AuthContext';
-import { setCookie } from '../../../lib/cookie';
 import {
   SLACK_CONNECT_SOURCE_MUTATION,
   UserIntegrationType,
 } from '../../../graphql/integrations';
-import { isDevelopment } from '../../../lib/constants';
 import { gqlClient } from '../../../graphql/common';
 import { useLogContext } from '../../../contexts/LogContext';
 import { LogEvent } from '../../../lib/log';
@@ -24,38 +21,19 @@ export type UseSlack = {
   }) => Promise<void>;
 };
 
-const scopes = ['channels:read', 'chat:write', 'channels:join', 'groups:read'];
-
 export const useSlack = (): UseSlack => {
-  const { user } = useAuthContext();
   const { logEvent } = useLogContext();
 
-  const connect = useCallback<UseSlack['connect']>(
-    async ({ redirectPath }) => {
-      const url = new URL('https://slack.com/oauth/v2/authorize');
+  const connect = useCallback<UseSlack['connect']>(({ redirectPath }) => {
+    // apiUrl is a relative proxy path on localhost, hence the base
+    const url = new URL(
+      `${apiUrl}/integrations/slack/auth/authorize`,
+      globalThis.location?.origin,
+    );
+    url.searchParams.set('redirectPath', redirectPath);
 
-      const redirectUrl = new URL(`${apiUrl}/integrations/slack/auth/callback`);
-      url.searchParams.append('redirect_uri', redirectUrl.toString());
-
-      url.searchParams.append('state', user!.id);
-      url.searchParams.append('scope', scopes.join(','));
-      url.searchParams.append(
-        'client_id',
-        process.env.NEXT_PUBLIC_SLACK_CLIENT_ID!,
-      );
-
-      setCookie('slackRedirectPath', redirectPath, {
-        path: '/',
-        maxAge: 3600,
-        secure: !isDevelopment,
-        domain: process.env.NEXT_PUBLIC_DOMAIN,
-        sameSite: 'lax',
-      });
-
-      window.location.href = url.toString();
-    },
-    [user],
-  );
+    window.location.href = url.toString();
+  }, []);
 
   const connectSource = useCallback<UseSlack['connectSource']>(
     async ({ integrationId, channelId, sourceId }) => {


### PR DESCRIPTION
## Why

Slack Marketplace review rejected our app partly because of the OAuth `state` parameter: we sent `user.id`, which is static per user, identical on every authorization request, and guessable. Slack requires a state that is randomly generated, unique per request, and non-guessable.

## What changed

The whole start of the OAuth flow moves server-side. `useSlack().connect` no longer builds the Slack authorize URL in the browser — it just redirects to the new API endpoint with the redirect path as a query param:

```
GET {apiUrl}/integrations/slack/auth/authorize?redirectPath=<path>
```

The API (companion PR, see below) requires the session cookie, mints a random single-use state, stores it in Redis keyed to the user, sets the `slackRedirectPath` cookie itself, and 307-redirects on to `https://slack.com/oauth/v2/authorize` with the right `client_id`, `scope`, `redirect_uri` and `state`.

Because the client no longer builds the Slack URL:

- the module-level `scopes` array is gone
- the `slackRedirectPath` cookie write (and the `setCookie` / `isDevelopment` imports) is gone — the API sets it
- `useAuthContext` is gone from this hook; the callback has no dependencies now
- `process.env.NEXT_PUBLIC_SLACK_CLIENT_ID` is no longer read here (the env var itself is untouched — the API owns the client id now)

`useSlack`'s exported `UseSlack` type and `connectSource` are unchanged.

`useSlack.ts` was the only place in this repo that built a `slack.com/oauth/v2/authorize` URL or read `NEXT_PUBLIC_SLACK_CLIENT_ID` outside of `.env` files.

## Deploy order

**This MUST deploy AFTER the companion `dailydotdev/daily-api` PR on branch `slack-oauth-state`** — the `/integrations/slack/auth/authorize` endpoint has to exist first, otherwise "Connect to Slack" 404s.

This is a deliberate breaking change: the API accepts only the new single-use state, with no fallback for the old `state = user.id` form. In the window between the API deploying and this shipping, a Slack connect started from the previous client build fails with `invalid state` and the user retries once this is out. The integration's adoption makes that an acceptable trade rather than an incident.

## Test plan

- New `useSlack.spec.ts` asserts the browser is sent to the API authorize endpoint with the right `redirectPath` (URL-encoded via `URLSearchParams`). The exact Slack URL is asserted API-side.
- `packages/shared` lint on the changed files and `node ./scripts/typecheck-strict-changed.js` pass; webapp `tsc` shows only the pre-existing unrelated backlog.

### Preview domain
https://slack-oauth-state.preview.app.daily.dev
