### PR TITLE
fix(quests): track shared post clicks from post page

### DIFF
--- a/packages/shared/src/graphql/quests.ts
+++ b/packages/shared/src/graphql/quests.ts
@@ -410,6 +410,22 @@ export const TRACK_QUEST_EVENT_MUTATION = gql`
   }
 `;
 
+export const TRACK_SHARED_POST_CLICK_MUTATION = gql`
+  mutation TrackSharedPostClick(
+    $referringUserId: ID!
+    $postId: ID!
+    $campaign: String!
+  ) {
+    trackSharedPostClick(
+      referringUserId: $referringUserId
+      postId: $postId
+      campaign: $campaign
+    ) {
+      _
+    }
+  }
+`;
+
 export const QUEST_UPDATE_SUBSCRIPTION = gql`
   subscription QuestUpdate {
     questUpdate {
@@ -433,4 +449,20 @@ export const trackQuestClientEvent = async (
   eventType: ClientQuestEventType,
 ): Promise<void> => {
   await gqlClient.request(TRACK_QUEST_EVENT_MUTATION, { eventType });
+};
+
+export const trackSharedPostClick = async ({
+  referringUserId,
+  postId,
+  campaign,
+}: {
+  referringUserId: string;
+  postId: string;
+  campaign: string;
+}): Promise<void> => {
+  await gqlClient.request(TRACK_SHARED_POST_CLICK_MUTATION, {
+    referringUserId,
+    postId,
+    campaign,
+  });
 };

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -29,6 +29,7 @@ export * from './useBookmarkProvider';
 export * from './usePlusSubscription';
 export * from './useClaimQuestReward';
 export * from './useQuestDashboard';
+export * from './useShareLinkClick';
 export * from './onboarding/useCheckExistingEmail';
 export * from './onboarding/useGenerateUsername';
 export * from './post/useBlockPostPanel';

--- a/packages/shared/src/hooks/useShareLinkClick.spec.tsx
+++ b/packages/shared/src/hooks/useShareLinkClick.spec.tsx
@@ -1,0 +1,204 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import type { NextRouter } from 'next/router';
+import { useRouter } from 'next/router';
+import { useAuthContext } from '../contexts/AuthContext';
+import { trackSharedPostClick } from '../graphql/quests';
+import { ReferralCampaignKey } from '../lib/referral';
+import {
+  getShareLinkClickKey,
+  isShareLinkClickCampaign,
+  shouldTrackShareLinkClick,
+  useShareLinkClick,
+} from './useShareLinkClick';
+
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../contexts/AuthContext', () => ({
+  useAuthContext: jest.fn(),
+}));
+
+jest.mock('../graphql/quests', () => ({
+  ...jest.requireActual('../graphql/quests'),
+  trackSharedPostClick: jest.fn(),
+}));
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+const mockUseAuthContext = useAuthContext as jest.MockedFunction<
+  typeof useAuthContext
+>;
+const mockTrackSharedPostClick = trackSharedPostClick as jest.MockedFunction<
+  typeof trackSharedPostClick
+>;
+
+const postId = 'post-1';
+const referringUserId = 'sharer-1';
+
+const setRouterQuery = (query: NextRouter['query']) => {
+  mockUseRouter.mockReturnValue({
+    query,
+  } as unknown as NextRouter);
+};
+
+const setViewer = ({
+  userId,
+  isAuthReady = true,
+}: {
+  userId?: string | null;
+  isAuthReady?: boolean;
+} = {}) => {
+  mockUseAuthContext.mockReturnValue({
+    user: userId ? { id: userId } : null,
+    isAuthReady,
+  } as unknown as ReturnType<typeof useAuthContext>);
+};
+
+describe('share link click helpers', () => {
+  it('should identify click campaigns and build stable keys', () => {
+    expect(isShareLinkClickCampaign(ReferralCampaignKey.SharePost)).toBe(true);
+    expect(isShareLinkClickCampaign(ReferralCampaignKey.ShareSlack)).toBe(true);
+    expect(isShareLinkClickCampaign(ReferralCampaignKey.ShareComment)).toBe(
+      false,
+    );
+    expect(
+      getShareLinkClickKey({
+        referringUserId,
+        postId,
+        campaign: ReferralCampaignKey.SharePost,
+      }),
+    ).toBe(`${referringUserId}:${postId}:${ReferralCampaignKey.SharePost}`);
+  });
+
+  it('should reject incomplete and self-click attribution', () => {
+    expect(
+      shouldTrackShareLinkClick({
+        campaign: ReferralCampaignKey.SharePost,
+        referringUserId,
+        postId,
+        userId: 'visitor-1',
+      }),
+    ).toBe(true);
+    expect(
+      shouldTrackShareLinkClick({
+        campaign: ReferralCampaignKey.SharePost,
+        referringUserId,
+        postId,
+        userId: referringUserId,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTrackShareLinkClick({
+        campaign: ReferralCampaignKey.ShareProfile,
+        referringUserId,
+        postId,
+      }),
+    ).toBe(false);
+    expect(
+      shouldTrackShareLinkClick({
+        campaign: ReferralCampaignKey.SharePost,
+        postId,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('useShareLinkClick', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setViewer();
+    setRouterQuery({
+      cid: ReferralCampaignKey.SharePost,
+      userid: referringUserId,
+    });
+    mockTrackSharedPostClick.mockResolvedValue(undefined);
+  });
+
+  it('should track an eligible anonymous post share click once', async () => {
+    const { rerender } = renderHook(
+      (props: { postId?: string }) => useShareLinkClick(props),
+      {
+        initialProps: { postId },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockTrackSharedPostClick).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockTrackSharedPostClick).toHaveBeenCalledWith({
+      referringUserId,
+      postId,
+      campaign: ReferralCampaignKey.SharePost,
+    });
+
+    rerender({ postId });
+
+    expect(mockTrackSharedPostClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should use the first query param value and ignore unrelated route changes', async () => {
+    const { rerender } = renderHook(
+      (props: { postId?: string }) => useShareLinkClick(props),
+      {
+        initialProps: { postId },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockTrackSharedPostClick).toHaveBeenCalledTimes(1);
+    });
+
+    setRouterQuery({
+      cid: [ReferralCampaignKey.SharePost, ReferralCampaignKey.ShareProfile],
+      userid: [referringUserId, 'other-sharer'],
+      unrelated: '1',
+    });
+    rerender({ postId });
+
+    expect(mockTrackSharedPostClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should skip self-clicks', () => {
+    setViewer({ userId: referringUserId });
+
+    renderHook(() => useShareLinkClick({ postId }));
+
+    expect(mockTrackSharedPostClick).not.toHaveBeenCalled();
+  });
+
+  it('should skip when attribution is incomplete or auth is not ready', () => {
+    setRouterQuery({ userid: referringUserId });
+    renderHook(() => useShareLinkClick({ postId }));
+
+    setRouterQuery({
+      cid: ReferralCampaignKey.SharePost,
+      userid: referringUserId,
+    });
+    renderHook(() => useShareLinkClick({}));
+
+    setViewer({ isAuthReady: false });
+    renderHook(() => useShareLinkClick({ postId }));
+
+    expect(mockTrackSharedPostClick).not.toHaveBeenCalled();
+  });
+
+  it('should not retry after a failed tracking request on rerender', async () => {
+    mockTrackSharedPostClick.mockRejectedValue(new Error('network error'));
+
+    const { rerender } = renderHook(
+      (props: { postId?: string }) => useShareLinkClick(props),
+      {
+        initialProps: { postId },
+      },
+    );
+
+    await waitFor(() => {
+      expect(mockTrackSharedPostClick).toHaveBeenCalledTimes(1);
+    });
+
+    rerender({ postId });
+
+    expect(mockTrackSharedPostClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/shared/src/hooks/useShareLinkClick.ts
+++ b/packages/shared/src/hooks/useShareLinkClick.ts
@@ -1,0 +1,89 @@
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/router';
+import { useAuthContext } from '../contexts/AuthContext';
+import { trackSharedPostClick } from '../graphql/quests';
+import { getFirstQueryParam } from '../lib/func';
+import { ReferralCampaignKey } from '../lib/referral';
+
+const SHARE_LINK_CLICK_CAMPAIGNS = new Set<string>([
+  ReferralCampaignKey.SharePost,
+  ReferralCampaignKey.ShareSlack,
+]);
+
+export const isShareLinkClickCampaign = (
+  campaign?: string | null,
+): campaign is ReferralCampaignKey =>
+  !!campaign && SHARE_LINK_CLICK_CAMPAIGNS.has(campaign);
+
+interface UseShareLinkClickProps {
+  postId?: string | null;
+  enabled?: boolean;
+}
+
+export const getShareLinkClickKey = ({
+  referringUserId,
+  postId,
+  campaign,
+}: {
+  referringUserId: string;
+  postId: string;
+  campaign: string;
+}): string => `${referringUserId}:${postId}:${campaign}`;
+
+export const shouldTrackShareLinkClick = ({
+  campaign,
+  referringUserId,
+  postId,
+  userId,
+}: {
+  campaign?: string | null;
+  referringUserId?: string | null;
+  postId?: string | null;
+  userId?: string | null;
+}): boolean =>
+  isShareLinkClickCampaign(campaign) &&
+  !!referringUserId &&
+  !!postId &&
+  referringUserId !== userId;
+
+export const useShareLinkClick = ({
+  postId,
+  enabled = true,
+}: UseShareLinkClickProps): void => {
+  const { user, isAuthReady } = useAuthContext();
+  const router = useRouter();
+  const trackedKeysRef = useRef(new Set<string>());
+  const campaign = getFirstQueryParam(router.query.cid);
+  const referringUserId = getFirstQueryParam(router.query.userid);
+
+  useEffect(() => {
+    if (
+      !enabled ||
+      !isAuthReady ||
+      !isShareLinkClickCampaign(campaign) ||
+      !referringUserId ||
+      !postId ||
+      referringUserId === user?.id
+    ) {
+      return;
+    }
+
+    const clickKey = getShareLinkClickKey({
+      referringUserId,
+      postId,
+      campaign,
+    });
+
+    if (trackedKeysRef.current.has(clickKey)) {
+      return;
+    }
+
+    trackedKeysRef.current.add(clickKey);
+
+    trackSharedPostClick({
+      referringUserId,
+      postId,
+      campaign,
+    }).catch(() => undefined);
+  }, [campaign, enabled, isAuthReady, postId, referringUserId, user?.id]);
+};

--- a/packages/webapp/__tests__/PostPage.tsx
+++ b/packages/webapp/__tests__/PostPage.tsx
@@ -51,6 +51,8 @@ import {
   FEED_SETTINGS_QUERY,
   REMOVE_FILTERS_FROM_FEED_MUTATION,
 } from '@dailydotdev/shared/src/graphql/feedSettings';
+import { TRACK_SHARED_POST_CLICK_MUTATION } from '@dailydotdev/shared/src/graphql/quests';
+import { ReferralCampaignKey } from '@dailydotdev/shared/src/lib/referral';
 import { TestBootProvider } from '@dailydotdev/shared/__tests__/helpers/boot';
 import * as hooks from '@dailydotdev/shared/src/hooks/useViewSize';
 import { UserVoteEntity } from '@dailydotdev/shared/src/hooks';
@@ -376,6 +378,46 @@ it('should format read time when available', async () => {
   renderPost();
   const el = await screen.findByTestId('readTime');
   expect(el).toHaveTextContent('8m read time');
+});
+
+it('should track attributed shared post clicks', async () => {
+  const onTrack = jest.fn();
+  const shareUserId = 'share-user';
+
+  mockRouter({
+    query: {
+      cid: ReferralCampaignKey.SharePost,
+      userid: shareUserId,
+    },
+  });
+
+  renderPost({}, [
+    createPostMock(),
+    createCommentsMock(),
+    {
+      request: {
+        query: TRACK_SHARED_POST_CLICK_MUTATION,
+        variables: {
+          referringUserId: shareUserId,
+          postId: defaultPost.id,
+          campaign: ReferralCampaignKey.SharePost,
+        },
+      },
+      result: () => {
+        onTrack();
+
+        return {
+          data: {
+            trackSharedPostClick: { _: true },
+          },
+        };
+      },
+    },
+  ]);
+
+  await waitFor(() => {
+    expect(onTrack).toHaveBeenCalledTimes(1);
+  });
 });
 
 it('should hide read time when not available', async () => {

--- a/packages/webapp/pages/posts/[id]/index.tsx
+++ b/packages/webapp/pages/posts/[id]/index.tsx
@@ -49,6 +49,7 @@ import {
   useEventListener,
   useJoinReferral,
   usePostById,
+  useShareLinkClick,
   useViewSize,
   ViewSize,
 } from '@dailydotdev/shared/src/hooks';
@@ -220,6 +221,7 @@ export const PostPage = ({
     },
   });
   useSlackShareReturn({ post });
+  useShareLinkClick({ postId: post?.id });
   const queryClient = useQueryClient();
   const postError = (isError
     ? queryClient.getQueryState(getPostByIdKey(id))?.error


### PR DESCRIPTION
## Summary
- Adds the shared post click mutation client and hook for attributed quest progress.
- Mounts the hook on the post page so shared daily.dev post links can credit the referring user.
- Adds focused coverage for post-page firing and hook eligibility behavior.

## Key decisions
- Fires only for post-share campaigns (`share_post` and `share_slack`) with both `userid` and a resolved post id.
- Skips self-clicks, runs for authenticated and anonymous visitors, and guards against repeat sends during rerenders.
- Swallows client-side tracking errors so the clicker's page is never disrupted.

## Verification
- `NODE_ENV=test pnpm exec jest packages/shared/src/hooks/useShareLinkClick.spec.tsx --runInBand`
- `NODE_ENV=test pnpm exec jest packages/webapp/__tests__/PostPage.tsx --runInBand`
- `NODE_ENV=test pnpm exec eslint packages/shared/src/hooks/useShareLinkClick.ts packages/shared/src/hooks/useShareLinkClick.spec.tsx packages/shared/src/graphql/quests.ts packages/webapp/pages/posts/[id]/index.tsx packages/webapp/__tests__/PostPage.tsx`
- `NODE_ENV=test pnpm run typecheck:strict:changed`

Closes ENG-1783

---
Created by Huginn 🐦‍⬛

### Preview domain
https://eng-1783-feedback-bug-report-use.preview.app.daily.dev