### PR TITLE
fix(webapp): avoid caching transient profile misses

### DIFF
--- a/packages/shared/src/lib/user.spec.ts
+++ b/packages/shared/src/lib/user.spec.ts
@@ -1,0 +1,41 @@
+import { classifyProfileRequest, type PublicProfile } from './user';
+import { ApiError } from '../graphql/common';
+
+const user = { id: 'u1', username: 'kramer' } as PublicProfile;
+
+describe('classifyProfileRequest', () => {
+  it('returns found when the profile response has a user', () => {
+    expect(classifyProfileRequest(200, { data: { user } })).toEqual({
+      status: 'found',
+      user,
+    });
+  });
+
+  it('returns notFound for the API code used by missing profiles', () => {
+    expect(
+      classifyProfileRequest(200, {
+        data: { user: null },
+        errors: [{ extensions: { code: ApiError.Forbidden } }],
+      }),
+    ).toEqual({ status: 'notFound' });
+  });
+
+  it('returns failed for a server error', () => {
+    const result = classifyProfileRequest(500);
+
+    expect(result.status).toEqual('failed');
+    expect(result).toMatchObject({
+      error: expect.objectContaining({
+        message: 'Failed to fetch profile: 500',
+      }),
+    });
+  });
+
+  it('returns failed for an unknown GraphQL error', () => {
+    const result = classifyProfileRequest(200, {
+      errors: [{ extensions: { code: 'BOOM' } }],
+    });
+
+    expect(result.status).toEqual('failed');
+  });
+});

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -12,7 +12,6 @@ import type { FeaturedAward, UserTransactionPublic } from '../graphql/njord';
 import type { Post } from '../graphql/posts';
 import type { TLocation } from '../graphql/autocomplete';
 import { generateQueryKey, RequestKey, StaleTime } from './query';
