### PR TITLE
fix(snapshot): keep the selection bar off Android's own menu

### DIFF
--- a/packages/shared/src/features/snapshot/SelectionSnapshotBar.spec.tsx
+++ b/packages/shared/src/features/snapshot/SelectionSnapshotBar.spec.tsx
@@ -112,6 +112,23 @@ describe('SelectionSnapshotBar placement', () => {
     expect(top).toBeLessThanOrEqual(800 - 44 - 8);
   });
 
+  it('sits below the quote on touch, clear of the platform menu', () => {
+    // Android's own Copy/Share menu takes the space above the selection.
+    Object.assign(globalThis, { innerHeight: 800, innerWidth: 1440 });
+    const desktop = globalThis.matchMedia;
+    globalThis.matchMedia = ((query: string) => ({
+      matches: query === '(pointer: coarse)',
+    })) as unknown as typeof globalThis.matchMedia;
+    rectAt({ top: 400, bottom: 440 });
+
+    renderBar();
+    select('body');
+
+    expect(parseFloat(barStyle().top)).toBeGreaterThan(440);
+
+    globalThis.matchMedia = desktop;
+  });
+
   it('keeps the bar clear of the side edges', () => {
     Object.assign(globalThis, { innerHeight: 800, innerWidth: 1440 });
     rectAt({ left: 1430, width: 10 });

--- a/packages/shared/src/features/snapshot/SelectionSnapshotBar.tsx
+++ b/packages/shared/src/features/snapshot/SelectionSnapshotBar.tsx
@@ -29,6 +29,14 @@ const BAR_HEIGHT = 44;
 const GAP = 8;
 /** Keeps the bar off the viewport edges when the quote runs to the margin. */
 const EDGE = 96;
+/** Clears the drag handles Android hangs under the end of a selection. */
+const HANDLE = 32;
+
+// Android draws its own Copy/Share menu over the selection, above it whenever
+// there is room. Taking the other side leaves both readable: the platform menu
+// only moves below the quote in the case where we then sit above it.
+const prefersBelow = () =>
+  globalThis.matchMedia?.('(pointer: coarse)').matches ?? false;
 
 const clamp = (value: number, min: number, max: number) =>
   // A viewport shorter than the bar's own margins has no valid band, and
@@ -38,10 +46,12 @@ const clamp = (value: number, min: number, max: number) =>
 const position = (selection: TextSelection) => {
   const above = selection.top - BAR_HEIGHT - GAP;
   const center = selection.left + selection.width / 2;
+  const { innerHeight, innerWidth } = globalThis;
+  const below = selection.bottom + GAP + (prefersBelow() ? HANDLE : 0);
+  const fits = !innerHeight || below + BAR_HEIGHT + GAP <= innerHeight;
   // Below the quote when it starts at the top of the viewport, where there is
   // no room above it.
-  const top = above < GAP ? selection.bottom + GAP : above;
-  const { innerHeight, innerWidth } = globalThis;
+  const top = above < GAP || (prefersBelow() && fits) ? below : above;
 
   return {
     // Clamped to the viewport, not just flipped: in the post modal the quote


### PR DESCRIPTION
## Problem

On Android, Chrome's native selection menu (Copy / Share / Select all) renders over our selection bar — see the report: both land in the space above the highlighted text.

That menu is browser chrome, not our DOM. There is no event to cancel and no CSS to suppress it; the only thing that removes it is `user-select: none`, which would also remove the selection the feature is built on. So this avoids the collision instead of hiding the menu.

## Change

On a coarse pointer, the bar prefers the space **below** the selection, clearing the drag handles Android hangs under it. This anti-correlates the two: the platform menu only moves below the quote when there is no room above, and that is exactly the case where our bar goes above. Mouse placement is unchanged.

## Verification

- `packages/shared` snapshot suites: 7 suites / 44 tests pass, including a new case asserting the bar sits below the quote under `(pointer: coarse)`.
- eslint + strict typecheck guard on the changed files: clean.

Worth a real-device check on the preview before merge — the handle clearance is a fixed 32px and Android's handle size varies with display density.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Preview domain
https://claude-android-selection-bar-ove.preview.app.daily.dev