### PR TITLE
feat(skills): add tldr-reel skill for social video generation

### DIFF
--- a/.claude/skills/tldr-reel/SKILL.md
+++ b/.claude/skills/tldr-reel/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: tldr-reel
+description: Build a "// TL;DR" short vertical video from a daily.dev article — the data contract, copy rules, image retrieval and timing derivation. Use when generating social video or slides for TikTok, YouTube Shorts or X from a daily.dev post.
+---
+
+# // TL;DR reel
+
+A 26–30s vertical video that retells one daily.dev article. Music and on-screen
+text only, **never a voiceover**. Six frames, one visual treatment, outro on the
+app icon.
+
+The goal is installs, not views. The format's job is to retell an article well
+enough in half a minute that a developer wants the source.
+
+```
+python3 scripts/fetch_article.py <daily.dev url> --out bundle.json
+python3 scripts/analyse_track.py track.mp3
+```
+
+The first resolves an article into every field the format needs plus scored
+background candidates. The second derives the timing from the music. Both hit
+public endpoints with no auth and print the flags that change what you build.
+
+---
+
+## The data contract
+
+Everything below is verified against `api.daily.dev/graphql` **unauthenticated**.
+
+### Available and reliable
+
+| Field | Notes |
+|---|---|
+| `title` | The raw article headline |
+| `summary` | ~4 sentences. **Can be null** on short or old posts |
+| `image` | Exactly one cover. **Can be null**, or a shared placeholder |
+| `tags` | Drives image retrieval |
+| `readTime`, `numUpvotes`, `numComments`, `views` | |
+| `source { name handle image }` | |
+| `trending` | Integer or null |
+| `creatorTwitter` | On the **post**, not the author. Often null |
+| `topComments` | Via `TOP_COMMENTS_QUERY`. Not used by this format |
+
+### Gated or unreliable — do not build on these
+
+- **`smartTitle`** — `fetchSmartTitle` returns `UNAUTHENTICATED`. Needs a
+  Personal Access Token. Use `title` instead.
+- **`hero`**, **`communitySentiment`** — queryable but frequently `null`, even on
+  well-engaged posts. Never load-bearing.
+
+### `majorHeadlines` is the better front door
+
+`majorHeadlines(first:)` returns the Happening Now highlights unauthenticated,
+and each carries an **editorial `headline`** that is far more readable than
+`title`, plus a `significance` flag:
+
+> `headline`: "Tailwind Labs joins Shopify as Tailwind CSS remains MIT-licensed"
+> `title`:    "Tailwind Labs is joining Shopify"
+
+That closes the `smartTitle` gap without auth. It also makes content selection
+easy: pull Happening Now, filter on `significance`, and the shortlist is already
+editorial.
+
+### Gotchas that cost real time
+
+- **Post ids are case sensitive.** `va5uoAWAC` resolves; `va5uoawac` returns
+  `NOT_FOUND`. `post(id:)` also accepts the full URL slug, so pasting a link works.
+- **`searchPosts` returns nothing unauthenticated.** Use `tagFeed` with
+  `ranking: TIME` and paginate for anything older than a few days.
+- **Declared GraphQL variables must be used**, or the query is rejected outright.
+- **A `Trends` or `Collections` source is daily.dev's own aggregation**, not an
+  outside publisher. There is nobody to credit on the outro — drop the credit line
+  and put image credits in the post caption.
+- **True image size comes from the CDN**, not the API: read
+  `server-timing: content-info;desc="width=…,height=…"`. Covers are typically
+  800px on the long edge and `owidth`/`oheight` match, so there is no larger
+  original to re-sign for.
+
+---
+
+## The format
+
+Six frames. **Frame 1 is the thesis**, frames 2–5 are the sequence, then the outro.
+
+| # | Frame | Job |
+|---|---|---|
+| 1 | Thesis | One sentence, no follow-up. The significance, not the event |
+| 2 | | The complication, or the options |
+| 3 | | The catch — what it costs |
+| 4 | | The shift, or the real benefit |
+| 5 | | The outcome, or the proof |
+| — | Outro | App icon, CTA copy, both store badges |
+
+### Frame 1 states significance, not the event
+
+The single most important copy rule.
+
+> "NVIDIA open-sourced Rust for CUDA." — what happened. A fact to file and scroll past.
+> **"NVIDIA is bringing Rust directly to the GPU."** — why it matters.
+
+Present tense. Written *from* the headline, never a transcription of it. It stands
+alone: no follow-up line, and one step larger than the story frames. It is the
+whole hook, so it is the one frame worth A/B testing per article.
+
+**Test:** read frame 1 aloud to someone. If they say "and?" rather than "wait,
+really?", it is reporting the event. Rewrite it before touching anything else.
+
+### Frames 2–5: the two-line rule
+
+Each is a **bold statement** and a **plain follow-up**:
+
+- **Bold = the turn.** What changed.
+- **Plain = the consequence.** What that meant.
+
+Never two turns in one frame. Never a turn with no consequence. That structure is
+what makes the sequence feel like it is going somewhere instead of listing facts.
+
+**Voice:** sentence case, full stops, plain words, no adjectives doing emotional
+work. Assumes a working developer; never explains what a terminal is.
+
+### Order must matter
+
+The requirement is **not** "does it tell a story" — it is "can the frames be
+shuffled". Both of these work:
+
+- **Chronological:** situation → complication → attempt → shift → outcome
+- **Logical:** the news → the options → the catch → the benefit → the proof
+
+If reordering the frames doesn't break anything, the article is wrong for this
+format. First-person experience reports and launch/acquisition news fit best.
+
+### Reading pace is the hard constraint
+
+Silent text is the only channel. The readable ceiling is about **3 words per
+second**; the deriver targets **2.85** for margin. **Hard cap 13 words per frame** —
+past that, split or cut it; no amount of extra runtime fixes it.
+
+**Runtime is an output, not a setting.** It falls out of bpm and word count, so
+"make it 25 seconds" is not a spec this format can honour. Two tracks reached
+almost the same length with different bar counts (14 vs 11) purely because of tempo.
+
+### Banned
+
+"You won't believe", "this changes everything", "devs hate this", emoji strings,
+ALL CAPS, exclamation marks, and any statement the next frame doesn't pay off.
+Every line must be literally true per the article.
+
+**Brand:** "daily.dev" is always lowercase. Never state a user count — the phrasing
+is "millions of developers".
+
+---
+
+## Frame geometry — 1080×1920
+
+| Element | Position |
+|---|---|
+| Photo | `inset:0`, `object-fit:cover`, **always full bleed** |
+| Scrim | `left:0 bottom:0 1080×1150`, `linear-gradient(to top, #0F1218, rgba(15,18,24,.88) 55%, rgba(15,18,24,.45) 78%, transparent)` |
+| Type | `left:80 bottom:280 width:840`, last baseline y=1640 |
+
+Type: statement **92px/800**, follow-up **62px/400**, both `#FFFFFF`, left
+aligned, ragged right. Hierarchy is size and weight only — colour is not carrying
+it, so both lines stay legible over any photo.
+
+The scrim's stops are weighted for the type, not spread evenly: the copy sits in
+the **0.85–0.95 alpha** band. Nothing else is on the frame — no logo, no chip, no
+numbers, no title card.
+
+**Safe zones:** platform chrome eats the top 220px, the right 160px, and roughly
+the bottom 320–400px. The type at 280px clearance is deliberately tight, so
+**captions must be one short line** on TikTok.
+
+### Motion
+
+- **Cuts land on the beat**; 0.55s crossfade, the incoming layer fading in on top
+  so there is no luminance dip.
+- **Ken Burns** on every photo, alternating direction per frame, roughly 1.05↔1.15
+  plus a 1–2% translate. Nothing is ever static.
+- **Typewriter at 21ms/char.** The old rule banned typewriter as slower than
+  reading; at this rate the longest line lands in ~0.75s, leaving ~3s of read.
+  Above ~35ms/char the ban applies again.
+- **Each frame's copy fades out over its last 0.30s**, before the next layer
+  arrives. Without this, outgoing and incoming text overlap for ~0.3s at every
+  transition — the most common bug in this format.
+
+### The outro
+
+Illustration background with a sustained eased zoom, app icon at 240px with a
+glow bloom on arrival, one paragraph at **68px weight 400** in four semantic
+lines, then both store badges **stacked at 537px wide**.
+
+Staged reveal: icon at +0.32s (after the crossfade clears), copy types from
++0.86s, badges rise **after** the copy finishes — the ask lands after the pitch.
+
+Two things that will silently regress:
+
+- **The glow must follow the icon.** Move the icon and a fixed glow ends up
+  lighting the copy instead.
+- **Store badges are not the same size out of the box.** Google's PNG carries 41px
+  of transparent padding per side — its artwork is 564×168 inside a 646×250 file.
+  Trim the padding, then match on **width** so stacked edges align, and keep the
+  gap at or above a quarter of the badge height for Google's clear-space rule.
+- **No repeating pulse or blink.** On a near-static frame it reads as a UI glitch,
+  not atmosphere.
+
+---
+
+## Image retrieval
+
+Every background must **fill the frame**. That single rule drives selection: a
+9:16 crop keeps only ~28% of a 16:9 image's width.
+
+**Order:** the article's own cover for frame 1 → same publisher as the article →
+same tag, any publisher (credit each in the caption) → the cover at several crops.
+
+**If the story is about a company, frame 1 is the company** — its logo, or its CEO.
+Nothing identifies the subject faster. The mark must be the *subject* of the cover,
+not a badge in a corner.
+
+### What survives a full-bleed crop
+
+- **Central or vertical subjects.** A receding aisle or corridor *gains* from 9:16.
+- **Repeating patterns** are crop-proof — code bars, colour swatches, circuitry.
+  A fragment reads the same as the whole.
+- **Wide logo lockups do not survive.** A `logoA × logoB` pair crops to nonsense.
+  Aim the crop instead: `object-position: 90%` puts the window on one mark so it
+  lands whole. Crops are steerable; treat position as a per-frame decision.
+
+### The visual gate
+
+Topical retrieval alone is not enough. A first pass once matched "debugging" to
+"aliasing bugs" and returned NVIDIA's *Efficient CUDA Debugging* covers — literal
+insects, their own visual pun. Semantically apt, visually wrong.
+
+**Reject:** burned-in text in the artwork (it competes with our type), human stock
+photography, faces, literal-pun imagery, off-topic subjects sharing only a tag.
+
+**Prefer:** abstract renders, product shots and real photography on dark grounds.
+A publisher with strong art direction tends to yield a coherent set.
+
+**Never place a statement over a recognisable person's face** — it reads as a quote
+attributed to them. Bias the crop so faces sit in the upper third.
+
+Two cheap signals worth scoring: **crop survival** `(h*9/16)/w`, and a
+**photographic test** — mean absolute horizontal pixel difference separates real
+photography from flat marketing graphics.
+
+**No automated rule catches all of this.** Someone has to look at the frames
+before publish.
+
+---
+
+## Publishing
+
+The article's real headline never appears on screen, so the caption carries it —
+along with source and image credits.
+
+**YouTube Shorts** indexes titles, so front-load the keywords and keep it under
+~60 chars. Use the thesis line so the video pays off its title immediately. Only
+the first three hashtags display; skip `#shorts`, it does nothing now.
+
+**TikTok:** one short caption line, or it collides with the type.
+
+**X:** tag the companies and the author *only* when the framing is neutral or
+positive about them — never as the target of a line that mocks or corrects them.
+Max two handles. `creatorTwitter` is on the post and often null, so treat author
+tagging as best-effort.
+
+---
+
+## Guardrails
+
+- **Publisher images** appear unmodified and full bleed, so credit is load-bearing.
+  Never use watermarked or paywalled images; keep a per-source opt-out; honour
+  takedowns same day.
+- **Music** needs commercial clearance on all three platforms *and* to be clear of
+  YouTube Content ID — a claim can silently mute or block a Short.
+- **A human approves every video before it publishes.** `publish` must be a
+  separate command reading an approval the render step cannot write, using a
+  different credential, and CI must never hold the posting credential.

