### PR TITLE
fix(share): copy absolute world and tool links

### DIFF
--- a/packages/shared/src/features/interests/hooks/useShareAgent.ts
+++ b/packages/shared/src/features/interests/hooks/useShareAgent.ts
@@ -1,17 +1,11 @@
 import { useState } from 'react';
 import { useShareOrCopyLink } from '../../../hooks/useShareOrCopyLink';
-import { webappUrl } from '../../../lib/constants';
+import { getAbsoluteWebappUrl } from '../../../lib/links';
 import { ReferralCampaignKey } from '../../../lib/referral';
 import type { UserInterest } from '../../../graphql/interests';
 
-export const agentShareLink = (query: string): string => {
-  const path = `${webappUrl}agent?q=${encodeURIComponent(query)}`;
-  // Must be absolute: the share pipeline runs `new URL(link)`, and `webappUrl`
-  // is a bare path in development, which threw rather than degrading.
-  const origin = globalThis?.location?.origin;
-
-  return origin ? new URL(path, origin).toString() : path;
-};
+export const agentShareLink = (query: string): string =>
+  getAbsoluteWebappUrl(`agent?q=${encodeURIComponent(query)}`);
 
 export const useShareAgent = (
   interest?: Pick<UserInterest, 'query'>,

--- a/packages/shared/src/hooks/useSourceMenuProps.tsx
+++ b/packages/shared/src/hooks/useSourceMenuProps.tsx
@@ -1,6 +1,7 @@
 import { useRouter } from 'next/router';
 import { useContentPreference } from './contentPreference/useContentPreference';
 import { webappUrl } from '../lib/constants';
+import { getAbsoluteWebappUrl } from '../lib/links';
 import type { SourceTooltip } from '../graphql/sources';
 import { ContentPreferenceType } from '../graphql/contentPreference';
 import { LogEvent } from '../lib/log';
@@ -58,7 +59,7 @@ const useSourceMenuProps = ({
     text: source?.handle
       ? `Check out ${source.handle} on daily.dev`
       : 'Check out this source on daily.dev',
-    link: source?.permalink || webappUrl,
+    link: source?.permalink || getAbsoluteWebappUrl(),
     cid: ReferralCampaignKey.ShareSource,
     logObject: () => ({
       event_name: LogEvent.ShareSource,

--- a/packages/shared/src/lib/links.spec.ts
+++ b/packages/shared/src/lib/links.spec.ts
@@ -1,4 +1,4 @@
-import { getPathnameWithQuery, withHttps } from './links';
+import { getAbsoluteWebappUrl, getPathnameWithQuery, withHttps } from './links';
 
 describe('lib/links tests', () => {
   it('should return links as https links', () => {
@@ -49,5 +49,36 @@ describe('getPathnameWithQuery', () => {
   it('ignores whitespace-only existing query', () => {
     expect(getPathnameWithQuery('/foo? ', new URLSearchParams())).toBe('/foo');
     expect(getPathnameWithQuery('/foo?   ', 'a=1')).toBe('/foo?a=1');
+  });
+});
+
+describe('getAbsoluteWebappUrl', () => {
+  // The test setup mirrors the webapp, where `webappUrl` is a bare `/`.
+  it('resolves the path against the page origin', () => {
+    expect(getAbsoluteWebappUrl('tools/docker')).toBe(
+      `${globalThis.location.origin}/tools/docker`,
+    );
+  });
+
+  it('points at the home page without a path', () => {
+    expect(getAbsoluteWebappUrl()).toBe(`${globalThis.location.origin}/`);
+  });
+
+  it('leaves an absolute webappUrl, as on the extension, alone', () => {
+    const previous = process.env.NEXT_PUBLIC_WEBAPP_URL;
+    process.env.NEXT_PUBLIC_WEBAPP_URL = 'https://app.daily.dev/';
+
+    try {
+      jest.isolateModules(() => {
+        // eslint-disable-next-line global-require, @typescript-eslint/no-var-requires
+        const links = require('./links');
+
+        expect(links.getAbsoluteWebappUrl('world/ido')).toBe(
+          'https://app.daily.dev/world/ido',
+        );
+      });
+    } finally {
+      process.env.NEXT_PUBLIC_WEBAPP_URL = previous;
+    }
   });
 });

--- a/packages/shared/src/lib/links.ts
+++ b/packages/shared/src/lib/links.ts
@@ -137,6 +137,16 @@ export const getPathnameWithQuery = (
 export const toWebappHref = (path: string): string =>
   path.startsWith('/') ? `${webappUrl}${path.slice(1)}` : path;
 
+// For links that leave the tab (share, copy): `webappUrl` is a bare `/` on the
+// webapp, and the share pipeline runs `new URL(link)` on whatever it is handed.
+// An absolute `webappUrl` (the extension) passes through unchanged.
+export const getAbsoluteWebappUrl = (path = ''): string => {
+  const url = `${webappUrl}${path}`;
+  const origin = globalThis?.location?.origin;
+
+  return origin ? new URL(url, origin).toString() : url;
+};
+
 export const agentsHighlightsPath = '/highlights/vibes';
 
 export const agentsHighlightsUrl = `${webappUrl}${agentsHighlightsPath.slice(

--- a/packages/shared/src/lib/referral.ts
+++ b/packages/shared/src/lib/referral.ts
@@ -8,4 +8,6 @@ export enum ReferralCampaignKey {
   ShareTag = 'share_tag',
   ShareAgent = 'share_agent',
   ShareSlack = 'share_slack',
+  ShareWorld = 'share_world',
+  ShareTool = 'share_tool',
 }

--- a/packages/webapp/__tests__/ToolPage.spec.tsx
+++ b/packages/webapp/__tests__/ToolPage.spec.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import nock from 'nock';
 import type { NextRouter } from 'next/router';
 import type { RenderResult } from '@testing-library/react';
-import { render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import AuthContext from '@dailydotdev/shared/src/contexts/AuthContext';
 import type { LoggedUser } from '@dailydotdev/shared/src/lib/user';
@@ -268,4 +268,20 @@ it('should render squads with the directory card details', async () => {
   ).toBeInTheDocument();
   expect(screen.getByText(/@platform/)).toBeInTheDocument();
   expect(screen.getByText('42 members')).toBeInTheDocument();
+});
+
+it('should copy an absolute, tracked link to the tool', async () => {
+  const writeText = jest.fn().mockResolvedValue(undefined);
+  Object.assign(navigator, { clipboard: { writeText } });
+  renderComponent(defaultProps, loggedUser);
+
+  const share = await screen.findByRole('button', { name: 'Share' });
+  await act(async () => {
+    fireEvent.click(share);
+  });
+
+  // `webappUrl` is a bare `/` on the webapp, which pastes as a dead link.
+  expect(writeText).toHaveBeenCalledWith(
+    `${globalThis.location.origin}/tools/docker?userid=${loggedUser.id}&cid=share_tool`,
+  );
 });

--- a/packages/webapp/__tests__/WorldShare.spec.tsx
+++ b/packages/webapp/__tests__/WorldShare.spec.tsx
@@ -1,10 +1,18 @@
 import type { ReactElement } from 'react';
 import React from 'react';
-import { fireEvent, render as rtlRender, screen } from '@testing-library/react';
+import {
+  act,
+  fireEvent,
+  render as rtlRender,
+  screen,
+} from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { PublicProfile } from '@dailydotdev/shared/src/lib/user';
 import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
 import { ShareProvider } from '@dailydotdev/shared/src/lib/share';
+import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
+import loggedUser from '@dailydotdev/shared/__tests__/fixture/loggedUser';
 import { WorldShare } from '../components/world/WorldShare';
 
 const mockShareOrCopy = jest.fn();
@@ -13,6 +21,10 @@ const mockUseShareOrCopyLink = jest.fn();
 jest.mock('@dailydotdev/shared/src/hooks/useShareOrCopyLink', () => ({
   useShareOrCopyLink: (props: unknown) => mockUseShareOrCopyLink(props),
 }));
+
+const { useShareOrCopyLink: actualUseShareOrCopyLink } = jest.requireActual(
+  '@dailydotdev/shared/src/hooks/useShareOrCopyLink',
+);
 
 const user = {
   id: 'u1',
@@ -23,6 +35,7 @@ const user = {
 interface ShareArgs {
   link: string;
   text: string;
+  cid?: ReferralCampaignKey;
   logObject: (provider: ShareProvider) => Record<string, unknown>;
 }
 
@@ -45,10 +58,9 @@ describe('WorldShare', () => {
   it('hands out an absolute link to the world', () => {
     render(<WorldShare user={user} isOwn={false} />);
 
-    // Absolute on purpose: the whole point is a link that survives the tab.
-    expect(argsOf().link).toBe(
-      `${process.env.NEXT_PUBLIC_WEBAPP_URL}world/ido`,
-    );
+    // Absolute on purpose: the whole point is a link that survives the tab,
+    // and `webappUrl` is a bare `/` on the webapp.
+    expect(argsOf().link).toBe(`${globalThis.location.origin}/world/ido`);
   });
 
   it('falls back to the id for a reader with no username', () => {
@@ -56,7 +68,32 @@ describe('WorldShare', () => {
       <WorldShare user={{ ...user, username: undefined }} isOwn={false} />,
     );
 
-    expect(argsOf().link).toBe(`${process.env.NEXT_PUBLIC_WEBAPP_URL}world/u1`);
+    expect(argsOf().link).toBe(`${globalThis.location.origin}/world/u1`);
+  });
+
+  it('tags the link with the world share campaign', () => {
+    render(<WorldShare user={user} isOwn={false} />);
+
+    expect(argsOf().cid).toBe(ReferralCampaignKey.ShareWorld);
+  });
+
+  it('copies a link that still works once pasted', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    mockUseShareOrCopyLink.mockImplementation(actualUseShareOrCopyLink);
+    rtlRender(
+      <TestBootProvider client={new QueryClient()} auth={{ user: loggedUser }}>
+        <WorldShare user={user} isOwn={false} />
+      </TestBootProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Share this world' }));
+    });
+
+    expect(writeText).toHaveBeenCalledWith(
+      `${globalThis.location.origin}/world/ido?userid=${loggedUser.id}&cid=share_world`,
+    );
   });
 
   it('names the owner when the world belongs to somebody else', () => {

--- a/packages/webapp/components/world/WorldShare.tsx
+++ b/packages/webapp/components/world/WorldShare.tsx
@@ -9,8 +9,9 @@ import {
 } from '@dailydotdev/shared/src/components/buttons/Button';
 import { Tooltip } from '@dailydotdev/shared/src/components/tooltip/Tooltip';
 import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopyLink';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
+import { getAbsoluteWebappUrl } from '@dailydotdev/shared/src/lib/links';
 import { LogEvent } from '@dailydotdev/shared/src/lib/log';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
 import type { ShareProvider } from '@dailydotdev/shared/src/lib/share';
 
 interface WorldShareProps {
@@ -43,7 +44,7 @@ export function WorldShare({
 }: WorldShareProps): ReactElement {
   const whose = isOwn ? 'my' : `${user.name}'s`;
   const [copying, onShareOrCopy] = useShareOrCopyLink({
-    link: `${webappUrl}world/${user.username || user.id}`,
+    link: getAbsoluteWebappUrl(`world/${user.username || user.id}`),
     text: worldName
       ? `Check out ${worldName}, ${whose} world on daily.dev`
       : `Check out ${whose} world on daily.dev`,
@@ -52,6 +53,7 @@ export function WorldShare({
       target_id: user.id,
       extra: JSON.stringify({ provider }),
     }),
+    cid: ReferralCampaignKey.ShareWorld,
   });
 
   return (

--- a/packages/webapp/pages/join/index.tsx
+++ b/packages/webapp/pages/join/index.tsx
@@ -29,6 +29,8 @@ const componentsMap: ReferralRecord<FunctionComponent<JoinPageProps>> = {
   [ReferralCampaignKey.ShareTag]: Referral,
   [ReferralCampaignKey.ShareAgent]: Referral,
   [ReferralCampaignKey.ShareSlack]: Referral,
+  [ReferralCampaignKey.ShareWorld]: Referral,
+  [ReferralCampaignKey.ShareTool]: Referral,
 };
 
 const referralCampaignValues = new Set<string>(

--- a/packages/webapp/pages/tools/[slug].tsx
+++ b/packages/webapp/pages/tools/[slug].tsx
@@ -91,8 +91,10 @@ import { useShareOrCopyLink } from '@dailydotdev/shared/src/hooks/useShareOrCopy
 import { anchorDefaultRel } from '@dailydotdev/shared/src/lib/strings';
 import { largeNumberFormat } from '@dailydotdev/shared/src/lib/numberFormat';
 import { publishTimeRelativeShort } from '@dailydotdev/shared/src/lib/dateFormat';
-import { webappUrl } from '@dailydotdev/shared/src/lib/constants';
-import { getDomainFromUrl } from '@dailydotdev/shared/src/lib/links';
+import {
+  getAbsoluteWebappUrl,
+  getDomainFromUrl,
+} from '@dailydotdev/shared/src/lib/links';
 import {
   ProfileImageSize,
   ProfilePicture,
@@ -101,6 +103,7 @@ import { ProfilePictureGroup } from '@dailydotdev/shared/src/components/ProfileP
 import { ToolLogo } from '@dailydotdev/shared/src/components/tools/ToolLogo';
 import { useLogContext } from '@dailydotdev/shared/src/contexts/LogContext';
 import { LogEvent, Origin, TargetType } from '@dailydotdev/shared/src/lib/log';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
 import { ActiveFeedNameContext } from '@dailydotdev/shared/src/contexts';
 import { FeedLayoutProvider } from '@dailydotdev/shared/src/contexts/FeedContext';
 import { TAG_FEED_QUERY } from '@dailydotdev/shared/src/graphql/feed';
@@ -356,13 +359,14 @@ const ToolPage = ({
   );
 
   const [copying, onShareOrCopy] = useShareOrCopyLink({
-    link: `${webappUrl}tools/${tool.slug}`,
+    link: getAbsoluteWebappUrl(`tools/${tool.slug}`),
     text: `Check out ${tool.title} on daily.dev`,
     logObject: (provider) => ({
       event_name: LogEvent.ShareTool,
       target_id: tool.slug,
       extra: JSON.stringify({ provider, origin: Origin.ToolPage }),
     }),
+    cid: ReferralCampaignKey.ShareTool,
   });
 
   const { data: followedStackers } = useQuery({


### PR DESCRIPTION
## Problem

`webappUrl` is `process.env.NEXT_PUBLIC_WEBAPP_URL`, which is a bare `/` on the webapp and absolute only in the extension. The world share button and the tool page share button built their links as `${webappUrl}world/...` and `${webappUrl}tools/...`, so the clipboard got `/world/<user>` and `/tools/<slug>`, which is a dead link once pasted.

## Fix

- New `getAbsoluteWebappUrl(path)` in `packages/shared/src/lib/links.ts`. It resolves the path against `location.origin` and leaves an absolute `webappUrl` (the extension) untouched. This is the approach `agentShareLink` already used and the one #6570 adds for Happening Now, pulled into one helper.
- Used in `WorldShare`, the tool page share, and `agentShareLink` (which no longer carries its own copy).
- Audit of the other `useShareOrCopyLink` / `useCopyLink` / `navigator.clipboard` call sites: the rest copy backend permalinks, `location.href`, or origin-built URLs. The one other case was `useSourceMenuProps`, which fell back to a bare `webappUrl` when a source had no permalink. That copied `/` and threw in `addLogQueryParams` once the `share_source` cid was attached, so it now uses the helper too.
- Tracking: the world and tool links now pass `cid` through `useShareOrCopyLink` (new `share_world` and `share_tool` campaign keys), like the other share buttons, so they get the referral `userid`/`cid` params and the shortener. `pages/join` maps both to the generic referral screen, and `useReferralConfig` already falls back to the default config.

## Relation to #6570

#6570 (still open) adds `getHighlightsShareUrl()` with the same origin logic. Whichever PR merges second should switch it to `getAbsoluteWebappUrl('highlights')`. The `ReferralCampaignKey` enum and the join page map both gain entries in both PRs, so expect a trivial conflict there.

## Tests

With `webappUrl` at `/` (the webapp and shared jest setups):
- `WorldShare.spec.tsx`: the old assertions expected the relative `/world/ido` and have been changed to expect the absolute link. There is also a cid check, plus a test that goes through the real share pipeline and asserts the clipboard gets `http://localhost/world/ido?userid=...&cid=share_world`.
- `ToolPage.spec.tsx`: clicking Share writes `http://localhost/tools/docker?userid=...&cid=share_tool` to the clipboard.
- `links.spec.ts`: the helper resolves against the origin, returns the home page when called with no path, and passes an absolute `webappUrl` through.

Checks run: `node ./scripts/typecheck-strict-changed.js`, eslint on the changed files, the affected shared specs, the full webapp jest suite (86 suites, 692 tests), and the full webapp tsc (no errors in changed files).

### Preview domain
https://fix-absolute-share-links.preview.app.daily.dev