### PR TITLE
feat(share): add Slack to the share bands

### DIFF
--- a/packages/shared/src/components/post/common/PostContentShare.tsx
+++ b/packages/shared/src/components/post/common/PostContentShare.tsx
@@ -80,6 +80,8 @@ export function PostContentShare({
       // shortens at press time and falls back to the tracked URL.
       link={post.commentsPermalink}
       onShare={onShare}
+      origin={Origin.PostContent}
+      post={post}
       text={post.title ?? post.sharedPost?.title ?? ''}
       title="Should anyone else see this post?"
     />

--- a/packages/shared/src/components/share/ShareActions.spec.tsx
+++ b/packages/shared/src/components/share/ShareActions.spec.tsx
@@ -12,6 +12,7 @@ import { ShareActions } from './ShareActions';
 import { TestBootProvider } from '../../../__tests__/helpers/boot';
 import { ShareProvider } from '../../lib/share';
 import { useViewSize } from '../../hooks/useViewSize';
+import { postWithCommunitySentiment as sharedPost } from '../../../__tests__/fixture/post';
 
 jest.mock('../../hooks/useViewSize', () => {
   const actual = jest.requireActual('../../hooks/useViewSize');
@@ -50,6 +51,15 @@ describe('ShareActions inline variant', () => {
     expect(screen.getByText('Copy link')).toBeInTheDocument();
     expect(screen.getByText('X')).toBeInTheDocument();
     expect(screen.getByText('WhatsApp')).toBeInTheDocument();
+  });
+
+  it('offers Slack only when there is a post to share', () => {
+    const { unmount } = renderComponent({ variant: 'inline' });
+    expect(screen.queryByText('Slack')).not.toBeInTheDocument();
+    unmount();
+
+    renderComponent({ variant: 'inline', post: sharedPost });
+    expect(screen.getByText('Slack')).toBeInTheDocument();
   });
 
   it('copies the link and reports the CopyLink provider', async () => {

--- a/packages/shared/src/components/share/ShareActions.tsx
+++ b/packages/shared/src/components/share/ShareActions.tsx
@@ -13,6 +13,8 @@ import { useShareOrCopyLink } from '../../hooks/useShareOrCopyLink';
 import { shouldUseNativeShare } from '../../lib/func';
 import { ShareProvider } from '../../lib/share';
 import type { ReferralCampaignKey } from '../../lib/referral';
+import type { Post } from '../../graphql/posts';
+import type { Origin } from '../../lib/log';
 import { CopyStateIcon } from './CopyStateIcon';
 import { SplitShareButton } from './SplitShareButton';
 
@@ -23,6 +25,10 @@ export interface ShareActionsProps {
   /** Share text / description used for native share + pre-filled network text. */
   text: string;
   cid?: ReferralCampaignKey;
+  /** The post being shared, when there is one: Slack shares a post. */
+  post?: Post;
+  /** Where the Slack share starts, for its own events. */
+  origin?: Origin;
   variant?: ShareActionsVariant;
   /** Desktop only: reveal the popover on hover as well as click. */
   openOnHover?: boolean;
@@ -50,6 +56,8 @@ export function ShareActions({
   link,
   text,
   cid,
+  post,
+  origin,
   variant = 'icon',
   openOnHover = false,
   buttonVariant = ButtonVariant.Tertiary,
@@ -87,6 +95,8 @@ export function ShareActions({
     <SocialShareList
       link={link}
       description={text}
+      post={post}
+      origin={origin}
       emailTitle={emailTitle}
       emailSummary={emailSummary}
       isCopying={copying}

--- a/packages/shared/src/components/share/ShareBand.tsx
+++ b/packages/shared/src/components/share/ShareBand.tsx
@@ -10,6 +10,8 @@ import {
 import { ButtonSize, ButtonVariant } from '../buttons/common';
 import type { ReferralCampaignKey } from '../../lib/referral';
 import type { ShareProvider } from '../../lib/share';
+import type { Post } from '../../graphql/posts';
+import type { Origin } from '../../lib/log';
 
 export interface ShareBandProps {
   title: string;
@@ -19,6 +21,9 @@ export interface ShareBandProps {
   text: string;
   /** Omit when `link` is already a tracked short URL — passing it double-shortens. */
   cid?: ReferralCampaignKey;
+  /** Adds Slack to the networks behind the chevron. */
+  post?: Post;
+  origin?: Origin;
   emailTitle?: string;
   /** Surface and spacing belong to the host: the two callers sit in different places. */
   className?: string;
@@ -40,6 +45,8 @@ export const ShareBand = ({
   link,
   text,
   cid,
+  post,
+  origin,
   emailTitle,
   className,
   onShare,
@@ -68,6 +75,8 @@ export const ShareBand = ({
       link={link}
       text={text}
       cid={cid}
+      post={post}
+      origin={origin}
       emailTitle={emailTitle}
       buttonVariant={ButtonVariant.Primary}
       buttonSize={ButtonSize.Small}

--- a/packages/shared/src/features/snapshot/EndOfThreadShare.tsx
+++ b/packages/shared/src/features/snapshot/EndOfThreadShare.tsx
@@ -57,6 +57,8 @@ export function EndOfThreadShare({
       description="Send it to someone who’d have opinions."
       link={post.commentsPermalink}
       onShare={onShare}
+      origin={Origin.EndOfConversation}
+      post={post}
       text={post.title ?? post.sharedPost?.title ?? ''}
       title="Enjoyed this discussion?"
     />


### PR DESCRIPTION
#6627 added Slack to the share surfaces. The two share bands from #6556 (the end-of-thread band and the post-upvote prompt) landed in parallel and build their network list through `ShareActions`, which never passed a post to `SocialShareList`. The list only offers Slack when it has a post, so the bands showed every network except Slack.

`ShareActions` and `ShareBand` now accept `post` and `origin` and forward them. `EndOfThreadShare` and `PostContentShare` pass theirs, so the Slack button appears behind the band's chevron and its `start share to slack` event carries the band's origin (`end of conversation`, `post content`).

The briefing's end band in #6563 uses `ShareBand` too; once this lands, it gets Slack by passing the brief post.

## Events

No new events. Slack's existing `start share to slack` now also fires from the two bands, with their origins.

## Experiment

None.

## Testing

- New `ShareActions` test: Slack is offered only when a post is passed.
- Share, snapshot, post and widget specs: 40 suites, 238 tests pass.
- `typecheck-strict-changed` clean, eslint clean, full webapp `tsc` clean apart from the known `__tests__` backlog.


### Preview domain
https://feat-share-band-slack.preview.app.daily.dev