--- a/.claude/skills/tldr-reel/scripts/analyse_track.py
+++ b/.claude/skills/tldr-reel/scripts/analyse_track.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Derive the reel's timing from a music file.
+
+    python3 analyse_track.py track.mp3 [more.mp3 ...]
+
+Detects tempo, beat phase and the strongest usable in-point, then derives how
+many bars each frame gets so the densest copy stays under the readable ceiling.
+Runtime is an OUTPUT of bpm + word count, never a target.
+
+Needs: ffmpeg on PATH, numpy, scipy.
+"""
+import json, math, pathlib, subprocess, sys
+import numpy as np
+from scipy.signal import stft
+
+SR, HOP = 22050, 256
+FPS = SR / HOP
+W_THESIS, W_STORY = 9, 13     # words in the thesis frame / densest story frame
+CEIL = 2.85                   # words/second: 5% under the ~3.0 readable ceiling
+OUTRO_TARGET = 6.5            # seconds; the outro needs room for a staged reveal
+MAX_TOTAL = 30.0
+
+
+def decode(path):
+    raw = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(path), "-ac", "1", "-ar", str(SR), "-f", "f32le", "-"],
+        capture_output=True).stdout
+    return np.frombuffer(raw, dtype=np.float32)
+
+
+def analyse(path):
+    x = decode(path)
+    if x.size == 0:
+        raise SystemExit(f"could not decode {path}")
+    dur = len(x) / SR
+
+    # onset envelope: positive spectral flux
+    f, _, Z = stft(x, fs=SR, nperseg=1024, noverlap=1024 - HOP)
+    flux = np.maximum(0, np.diff(np.log1p(10 * np.abs(Z)), axis=1)).sum(axis=0)
+    flux = (flux - flux.mean()) / (flux.std() + 1e-9)
+
+    # tempo: autocorrelation, reinforced at 2x and 4x the lag so bar-level
+    # periodicity outvotes a spurious half-time match
+    ac = np.correlate(flux, flux, mode="full")[len(flux) - 1:]
+    ac /= (ac[0] + 1e-9)
+    best = None
+    for bpm in np.arange(70, 171, 0.1):
+        lag = int(round(60.0 / bpm * FPS))
+        if lag < 2 or lag >= len(ac):
+            continue
+        score = ac[lag] + sum(0.5 * ac[lag * m] for m in (2, 4) if lag * m < len(ac))
+        if best is None or score > best[1]:
+            best = (float(bpm), float(score))
+    bpm, conf = best
+    beat = 60.0 / bpm
+    bar = beat * 4
+
+    # beat phase: correlate the flux against a pulse train
+    period = beat * FPS
+    phase = max(((np.arange(o, len(flux) - 1, period).astype(int), o) for o in np.arange(0, period, 0.25)),
+                key=lambda t: flux[t[0]].mean())[1] / FPS
+
+    # bar layout from the copy budget, quantised up to a half bar
+    q = lambda need: max(1.0, math.ceil(need / bar * 2) / 2)
+    b_story, b_thesis = q(W_STORY / CEIL), q(W_THESIS / CEIL)
+    b_outro = round(OUTRO_TARGET / bar * 2) / 2
+    bars = [b_thesis] + [b_story] * 4 + [b_outro]
+    total = sum(bars) * bar
+    # trade outro bars down before ever rushing the copy
+    while total > MAX_TOTAL and b_outro > 2.5:
+        b_outro -= 0.5
+        bars = [b_thesis] + [b_story] * 4 + [b_outro]
+        total = sum(bars) * bar
+
+    # in-point: the strongest sustained window of `total`, snapped to a bar line
+    win = int(0.25 * SR)
+    rms = np.sqrt(np.convolve(x ** 2, np.ones(win) / win, mode="same"))
+    need = int(total * SR)
+    if need >= len(rms):
+        inpoint = phase
+    else:
+        c = np.cumsum(np.insert(rms, 0, 0))
+        i = int(np.argmax((c[need:] - c[:-need]) / need))
+        inpoint = phase + round((i / SR - phase) / bar) * bar
+        if inpoint < 0 or inpoint + total > dur:
+            inpoint = phase + max(0, math.floor((dur - total - phase) / bar)) * bar
+
+    return {
+        "file": pathlib.Path(path).name, "duration": round(dur, 2),
+        "bpm": round(bpm, 1), "confidence": round(conf, 3),
+        "beat": round(beat, 4), "bar": round(bar, 4), "phase": round(float(phase), 3),
+        "inpoint": round(float(inpoint), 3), "bars": bars, "total": round(total, 3),
+        "pace_story": round(W_STORY / (b_story * bar), 2),
+        "fits": bool(total <= dur),
+    }
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    rows = [analyse(p) for p in sys.argv[1:]]
+    print(json.dumps(rows, indent=1))
+    print(f"\n{'track':32} {'bpm':>6} {'conf':>5} {'in':>7} {'total':>6} {'w/s':>5} {'fits':>5}",
+          file=sys.stderr)
+    for r in rows:
+        print(f"{r['file'][:31]:32} {r['bpm']:6.1f} {r['confidence']:5.2f} {r['inpoint']:7.2f} "
+              f"{r['total']:6.2f} {r['pace_story']:5.2f} {'yes' if r['fits'] else 'NO':>5}",
+              file=sys.stderr)
+        if r["confidence"] < 0.70:
+            print(f"  ^ low tempo confidence — verify by ear", file=sys.stderr)
+        if not r["fits"]:
+            print(f"  ^ track is {r['duration']}s but the cut needs {r['total']}s", file=sys.stderr)

--- a/.claude/skills/tldr-reel/scripts/fetch_article.py
+++ b/.claude/skills/tldr-reel/scripts/fetch_article.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Resolve a daily.dev article into everything a // TL;DR reel needs.
+
+    python3 fetch_article.py <url|slug|postId> [--out bundle.json]
+
+Talks to the public API with no auth. Prints a human summary and writes a JSON
+bundle: the post fields, the Happening Now headline if the post has one, and a
+scored list of candidate background images from the post's own tags.
+"""
+import json, re, subprocess, sys, urllib.parse
+from concurrent.futures import ThreadPoolExecutor
+
+API = "https://api.daily.dev/graphql"
+
+POST_Q = """query Post($id: ID!) { post(id: $id) {
+  id title summary image readTime tags numUpvotes numComments views createdAt
+  trending commentsPermalink creatorTwitter
+  source { name handle image }
+} }"""
+
+HEADLINES_Q = """query MajorHeadlines($first: Int) { majorHeadlines(first: $first) {
+  edges { node { id headline significance highlightedAt channel post { id } } } } }"""
+
+TAGFEED_Q = """query TagFeed($tag: String!, $first: Int, $ranking: Ranking) {
+  page: tagFeed(tag: $tag, first: $first, ranking: $ranking) {
+    edges { node { id title image source { name handle } } } } }"""
+
+
+def gql(query, variables):
+    body = json.dumps({"query": query, "variables": variables})
+    out = subprocess.run(
+        ["curl", "-s", "-m", "30", "-X", "POST", API,
+         "-H", "Content-Type: application/json", "--data", body],
+        capture_output=True, text=True).stdout
+    d = json.loads(out)
+    if d.get("errors"):
+        raise SystemExit("API error: " + d["errors"][0]["message"])
+    return d["data"]
+
+
+def post_ref(arg):
+    """Accepts a full URL, a slug, or a raw post id.
+
+    post(id:) resolves the full URL slug as well as the id, so pasting a link
+    works. Note ids are CASE SENSITIVE: va5uoAWAC resolves, va5uoawac 404s.
+    """
+    if arg.startswith("http"):
+        path = urllib.parse.urlparse(arg).path
+        return path.rstrip("/").split("/")[-1]
+    return arg
+
+
+def head_dims(url):
+    """Real pixel size, from the CDN's own server-timing header."""
+    out = subprocess.run(["curl", "-sI", "-m", "12", url], capture_output=True, text=True).stdout
+    m = re.search(r'content-info;desc="([^"]+)"', out)
+    if not m:
+        return (0, 0)
+    d = dict(kv.split("=") for kv in m.group(1).split(",") if "=" in kv)
+    return (int(d.get("width") or 0), int(d.get("height") or 0))
+
+
+def candidates(tags, exclude_id):
+    pool = {}
+    jobs = [(t, r) for t in tags for r in ("POPULARITY", "TIME")]
+
+    def one(job):
+        tag, ranking = job
+        try:
+            d = gql(TAGFEED_Q, {"tag": tag, "first": 50, "ranking": ranking})
+        except SystemExit:
+            return tag, []
+        return tag, [e["node"] for e in d["page"]["edges"]]
+
+    with ThreadPoolExecutor(max_workers=8) as ex:
+        for tag, nodes in ex.map(one, jobs):
+            for n in nodes:
+                img = n.get("image") or ""
+                # placeholder covers are a shared stock asset, never usable
+                if not img or "Placeholder" in img or n["id"] == exclude_id:
+                    continue
+                n.setdefault("tag", tag)
+                pool.setdefault(n["id"], n)
+
+    items = list(pool.values())
+    with ThreadPoolExecutor(max_workers=16) as ex:
+        dims = list(ex.map(lambda n: head_dims(n["image"]), items))
+    out = []
+    for n, (w, h) in zip(items, dims):
+        if not w or not h:
+            continue
+        # a full-bleed 9:16 crop keeps only (h*9/16)/w of the width
+        keep = min(1.0, (h * 9 / 16) / w)
+        out.append({"id": n["id"], "title": n["title"], "image": n["image"],
+                    "source": n["source"]["name"], "tag": n["tag"],
+                    "width": w, "height": h, "crop_keep": round(keep, 3)})
+    out.sort(key=lambda c: -c["crop_keep"])
+    return out
+
+
+def main():
+    if len(sys.argv) < 2:
+        raise SystemExit(__doc__)
+    ref = post_ref(sys.argv[1])
+    post = gql(POST_Q, {"id": ref})["post"]
+    if not post:
+        raise SystemExit(f"no post for {ref!r} — check case, ids are case sensitive")
+
+    hl = None
+    for e in gql(HEADLINES_Q, {"first": 50})["majorHeadlines"]["edges"]:
+        n = e["node"]
+        if (n.get("post") or {}).get("id") == post["id"]:
+            hl = {k: n[k] for k in ("headline", "significance", "highlightedAt", "channel")}
+            break
+
+    cands = candidates(post["tags"] or [], post["id"])
+    own_source = (post["source"] or {}).get("handle") in ("trends", "collections")
+
+    bundle = {
+        "post": post,
+        "highlight": hl,
+        "flags": {
+            "has_cover": bool(post.get("image")) and "Placeholder" not in (post.get("image") or ""),
+            "source_is_dailydev": own_source,
+            "has_editorial_headline": bool(hl),
+            "creator_twitter": post.get("creatorTwitter"),
+        },
+        "image_candidates": cands,
+    }
+    out = "bundle.json"
+    if "--out" in sys.argv:
+        out = sys.argv[sys.argv.index("--out") + 1]
+    with open(out, "w") as f:
+        json.dump(bundle, f, indent=1)
+
+    p = post
+    print(f"id            {p['id']}")
+    print(f"title         {p['title']}")
+    print(f"headline      {hl['headline'] if hl else '(not a Happening Now highlight)'}")
+    print(f"significance  {hl['significance'] if hl else '-'}")
+    print(f"source        {(p['source'] or {}).get('name')}"
+          f"{'   << daily.dev own aggregation: no publisher credit' if own_source else ''}")
+    print(f"cover         {'yes' if bundle['flags']['has_cover'] else 'NONE — every frame must be retrieved'}")
+    print(f"tags          {', '.join(p['tags'] or [])}")
+    print(f"readTime      {p['readTime']}   upvotes {p['numUpvotes']}   trending {p['trending']}")
+    print(f"candidates    {len(cands)} images; {sum(1 for c in cands if c['crop_keep'] >= 0.55)} "
+          f"survive a full-bleed crop well")
+    print(f"\nsummary\n{p['summary']}")
+    print(f"\nwrote {out}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a `tldr-reel` skill so anyone — or any agent — can generate a **// TL;DR** reel from a daily.dev article: a 26–30s vertical video, music and on-screen text only, no voiceover.

Skill only. No app code, no CI or typecheck surface.

## Why this is worth committing

Most of it is knowledge that is expensive to rediscover, and all of it was verified by running against the live API and by rendering frames and looking at them.

**The data contract** — what is actually usable without auth:

- `title`, `summary`, `image`, `tags`, `readTime`, `source`, engagement, `trending` are reliable (with `summary` and `image` both nullable)
- `fetchSmartTitle` returns `UNAUTHENTICATED` — needs a PAT, so don't design around it
- `hero` and `communitySentiment` are queryable but frequently `null`, even on well-engaged posts
- `majorHeadlines` carries an **editorial `headline`** that is far more readable than `title`, which closes the `smartTitle` gap with no auth — and `significance` makes content selection an editorial shortlist rather than a scoring problem

**Gotchas that cost real time:**

- post ids are **case sensitive** (`va5uoAWAC` resolves, `va5uoawac` 404s), and `post(id:)` also accepts the full URL slug
- `searchPosts` returns nothing unauthenticated — use `tagFeed` with `ranking: TIME`
- true image dimensions live in the CDN's `server-timing` header, not the API
- a `Trends` or `Collections` source is our own aggregation, so there is no publisher to credit

**The creative rules**, which were arrived at by rendering and looking rather than by reasoning: frame 1 states significance rather than the event, the two-line turn/consequence structure, a 13-word cap derived from the ~3 words/second readable ceiling, and runtime as an *output* of bpm plus word count rather than a target.

## Scripts

Both tested end to end against the live API:

| Script | Does |
|---|---|
| `fetch_article.py <url>` | Resolves an article into a JSON bundle plus scored background candidates, including crop survival for full-bleed use, and flags no-cover / own-source cases |
| `analyse_track.py <mp3>` | Derives tempo, beat phase, in-point and the bar layout; warns on low tempo confidence and on tracks too short for the cut |

```
$ python3 scripts/fetch_article.py https://daily.dev/posts/tailwind-labs-is-joining-shopify-5wtla8j7j
headline      Tailwind Labs joins Shopify as Tailwind CSS remains MIT-licensed
significance  major
source        Collections   << daily.dev own aggregation: no publisher credit
candidates    340 images; 20 survive a full-bleed crop well
```

## Testing

- Both scripts run clean against the public API with no auth
- Three reels were produced from this spec end to end (Tailwind/Shopify, GPT-Image-2.5, CUDA Rust) at 1080×1920, H.264 + AAC
- No repo code paths touched, so nothing to regress

## Note for review

The render pipeline itself is not in this PR — it is a local prototype (HTML + Playwright + ffmpeg). The skill documents the frame geometry, motion values and the traps that bit during development, so it stands on its own as a spec for whoever builds the production version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://feat-tldr-reel-skill.preview.app.daily.dev