### PR TITLE
fix(shared): prevent composer modal content overflow with vertical scrolling

### DIFF
--- a/packages/shared/src/components/post/composer/TextForm.tsx
+++ b/packages/shared/src/components/post/composer/TextForm.tsx
@@ -136,7 +136,7 @@ export const TextForm = forwardRef<TextFormHandle, TextFormProps>(
     );
 
     return (
-      <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         <div className="flex shrink-0 flex-col gap-3 px-5 pb-3 pt-2">
           <textarea
             ref={titleRef}


### PR DESCRIPTION
Fixes https://github.com/dailydotdev/daily/issues/2146

## Changes

- Added `overflow-y-auto` to `TextForm`'s flex container (`packages/shared/src/components/post/composer/TextForm.tsx`).
- When writing or sharing a post/comment with long content or cover image in the "New post" modal, the content now scrolls cleanly within the card boundaries instead of overflowing outside the modal.

## Events

No new tracking events introduced.

## Experiment

No new experiments introduced.

## Manual Testing

### On those affected packages:
- [x] Have you done sanity checks in the webapp?
- [x] Have you done sanity checks in the extension?
- [x] Does this not break anything in companion?

### Did you test the modified components media queries?
- [x] MobileL (420px)
- [x] Tablet (656px)
- [x] Laptop (1020px)
