### PR TITLE
fix(share): hide the post header copy link on mobile

### DIFF
--- a/packages/shared/src/components/post/PostMenuOptions.spec.tsx
+++ b/packages/shared/src/components/post/PostMenuOptions.spec.tsx
@@ -48,6 +48,15 @@ describe('PostMenuOptions copy link', () => {
     );
   });
 
+  it('stays off the mobile headers, which have no room for it', () => {
+    // The ⋯ menu keeps "Share via" at every width, so the phone loses the
+    // shortcut, not the ability to share.
+    renderActions(post);
+
+    expect(copyLink()).toHaveClass('hidden', 'laptop:flex');
+    expect(screen.getByLabelText('Options')).not.toHaveClass('hidden');
+  });
+
   it('restyles the menu trigger alone, never the copy link beside it', () => {
     // The focus card rotates the ⋯ glyph 90°. Put on a wrapper, that rotation
     // also turned the copy link and its confirmation check on their side.

--- a/packages/shared/src/components/post/PostMenuOptions.tsx
+++ b/packages/shared/src/components/post/PostMenuOptions.tsx
@@ -60,6 +60,7 @@ export function PostMenuOptions({
         <Tooltip side="bottom" content="Copy link">
           <Button
             aria-label="Copy link"
+            className="hidden laptop:flex"
             icon={<CopyStateIcon copied={linkCopied} icon={LinkIcon} />}
             onClick={onCopyLink}
             size={buttonSize}


### PR DESCRIPTION
The copy link we recently added beside the `⋯` menu crowds the post page header on a phone. That header (`GoBackHeaderMobile`) already carries the back button, Read post and the menu, so the extra glyph left nothing to spare.

## Changes

`PostMenuOptions` is the single place the copy link lives, and every post header (`PostHeaderActions`, `CollectionPostHeaderActions`, `PostFocusCard`, `EngagementRail`) pulls it in — so one class covers every header instance.

- `PostMenuOptions.tsx` — the copy-link button now carries `hidden laptop:flex`.
- `PostMenuOptions.spec.tsx` — one test asserting the link carries the responsive classes while the `⋯` trigger does not.

## Key decisions

**Gated at `laptop`, not `tablet`.** The post page already splits on exactly that line: the mobile header is `laptop:hidden`, and the desktop action cluster in `PostSourceInfo.tsx` is `hidden laptop:flex`. Hiding below `laptop` puts the copy link precisely where the roomy header is.

**Class on the button, not a wrapper.** The `⋯` trigger is the link's fragment sibling and has to stay — a wrapper selector would take both down. This is the same trap `menuTriggerClassName` and an existing test already guard against.

**Nothing is lost on mobile.** The `⋯` menu still offers "Share via", which opens the share modal with its own copy link. The phone loses the shortcut, not the ability to share.

**CSS rather than `useViewSize`.** Keeps it SSR-safe with no hydration flash, and leaves the button in the DOM so the existing cross-package tests that assert post header structure keep passing.

## Verification

- `pnpm --filter shared test src/components/post/PostMenuOptions.spec.tsx` — 10/10 pass (the package `test` script runs eslint first; clean at `--max-warnings 0`).
- Broader shared post/share/hooks selection — 34 suites, 193 tests pass.
- `pnpm --filter webapp test` — 86 suites, 692 tests pass.
- `node ./scripts/typecheck-strict-changed.js` — passes.
- Prettier clean on both files.

Two pre-existing failures were checked against a reverted-tree baseline and confirmed unrelated to this change: `jest src/components/post` exits 1 despite all suites passing (a post-teardown async log in the ads query), and full webapp `tsc` reports 15 errors in unrelated `__tests__` files. Both are identical on baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes ENG-2077

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-2077-hide-the-copy-link-on-m.preview.app.daily.dev