-import { ApiError } from '../graphql/common';
 
 export enum Roles {
   Moderator = 'moderator',
@@ -256,7 +255,7 @@ export type ProfileRequestResult =
   | { status: 'notFound' }
   | { status: 'failed'; error: Error };
 
-const profileNotFoundErrorCodes = [ApiError.Forbidden, ApiError.NotFound];
+const profileNotFoundErrorCodes = new Set(['FORBIDDEN', 'NOT_FOUND']);
 
 export const classifyProfileRequest = (
   status: number,
@@ -278,7 +277,7 @@ export const classifyProfileRequest = (
   }
 
   const errorCode = response?.errors?.[0]?.extensions?.code;
-  if (profileNotFoundErrorCodes.includes(errorCode as ApiError)) {
+  if (errorCode && profileNotFoundErrorCodes.has(errorCode)) {
     return { status: 'notFound' };
   }
 

--- a/packages/shared/src/lib/user.ts
+++ b/packages/shared/src/lib/user.ts
@@ -12,6 +12,7 @@ import type { FeaturedAward, UserTransactionPublic } from '../graphql/njord';
 import type { Post } from '../graphql/posts';
 import type { TLocation } from '../graphql/autocomplete';
 import { generateQueryKey, RequestKey, StaleTime } from './query';
+import { ApiError } from '../graphql/common';
 
 export enum Roles {
   Moderator = 'moderator',
@@ -239,7 +240,55 @@ export async function deleteAccount(): Promise<void> {
   }
 }
 
-const getProfileRequest = async (id: string) => {
+type ProfileRequestResponse = {
+  data?: {
+    user?: PublicProfile | null;
+  };
+  errors?: {
+    extensions?: {
+      code?: string;
+    };
+  }[];
+};
+
+export type ProfileRequestResult =
+  | { status: 'found'; user: PublicProfile }
+  | { status: 'notFound' }
+  | { status: 'failed'; error: Error };
+
+const profileNotFoundErrorCodes = [ApiError.Forbidden, ApiError.NotFound];
+
+export const classifyProfileRequest = (
+  status: number,
+  response?: ProfileRequestResponse,
+): ProfileRequestResult => {
+  if (status === 404) {
+    return { status: 'notFound' };
+  }
+
+  if (status >= 400) {
+    return {
+      status: 'failed',
+      error: new Error(`Failed to fetch profile: ${status}`),
+    };
+  }
+
+  if (response?.data?.user) {
+    return { status: 'found', user: response.data.user };
+  }
+
+  const errorCode = response?.errors?.[0]?.extensions?.code;
+  if (profileNotFoundErrorCodes.includes(errorCode as ApiError)) {
+    return { status: 'notFound' };
+  }
+
+  return {
+    status: 'failed',
+    error: new Error('Failed to fetch profile'),
+  };
+};
+
+const getProfileRequest = async (id: string): Promise<ProfileRequestResult> => {
   const userRes = await fetch(graphqlUrl, {
     method: 'POST',
     headers: {
@@ -253,12 +302,14 @@ const getProfileRequest = async (id: string) => {
     }),
     credentials: 'include',
   });
-  if (userRes.status === 404) {
-    throw new Error('not found');
+
+  const status = userRes.status ?? 200;
+  if (status === 404 || status >= 400) {
+    return classifyProfileRequest(status);
   }
 
-  const response = await userRes.json();
-  return response?.data?.user;
+  const response = (await userRes.json()) as ProfileRequestResponse;
+  return classifyProfileRequest(status, response);
 };
 
 const getProfileV2ExtraRequest = async (
@@ -286,7 +337,19 @@ const getProfileV2ExtraRequest = async (
 };
 
 export async function getProfile(id: string): Promise<PublicProfile> {
-  return await getProfileRequest(id);
+  const result = await getProfileRequest(id);
+  return (result.status === 'found' ? result.user : undefined) as PublicProfile;
+}
+
+export async function getProfileForStaticProps(
+  id: string,
+): Promise<Exclude<ProfileRequestResult, { status: 'failed' }>> {
+  const result = await getProfileRequest(id);
+  if (result.status === 'failed') {
+    throw result.error;
+  }
+
+  return result;
 }
 
 export async function getProfileV2Extra(

--- a/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
+++ b/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
@@ -1,9 +1,7 @@
 import type { GetStaticPropsContext } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
-import {
-  getProfileForStaticProps,
-  getProfileV2Extra,
-} from '@dailydotdev/shared/src/lib/user';
+import { getProfileV2Extra } from '@dailydotdev/shared/src/lib/user';
+import { ApiError } from '@dailydotdev/shared/src/graphql/common';
 import {
   getStaticPaths,
   getStaticProps,
@@ -13,7 +11,6 @@ import { getStaticProps as getWorldStaticProps } from '../pages/world/[userId]';
 
 jest.mock('@dailydotdev/shared/src/lib/user', () => ({
   ...jest.requireActual('@dailydotdev/shared/src/lib/user'),
-  getProfileForStaticProps: jest.fn(),
   getProfileV2Extra: jest.fn(),
 }));
 
@@ -21,9 +18,9 @@ jest.mock('../components/world/profileWorld', () => ({
   hasPublicWorld: jest.fn(),
 }));
 
-const mockedGetProfileForStaticProps = getProfileForStaticProps as jest.Mock;
 const mockedGetProfileV2Extra = getProfileV2Extra as jest.Mock;
 const mockedHasPublicWorld = hasPublicWorld as jest.Mock;
+const fetchMock = jest.fn();
 
 // Mirrors the (unexported) ProfileParams in ProfileLayout. Typing the
 // helper as GetStaticPropsContext<ParsedUrlQuery> compiles under the
@@ -35,8 +32,16 @@ interface ProfileParams extends ParsedUrlQuery {
 const context = (userId?: string) =>
   ({ params: { userId } } as unknown as GetStaticPropsContext<ProfileParams>);
 
+const respondProfile = (body: unknown, status = 200) =>
+  fetchMock.mockResolvedValue({
+    status,
+    json: async () => body,
+  });
+
 beforeEach(() => {
   jest.clearAllMocks();
+  fetchMock.mockReset();
+  global.fetch = fetchMock as unknown as typeof fetch;
 });
 
 // `pages/[userId]` is a ROOT-LEVEL dynamic route, so it claims every
@@ -58,7 +63,10 @@ describe('profile getStaticPaths', () => {
 
 describe('profile getStaticProps', () => {
   it('returns notFound when the handle does not resolve to a user', async () => {
-    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'notFound' });
+    respondProfile({
+      data: { user: null },
+      errors: [{ extensions: { code: ApiError.NotFound } }],
+    });
 
     await expect(
       getStaticProps(context('definitely-not-a-user')),
@@ -70,11 +78,14 @@ describe('profile getStaticProps', () => {
       notFound: true,
       revalidate: 60,
     });
-    expect(mockedGetProfileForStaticProps).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it('returns notFound when the profile is forbidden, without confirming it exists', async () => {
-    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'notFound' });
+    respondProfile({
+      data: { user: null },
+      errors: [{ extensions: { code: ApiError.Forbidden } }],
+    });
 
     await expect(getStaticProps(context('blocked-user'))).resolves.toEqual({
       notFound: true,
@@ -84,7 +95,7 @@ describe('profile getStaticProps', () => {
 
   it('still serves a real profile', async () => {
     const user = { id: 'u1', username: 'kramer', noindex: false };
-    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'found', user });
+    respondProfile({ data: { user } });
     mockedGetProfileV2Extra.mockResolvedValue({ userStats: { numPosts: 1 } });
     mockedHasPublicWorld.mockResolvedValue(true);
 
@@ -99,15 +110,44 @@ describe('profile getStaticProps', () => {
     });
   });
 
-  it('rethrows unexpected errors rather than hiding them as a 404', async () => {
-    const boom = new Error('boom');
-    mockedGetProfileForStaticProps.mockRejectedValue(boom);
+  it('rethrows HTTP failures rather than hiding them as a 404', async () => {
+    respondProfile({ errors: [{ message: 'boom' }] }, 500);
 
-    await expect(getStaticProps(context('kramer'))).rejects.toEqual(boom);
+    await expect(getStaticProps(context('kramer'))).rejects.toThrow(
+      'Failed to fetch profile: 500',
+    );
+  });
+
+  it('rethrows network errors rather than hiding them as a 404', async () => {
+    const error = new Error('network down');
+    fetchMock.mockRejectedValue(error);
+
+    await expect(getStaticProps(context('kramer'))).rejects.toEqual(error);
+  });
+
+  it('rethrows aborts rather than hiding them as a 404', async () => {
+    const abort = Object.assign(new Error('aborted'), { name: 'AbortError' });
+    fetchMock.mockRejectedValue(abort);
+
+    await expect(getStaticProps(context('kramer'))).rejects.toEqual(abort);
+  });
+
+  it('rethrows unrecognised GraphQL errors rather than hiding them as a 404', async () => {
+    respondProfile({
+      data: { user: null },
+      errors: [{ extensions: { code: 'BOOM' } }],
+    });
+
+    await expect(getStaticProps(context('kramer'))).rejects.toThrow(
+      'Failed to fetch profile',
+    );
   });
 
   it('forwards a world profile notFound result unchanged', async () => {
-    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'notFound' });
+    respondProfile({
+      data: { user: null },
+      errors: [{ extensions: { code: ApiError.Forbidden } }],
+    });
 
     await expect(getWorldStaticProps(context('blocked-user'))).resolves.toEqual(
       {

--- a/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
+++ b/packages/webapp/__tests__/ProfileLayoutStaticProps.tsx
@@ -1,7 +1,7 @@
 import type { GetStaticPropsContext } from 'next';
 import type { ParsedUrlQuery } from 'querystring';
 import {
-  getProfile,
+  getProfileForStaticProps,
   getProfileV2Extra,
 } from '@dailydotdev/shared/src/lib/user';
 import {
@@ -9,10 +9,11 @@ import {
   getStaticProps,
 } from '../components/layouts/ProfileLayout';
 import { hasPublicWorld } from '../components/world/profileWorld';
+import { getStaticProps as getWorldStaticProps } from '../pages/world/[userId]';
 
 jest.mock('@dailydotdev/shared/src/lib/user', () => ({
   ...jest.requireActual('@dailydotdev/shared/src/lib/user'),
-  getProfile: jest.fn(),
+  getProfileForStaticProps: jest.fn(),
   getProfileV2Extra: jest.fn(),
 }));
 
@@ -20,7 +21,7 @@ jest.mock('../components/world/profileWorld', () => ({
   hasPublicWorld: jest.fn(),
 }));
 
-const mockedGetProfile = getProfile as jest.Mock;
+const mockedGetProfileForStaticProps = getProfileForStaticProps as jest.Mock;
 const mockedGetProfileV2Extra = getProfileV2Extra as jest.Mock;
 const mockedHasPublicWorld = hasPublicWorld as jest.Mock;
 
@@ -57,7 +58,7 @@ describe('profile getStaticPaths', () => {
 
 describe('profile getStaticProps', () => {
   it('returns notFound when the handle does not resolve to a user', async () => {
-    mockedGetProfile.mockResolvedValue(null);
+    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'notFound' });
 
     await expect(
       getStaticProps(context('definitely-not-a-user')),
@@ -69,13 +70,11 @@ describe('profile getStaticProps', () => {
       notFound: true,
       revalidate: 60,
     });
-    expect(mockedGetProfile).not.toHaveBeenCalled();
+    expect(mockedGetProfileForStaticProps).not.toHaveBeenCalled();
   });
 
   it('returns notFound when the profile is forbidden, without confirming it exists', async () => {
-    mockedGetProfile.mockRejectedValue({
-      response: { errors: [{ extensions: { code: 'FORBIDDEN' } }] },
-    });
+    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'notFound' });
 
     await expect(getStaticProps(context('blocked-user'))).resolves.toEqual({
       notFound: true,
@@ -85,7 +84,7 @@ describe('profile getStaticProps', () => {
 
   it('still serves a real profile', async () => {
     const user = { id: 'u1', username: 'kramer', noindex: false };
-    mockedGetProfile.mockResolvedValue(user);
+    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'found', user });
     mockedGetProfileV2Extra.mockResolvedValue({ userStats: { numPosts: 1 } });
     mockedHasPublicWorld.mockResolvedValue(true);
 
@@ -101,9 +100,20 @@ describe('profile getStaticProps', () => {
   });
 
   it('rethrows unexpected errors rather than hiding them as a 404', async () => {
-    const boom = { response: { errors: [{ extensions: { code: 'BOOM' } }] } };
-    mockedGetProfile.mockRejectedValue(boom);
+    const boom = new Error('boom');
+    mockedGetProfileForStaticProps.mockRejectedValue(boom);
 
     await expect(getStaticProps(context('kramer'))).rejects.toEqual(boom);
+  });
+
+  it('forwards a world profile notFound result unchanged', async () => {
+    mockedGetProfileForStaticProps.mockResolvedValue({ status: 'notFound' });
+
+    await expect(getWorldStaticProps(context('blocked-user'))).resolves.toEqual(
+      {
+        notFound: true,
+        revalidate: 60,
+      },
+    );
   });
 });

--- a/packages/webapp/components/layouts/ProfileLayout/index.tsx
+++ b/packages/webapp/components/layouts/ProfileLayout/index.tsx
@@ -2,7 +2,7 @@ import type { ReactElement, ReactNode } from 'react';
 import React, { useEffect, useState } from 'react';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import {
-  getProfile,
+  getProfileForStaticProps,
   getProfileV2Extra,
 } from '@dailydotdev/shared/src/lib/user';
 import dynamic from 'next/dynamic';
@@ -229,10 +229,12 @@ export async function getStaticProps({
     return profileNotFound;
   }
   try {
-    const user = await getProfile(userId);
-    if (!user) {
+    const profile = await getProfileForStaticProps(userId);
+    if (profile.status === 'notFound') {
       return profileNotFound;
     }
+
+    const { user } = profile;
     // Both only need the resolved id, so neither has to wait on the other.
     const [data, hasWorld] = await Promise.all([
       getProfileV2Extra(user.id),


### PR DESCRIPTION
## Summary
- Add a classified profile fetch path for static props so real missing profiles return `notFound`, while transient or unknown failures throw instead of being cached as 404s.
- Keep the client-facing `getProfile` no-data contract and use `getProfileForStaticProps` only for ISR/static generation.
- Extend profile static-props coverage, including `world/[userId]` forwarding `notFound` unchanged.

## Key decisions
- Treat `FORBIDDEN`/`NOT_FOUND` profile responses as real not-found results for profile ISR.
- Treat HTTP 5xx, network failures, and unknown GraphQL errors as retryable failures by rethrowing.

Issue: https://linear.app/dailydev/issue/ENG-1930/feedback-bug-report-error-occurs-when-navigating-to-profile-page-after

Closes ENG-1930

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1930-feedback-bug-report-err.preview.app.daily.dev